### PR TITLE
spin_locked_gcd: Move PagingAllocator::new() before init_paging()

### DIFF
--- a/dxe_core/src/gcd/spin_locked_gcd.rs
+++ b/dxe_core/src/gcd/spin_locked_gcd.rs
@@ -2296,7 +2296,8 @@ impl SpinLockedGcd {
     }
 
     pub(crate) fn init_paging(&self, hob_list: &HobList) {
-        self.memory.lock().init_paging(hob_list, PagingAllocator::new());
+        let page_allocator = PagingAllocator::new();
+        self.memory.lock().init_paging(hob_list, page_allocator);
     }
 
     /// This service adds reserved memory, system memory, or memory-mapped I/O resources to the global coherency domain of the processor.


### PR DESCRIPTION
## Description

Currently, the PagingAllocator::new() call still occurs within the GCD lock. Move it such that it PagingAllocator releases the lock prior to reacquiring it again for paging init.

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

- Intel physical platform

## Integration Instructions

- N/A