### PR TITLE
release workflow: Additional Updates

### DIFF
--- a/.github/workflows/ReleaseWorkflow.yml
+++ b/.github/workflows/ReleaseWorkflow.yml
@@ -11,9 +11,6 @@ name: Publish
 on:
   workflow_call:
     secrets:
-      GH_PAT:
-        description: 'The GitHub Personal Access Token to use for authenticating with GitHub'
-        required: true
       CRATES_IO_TOKEN:
         description: 'The token to use for authenticating with crates.io'
         required: true
@@ -35,11 +32,6 @@ jobs:
 
       - name: 🛠️ Download Rust Tools 🛠️
         uses: pop-project/uefi-dxe-core/.github/actions/rust-tool-cache@main
-
-      - name: Add Credentials # Remove once repositories are public
-        run: |
-          git config --global url."https://${{ secrets.GH_PAT }}@github.com".insteadOf https://github.com
-        shell: bash
 
       - name: Get Release Tag
         id: release_tag


### PR DESCRIPTION
## Description

The previous update to the release workflow, while working in terms of creating branches and publishing PRs, ended up breaking the actual publish logic, which went untested. The following changes were made to fix the issues:

Provides additional updates to the release workflow including:

1. Checking out the branch (and push it to origin) before doing a dry-run or release to prevent cargo release from erroring saying it cannot push from `HEAD` (i.e. a floating commit, which is what we checkout when running from a tag release trigger)
2. Add the `--registry UefiRust` so that the dry run does not think we are attempting to create new crates instead of updating versions (it was looking at crates.io by default)
3. Allow cargo-release to push to the remote now that the branch exists before running it.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

I generated and added an PAT so that the pipeline could talk to the UefiRust registry. I commented out the final publish, but allowed the --dry-run to run, which succeeded.

## Integration Instructions

N/A
