### PR TITLE
rust-tool-cache: bugfix `rustup toolchain install` step

### DIFF
--- a/.github/actions/rust-tool-cache/action.yml
+++ b/.github/actions/rust-tool-cache/action.yml
@@ -33,6 +33,7 @@ runs:
       shell: bash
       run: |
         rustup toolchain install
+      if: steps.tool-cache.outputs.cache-hit != 'true'
       continue-on-error: true
 
     - name: Install cargo-binstall


### PR DESCRIPTION
## Description

if rustup < 1.28.0, the `rustup toolchain install` command will fail, but cargo will automatically install the toolchain in the next step. This is because rustup less than 1.28.0 automatically installs the toolchain if it is not found whereas this functionality was removed in 1.28.0 in favor of being able to call rustup toolchain install without the need to specify the toolchain name.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

https://github.com/OpenDevicePartnership/uefi-dxe-core/actions/runs/13728279564/job/38399737000?pr=282

## Integration Instructions

N/A
