### PR TITLE
rust-tool-cache: Install toolchain on cache miss

### DIFF
--- a/.github/actions/rust-tool-cache/action.yml
+++ b/.github/actions/rust-tool-cache/action.yml
@@ -23,6 +23,13 @@ runs:
           ~/.rustup/toolchains/
         key: ${{ runner.os }}-rust-tools-${{ hashFiles('**/rust-toolchain.toml' )}}
 
+    # Installs toolchain specified in the rust-toolchain.toml file
+    - name: Install toolchains
+      shell: bash
+      run: |
+        rustup toolchain install
+      if: steps.tool-cache.outputs.cache-hit != 'true'
+
     - name: Install cargo-binstall
       uses: cargo-bins/cargo-binstall@v1.10.17
 

--- a/README.md
+++ b/README.md
@@ -45,10 +45,14 @@ The following instructions install Rust.
 
    \>`cargo --version`
 
-3. While the specific toolchains and components specified in `[toolchain]` section of the `rust-toolchain.toml` are
-automatically gathered by cargo, the tools in the `[tools]` section, such as `cargo-make` are not. At a minimum, you
-should download `cargo-make` and `cargo-tarpaulin`, however it is suggested that you download all tools in the
-`[tools]` section of the `rust-toolchain.toml`.
+3. Install toolchain specified in `rust-toolchain.toml`
+
+   \>`rustup toolchain install`
+
+4. While the specific toolchains and components specified in `[toolchain]` section of the `rust-toolchain.toml` are
+automatically installed with `rustup toolchain install`, the tools in the `[tools]` section, such as `cargo-make`
+are not. At a minimum, you should download `cargo-make` and `cargo-tarpaulin`, however it is suggested that you
+download all tools in the `[tools]` section of the `rust-toolchain.toml`.
 
 ### DXE Core Goals
 


### PR DESCRIPTION
## Description

[rustup 1.28.0](https://blog.rust-lang.org/2025/03/02/Rustup-1.28.0.html) will no longer automatically install the rust toolchain specified in the rust-toolchain.toml file. Due to this, we must manually install the toolchain on a cache miss.

closes #274 

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Updated channel to 1.81.0 to ensure a cache miss and the version is downloaded.

## Integration Instructions

N/A
