### PR TITLE
Add get_memory_descriptor_for_address(), preserve existing attributes when configuring access attributes on a block.

### DIFF
--- a/dxe_core/src/image.rs
+++ b/dxe_core/src/image.rs
@@ -76,7 +76,13 @@ impl ImageStack {
         // attempt to set the memory space attributes for the stack guard page.
         // if we fail, we should still try to continue to boot
         // the stack grows downwards, so stack here is the guard page
-        if let Err(err) = dxe_services::core_set_memory_space_attributes(stack, UEFI_PAGE_SIZE as u64, efi::MEMORY_RP) {
+        let attributes = match dxe_services::core_get_memory_space_descriptor(stack) {
+            Ok(descriptor) => descriptor.attributes,
+            Err(_) => 0,
+        };
+        if let Err(err) =
+            dxe_services::core_set_memory_space_attributes(stack, UEFI_PAGE_SIZE as u64, attributes | efi::MEMORY_RP)
+        {
             log::error!("Failed to set memory space attributes for stack guard page: {:#x?}", err);
             debug_assert!(false);
         }


### PR DESCRIPTION
## Description

* Adds `get_memory_descriptor_for_address()` function to GCD
* Updates memory protections code to preserve existing attributes when configuring access attributes on a memory block.

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Booted to windows on hardware platform, confirmed issues around caching attributes no longer observed.

## Integration Instructions

N/A

