### PR TITLE
Page Pool Size Update

### DIFF
--- a/dxe_core/src/gcd/spin_locked_gcd.rs
+++ b/dxe_core/src/gcd/spin_locked_gcd.rs
@@ -181,7 +181,7 @@ type GcdFreeFn =
 // which will deadlock. This sets the pool to an initial size that should be large enough to track all pages for any
 // reasonable allocation in the global allocator to avoid this problem.
 //
-const PAGE_POOL_MIN_CAPACITY: usize = 1024;
+const PAGE_POOL_MIN_CAPACITY: usize = 1024 * 32;
 
 #[derive(Debug)]
 struct PagingAllocator {


### PR DESCRIPTION
## Description

Update the page pool to begin with 32k entries to avoid FSB lock re-entry. This is larger than the largest observed size needed for pages in the page table.

Another approach is being explored that makes the preallocation of pages for the page pool unneccesary, but in the meantime this change is required to avoid the re-entrant lock in Q35 and SBSA today.

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Booted on Q35 and SBSA with paging updates.

## Integration Instructions

N/A.
