### PR TITLE
Change GitHub org name from pop-project to OpenDevicePartnership

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -7,5 +7,5 @@
 blank_issues_enabled: false
 contact_links:
   - name: 📃 Documentation
-    url: https://pop-project.github.io/uefi-dxe-core/
+    url: https://OpenDevicePartnership.github.io/uefi-dxe-core/
     about: Goals, principles, repo layout, build instructions, and more.

--- a/.github/workflows/CiWorkflow.yml
+++ b/.github/workflows/CiWorkflow.yml
@@ -46,7 +46,7 @@ jobs:
           args: "**/*.md"
 
       - name: 🛠️ Download Rust Tools 🛠️
-        uses: pop-project/uefi-dxe-core/.github/actions/rust-tool-cache@main
+        uses: OpenDevicePartnership/uefi-dxe-core/.github/actions/rust-tool-cache@main
 
       - name: 📖 Build Book 📖
         run: mdbook build ${{ inputs.mdbook-path }}
@@ -68,7 +68,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: 🛠️ Download Rust Tools 🛠️
-        uses: pop-project/uefi-dxe-core/.github/actions/rust-tool-cache@main
+        uses: OpenDevicePartnership/uefi-dxe-core/.github/actions/rust-tool-cache@main
 
       - name: Setup Cred Provider
         if: runner.os == 'Linux'

--- a/.github/workflows/ReleaseWorkflow.yml
+++ b/.github/workflows/ReleaseWorkflow.yml
@@ -30,15 +30,15 @@ jobs:
         uses: actions/checkout@v4
 
       - name: 🛠️ Download Rust Tools 🛠️
-        uses: pop-project/uefi-dxe-core/.github/actions/rust-tool-cache@main
+        uses: OpenDevicePartnership/uefi-dxe-core/.github/actions/rust-tool-cache@main
 
       - name: Get Release Tag
         id: release_tag
         run: |
           tag_name="${{ github.event.release.tag_name }}"
-          
+
           # remove the leading 'v' if it exists
-          release_tag="${tag_name#v}" 
+          release_tag="${tag_name#v}"
 
           echo "Release Tag: $release_tag"
           echo "tag=$release_tag" >> $GITHUB_OUTPUT
@@ -56,7 +56,7 @@ jobs:
         run: |
           git config --global user.name "github-actions[bot]"
           git config --global user.email "github-actions[bot]@users.noreply.github.com"
-    
+
       - name: Checkout New Branch
         run: |
           git checkout -b "github-actions/release-${{ steps.release_tag.outputs.tag }}"

