### PR TITLE
CiWorkflow.yml: Allow any branch for dry run

### DIFF
--- a/.github/workflows/CiWorkflow.yml
+++ b/.github/workflows/CiWorkflow.yml
@@ -102,7 +102,7 @@ jobs:
           RUSTC_BOOTSTRAP: 1
       
       - name: Crate Release Dry Run
-        run: cargo release --no-tag --workspace --no-push --allow-branch * --registry UefiRust
+        run: cargo release --no-tag --workspace --no-push --allow-branch '*' --registry UefiRust
 
       - name: 🧪 Run Tests 🧪
         run: cargo make coverage


### PR DESCRIPTION
## Description

The dry run step fails when CI is executed on a merge into 'main' because the allowed branches do not include 'main'. This PR allows any branch so that merges into main pass the post-merge CI.

<img width="595" alt="image" src="https://github.com/user-attachments/assets/1636ca0f-ed59-478a-8aec-18c70aa72f74" />

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

ran `cargo release --no-tag --workspace --no-push --allow-branch HEAD --registry UefiRust`  on a branch not named `HEAD` and watched it fail. ran `cargo release --no-tag --workspace --no-push --allow-branch '*' --registry UefiRust` on a branch not named `HEAD` and watch it succeed.

## Integration Instructions

N/A