### PR TITLE
dxe_core: Check DXE Core Mem Allocation Module HOB GUID

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,10 +16,10 @@ edition = "2021"
 rust-version = "1.80.0"
 
 [workspace.dependencies]
-uefi_sdk = { git = "https://github.com/pop-project/uefi-sdk", rev = "v0.1.1" }
-uefi_cpu = { git = "https://github.com/pop-project/uefi-core.git", rev = "v6.0.0" }
-uefi_debugger = { git = "https://github.com/pop-project/uefi-core.git", rev = "v6.0.0" }
-section_extractor = { git = "https://github.com/pop-project/uefi-core.git", rev = "v6.0.0" }
+uefi_sdk = { git = "https://github.com/pop-project/uefi-sdk", rev = "v0.1.2" }
+uefi_cpu = { git = "https://github.com/pop-project/uefi-core.git", rev = "v6.0.1" }
+uefi_debugger = { git = "https://github.com/pop-project/uefi-core.git", rev = "v6.0.1" }
+section_extractor = { git = "https://github.com/pop-project/uefi-core.git", rev = "v6.0.1" }
 corosensei = { git = "https://github.com/pop-project/uefi-corosensei.git", rev = "d27241e17a5f3c0703fe9871e6f68cd838c05c6d", default-features = false }
 
 uefi_test_macro = { path = "crates/uefi_test_macro", version = "5.0.0" }

--- a/dxe_core/src/misc_boot_services.rs
+++ b/dxe_core/src/misc_boot_services.rs
@@ -40,10 +40,6 @@ static PRE_EXIT_BOOT_SERVICES_SIGNAL: AtomicBool = AtomicBool::new(false);
 pub const PRE_EBS_GUID: efi::Guid =
     efi::Guid::from_fields(0x5f1d7e16, 0x784a, 0x4da2, 0xb0, 0x84, &[0xf8, 0x12, 0xf2, 0x3a, 0x8d, 0xce]);
 
-// DxeCore module GUID (23C9322F-2AF2-476A-BC4C-26BC88266C71)
-pub const DXE_CORE_GUID: efi::Guid =
-    efi::Guid::from_fields(0x23C9322F, 0x2AF2, 0x476A, 0xBC, 0x4C, &[0x26, 0xBC, 0x88, 0x26, 0x6C, 0x71]);
-
 // TODO [END]: LOCAL (TEMP) GUID DEFINITIONS (MOVE LATER)
 
 extern "efiapi" fn calculate_crc32(data: *mut c_void, data_size: usize, crc_32: *mut u32) -> efi::Status {
@@ -285,7 +281,7 @@ pub extern "efiapi" fn exit_boot_services(_handle: efi::Handle, map_key: usize) 
                 status_code::EFI_PROGRESS_CODE,
                 status_code::EFI_SOFTWARE_EFI_BOOT_SERVICE | status_code::EFI_SW_BS_PC_EXIT_BOOT_SERVICES,
                 0,
-                &DXE_CORE_GUID,
+                &guid::DXE_CORE,
                 core::ptr::null(),
             );
         }


### PR DESCRIPTION
## Description

Closes #182 

Currently the first Memory Allocation Module HOB is assumed to be the DXE Core. To make identification more robust and ensure other assumptions about the DXE Core GUID are correct, this change also checks that a HOB is present with a DXE Core module name GUID that matches.

- [x] Impacts functionality?
- [ ] Impacts security?
- [x] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

- Cargo build and test
- QEMU boot with expected and unexpected DXE Core FFS GUID

## Integration Instructions

- Ensure that the DXE Core GUID used matches [`uefi_sdk::guid::DXE_CORE`](https://github.com/pop-project/uefi-sdk/blob/128e0e2464750d527d3615153fc0b173390e568f/uefi_sdk/src/guid.rs#L24-L34) (`23C9322F-2AF2-476A-BC4C-26BC88266C71`). For this reason, the change has been marked as potentially breaking.