### PR TITLE
Fix polarity inversion on boot_policy logic in load_image implementation

### DIFF
--- a/dxe_core/src/image.rs
+++ b/dxe_core/src/image.rs
@@ -635,7 +635,7 @@ fn get_buffer_by_file_path(
         return Ok((buffer, false, 0));
     }
 
-    if boot_policy {
+    if !boot_policy {
         if let Ok(buffer) =
             get_file_buffer_from_load_protocol(efi::protocols::load_file2::PROTOCOL_GUID, false, file_path)
         {


### PR DESCRIPTION
## Description

Bugfix: boot_policy conditional logic was inverted from correct behavior.

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

This impacts the loading of PCI Option ROMs. Confirmed proper loading of ROMs with this change. 

## Integration Instructions

N/A
