### PR TITLE
CI: dry run publishing to a registry

### DIFF
--- a/.github/workflows/CiWorkflow.yml
+++ b/.github/workflows/CiWorkflow.yml
@@ -102,7 +102,7 @@ jobs:
           RUSTC_BOOTSTRAP: 1
       
       - name: Crate Release Dry Run
-        run: cargo release --no-tag --workspace --no-push --registry UefiRust
+        run: cargo release --no-tag --workspace --no-push --allow-branch HEAD --registry UefiRust
 
       - name: 🧪 Run Tests 🧪
         run: cargo make coverage


### PR DESCRIPTION
## Description

Changes to a crate's Cargo.toml package
information can result in a crate not being able
to publish to a registry (such as a description
missing). This PR adds a new step to our CI that
attempts to publish the crate to the registry
before the PR is merged. This will ensure the
break will be caught before it is merged in,
instead of during the release process.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

This PRs workflow

## Integration Instructions

N/A
