### PR TITLE
dxe_core: Use Type-State pattern

### DIFF
--- a/dxe_core/src/lib.rs
+++ b/dxe_core/src/lib.rs
@@ -161,11 +161,12 @@ pub struct NoAlloc;
 /// to the `Alloc` phase. Each phase provides a subset of methods that are available to the struct, allowing
 /// for a more controlled configuration and execution process.
 ///
-/// During the `NoAlloc` phase, the struct provides methods to configure the dxe core's cpu related
-/// functionality, the section extractor. During this time, no allocations are available.
+/// During the `NoAlloc` phase, the struct provides methods to configure the DXE core environment
+/// prior to allocation capability such as CPU functionality and section extraction. During this time,
+/// no allocations are available.
 ///
 /// Once the [initialize](Core::initialize) method is called, the struct transitions to the `Alloc` phase,
-/// which provides methods for adding configuration and components with the dxe core, and eventually starting the
+/// which provides methods for adding configuration and components with the DXE core, and eventually starting the
 /// dispatching process and eventual handoff to the BDS phase.
 ///
 /// ## Examples


### PR DESCRIPTION
Convert the dxe_core Core struct to use the Type-State pattern to prevent allocations for the short period of time before the global allocator is fully initialized instead of having two completely separate structs for the two different states.

The Type-State pattern is a way to gate functionality to certain states by using the type system and phantom data to implement functions for certain states and prevent them, at compile time, from being used in other states.

## Description

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

CI passes and the platform builds with no integration steps

## Integration Instructions

N/A
