### PR TITLE
Add label syncer workflow

### DIFF
--- a/.github/workflows/LabelSyncer.yml
+++ b/.github/workflows/LabelSyncer.yml
@@ -1,0 +1,38 @@
+# This workflow syncs GitHub labels to the integrating repository.
+#
+# The labels are declaratively defined in .github/Labels.yml.
+#
+# Copyright (c) Microsoft Corporation.
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+# For more information, see:
+# https://github.com/EndBug/label-sync
+
+name: Label Sync Workflow
+
+on:
+  workflow_call:
+    secrets:
+      GH_PAT:
+        description: "GitHub Personal Access Token"
+        required: true
+
+jobs:
+  sync:
+    name: Sync
+    runs-on: ubuntu-latest
+
+    permissions:
+      issues: write
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          sparse-checkout: .github/Labels.yml
+          token: ${{ secrets.GH_PAT }}
+
+      - name: Sync Labels
+        uses: EndBug/label-sync@v2
+        with:
+          config-file: .github/Labels.yml
+          delete-other-labels: false

--- a/.github/workflows/label-sync.yml
+++ b/.github/workflows/label-sync.yml
@@ -1,0 +1,26 @@
+# This workflow syncs GitHub labels to the common set of labels defined for UEFI repos.
+#
+# All repos should sync at the same time.
+#   '0 0,12 * * *''
+#
+# Copyright (c) Microsoft Corporation.
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+
+name: Sync GitHub Labels
+
+on:
+  schedule:
+    # At minute 0 past hour 0 and 12
+    # https://crontab.guru/#0_0,12_*_*_*
+    - cron: '0 0,12 * * *'
+  workflow_dispatch:
+
+jobs:
+  sync:
+
+    permissions:
+      issues: write
+
+    uses: ./.github/workflows/LabelSyncer.yml
+    secrets: inherit


### PR DESCRIPTION
## Description

Workflow is used to ensure any labels defined for the project are available.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

- Run workflow on fork and verify labels are synced as expected

## Integration Instructions

Reuse the LabelSyncer.yml workflow in another project GitHub repo if labels should
be synced there.