### PR TITLE
Changes for internal crate publishing

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,2 +1,5 @@
 [net]
 git-fetch-with-cli = true
+
+[registries]
+UefiRust = { index = "sparse+https://pkgs.dev.azure.com/microsoft/MsUEFI/_packaging/UefiRust/Cargo/index/" }

--- a/.github/workflows/CiWorkflow.yml
+++ b/.github/workflows/CiWorkflow.yml
@@ -47,7 +47,7 @@ jobs:
 
       - name: 🛠️ Download Rust Tools 🛠️
         uses: pop-project/uefi-dxe-core/.github/actions/rust-tool-cache@main
-      
+
       - name: 📖 Build Book 📖
         run: mdbook build ${{ inputs.mdbook-path }}
         if: ${{ inputs.mdbook-path != '' }}
@@ -62,24 +62,45 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-latest, windows-latest ]
-        
+
     steps:
       - name: ✅ Checkout Repository ✅
         uses: actions/checkout@v4
-    
+
       - name: 🛠️ Download Rust Tools 🛠️
         uses: pop-project/uefi-dxe-core/.github/actions/rust-tool-cache@main
-      
+
       - name: Add Credentials # Remove once repositories are public
         run: |
           git config --global url."https://${{ secrets.GH_PAT }}@github.com".insteadOf https://github.com
         shell: bash
 
+      - name: Setup Cred Provider
+        if: runner.os == 'Linux'
+        run: |
+          mkdir -p ~/.cargo
+          cat <<EOF >> ~/.cargo/config.toml
+          [registry]
+          global-credential-providers = ["cargo:token"]
+          EOF
+
+      - name: Setup Cred Provider
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          $path = "$HOME\.cargo\config.toml"
+          New-Item -ItemType Directory -Force -Path "$HOME\.cargo" | Out-Null
+          "[registry]" | Out-File -Append -FilePath $path
+          'global-credential-providers = ["cargo:token"]' | Out-File -Append -FilePath $path
+
+      - name: Login to Registry
+        run: cargo login "${{ secrets.CRATES_IO_TOKEN }}" --registry UefiRust
+
       - name: Run cargo-fmt
         run: cargo fmt --all --check
         env:
           RUSTC_BOOTSTRAP: 1
-      
+
       - name: Run cargo-clippy
         run: cargo clippy --all-targets --all-features -- -D warnings
         env:
@@ -111,7 +132,7 @@ jobs:
 
       - name: Build AArch64
         run: cargo make build-aarch64
-      
+
       - name: Upload Artifacts
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/ReleaseWorkflow.yml
+++ b/.github/workflows/ReleaseWorkflow.yml
@@ -34,12 +34,12 @@ jobs:
 
       - name: 🛠️ Download Rust Tools 🛠️
         uses: pop-project/uefi-dxe-core/.github/actions/rust-tool-cache@main
-      
+
       - name: Add Credentials # Remove once repositories are public
         run: |
           git config --global url."https://${{ secrets.GH_PAT }}@github.com".insteadOf https://github.com
         shell: bash
-      
+
       - name: Get Current Draft Release
         id: draft_release
         uses: actions/github-script@v7
@@ -68,25 +68,33 @@ jobs:
               console.log(`Draft Release ID: ${draftRelease.id}`);
               console.log(`Draft Release Tag: ${tag}`);
             }
-        
+
+      - name: Setup Cred Provider
+        run: |
+          mkdir -p ~/.cargo
+          cat <<EOF >> ~/.cargo/config.toml
+          [registry]
+          global-credential-providers = ["cargo:token"]
+          EOF
+
+      - name: Login to Registry
+        run: cargo login "${{ secrets.CRATES_IO_TOKEN }}" --registry UefiRust
+
       - name: Cargo Release Dry Run
         run: cargo release ${{ steps.draft_release.outputs.tag }} --workspace
         env:
           RUSTC_BOOTSTRAP: 1
-      
-      - name: Login to Crates.io
-        run: cargo login ${{ secrets.CRATES_IO_TOKEN }}
-      
+
       - name: Update git credentials
         run: |
           git config --global user.name "github-actions[bot]"
           git config --global user.email "github-actions[bot]@users.noreply.github.com"
-      
+
       - name: Cargo Release
         run: cargo release ${{ steps.draft_release.outputs.tag }} -x --no-tag --no-confirm --workspace
         env:
           RUSTC_BOOTSTRAP: 1
-  
+
       - name: Wait for Release Draft Updater
         uses: actions/github-script@v7
         with:
@@ -118,7 +126,7 @@ jobs:
                 attempt++;
               }
             }
-            
+
             if (!completed) {
               core.setFailed("Release Drafter did not complete in time. Please perform the release manually.");
             }


### PR DESCRIPTION
## Description

Minor updates to ReleaseWorkflow.yml to handle publishing to an internal feed.

Add the feed info in .cargo/config.toml.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Published crates from uefi-sdk.

- Worfklow Run: [Publish Release](https://github.com/pop-project/uefi-sdk/actions/runs/12700169589)
- Feed with published crates: [UefiRust](https://dev.azure.com/microsoft/MsUEFI/_artifacts/feed/UefiRust)

## Integration Instructions

- Repos using the workflow should be publishing to the `UefiRust` feed for now.