### PR TITLE
workspace: re-target reusable action

### DIFF
--- a/.github/workflows/CiWorkflow.yml
+++ b/.github/workflows/CiWorkflow.yml
@@ -54,7 +54,7 @@ jobs:
         uses: actions/checkout@v4
     
       - name: 🛠️ Download Rust Tools 🛠️
-        uses: ./.github/actions/rust-tool-cache
+        uses: pop-project/uefi-dxe-core/.github/actions/rust-tool-cache@main
       
       - name: Add Credentials # Remove once repositories are public
         run: |

--- a/.github/workflows/publish-mdbook.yml
+++ b/.github/workflows/publish-mdbook.yml
@@ -32,7 +32,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: 🛠️ Download Rust Tools 🛠️
-        uses: ./.github/actions/rust-tool-cache
+        uses: pop-project/uefi-dxe-core/.github/actions/rust-tool-cache@main
 
       - name: 📄 Build Documentation 📄
         run: mdbook build docs


### PR DESCRIPTION
## Description

When making a workflow re-usable, and other workflows or actions must also be re-usable. Previously, the rust-tool-cache action was not referenced via the "reusable" way (it was referenced locally) and due to this, the workflow would look for the action in the consuming repository rather than in uefi-dxe-core.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

CI continues to run successfully locally, and that other pop-projects can access this action (See https://github.com/pop-project/uefi-core/actions/runs/11369849997)

## Integration Instructions

N/A
