### PR TITLE
Update to use uefi_sdk and uefi_core version 3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,13 +16,11 @@ edition = "2021"
 rust-version = "1.80.0"
 
 [workspace.dependencies]
-uefi_cpu_init = {git = "https://github.com/pop-project/uefi-core.git", rev = "b718f06418ab6041289341a209fa22c0f1d69ba9"}
-uefi_core = {git = "https://github.com/pop-project/uefi-core.git", rev = "b718f06418ab6041289341a209fa22c0f1d69ba9"}
-uefi_interrupt = {git = "https://github.com/pop-project/uefi-core.git", rev = "b718f06418ab6041289341a209fa22c0f1d69ba9"}
-uefi_logger = {git = "https://github.com/pop-project/uefi-core.git", rev = "b718f06418ab6041289341a209fa22c0f1d69ba9"}
-uefi_debugger = { git = "https://github.com/pop-project/uefi-core.git", rev = "b718f06418ab6041289341a209fa22c0f1d69ba9"}
-section_extractor = {git = "https://github.com/pop-project/uefi-core.git", rev = "b718f06418ab6041289341a209fa22c0f1d69ba9"}
-serial_writer = {git = "https://github.com/pop-project/uefi-core.git", rev = "b718f06418ab6041289341a209fa22c0f1d69ba9"}
+uefi_sdk = { git = "https://github.com/pop-project/uefi-sdk", rev = "ee76ceb89f003b1c5d62573d8fe862ce31baf503" }
+uefi_cpu_init = {git = "https://github.com/pop-project/uefi-core.git", rev = "v3.0.0"}
+uefi_interrupt = {git = "https://github.com/pop-project/uefi-core.git", rev = "v3.0.0"}
+uefi_debugger = { git = "https://github.com/pop-project/uefi-core.git", rev = "v3.0.0"}
+section_extractor = {git = "https://github.com/pop-project/uefi-core.git", rev = "v3.0.0"}
 corosensei = {git = "https://github.com/pop-project/uefi-corosensei.git", rev = "d27241e17a5f3c0703fe9871e6f68cd838c05c6d", default-features = false }
 
 uefi_test_macro = { path = "crates/uefi_test_macro", version = "2.0.2" }

--- a/adv_logger/Cargo.toml
+++ b/adv_logger/Cargo.toml
@@ -7,9 +7,7 @@ edition = "2021"
 
 [dependencies]
 log = { workspace = true }
-uefi_core = { workspace = true }
-uefi_logger = { workspace = true }
-serial_writer = { workspace = true }
+uefi_sdk = { workspace = true }
 mu_pi = { workspace = true }
 r-efi = { workspace = true }
 spin = { workspace = true }

--- a/adv_logger/src/component.rs
+++ b/adv_logger/src/component.rs
@@ -14,9 +14,9 @@ use core::{ffi::c_void, ptr};
 use mu_pi::hob::{Hob, PhaseHandoffInformationTable};
 use r_efi::efi;
 use uefi_component_interface::{DxeComponent, DxeComponentInterface};
