### PR TITLE
rust-tool-cache: Gracefully handle rust-toolchain.toml issues

### DIFF
--- a/.github/actions/rust-tool-cache/action.yml
+++ b/.github/actions/rust-tool-cache/action.yml
@@ -22,16 +22,28 @@ runs:
           ~/.cargo/bin/
           ~/.rustup/toolchains/
         key: ${{ runner.os }}-rust-tools-${{ hashFiles('**/rust-toolchain.toml' )}}
-    
+
     - name: Install cargo-binstall
-      uses: cargo-bins/cargo-binstall@v1.10.17      
+      uses: cargo-bins/cargo-binstall@v1.10.17
 
     # Read any tools from rust-toolchain.toml file and installs them
     - name: Install Rust Tools
       shell: bash
       run: |
+        FILE="rust-toolchain.toml"
+
+        if [ ! -f "$FILE" ]; then
+          echo "::error::File $FILE not found."
+          exit 1
+        fi
+
+        if ! grep -q '^\[tools\]' "$FILE"; then
+          echo "::warning::[tools] section not found in $FILE."
+          exit 1
+        fi
+
         # Extract tools section from rust-toolchain.toml
-        sed -n '/\[tools\]/,/^$/p' rust-toolchain.toml | grep -v '\[tools\]' | while read -r line; do
+        sed -n '/\[tools\]/,/^$/p' "$FILE" | grep -v '\[tools\]' | while read -r line; do
           # Extract tool name and clean it
           TOOL_NAME=${line%%=*}
           TOOL_NAME=${TOOL_NAME//[[:space:]]/}


### PR DESCRIPTION
## Description

Print obvious errors if either the file is missing or the `[tools]` section is not found.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

- rust-toolchain.toml not present
- [tools] section missing in rust-toolchain.toml
- [tools] section present in rust-toolchain.toml

## Integration Instructions

- N/A