### PR TITLE
uefi_allocator: Remove panic on free pool signature mismatch

### DIFF
--- a/dxe_core/src/allocator/uefi_allocator.rs
+++ b/dxe_core/src/allocator/uefi_allocator.rs
@@ -148,7 +148,10 @@ impl UefiAllocator {
         let allocation_info: *mut AllocationInfo = ((buffer as usize) - offset) as *mut AllocationInfo;
 
         //must be true for any pool allocation
-        assert!((*allocation_info).signature == POOL_SIG);
+        if (*allocation_info).signature != POOL_SIG {
+            debug_assert!(false, "Pool signature is incorrect.");
+            return efi::Status::INVALID_PARAMETER;
+        }
         // check if allocation is from this pool.
         if (*allocation_info).memory_type != self.memory_type {
             return efi::Status::NOT_FOUND;


### PR DESCRIPTION
## Description

Replaces `assert!()` with `debug_assert!()` and return of an invalid parameter EFI status code when the given pool buffer signature is invalid.

This is to reduce the fatality of the condition in release builds for misbehaving hardware while still brining attention to developers in debug builds.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

- Build and unit tests
- Boot to EFI shell on QEMU

## Integration Instructions

N/A - Reduces strictness during free pool validation.