### PR TITLE
uefi_test: cleanup macro usage

### DIFF
--- a/crates/uefi_test_macro/src/lib.rs
+++ b/crates/uefi_test_macro/src/lib.rs
@@ -117,7 +117,7 @@ fn generate_expanded_test_case(
         #[uefi_test::linkme::distributed_slice(uefi_test::__private_api::TEST_CASES)]
         #[linkme(crate = uefi_test::linkme)]
         #[allow(non_upper_case_globals)]
-        static #struct_name: uefi_test::__private_api::TestCase = 
+        static #struct_name: uefi_test::__private_api::TestCase =
         uefi_test::__private_api::TestCase {
             name: concat!(module_path!(), "::", stringify!(#fn_name)),
             skip: #skip,
@@ -190,7 +190,7 @@ mod tests {
             #[uefi_test::linkme::distributed_slice(uefi_test::__private_api::TEST_CASES)]
             #[linkme(crate = uefi_test::linkme)]
             #[allow(non_upper_case_globals)]
-            static __my_test_case_TestCase: uefi_test::__private_api::TestCase = 
+            static __my_test_case_TestCase: uefi_test::__private_api::TestCase =
             uefi_test::__private_api::TestCase {
                 name: concat!(module_path!(), "::", stringify!(my_test_case)),
                 skip: true,


### PR DESCRIPTION
## Description

in the uefi_test macro, we originally manually expanded the code generated by the `distributed_slice` macro from linkme, as we were under the impression that the path to the linkme crate was hardcoded as `::linkme`. After additional review of the linkme code (because it was not mentioned in the linkme documentation), it was discovered that an attribute macro is available to override the path to the linkme crate (`#[linkme(crate = "path::to::linkme")]`).

This commit removes the manual expansion of the macro and replaces it with the macro itself, using the path override attribute to specify the path to the linkme crate. An additional benefit is that the tests can now focus only on the static test case our macro is generating.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Verified that the code continues to compile and the tests continue to be located.

## Integration Instructions

N/A
