### PR TITLE
Ensure that page_pool doesn't grow unnecessarily

### DIFF
--- a/dxe_core/src/gcd/spin_locked_gcd.rs
+++ b/dxe_core/src/gcd/spin_locked_gcd.rs
@@ -327,6 +327,20 @@ impl GCD {
             }
         }
 
+        let paging_allocator = if let Some(pt) = self.page_table.as_mut() {
+            pt.borrow_allocator()
+        } else {
+            return Err(efi::Status::NOT_READY);
+        };
+
+        let current_pages = paging_allocator.page_pool.len();
+
+        if current_pages >= needed_pages {
+            return Ok(());
+        }
+
+        let needed_pages = needed_pages - current_pages;
+
         if needed_pages > 0 {
             match self.allocate_memory_space(
                 DEFAULT_ALLOCATION_STRATEGY,


### PR DESCRIPTION
## Description

Observed that over time the page_pool continues to grow (i.e. not all the pages allocated into the page_pool are always consumed). This patch adds a check to ensure that the page_pool only increases by the amount actually required, accounting for any unused pages that are already in the pool. 

It's anticipated this will be a short-term fix until the self-mapped paging implementation is completed and tested. 

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

No longer observing FsbLock re-entrancy and winloader memory map stability crashes with this modification.

## Integration Instructions

N/A
