### PR TITLE
uefi-dxe-core: ingest uefi-core's uefi-cpu refactored changes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,11 +16,10 @@ edition = "2021"
 rust-version = "1.80.0"
 
 [workspace.dependencies]
-uefi_sdk = { git = "https://github.com/pop-project/uefi-sdk", rev = "v0.1.0" }
-uefi_cpu_init = { git = "https://github.com/pop-project/uefi-core.git", rev = "v4.1.1" }
-uefi_interrupt = { git = "https://github.com/pop-project/uefi-core.git", rev = "v4.1.1" }
-uefi_debugger = { git = "https://github.com/pop-project/uefi-core.git", rev = "v4.1.1" }
-section_extractor = { git = "https://github.com/pop-project/uefi-core.git", rev = "v4.1.1" }
+uefi_sdk = { git = "https://github.com/pop-project/uefi-sdk", rev = "v0.1.1" }
+uefi_cpu = { git = "https://github.com/pop-project/uefi-core.git", rev = "v6.0.0" }
+uefi_debugger = { git = "https://github.com/pop-project/uefi-core.git", rev = "v6.0.0" }
+section_extractor = { git = "https://github.com/pop-project/uefi-core.git", rev = "v6.0.0" }
 corosensei = { git = "https://github.com/pop-project/uefi-corosensei.git", rev = "d27241e17a5f3c0703fe9871e6f68cd838c05c6d", default-features = false }
 
 uefi_test_macro = { path = "crates/uefi_test_macro", version = "2.0.2" }

--- a/docs/src/integrate/dxe_core.md
+++ b/docs/src/integrate/dxe_core.md
@@ -78,7 +78,7 @@ trait. However multiple implementations are provided via [section_extractor](htt
 such as brotli, crc32, uefi_decompress, etc.
 
 `EfiCpuInit` is an abstraction point for architecture specific initialization steps.
-Implementations are provided via [uefi_cpu_init](https://github.com/pop-project/uefi-core/tree/main/uefi_cpu_init),
+Implementations are provided via [uefi_cpu](https://github.com/pop-project/uefi-core/tree/main/uefi_cpu),
 however if necessary, a platform can create their own implementation via the [EfiCpuInit](https://github.com/pop-project/uefi-core/blob/main/uefi_core/src/interface.rs)
 trait.
 
@@ -215,7 +215,7 @@ pub extern "efiapi" fn _start(physical_hob_list: *const c_void) -> ! {
     adv_logger_component.init_advanced_logger(physical_hob_list).unwrap();
 
     Core::default()
-        .with_cpu_init(uefi_cpu_init::X64EfiCpuInit::default())
+        .with_cpu_init(uefi_cpu::EfiCpuInitX64::default())
         .with_section_extractor(section_extractor::CompositeSectionExtractor::default())
         .initialize(physical_hob_list)
         .with_driver(Box::new(adv_logger_component))

--- a/dxe_core/Cargo.toml
+++ b/dxe_core/Cargo.toml
@@ -38,8 +38,7 @@ uuid = { workspace = true }
 uefi_sdk = { workspace = true }
 uefi_collections = { workspace = true }
 uefi_component_interface = { workspace = true }
-uefi_cpu_init = { workspace = true }
-uefi_interrupt = { workspace = true }
+uefi_cpu = { workspace = true }
 uefi_debugger = { workspace = true }
 uefi_device_path = { workspace = true }
 uefi_depex = { workspace = true}
@@ -53,7 +52,7 @@ mockall = { workspace = true }
 [features]
 default = []
 std = ["uefi_sdk/std"]
-doc = ["uefi_cpu_init/doc", "uefi_interrupt/doc"]
+doc = ["uefi_cpu/doc"]
 
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(tarpaulin_include)'] }

--- a/dxe_core/examples/std.rs
+++ b/dxe_core/examples/std.rs
@@ -37,8 +37,8 @@ fn main() -> uefi_sdk::error::Result<()> {
 
     let hob_list = build_hob_list();
     Core::default()
-        .with_cpu_init(uefi_cpu_init::NullEfiCpuInit)
-        .with_interrupt_manager(uefi_interrupt::InterruptManagerNull::default())
+        .with_cpu_init(uefi_cpu::cpu::EfiCpuInitNull::default())
+        .with_interrupt_manager(uefi_cpu::interrupts::InterruptManagerNull::default())
         .with_section_extractor(section_extractor::CompositeSectionExtractor::default())
         // Add any config knob functions for pre-gcd-init Core
         // .with_some_config(true)


### PR DESCRIPTION
## Description

uefi-dxe-core: ingest uefi-core's uefi-cpu refactored changes.

- [x] Impacts functionality?
- [ ] Impacts security?
- [x] Breaking change?
- [x] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Unit Tested

## Integration Instructions

Once this is checked in, I will increment the version, create a GitHub release, and finally integrate the changes from both `uefi-core` and `uefi-dxe-core` into `qemu-rust-bins`.
