### PR TITLE
CiWorkflow: Remove GH_PAT requirement

### DIFF
--- a/.github/workflows/CiWorkflow.yml
+++ b/.github/workflows/CiWorkflow.yml
@@ -17,8 +17,8 @@ on:
         default: ""
         type: string
     secrets:
-      GH_PAT:
-        description: "GitHub Personal Access Token"
+      CRATES_IO_TOKEN:
+        description: "Token to access the UefiRust registry"
         required: true
 
 jobs:
@@ -69,11 +69,6 @@ jobs:
 
       - name: 🛠️ Download Rust Tools 🛠️
         uses: pop-project/uefi-dxe-core/.github/actions/rust-tool-cache@main
-
-      - name: Add Credentials # Remove once repositories are public
-        run: |
-          git config --global url."https://${{ secrets.GH_PAT }}@github.com".insteadOf https://github.com
-        shell: bash
 
       - name: Setup Cred Provider
         if: runner.os == 'Linux'


### PR DESCRIPTION
## Description

with the move from direct repository access for dependencies to using a private registry, the GH_PAT is no longer needed for CI. Instead, the CRATES_IO_TOKEN is used to authenticate with the private registry.

This commit updates the required secret to be CRATES_IO_TOKEN instead of GH_PAT.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

CI passes

## Integration Instructions

Consuming repositories should add the CRATES_IO_TOKEN secret to their list of secrets, and remove the GH_PAT secret.
