### PR TITLE
Temporarily Comment out init_performance_lib

### DIFF
--- a/dxe_core/src/lib.rs
+++ b/dxe_core/src/lib.rs
@@ -321,19 +321,23 @@ where
         }
 
         let boot_services_ptr;
-        let runtime_services_ptr;
+        // let runtime_services_ptr;
         {
             let mut st = systemtables::SYSTEM_TABLE.lock();
             boot_services_ptr = st.as_mut().unwrap().boot_services_mut() as *mut efi::BootServices;
-            runtime_services_ptr = st.as_mut().unwrap().runtime_services_mut() as *mut efi::RuntimeServices;
+            // runtime_services_ptr = st.as_mut().unwrap().runtime_services_mut() as *mut efi::RuntimeServices;
         }
         tpl_lock::init_boot_services(boot_services_ptr);
 
         memory_attributes_table::init_memory_attributes_table_support();
 
-        _ = uefi_performance::init_performance_lib(&hob_list, unsafe { boot_services_ptr.as_ref().unwrap() }, unsafe {
-            runtime_services_ptr.as_ref().unwrap()
-        });
+        // This is currently commented out as it is breaking top of tree booting Q35 as qemu64 does not support
+        // reading the time stamp counter in the way done in this code and results in a divide by zero exception.
+        // Other cpu models crash in various other ways. It will be resolved, but is removed now to unblock other
+        // development
+        // _ = uefi_performance::init_performance_lib(&hob_list, unsafe { boot_services_ptr.as_ref().unwrap() }, unsafe {
+        //     runtime_services_ptr.as_ref().unwrap()
+        // });
 
         CorePostInit::new(/* Potentially transfer configuration data here. */)
     }


### PR DESCRIPTION
## Description

Top of tree Q35 crashes with init_performance_lib, as qemu64 does not support invtsc, resulting in a divide by zero error. Other cpu models crash the system in various other ways. This is commented out for now to unblock development while other approaches are considered.

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Tested by booting Q35 to Windows.

## Integration Instructions

N/A.
