### PR TITLE
Makefile.toml: Add a 'cargo make all' task for PR readiness

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -6,7 +6,7 @@ RUSTC_BOOTSTRAP = 1
 NO_STD_FLAGS = "--profile ${RUSTC_PROFILE} -Zbuild-std=core,compiler_builtins,alloc -Zbuild-std-features=compiler-builtins-mem -Zunstable-options --timings=html"
 STD_FLAGS = "--profile ${RUSTC_PROFILE} --features std"
 TEST_FLAGS = { value = "", condition = { env_not_set = ["TEST_FLAGS"] } }
-COV_FLAGS = { value = "--workspace --out html --out xml --exclude-files **/tests/* --exclude-files **/benches/*", condition = { env_not_set = ["COV_FLAGS"] } }
+COV_FLAGS = { value = "--workspace --out html --out xml --exclude-files **/tests/* --exclude-files **/benches/* --exclude uefi_test_macro", condition = { env_not_set = ["COV_FLAGS"] } }
 
 [env.development]
 RUSTC_PROFILE = "dev"
@@ -210,3 +210,33 @@ description = "Builds all rust documentation in the workspace. Example `cargo ma
 env = { RUSTDOCFLAGS = "-D warnings"}
 command = "cargo"
 args = ["doc", "@@split(INDIVIDUAL_PACKAGE_TARGETS, )", "--features", "doc", "--open"]
+
+[tasks.clippy]
+description = "Run cargo clippy."
+clear = true
+command = "cargo"
+args = ["clippy", "--all-targets", "--all-features", "--", "-D", "warnings"]
+
+[tasks.fmt]
+description = "Run cargo format."
+clear = true
+command = "cargo"
+args = ["fmt", "--all"]
+
+[tasks.cspell]
+description = "Run cspell for spell checking." # npm install -g cspell@latest
+script = "cspell --quiet  --no-progress --no-summary  --dot --gitignore -e \"{.git/**,.github/**,.vscode/**}\" ."
+
+[tasks.all]
+description = "Run all tasks for PR readiness."
+dependencies = [
+    "clippy",
+    "cspell",
+    "build",
+    "build-x64",
+    "build-aarch64",
+    "test",
+    "coverage",
+    "fmt",
+    "doc",
+]

--- a/crates/uefi_test_macro/Cargo.toml
+++ b/crates/uefi_test_macro/Cargo.toml
@@ -11,6 +11,20 @@ description = "Proc macros for UEFI testing."
 
 [lib]
 proc-macro = true
+# NOTE: Procedural macro crates depend on std-xxxxx.dll. When Tarpaulin tries to
+# run the test binary directly, it fails to find std-xxxxx.dll. This does not
+# happen when invoking `cargo test` because it appropriately sets the Rust
+# compiler binary path (sysroot) before running the test binaries. Based on the
+# discussion at https://github.com/xd009642/tarpaulin/issues/1642, below are
+# some workarounds to enable code coverage at the workspace level:
+# 1. Mark this crate as not test-ready by setting `test = false` here. The unit
+#    tests in this crate can still be run manually using `cargo test
+#    --all-targets`.
+# 2. Pass `--exclude uefi_test_macro` to the `cargo tarpaulin` command to
+#    exclude this package from code coverage.
+# 3. This dependency issue seems to be fixed in Rust 1.82 (untested).
+#
+# We are opting for workaround #2.
 
 [features]
 default = []


### PR DESCRIPTION
## Description

Makefile.toml: Add a `cargo make all` task for PR readiness. This makes it slightly easier to run all tasks for PR readiness in one command. It also includes cspell task, so a onetime installation of cspell is needed via `npm install -g cspell@latest`.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

N/A

## Integration Instructions

N/A
