### PR TITLE
Fix by Kai - Increased PAGE_POOL_MIN_CAPACITY from 1024 * 32 to 1024 …

### DIFF
--- a/dxe_core/src/gcd/spin_locked_gcd.rs
+++ b/dxe_core/src/gcd/spin_locked_gcd.rs
@@ -180,7 +180,7 @@ type GcdFreeFn =
 // track all the pages in the page pool, Vec will attempt to expand leading to a re-entrant access to the global allocator
 // which will deadlock. This sets the pool to an initial size that should be large enough to track all pages for any
 // reasonable allocation in the global allocator to avoid this problem.
-// Increased PAGE_POOL_MIN_CAPACITY from 1024 * 32 to 1024 * 512 to avoid re-entrant access issues caused by 
+// Increased PAGE_POOL_MIN_CAPACITY from 1024 * 32 to 1024 * 512 to avoid re-entrant access issues caused by
 // resizing the vector
 //
 const PAGE_POOL_MIN_CAPACITY: usize = 1024 * 512;


### PR DESCRIPTION
## Description

Increased PAGE_POOL_MIN_CAPACITY from 1024 * 32 to 1024 * 512 to avoid re-entrant access issues caused by resizing the vector

This fix aims to fix the UEFI crash with respect to OS installation via USB Key. Increasing Min Capacity resolved the issue.

- [x] Impacts functionality? - Yes  with out changes, it crashes on OS installation via USB key.
- [ ] Impacts security? - No
- [ ] Breaking change? - No
- [ ] Includes tests? - No
- [ ] Includes documentation? - No

## How This Was Tested

It was tested by USB installation on a physical platform which uses dxe-core. Fix is from Kai Ching. 

## Integration Instructions

N/A