### PR TITLE
Only notify BeforeExitBootServices once and don't lock memory until after

### DIFF
--- a/dxe_core/src/misc_boot_services.rs
+++ b/dxe_core/src/misc_boot_services.rs
@@ -251,9 +251,6 @@ pub extern "efiapi" fn exit_boot_services(_handle: efi::Handle, map_key: usize) 
         EXIT_BOOT_SERVICES_CALLED.store(true, Ordering::SeqCst);
     }
 
-    // Lock the memory space to prevent edits to the memory map after this point.
-    GCD.lock_memory_space();
-
     // Disable the timer
     match PROTOCOL_DB.locate_protocol(protocols::timer::PROTOCOL_GUID) {
         Ok(timer_arch_ptr) => {
@@ -263,6 +260,9 @@ pub extern "efiapi" fn exit_boot_services(_handle: efi::Handle, map_key: usize) 
         }
         Err(err) => log::error!("Unable to locate timer arch: {:?}", err),
     };
+
+    // Lock the memory space to prevent edits to the memory map after this point.
+    GCD.lock_memory_space();
 
     // Terminate the memory map
     // According to UEFI spec, in case of an incomplete or failed EBS call we must restore boot services memory allocation functionality


### PR DESCRIPTION
## Description

The recent Advanced Logger fix exposed another issue. During the BeforeExitBootServices callback, the C based Advanced Logger File Logger will flush the logs a final time during this callback. Because of the existing early GCD lock this causes an assertion failure. However, there is not strong alternative for such a scenario so this change will only lock the GCD after calling BeforeExitBootServices. 

Additionaly this change makes BeforeExitBootServices only be invoked once which is the behavior specified in the [UEFI Specification](https://uefi.org/specs/UEFI/2.10/07_Services_Boot_Services.html#efi-boot-services-exitbootservices). This provides the additional benefit of prevent events that do not register themselves from hitting the assert on a subsequent call from BeforeExitBootServices.

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Tested boot to Windows on Q35

## Integration Instructions

N/A
