### PR TITLE
dxe_core: Resolved unused code warnings.

### DIFF
--- a/dxe_core/src/allocator/uefi_allocator.rs
+++ b/dxe_core/src/allocator/uefi_allocator.rs
@@ -58,6 +58,7 @@ impl UefiAllocator {
     /// Indicates whether the given pointer falls within a memory region managed by this allocator.
     ///
     /// See [`SpinLockedFixedSizeBlockAllocator::contains`]
+    #[allow(dead_code)]
     pub fn contains(&self, ptr: NonNull<u8>) -> bool {
         self.allocator.contains(ptr)
     }
@@ -199,6 +200,7 @@ impl UefiAllocator {
     }
 
     /// Returns the preferred memory range, if any.
+    #[allow(dead_code)]
     pub fn preferred_range(&self) -> Option<Range<efi::PhysicalAddress>> {
         self.allocator.preferred_range()
     }

--- a/dxe_core/src/event_db.rs
+++ b/dxe_core/src/event_db.rs
@@ -378,6 +378,7 @@ impl EventDb {
         Ok(self.events.get(&id).ok_or(efi::Status::INVALID_PARAMETER)?.event_type)
     }
 
+    #[allow(dead_code)]
     fn get_notification_data(&mut self, event: efi::Event) -> Result<EventNotification, efi::Status> {
         let id = event as usize;
         if let Some(found_event) = self.events.get(&id) {
@@ -597,10 +598,7 @@ impl SpinLockedEventDb {
     }
 
     /// Indicates whether the given event is in the signaled state
-    ///
-    /// ## Errors
-    ///
-    /// Returns r_efi:efi::Status::INVALID_PARAMETER if incorrect parameters are given.
+    #[allow(dead_code)]
     pub fn is_signaled(&self, event: efi::Event) -> bool {
         self.lock().is_signaled(event)
     }
@@ -610,6 +608,7 @@ impl SpinLockedEventDb {
     /// ## Errors
     ///
     /// Returns r_efi:efi::Status::INVALID_PARAMETER if incorrect parameters are given.
+    #[allow(dead_code)]
     pub fn clear_signal(&self, event: efi::Event) -> Result<(), efi::Status> {
         self.lock().clear_signal(event)
     }
@@ -644,6 +643,7 @@ impl SpinLockedEventDb {
     /// ## Errors
     ///
     /// Returns r_efi:efi::Status::INVALID_PARAMETER if incorrect parameters are given.
+    #[allow(dead_code)]
     pub fn get_notification_data(&self, event: efi::Event) -> Result<EventNotification, efi::Status> {
         self.lock().get_notification_data(event)
     }

--- a/dxe_core/src/gcd/io_block.rs
+++ b/dxe_core/src/gcd/io_block.rs
@@ -222,6 +222,8 @@ impl IoBlock {
     pub fn len(&self) -> usize {
         self.as_ref().length as usize
     }
+
+    #[allow(dead_code)]
     pub fn is_empty(&self) -> bool {
         self.len() == 0
     }

--- a/dxe_core/src/gcd/memory_block.rs
+++ b/dxe_core/src/gcd/memory_block.rs
@@ -311,6 +311,7 @@ impl MemoryBlock {
         self.as_ref().length as usize
     }
 
+    #[allow(dead_code)]
     pub fn is_empty(&self) -> bool {
         self.len() == 0
     }

--- a/dxe_core/src/gcd/spin_locked_gcd.rs
+++ b/dxe_core/src/gcd/spin_locked_gcd.rs
@@ -1389,6 +1389,7 @@ impl SpinLockedGcd {
     /// This call potentially invalidates all allocations made by any allocator on top of this GCD.
     /// Caller is responsible for ensuring that no such allocations exist.
     ///
+    #[cfg(test)]
     pub unsafe fn reset(&self) {
         let (mut mem, mut io) = (self.memory.lock(), self.io.lock());
         mem.maximum_address = 0;

--- a/dxe_core/src/protocol_db.rs
+++ b/dxe_core/src/protocol_db.rs
@@ -570,6 +570,7 @@ impl SpinLockedProtocolDb {
     ///
     /// This call completely resets the protocol database and is intended mostly for use in test.
     ///
+    #[cfg(test)]
     pub unsafe fn reset(&self) {
         let mut inner = self.inner.lock();
         inner.handles.clear();


### PR DESCRIPTION
## Description

Within multiple modules that were previously standalone crates ( specifically, uefi_allocator, uefi_event, uefi_protocol_db, and uefi_gcd), multiple functions were unused in the code base. However these functions were marked as public and were part of the public interface for their respective crates, so no warnings were generated as this is typically expected.

After moving these crates inwards, they are no longer apart of the crate's public interface. Due to this, the compiler correctly detects and reports that they are unused. An interesting note, however, is that the compiler does not detect this when building the crate itself, only when building a binary that consumes this crate.

This commit resolves these warnings primarily by marking these functions with the #[allow(dead_code)] attribute, as they are hypothetically useful, and could start to be consumed in the future. A few of the functions were configured to only exist for test builds as they are for testing purposes only.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Passes CI, and qemu binaries continue to build

## Integration Instructions

N/A 
