### PR TITLE
Move debugger initialization to after allocator

### DIFF
--- a/dxe_core/src/lib.rs
+++ b/dxe_core/src/lib.rs
@@ -271,7 +271,6 @@ where
         PROTOCOL_DB.init_protocol_db();
         // Initialize full allocation support.
         allocator::init_memory_support(&hob_list);
-
         // we have to relocate HOBs after memory services are initialized as we are going to allocate memory and
         // the initial free memory may not be enough to contain the HOB list. We need to relocate the HOBs because
         // the initial HOB list is not in mapped memory as passed from pre-DXE.


### PR DESCRIPTION
## Description

Moves the debugger to later after allocator initialization in preparation for coming debugger crate changes. 

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Tested on Q35 with local debugger changes

## Integration Instructions

N/A
