### PR TITLE
.cargo/config.toml: Replace crates.io with internal feed

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -3,3 +3,6 @@ git-fetch-with-cli = true
 
 [registries]
 UefiRust = { index = "sparse+https://pkgs.dev.azure.com/microsoft/MsUEFI/_packaging/UefiRust/Cargo/index/" }
+
+[source.crates-io]
+replace-with = "UefiRust"


### PR DESCRIPTION
## Description

Pull crates from the internal feed with a crates.io upstream.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Local build and server CI.

## Integration Instructions

Use a cred provider (like [`msrustup`](https://eng.ms/docs/more/languages-at-microsoft/rust/articles/gettingstarted/install/msrustup) to the feed at https://dev.azure.com/microsoft/MsUEFI/_artifacts/feed/UefiRust.