### PR TITLE
rust-toolchain.toml: Add additional required components

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,7 +1,7 @@
 [toolchain]
 channel = "1.80.0"
 targets = ["x86_64-unknown-uefi", "aarch64-unknown-uefi"]
-components = ["rust-src"]
+components = ["rust-src", "clippy", "rustfmt", "rust-docs"]
 
 # A custom section for CI pipelines to install tools
 [tools]


### PR DESCRIPTION
## Description

These additional requirements must be specified so that the command `rustup toolchain install` installs all necessary components, just in case the user (or CI runner) does not have them installed.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

#287

## Integration Instructions

N/A
