### PR TITLE
.github: reconvene matrix jobs

### DIFF
--- a/.github/workflows/CiWorkflow.yml
+++ b/.github/workflows/CiWorkflow.yml
@@ -95,3 +95,14 @@ jobs:
           path: |
             Cargo.lock
             target/cobertura.xml
+
+  finalize:
+    name: Finalize
+
+    needs: [ run ]
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Finish
+        run: echo "CI Complete"


### PR DESCRIPTION
## Description

The ci workflow generates a matrix of jobs to execute and github cannot specify those jobs as needing to complete before a PR can be merged. To get around this, we hardcode one final job that will be run after all the other jobs are done. This will allow branch rules to be set requiring that the final job is successful before a PR can be merged.

## How This Was Tested

N/A

## Integration Instructions

Integrators should set a branch rule requiring the final job to finish before a PR can be merged.
