### PR TITLE
dxe_core: support non-static instanced components

### DIFF
--- a/dxe_core/bin/aarch64.rs
+++ b/dxe_core/bin/aarch64.rs
@@ -36,15 +36,16 @@ static LOGGER: AdvancedLogger<serial_writer::UartPl011> = AdvancedLogger::new(
 
 type DxeCore = Core<uefi_cpu_init::NullCpuInitializer, section_extractor::CompositeSectionExtractor>;
 
-static ADV_LOGGER: AdvancedLoggerComponent<serial_writer::UartPl011> = AdvancedLoggerComponent::new(&LOGGER);
-
 #[cfg_attr(target_os = "uefi", export_name = "efi_main")]
 pub extern "efiapi" fn _start(physical_hob_list: *const c_void) -> ! {
     log::set_logger(&LOGGER).map(|()| log::set_max_level(log::LevelFilter::Trace)).unwrap();
-    let _ = ADV_LOGGER.init_advanced_logger(physical_hob_list);
+
+    let hello_world_component = HelloWorldComponent::default();
+    let adv_logger_component = AdvancedLoggerComponent::new(&LOGGER);
+    adv_logger.init_advanced_logger(physical_hob_list).unwrap();
 
     let mut dxe_core = DxeCore { ..Default::default() };
-    dxe_core.start(physical_hob_list, &[&HelloWorldComponent, &ADV_LOGGER]).unwrap();
+    dxe_core.start(physical_hob_list, &[&hello_world_component, &adv_logger_component]).unwrap();
     log::info!("Dead Loop Time");
     loop {}
 }

--- a/dxe_core/bin/std.rs
+++ b/dxe_core/bin/std.rs
@@ -36,8 +36,10 @@ fn main() -> uefi_core::error::Result<()> {
     log::set_logger(&LOGGER).map(|()| log::set_max_level(log::LevelFilter::Trace)).unwrap();
 
     let hob_list = build_hob_list();
+
+    let hello_world_component = HelloWorldComponent::default();
     let mut dxe_core = DxeCore { ..Default::default() };
-    dxe_core.start(hob_list, &[&HelloWorldComponent])
+    dxe_core.start(hob_list, &[&hello_world_component])
 }
 
 const MEM_SIZE: u64 = 0x2000000;

--- a/dxe_core/bin/x64.rs
+++ b/dxe_core/bin/x64.rs
@@ -36,15 +36,16 @@ static LOGGER: AdvancedLogger<serial_writer::Uart16550> = AdvancedLogger::new(
 
 type DxeCore = Core<uefi_cpu_init::X64CpuInitializer, section_extractor::CompositeSectionExtractor>;
 
-static ADV_LOGGER: AdvancedLoggerComponent<serial_writer::Uart16550> = AdvancedLoggerComponent::new(&LOGGER);
-
 #[cfg_attr(target_os = "uefi", export_name = "efi_main")]
 pub extern "efiapi" fn _start(physical_hob_list: *const c_void) -> ! {
     log::set_logger(&LOGGER).map(|()| log::set_max_level(log::LevelFilter::Trace)).unwrap();
-    let _ = ADV_LOGGER.init_advanced_logger(physical_hob_list);
+
+    let hello_world_component = HelloWorldComponent::default();
+    let adv_logger_component = AdvancedLoggerComponent::new(&LOGGER);
+    adv_logger_component.init_advanced_logger(physical_hob_list).unwrap();
 
     let mut dxe_core = DxeCore { ..Default::default() };
-    dxe_core.start(physical_hob_list, &[&HelloWorldComponent, &ADV_LOGGER]).unwrap();
+    dxe_core.start(physical_hob_list, &[&hello_world_component, &adv_logger_component]).unwrap();
     log::info!("Dead Loop Time");
     loop {}
 }

--- a/dxe_core/src/lib.rs
+++ b/dxe_core/src/lib.rs
@@ -66,11 +66,7 @@ where
     CpuInitializer: interface::CpuInitializer + Default,
     SectionExtractor: fw_fs::SectionExtractor + Default + Copy + 'static,
 {
-    pub fn start(
-        &mut self,
-        physical_hob_list: *const c_void,
-        drivers: &[&'static dyn DxeComponent],
-    ) -> error::Result<()> {
+    pub fn start(&mut self, physical_hob_list: *const c_void, drivers: &[&dyn DxeComponent]) -> error::Result<()> {
         self.cpu.initialize();
         let (free_memory_start, free_memory_size) = gcd::init_gcd(physical_hob_list);
 

--- a/sample_components/src/hello_world.rs
+++ b/sample_components/src/hello_world.rs
@@ -12,6 +12,7 @@ use log::info;
 use uefi_component_interface::{DxeComponent, DxeComponentInterface};
 use uefi_core::error::Result;
 
+#[derive(Default)]
 pub struct HelloWorldComponent;
 
 impl DxeComponent for HelloWorldComponent {


### PR DESCRIPTION
## Description

dxe_core local driver execution required the component be `&dyn DxeComponent + 'static` as we were using `Coroutine` from the the corosensei crate, which was a re-definition of the `ScopedCoroutine` type with a `static` lifetime bound. By switching to the `ScopedCoroutine` for executing local drivers, we remove this static requirement and allow for non-static instanced components to be executed.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Repo CI

## Integration Instructions

Any currently static components can be moved into the `_start` function for a dxe core binary.
