### PR TITLE
Fix perf macros

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ sample_components = { path = "sample_components", version = "8" }
 uefi_collections = { path = "crates/uefi_collections", version = "8", default-features = false }
 uefi_depex = { path = "crates/uefi_depex", version = "8" }
 uefi_device_path = { path = "crates/uefi_device_path", version = "8" }
-uefi_performance = { path = "crates/uefi_performance", version = "8", features = ["instrument_performance"] }
+uefi_performance = { path = "crates/uefi_performance", version = "8" }
 uefi_test = { path = "uefi_test", version = "8" }
 uefi_test_macro = { path = "crates/uefi_test_macro", version = "8" }
 
@@ -50,7 +50,7 @@ linked_list_allocator = "^0.10"
 log = { version = "^0.4", default-features = false }
 mockall = "0.13.0"
 mu_pi = { version = "^5.2" }
-mu_rust_helpers = { path = "C:/Users/sherryfan/mu_rust_helpers" }
+mu_rust_helpers = { version = "2" }
 paging = { version = "1.0.1" }
 rand = "^0.8"
 r-efi = { version = "^5.2.0", default-features = false }

--- a/dxe_core/src/lib.rs
+++ b/dxe_core/src/lib.rs
@@ -389,11 +389,11 @@ where
         }
 
         let boot_services_ptr;
-        let runtime_services_ptr;
+        // let runtime_services_ptr;
         {
             let mut st = systemtables::SYSTEM_TABLE.lock();
             boot_services_ptr = st.as_mut().unwrap().boot_services_mut() as *mut efi::BootServices;
-            runtime_services_ptr = st.as_mut().unwrap().runtime_services_mut() as *mut efi::RuntimeServices;
+            // runtime_services_ptr = st.as_mut().unwrap().runtime_services_mut() as *mut efi::RuntimeServices;
         }
         tpl_lock::init_boot_services(boot_services_ptr);
 
@@ -403,9 +403,9 @@ where
         // reading the time stamp counter in the way done in this code and results in a divide by zero exception.
         // Other cpu models crash in various other ways. It will be resolved, but is removed now to unblock other
         // development
-        _ = uefi_performance::init_performance_lib(&hob_list, unsafe { boot_services_ptr.as_ref().unwrap() }, unsafe {
-            runtime_services_ptr.as_ref().unwrap()
-        });
+        // _ = uefi_performance::init_performance_lib(&hob_list, unsafe { boot_services_ptr.as_ref().unwrap() }, unsafe {
+        //     runtime_services_ptr.as_ref().unwrap()
+        // });
 
         self.storage.set_boot_services(boot_services_ptr);
         Core {


### PR DESCRIPTION
## Description
Because of the way macros are expanded, the previous way of using cfg! was incorrect. This PR fixes that bug.
 
- [X] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested
Enabling perf works correctly now.

## Integration Instructions
N/A