### PR TITLE
Minor aesthetic logging fix

### DIFF
--- a/dxe_core/src/image.rs
+++ b/dxe_core/src/image.rs
@@ -1104,7 +1104,7 @@ pub fn core_start_image(image_handle: efi::Handle) -> Result<(), efi::Status> {
         CoroutineResult::Return(status) => status,
     };
 
-    log::info!("start_image entrypoint exit with status: {:#x?}", status);
+    log::info!("start_image entrypoint exit with status: {:x?}", status);
 
     // because we used exit() to return from the coroutine (as opposed to
     // returning naturally from it), the coroutine is marked as suspended rather


### PR DESCRIPTION
## Description

Remove the `#` from start_image status print to avoid unnecessary newlines. 

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Before: 
```
INFO - start_image entrypoint exit with status: Status(
    0x0,
)
```
After:
```
INFO - start_image entrypoint exit with status: Status(0)
```

## Integration Instructions

N/A
