### PR TITLE
uefi-dxe-core: Bump all crate versions to 5.0.0 to match next Github tag

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,12 +22,12 @@ uefi_debugger = { git = "https://github.com/pop-project/uefi-core.git", rev = "v
 section_extractor = { git = "https://github.com/pop-project/uefi-core.git", rev = "v6.0.0" }
 corosensei = { git = "https://github.com/pop-project/uefi-corosensei.git", rev = "d27241e17a5f3c0703fe9871e6f68cd838c05c6d", default-features = false }
 
-uefi_test_macro = { path = "crates/uefi_test_macro", version = "2.0.2" }
-uefi_test = { path = "uefi_test", version = "2.0.2" }
-uefi_collections = { path = "crates/uefi_collections", version = "2.0.2", default-features = false }
-uefi_depex = { path = "crates/uefi_depex", version = "2.0.2" }
-uefi_device_path = { path = "crates/uefi_device_path", version = "2.0.2" }
-uefi_component_interface = { path = "crates/uefi_component_interface", version = "2.0.2" }
+uefi_test_macro = { path = "crates/uefi_test_macro", version = "5.0.0" }
+uefi_test = { path = "uefi_test", version = "5.0.0" }
+uefi_collections = { path = "crates/uefi_collections", version = "5.0.0", default-features = false }
+uefi_depex = { path = "crates/uefi_depex", version = "5.0.0" }
+uefi_device_path = { path = "crates/uefi_device_path", version = "5.0.0" }
+uefi_component_interface = { path = "crates/uefi_component_interface", version = "5.0.0" }
 
 adv_logger = { path = "adv_logger" }
 sample_components = { path = "sample_components" }

--- a/adv_logger/Cargo.toml
+++ b/adv_logger/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "adv_logger"
-version = "2.0.2"
+version = "5.0.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/crates/uefi_collections/Cargo.toml
+++ b/crates/uefi_collections/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uefi_collections"
-version = "2.0.2"
+version = "5.0.0"
 edition = "2021"
 readme = "README.md"
 description = "Collection types to the dxe_core."

--- a/crates/uefi_component_interface/Cargo.toml
+++ b/crates/uefi_component_interface/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uefi_component_interface"
-version = "2.0.2"
+version = "5.0.0"
 edition = "2021"
 readme = "README.md"
 description = "The trait interface any dxe component should implement to be executed by the DXE Core."

--- a/crates/uefi_depex/Cargo.toml
+++ b/crates/uefi_depex/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uefi_depex"
-version = "2.0.2"
+version = "5.0.0"
 edition = "2021"
 readme = "README.md"
 description = "A Depex parsing implementation for the dxe_core."

--- a/crates/uefi_device_path/Cargo.toml
+++ b/crates/uefi_device_path/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uefi_device_path"
-version = "2.0.2"
+version = "5.0.0"
 edition = "2021"
 readme = "README.md"
 description = "A Device Path parsing implementation for the dxe_core."

--- a/crates/uefi_test_macro/Cargo.toml
+++ b/crates/uefi_test_macro/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uefi_test_macro"
-version = "2.0.2"
+version = "5.0.0"
 edition = "2021"
 readme = "README.md"
 description = "Proc macros for the uefi_test crate."

--- a/dxe_core/Cargo.toml
+++ b/dxe_core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dxe_core"
-version = "2.0.2"
+version = "5.0.0"
 edition = "2021"
 readme = "../README.md"
 description = "A pure rust implementation of the UEFI DXE Core."

--- a/sample_components/Cargo.toml
+++ b/sample_components/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sample_components"
-version = "2.0.2"
+version = "5.0.0"
 edition = "2021"
 
 [lib]

--- a/uefi_test/Cargo.toml
+++ b/uefi_test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uefi_test"
-version = "2.0.2"
+version = "5.0.0"
 edition = "2021"
 readme = "README.md"
 description = "An on-platform test harness for UEFI firmware."


### PR DESCRIPTION
## Description

uefi-dxe-core: Bump all crate versions to 5.0.0 to match next Github tag

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

NA

## Integration Instructions

Once this is checked in, I will create a GitHub release, and finally integrate the changes from both `uefi-core` and `uefi-dxe-core` into `qemu-rust-bins`.

