### PR TITLE
.git-blame-ignore-revs: Update commit sha

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,2 +1,2 @@
 # Repo: Apply CRLF -> LF conversion to all rust files
-010aff293da05a865af1614e058915d10cabb107
+2e7cdb2c1572877c5aa8f23fd55131ce4f6385de


### PR DESCRIPTION
## Description

Apparently even on a rebase & ff when both commits are top of tree, the commit sha is changed, so the second commit in the rebase in #268 that added the .git-blame-ignore-revs file was ultimately not the correct commit sha. This commit updates to the correct sha now that the commit has been merged.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

N/A

## Integration Instructions

N/A