### PR TITLE
gcd: Accommodating EfiError

### DIFF
--- a/dxe_core/src/gcd.rs
+++ b/dxe_core/src/gcd.rs
@@ -20,7 +20,7 @@ use uefi_sdk::base::{align_down, align_up};
 
 use crate::GCD;
 
-pub use spin_locked_gcd::{AllocateType, Error, MapChangeType, SpinLockedGcd};
+pub use spin_locked_gcd::{AllocateType, MapChangeType, SpinLockedGcd};
 
 pub fn init_gcd(physical_hob_list: *const c_void) {
     let mut free_memory_start: u64 = 0;


### PR DESCRIPTION
The GCD currently defines its own error codes. However, it constantly needs to convert to EfiError. I believe that this is a legacy of the GCD being one of the first components written.

Follow the rest of dxe_core behavior and use EfiError instead of custom error codes. Custom error codes should be used for non-UEFI specific reusable crates.

How This Was Tested
Code was run and tested in QEMU emulator to make sure that it boots up fine.

Coverage was good

Cargo make test also was good.