### PR TITLE
dxe_core: Add EFI_MEMORY_MAP trace logging

### DIFF
--- a/dxe_core/src/memory_attributes_table.rs
+++ b/dxe_core/src/memory_attributes_table.rs
@@ -18,7 +18,7 @@ use core::{
 };
 
 use crate::{
-    allocator::{core_allocate_pool, core_free_pool, get_memory_map_descriptors},
+    allocator::{core_allocate_pool, core_free_pool, get_memory_map_descriptors, MemoryDescriptorSlice},
     events::EVENT_DB,
     misc_boot_services::core_install_configuration_table,
     systemtables,
@@ -72,18 +72,7 @@ impl Debug for MemoryAttributesTable {
         writeln!(f, "  reserved: {:#X}", mat.reserved)?;
         writeln!(f, "  entries: [")?;
 
-        writeln!(
-            f,
-            "    {:<6} {:<20} {:<20} {:<20} {:<20}",
-            "Type", "Physical Start", "Virtual Start", "Number of Pages", "Attributes"
-        )?;
-        for entry in entries {
-            writeln!(
-                f,
-                "    {:<#6X?} {:<#20X} {:<#20X} {:<#20X} {:<#20X?}",
-                entry.r#type, entry.physical_start, entry.virtual_start, entry.number_of_pages, entry.attribute
-            )?;
-        }
+        writeln!(f, "{:?}", MemoryDescriptorSlice(entries))?;
 
         writeln!(f, "  ]")?;
         writeln!(f, "}}")


### PR DESCRIPTION
## Description

This adds a new target for logging: efi_memory_map. When set to debug level for a platform, the EFI_MEMORY_MAP will be pretty printed in the log whenever it is created. Info logging was chosen over trace because trace logging prints the file name before each line, which takes up too much room for what this table needs to be easily read and it is distracting with so many lines.

This commits also changes the MAT logic to use the memory descriptor pretty print logic created in this commit, though it does not tie it to the efi_memory_map logging target or any other, as the MAT is created less often and has fewer members and is useful to be in the log by default.

The column sizes and individual column member spacing was tested and adjusted so it lined up visually, even though the numbers in the format strings appear off.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Tested with printing enabled/disabled for target and seeing both memory map and MAT and only MAT prints.

## Integration Instructions

In the platform's dxe core binary wrapper, set

```rust
uefi_logger::Format::Standard,
    &[
        ("efi_memory_map", log::LevelFilter::Debug),
    ],
```
to enable printing the EFI_MEMORY_MAP.