### PR TITLE
remove cargo-tarpaulin proc macro crate workaround

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -6,8 +6,6 @@ RUSTC_BOOTSTRAP = 1
 NO_STD_FLAGS = "--profile ${RUSTC_PROFILE} -Zbuild-std=core,compiler_builtins,alloc -Zbuild-std-features=compiler-builtins-mem -Zunstable-options --timings=html"
 STD_FLAGS = "--profile ${RUSTC_PROFILE} --features std"
 TEST_FLAGS = { value = "", condition = { env_not_set = ["TEST_FLAGS"] } }
-# TODO: Remove when https://github.com/xd009642/tarpaulin/issues/1642 is resolved.
-COV_FILTER = { value = "-e uefi_test_macro", condition = { platforms = ["windows"], env_true = ["CARGO_MAKE_CI"] } }
 COV_FLAGS = { value = "--workspace --out html --out xml --exclude-files **/tests/* --exclude-files **/benches/*", condition = { env_not_set = ["COV_FLAGS"] } }
 
 [env.development]
@@ -122,7 +120,7 @@ dependencies = ["individual-package-targets"]
 description = "Build and run all tests and calculate coverage."
 clear = true
 command = "cargo"
-args = ["tarpaulin", "@@split(COV_FLAGS, )", "@@split(COV_FILTER, )", "--output-dir", "${CARGO_MAKE_WORKSPACE_WORKING_DIRECTORY}/target"]
+args = ["tarpaulin", "@@split(COV_FLAGS, )", "--output-dir", "${CARGO_MAKE_WORKSPACE_WORKING_DIRECTORY}/target"]
 dependencies = ["individual-package-targets"]
 
 [tasks.coverage-filter]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -6,7 +6,7 @@ components = ["rust-src"]
 # A custom section for CI pipelines to install tools
 [tools]
 cargo-make = "0.37.21"
-cargo-tarpaulin = "0.31.2"
+cargo-tarpaulin = "0.31.5"
 cargo-release = "0.25.12"
 mdbook = "0.4.40"
 mdbook-mermaid = "0.14.0"


### PR DESCRIPTION
## Description

Running host based unit tests on proc-macro crates was broken as noted in https://github.com/xd009642/tarpaulin/issues/1642. This has been resolved in the 0.31.5 release of cargo-tarpaulin. This commit removes the workaround and updates the tool.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

CI now passes while also running host based unit tests on the `uefi_test_macro` proc marcro crate.

## Integration Instructions

Developers need to update their local version of cargo-tarpaulin to 0.31.5 or greater.
