### PR TITLE
Remove release_max_level_warn from log features.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,9 +45,7 @@ goblin = { version = "^0.9", default-features = false, features = [
 ] }
 lazy_static = { version = "^1", features = ["spin_no_std"] }
 linked_list_allocator = "^0.10"
-log = { version = "^0.4", default-features = false, features = [
-    "release_max_level_warn",
-] }
+log = { version = "^0.4", default-features = false }
 mockall = "0.13.0"
 mu_pi = { git = "https://github.com/microsoft/mu_rust_pi.git", tag = "v5.1.0" }
 mu_rust_helpers = { git = "https://github.com/microsoft/mu_rust_helpers.git", tag = "v1.2.0" }


### PR DESCRIPTION
## Description

If this feature is specified here, consuming crates cannot override the release_max_* level for configuration of debug - i.e.  consuming projects are forced to `release_max_level_warn`.

Removing this is consistent with guidance from the [log crate](https://docs.rs/log/0.4.22/log/#compile-time-filters):
```
Libraries should avoid using the max level features because they’re global and can’t be changed once they’re set.
```

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Confirmed that consuming crates using dxe_core can now adjust release_max_level_* as desired.

## Integration Instructions

N/A