-use uefi_core::{
+use uefi_sdk::{
     error::{EfiError, Result},
-    interface::SerialIO,
+    serial::SerialIO,
 };
 
 use crate::{logger::AdvancedLogger, memory_log, memory_log::AdvLoggerInfo};
@@ -172,12 +172,12 @@ mod tests {
     use core::mem::size_of;
 
     use mu_pi::hob::{header::Hob, GuidHob, GUID_EXTENSION};
-    use serial_writer::UartNull;
+    use uefi_sdk::serial::UartNull;
 
     use super::*;
 
     static TEST_LOGGER: AdvancedLogger<UartNull> =
-        AdvancedLogger::new(uefi_logger::Format::Standard, &[], log::LevelFilter::Trace, UartNull {});
+        AdvancedLogger::new(uefi_sdk::log::Format::Standard, &[], log::LevelFilter::Trace, UartNull {});
 
     unsafe fn create_adv_logger_hob_list() -> *const c_void {
         const LOG_LEN: usize = 0x2000;

--- a/adv_logger/src/lib.rs
+++ b/adv_logger/src/lib.rs
@@ -26,14 +26,14 @@
 //! # use core::ffi::c_void;
 //! use adv_logger::{component::AdvancedLoggerComponent, logger::AdvancedLogger};
 //!
-//! static LOGGER: AdvancedLogger<serial_writer::UartNull> = AdvancedLogger::new(
-//!      uefi_logger::Format::Standard,
+//! static LOGGER: AdvancedLogger<uefi_sdk::serial::UartNull> = AdvancedLogger::new(
+//!      uefi_sdk::log::Format::Standard,
 //!      &[("goblin", log::LevelFilter::Off), ("uefi_depex_lib", log::LevelFilter::Off)],
 //!      log::LevelFilter::Trace,
-//!      serial_writer::UartNull{},
+//!      uefi_sdk::serial::UartNull{},
 //! );
 //!
-//! static ADV_LOGGER: AdvancedLoggerComponent<serial_writer::UartNull> = AdvancedLoggerComponent::new(&LOGGER);
+//! static ADV_LOGGER: AdvancedLoggerComponent<uefi_sdk::serial::UartNull> = AdvancedLoggerComponent::new(&LOGGER);
 //!
 //! fn _start(physical_hob_list: *const c_void) {
 //!     log::set_logger(&LOGGER).map(|()| log::set_max_level(log::LevelFilter::Trace)).unwrap();

--- a/adv_logger/src/logger.rs
+++ b/adv_logger/src/logger.rs
@@ -14,8 +14,8 @@ use core::marker::Send;
 use log::Level;
 use r_efi::efi;
 use spin::Once;
-use uefi_core::interface::SerialIO;
-use uefi_logger::Format;
+use uefi_sdk::log::Format;
+use uefi_sdk::serial::SerialIO;
 
 /// The logger for memory/hardware port logging.
 pub struct AdvancedLogger<'a, S>

--- a/crates/uefi_component_interface/Cargo.toml
+++ b/crates/uefi_component_interface/Cargo.toml
@@ -11,4 +11,4 @@ repository.workspace = true
 
 [dependencies]
 r-efi = { workspace = true }
-uefi_core = { workspace = true }
+uefi_sdk = { workspace = true }

--- a/crates/uefi_component_interface/src/lib.rs
+++ b/crates/uefi_component_interface/src/lib.rs
@@ -10,7 +10,7 @@
 
 use core::{ffi::c_void, option::Option, result::Result};
 use r_efi::efi;
-use uefi_core::error;
+use uefi_sdk::error;
 
 /// A trait wrapper for the DXE component interfaces. This is an initial implementation
 /// and will be replaced by a more robust component interface in the future.

--- a/docs/src/integrate/dxe_core.md
+++ b/docs/src/integrate/dxe_core.md
@@ -136,25 +136,25 @@ adv_logger = "$(VERSION)
 Next, update main.rs with the following:
 
 ``` rust
-static LOGGER: AdvancedLogger<serial_writer::Uart16550> = AdvancedLogger::new(
-    uefi_logger::Format::Standard,
+static LOGGER: AdvancedLogger<uefi_sdk::serial::Uart16550> = AdvancedLogger::new(
+    uefi_sdk::log::Format::Standard,
     &[
         ("goblin", log::LevelFilter::Off),
         ("uefi_depex_lib", log::LevelFilter::Off),
         ("gcd_measure", log::LevelFilter::Off),
     ],
     log::LevelFilter::Trace,
-    serial_writer::Uart16550::new(serial_writer::Interface::Io(0x402)),
+    uefi_sdk::serial::Uart16550::new(uefi_sdk::serial::Interface::Io(0x402)),
 );
 
-static ADV_LOGGER_COMP: AdvancedLoggerComponent<serial_writer::Uart16550> = AdvancedLoggerComponent::new(&LOGGER); 
+static ADV_LOGGER_COMP: AdvancedLoggerComponent<uefi_sdk::serial::Uart16550> = AdvancedLoggerComponent::new(&LOGGER);
 
 #[cfg_attr(target_os = "uefi", export_name = "efi_main")]
 pub extern "efiapi" fn _start(physical_hob_list: *const c_void) -> ! {
     log::set_logger(&LOGGER).map(|()| log::set_max_level(log::LevelFilter::Trace)).unwrap();
-    let adv_logger = AdvancedLoggerComponent::<serial_writer::Uart16550>::new(&LOGGER);
+    let adv_logger = AdvancedLoggerComponent::<uefi_sdk::serial::Uart16550>::new(&LOGGER);
     adv_logger.init_advanced_logger(physical_hob_list);
-    
+
     Core::default()
         .with_section_extractor(BrotliSectionExtractor::default())
         .with_cpu_initializer(X64CpuInitializer::default())
@@ -197,21 +197,21 @@ fn panic(info: &PanicInfo) -> ! {
     loop {}
 }
 
-static LOGGER: AdvancedLogger<serial_writer::Uart16550> = AdvancedLogger::new(
-    uefi_logger::Format::Standard,
+static LOGGER: AdvancedLogger<uefi_sdk::serial::Uart16550> = AdvancedLogger::new(
+    uefi_sdk::log::Format::Standard,
     &[
         ("goblin", log::LevelFilter::Off),
         ("uefi_depex_lib", log::LevelFilter::Off),
         ("gcd_measure", log::LevelFilter::Off),
     ],
     log::LevelFilter::Trace,
-    serial_writer::Uart16550::new(serial_writer::Interface::Io(0x402)),
+    uefi_sdk::serial::Uart16550::new(uefi_sdk::serial::Interface::Io(0x402)),
 );
 
 #[cfg_attr(target_os = "uefi", export_name = "efi_main")]
 pub extern "efiapi" fn _start(physical_hob_list: *const c_void) -> ! {
     log::set_logger(&LOGGER).map(|()| log::set_max_level(log::LevelFilter::Trace)).unwrap();
-    let adv_logger_component = AdvancedLoggerComponent::<serial_writer::Uart16550>::new(&LOGGER);
+    let adv_logger_component = AdvancedLoggerComponent::<uefi_sdk::serial::Uart16550>::new(&LOGGER);
     adv_logger_component.init_advanced_logger(physical_hob_list).unwrap();
 
     Core::default()

--- a/dxe_core/Cargo.toml
+++ b/dxe_core/Cargo.toml
@@ -31,7 +31,7 @@ r-efi = { workspace = true }
 spin = { workspace = true}
 uuid = { workspace = true }
 
-uefi_core = { workspace = true }
+uefi_sdk = { workspace = true }
 uefi_component_interface = { workspace = true }
 uefi_cpu_init = { workspace = true }
 uefi_gcd = { workspace = true }
@@ -47,13 +47,11 @@ uefi_tpl_lock = { workspace = true }
 
 [dev-dependencies]
 sample_components = { workspace = true }
-uefi_logger = { workspace = true }
-serial_writer = { workspace = true }
 section_extractor = { workspace = true }
 
 [features]
 default = []
-std = ["uefi_logger/std", "serial_writer/std"]
+std = ["uefi_sdk/std"]
 doc = ["uefi_cpu_init/doc", "uefi_interrupt/doc"]
 
 [lints.rust]

--- a/dxe_core/examples/std.rs
+++ b/dxe_core/examples/std.rs
@@ -19,18 +19,18 @@ use r_efi::efi;
 use sample_components::HelloComponent;
 use std::ffi::c_void;
 
-static LOGGER: uefi_logger::SerialLogger<serial_writer::Terminal> = uefi_logger::SerialLogger::new(
-    uefi_logger::Format::Standard,
+static LOGGER: uefi_sdk::log::SerialLogger<uefi_sdk::serial::Terminal> = uefi_sdk::log::SerialLogger::new(
+    uefi_sdk::log::Format::Standard,
     &[
         ("goblin", log::LevelFilter::Off),
         ("uefi_depex_lib", log::LevelFilter::Off),
         ("gcd_measure", log::LevelFilter::Off),
     ],
     log::LevelFilter::Trace,
-    serial_writer::Terminal {},
+    uefi_sdk::serial::Terminal {},
 );
 
-fn main() -> uefi_core::error::Result<()> {
+fn main() -> uefi_sdk::error::Result<()> {
     if log::set_logger(&LOGGER).map(|()| log::set_max_level(log::LevelFilter::Trace)).is_err() {
         log::warn!("Global logger has already been set.");
     }

--- a/dxe_core/src/lib.rs
+++ b/dxe_core/src/lib.rs
@@ -9,11 +9,11 @@
 //! # #[derive(Default, Clone, Copy)]
 //! # struct Driver;
 //! # impl uefi_component_interface::DxeComponent for Driver {
-//! #     fn entry_point(&self, _: &dyn uefi_component_interface::DxeComponentInterface) -> uefi_core::error::Result<()> { Ok(()) }
+//! #     fn entry_point(&self, _: &dyn uefi_component_interface::DxeComponentInterface) -> uefi_sdk::error::Result<()> { Ok(()) }
 //! # }
 //! # #[derive(Default, Clone, Copy)]
 //! # struct CpuInitExample;
-//! # impl uefi_core::interface::CpuInitializer for CpuInitExample {
+//! # impl uefi_cpu_init::CpuInitializer for CpuInitExample {
 //! #     fn initialize(&mut self) { }
 //! # }
 //! # #[derive(Default, Clone, Copy)]
@@ -24,7 +24,7 @@
 //! # #[derive(Default, Clone, Copy)]
 //! # struct InterruptManagerExample;
 //! # impl uefi_interrupt::InterruptManager for InterruptManagerExample {
-//! #     fn initialize(&mut self) -> uefi_core::error::Result<()> { Ok(()) }
+//! #     fn initialize(&mut self) -> uefi_sdk::error::Result<()> { Ok(()) }
 //! # }
 //! # let physical_hob_list = core::ptr::null();
 //! dxe_core::Core::default()
@@ -77,11 +77,11 @@ use alloc::{boxed::Box, vec::Vec};
 use mu_pi::{fw_fs, hob::HobList, protocols::bds};
 use r_efi::efi::{self};
 use uefi_component_interface::DxeComponent;
-use uefi_core::{
-    error::{self, Result},
-    if_aarch64, if_x64, interface,
-};
 use uefi_gcd::gcd::SpinLockedGcd;
+use uefi_sdk::{
+    error::{self, Result},
+    if_aarch64, if_x64,
+};
 
 pub(crate) static GCD: SpinLockedGcd = SpinLockedGcd::new(Some(events::gcd_map_change));
 
@@ -110,11 +110,11 @@ if_aarch64! {
 /// # #[derive(Default, Clone, Copy)]
 /// # struct Driver;
 /// # impl uefi_component_interface::DxeComponent for Driver {
-/// #     fn entry_point(&self, _: &dyn uefi_component_interface::DxeComponentInterface) -> uefi_core::error::Result<()> { Ok(()) }
+/// #     fn entry_point(&self, _: &dyn uefi_component_interface::DxeComponentInterface) -> uefi_sdk::error::Result<()> { Ok(()) }
 /// # }
 /// # #[derive(Default, Clone, Copy)]
 /// # struct CpuInitExample;
-/// # impl uefi_core::interface::CpuInitializer for CpuInitExample {
+/// # impl uefi_cpu_init::CpuInitializer for CpuInitExample {
 /// #     fn initialize(&mut self) { }
 /// # }
 /// # #[derive(Default, Clone, Copy)]
@@ -125,7 +125,7 @@ if_aarch64! {
 /// # #[derive(Default, Clone, Copy)]
 /// # struct InterruptManagerExample;
 /// # impl uefi_interrupt::InterruptManager for InterruptManagerExample {
-/// #     fn initialize(&mut self) -> uefi_core::error::Result<()> { Ok(()) }
+/// #     fn initialize(&mut self) -> uefi_sdk::error::Result<()> { Ok(()) }
 /// # }
 /// # let physical_hob_list = core::ptr::null();
 /// dxe_core::Core::default()
@@ -140,7 +140,7 @@ if_aarch64! {
 #[derive(Default)]
 pub struct Core<CpuInitializer, SectionExtractor, InterruptManager>
 where
-    CpuInitializer: interface::CpuInitializer + Default,
+    CpuInitializer: uefi_cpu_init::CpuInitializer + Default,
     SectionExtractor: fw_fs::SectionExtractor + Default + Copy + 'static,
     InterruptManager: uefi_interrupt::InterruptManager + Default + Copy + 'static,
 {
@@ -151,7 +151,7 @@ where
 
 impl<CpuInitializer, SectionExtractor, InterruptManager> Core<CpuInitializer, SectionExtractor, InterruptManager>
 where
-    CpuInitializer: interface::CpuInitializer + Default,
+    CpuInitializer: uefi_cpu_init::CpuInitializer + Default,
     SectionExtractor: fw_fs::SectionExtractor + Default + Copy + 'static,
     InterruptManager: uefi_interrupt::InterruptManager + Default + Copy + 'static,
 {

--- a/sample_components/Cargo.toml
+++ b/sample_components/Cargo.toml
@@ -9,7 +9,7 @@ path = "src/lib.rs"
 
 [dependencies]
 log = { workspace = true }
-uefi_core = { workspace = true }
+uefi_sdk = { workspace = true }
 uefi_component_interface = { workspace = true }
 
 [features]

--- a/sample_components/src/hello.rs
+++ b/sample_components/src/hello.rs
@@ -10,7 +10,7 @@
 //!
 use log::info;
 use uefi_component_interface::{DxeComponent, DxeComponentInterface};
-use uefi_core::error::Result;
+use uefi_sdk::error::Result;
 
 #[derive(Default)]
 pub struct HelloComponent {

--- a/uefi_test/Cargo.toml
+++ b/uefi_test/Cargo.toml
@@ -18,7 +18,7 @@ path = "src/lib.rs"
 [dependencies]
 log = { workspace = true }
 uefi_component_interface = { workspace = true }
-uefi_core = { workspace = true }
+uefi_sdk = { workspace = true }
 uefi_test_macro = { workspace = true }
 linkme = { workspace = true}
 

--- a/uefi_test/src/lib.rs
+++ b/uefi_test/src/lib.rs
@@ -214,7 +214,7 @@ impl TestRunnerComponent {
 }
 
 impl DxeComponent for TestRunnerComponent {
-    fn entry_point(&self, interface: &dyn DxeComponentInterface) -> uefi_core::error::Result<()> {
+    fn entry_point(&self, interface: &dyn DxeComponentInterface) -> uefi_sdk::error::Result<()> {
         let test_list = __private_api::test_cases();
         let count = test_list.len();
         match count {


### PR DESCRIPTION
## Description

Updates uefi_core to version 3 and consumes the uefi_sdk crate for migrated functionality.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [x] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Tested on Q35

## Integration Instructions

N/A