--- a/.github/workflows/publish-mdbook.yml
+++ b/.github/workflows/publish-mdbook.yml
@@ -32,7 +32,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: 🛠️ Download Rust Tools 🛠️
-        uses: pop-project/uefi-dxe-core/.github/actions/rust-tool-cache@main
+        uses: OpenDevicePartnership/uefi-dxe-core/.github/actions/rust-tool-cache@main
 
       - name: 📄 Build Documentation 📄
         run: mdbook build docs

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ members = [
 [workspace.package]
 version = "7.1.2"
 publish = ["UefiRust"]
-repository = "https://github.com/pop-project/uefi-dxe-core"
+repository = "https://github.com/OpenDevicePartnership/uefi-dxe-core"
 license = "BSD-2-Clause-Patent"
 edition = "2021"
 rust-version = "1.80.0"

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Before making pull requests at a minimum, run:
 ## Documentation
 
 We have "Getting Started" documentation located in this repository at `docs/*`. The latest documentation can be found
-at <https://pop-project.github.io/uefi-dxe-core/>, however this documentation can also be self-hosted via
+at <https://OpenDevicePartnership.github.io/uefi-dxe-core/>, however this documentation can also be self-hosted via
 ([mdbook](https://github.com/rust-lang/mdBook)). Once you all dependencies installed as specified below, you can run
 `mdbook serve docs` to self host the getting started book.
 

--- a/crates/uefi_performance/src/lib.rs
+++ b/crates/uefi_performance/src/lib.rs
@@ -245,7 +245,7 @@ extern "efiapi" fn create_performance_measurement(
 
     match perf_id {
         PerfId::MODULE_START | PerfId::MODULE_END => {
-            // TODO: https://github.com/pop-project/uefi-dxe-core/issues/195
+            // TODO: https://github.com/OpenDevicePartnership/uefi-dxe-core/issues/195
             log::warn!(
                 "[Module: {}, Line: {}, Function: {}] TODO: This path need to be verified. It has not been tested yet.",
                 module_path!(),
@@ -258,7 +258,7 @@ extern "efiapi" fn create_performance_measurement(
             }
         }
         PerfId::MODULE_LOAD_IMAGE_START | PerfId::MODULE_LOAD_IMAGE_END => {
-            // TODO: https://github.com/pop-project/uefi-dxe-core/issues/195
+            // TODO: https://github.com/OpenDevicePartnership/uefi-dxe-core/issues/195
             log::warn!(
                 "[Module: {}, Line: {}, Function: {}] TODO: This path need to be verified. It has not been tested yet.",
                 module_path!(),
@@ -284,7 +284,7 @@ extern "efiapi" fn create_performance_measurement(
         | PerfId::MODULE_DB_STOP_START
         | PerfId::MODULE_DB_STOP_END
         | PerfId::MODULE_DB_START => {
-            // TODO: https://github.com/pop-project/uefi-dxe-core/issues/195
+            // TODO: https://github.com/OpenDevicePartnership/uefi-dxe-core/issues/195
             log::warn!(
                 "[Module: {}, Line: {}, Function: {}] TODO: This path need to be verified. It has not been tested yet.",
                 module_path!(),
@@ -297,7 +297,7 @@ extern "efiapi" fn create_performance_measurement(
             }
         }
         PerfId::MODULE_DB_END => {
-            // TODO: https://github.com/pop-project/uefi-dxe-core/issues/195
+            // TODO: https://github.com/OpenDevicePartnership/uefi-dxe-core/issues/195
             log::warn!(
                 "[Module: {}, Line: {}, Function: {}] TODO: This path need to be verified. It has not been tested yet.",
                 module_path!(),
@@ -311,7 +311,7 @@ extern "efiapi" fn create_performance_measurement(
                 let record = GuidQwordStringEventRecord::new(perf_id, 0, timestamp, guid, address as u64, &module_name);
                 _ = &FBPT.lock().add_record(record);
             }
-            // TODO something to do if address is not 0 need example to continue development. (https://github.com/pop-project/uefi-dxe-core/issues/194)
+            // TODO something to do if address is not 0 need example to continue development. (https://github.com/OpenDevicePartnership/uefi-dxe-core/issues/194)
         }
         PerfId::PERF_EVENT_SIGNAL_START
         | PerfId::PERF_EVENT_SIGNAL_END
@@ -337,7 +337,7 @@ extern "efiapi" fn create_performance_measurement(
             _ = &FBPT.lock().add_record(record);
         }
         _ if attribute != PerfAttribute::PerfEntry => {
-            // TODO: https://github.com/pop-project/uefi-dxe-core/issues/195
+            // TODO: https://github.com/OpenDevicePartnership/uefi-dxe-core/issues/195
             log::warn!(
                 "[Module: {}, Line: {}, Function: {}] TODO: This path need to be verified. It has not been tested yet.",
                 module_path!(),
@@ -458,16 +458,16 @@ fn get_module_info_from_handle(
         let _image_bytes = unsafe {
             slice::from_raw_parts(loaded_image.image_base as *const _ as *const u8, loaded_image.image_size as usize)
         };
-        // TODO: Find Module name in handle (image_bytes) (https://github.com/pop-project/uefi-dxe-core/issues/187).
+        // TODO: Find Module name in handle (image_bytes) (https://github.com/OpenDevicePartnership/uefi-dxe-core/issues/187).
 
         return Ok((Some(String::from("TODO Get name from UefiPeInfo")), guid));
     }
 
     // Method 2 - Get the name string from ComponentName2
-    // TODO: https://github.com/pop-project/uefi-dxe-core/issues/192
+    // TODO: https://github.com/OpenDevicePartnership/uefi-dxe-core/issues/192
 
     // Method 3 - Get the name string from FFS UI Section.
-    // TODO: https://github.com/pop-project/uefi-dxe-core/issues/193
+    // TODO: https://github.com/OpenDevicePartnership/uefi-dxe-core/issues/193
 
     Ok((None, guid))
 }

--- a/docs/src/dev/other.md
+++ b/docs/src/dev/other.md
@@ -18,10 +18,10 @@ Other repositories related to the uefi-dxe-core project.
 
 | Repository | Description |
 |------------|-------------|
-| [uefi-dxe-core](https://github.com/pop-project/uefi-dxe-core) | The pure-rust implementation of the UEFI DXE Core. |
-| [uefi-core](https://github.com/pop-project/uefi-core) | Abstraction point implementations, such as for CPU initialization, serial writing, logging, etc. |
-| [mtrr](https://github.com/pop-project/mtrr) | Memory Type Range Registers for x86_64. |
-| [paging](https://github.com/pop-project/paging) | Paging implementation. |
+| [uefi-dxe-core](https://github.com/OpenDevicePartnership/uefi-dxe-core) | The pure-rust implementation of the UEFI DXE Core. |
+| [uefi-core](https://github.com/OpenDevicePartnership/uefi-core) | Abstraction point implementations, such as for CPU initialization, serial writing, logging, etc. |
+| [mtrr](https://github.com/OpenDevicePartnership/mtrr) | Memory Type Range Registers for x86_64. |
+| [paging](https://github.com/OpenDevicePartnership/paging) | Paging implementation. |
 | [r-efi](https://github.com/r-efi/r-efi) | UEFI reference specification protocol constants and definitions. |
 | [mu_rust_pi](https://github.com/microsoft/mu_rust_pi) | Platform initialization (PI) specification definitions and support code. |
 | [mu_rust_helpers](https://github.com/microsoft/mu_rust_helpers) | Miscellaneous rust UEFI helper code. |

--- a/docs/src/dxe_core/testing.md
+++ b/docs/src/dxe_core/testing.md
@@ -1,7 +1,7 @@
 # DXE Core Testing
 
 Writing DXE Core tests follows all the same principles defined in the [Testing](../dev/testing.md) chapter, so if you
-have not reviewed it yet, please do so before continuing. One of the reasons that [uefi-dxe-core](https://github.com/pop-project/uefi-dxe-core)
+have not reviewed it yet, please do so before continuing. One of the reasons that [uefi-dxe-core](https://github.com/OpenDevicePartnership/uefi-dxe-core)
 is split into multiple crates and merged the the `dxe_core` umbrella crate is to support code separation and ease of
 unit testing. Support crates (in the `crates/*` folder) should not contain any static data used by the core. Instead,
 they should provide the generic implementation details that the core uses to function. This simplifies unit tests, code
@@ -18,7 +18,7 @@ static pieces of data that are referenced throughout the codebase. Since unit te
 that multiple tests may be manipulating this static data at the same time. This will lead to either dead-locks, panics,
 or the static data being in an unexpected state for the test.
 
-To help with this issue in the dxe_core crate, a [test_support](https://github.com/pop-project/uefi-dxe-core/blob/main/dxe_core/src/test_support.rs)
+To help with this issue in the dxe_core crate, a [test_support](https://github.com/OpenDevicePartnership/uefi-dxe-core/blob/main/dxe_core/src/test_support.rs)
 module was added to make writing tests more convenient. The most important functionality in the module is the
 `with_global_lock` function which takes your test closure / function as a parameter. This function locks a private
 global mutex, ensuring you have exclusive access to all statics within the dxe_core.

--- a/docs/src/integrate/dxe_core.md
+++ b/docs/src/integrate/dxe_core.md
@@ -18,7 +18,7 @@ dxe_core = "$(VERSION)"
 If you want the latest and greatest, you can use the `main` branch from our github repository:
 
 ``` toml
-dxe_core = { git = "https://github.com/pop-project/uefi-dxe-core", branch = "main" }
+dxe_core = { git = "https://github.com/OpenDevicePartnership/uefi-dxe-core", branch = "main" }
 ```
 ````
 
@@ -74,12 +74,12 @@ points of abstraction, `SectionExtractor` and `EfiCpuInit`.
 extraction methods it supports. As an example, a platform may only compress it's sections with
 brotli, so it only needs to support brotli extractions. A platform may create their own extractor,
 it only needs implement the [SectionExtractor](https://github.com/microsoft/mu_rust_pi/blob/c8dd7f990d87746cfae9a5e821ad69501c46f346/src/fw_fs.rs#L77)
-trait. However multiple implementations are provided via [section_extractor](https://github.com/pop-project/uefi-core/tree/main/section_extractor),
+trait. However multiple implementations are provided via [section_extractor](https://github.com/OpenDevicePartnership/uefi-core/tree/main/section_extractor),
 such as brotli, crc32, uefi_decompress, etc.
 
 `EfiCpuInit` is an abstraction point for architecture specific initialization steps.
-Implementations are provided via [uefi_cpu](https://github.com/pop-project/uefi-core/tree/main/uefi_cpu),
-however if necessary, a platform can create their own implementation via the [EfiCpuInit](https://github.com/pop-project/uefi-core/blob/main/uefi_core/src/interface.rs)
+Implementations are provided via [uefi_cpu](https://github.com/OpenDevicePartnership/uefi-core/tree/main/uefi_cpu),
+however if necessary, a platform can create their own implementation via the [EfiCpuInit](https://github.com/OpenDevicePartnership/uefi-core/blob/main/uefi_core/src/interface.rs)
 trait.
 
 ```admonish note

--- a/dxe_core/src/lib.rs
+++ b/dxe_core/src/lib.rs
@@ -1,7 +1,7 @@
 //! DXE Core
 //!
 //! A pure rust implementation of the UEFI DXE Core. Please review the getting started documentation at
-//! <https://pop-project.github.io/uefi-dxe-core/> for more information.
+//! <https://OpenDevicePartnership.github.io/uefi-dxe-core/> for more information.
 //!
 //! ## Examples
 //!


### PR DESCRIPTION
## Description

The org name has switched to OpenDevicePartnership so all references to the previous org name are updated.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

- Verified new URLs.
- Note: "pop-project" will redirect to "OpenDevicePartnership" so the old URLs will still work for now.
  - https://github.com/pop-project will return 404 until/if it is claimed by someone else.

## Integration Instructions

N/A