### PR TITLE
rust-tool-cache: use cargo binstall

### DIFF
--- a/.github/actions/rust-tool-cache/action.yml
+++ b/.github/actions/rust-tool-cache/action.yml
@@ -22,6 +22,9 @@ runs:
           ~/.cargo/bin/
           ~/.rustup/toolchains/
         key: ${{ runner.os }}-rust-tools-${{ hashFiles('**/rust-toolchain.toml' )}}
+    
+    - name: Install cargo-binstall
+      uses: cargo-bins/cargo-binstall@v1.10.17      
 
     # Read any tools from rust-toolchain.toml file and installs them
     - name: Install Rust Tools
@@ -29,8 +32,24 @@ runs:
       run: |
         # Extract tools section from rust-toolchain.toml
         sed -n '/\[tools\]/,/^$/p' rust-toolchain.toml | grep -v '\[tools\]' | while read -r line; do
-          TOOL_NAME=$(echo "$line" | awk -F'=' '{gsub(/ /, "", $1); print $1}')
-          TOOL_VERSION=$(echo "$line" | awk -F'=' '{gsub(/["'\'']/,"",$2); print $2}')
-          cargo install "$TOOL_NAME" --version "$TOOL_VERSION"
+          # Extract tool name and clean it
+          TOOL_NAME=${line%%=*}
+          TOOL_NAME=${TOOL_NAME//[[:space:]]/}
+          TOOL_NAME="${TOOL_NAME//$'\n'/}"
+
+          # Extract tool version and clean it
+          TOOL_VERSION=${line#*=}
+          TOOL_VERSION=${TOOL_VERSION//[[:space:]]/}
+          TOOL_VERSION=${TOOL_VERSION//\"/}
+          TOOL_VERSION="${TOOL_VERSION//$'\n'/}"
+
+          echo ""
+          echo "##################################################################"
+          echo "Installing $TOOL_NAME@$TOOL_VERSION"
+          echo "##################################################################"
+          echo ""
+
+          # Attempt to binstall the tool first. If it fails, install it using cargo
+          cargo binstall -y $TOOL_NAME --version $TOOL_VERSION || cargo install $TOOL_NAME --version $TOOL_VERSION
         done
       if: steps.tool-cache.outputs.cache-hit != 'true'


### PR DESCRIPTION
## Description

cargo install has shown to be an unreliable way to compile and install
tools for any project that does not use the current latest version of
rust. This is because some tools allow for relaxed versions of their
dependencies, which will cause cargo to attempt to use the latest
version of the dependency, which may not be compatible with the 
version of rust being used in the repository.

This change switches to using cargo binstall, which simply downloads
the compiled tool, with a fallback to cargo install if the tool does
not support binstall.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Validated installing tools continues to work when cache fails. Successful run here: https://github.com/pop-project/uefi-dxe-core/actions/runs/12378250581/job/34549734056?pr=196

## Integration Instructions

N/A
