### PR TITLE
CI Workflow: Fix Release Dry run task to build nightly features

### DIFF
--- a/.github/workflows/CiWorkflow.yml
+++ b/.github/workflows/CiWorkflow.yml
@@ -100,9 +100,11 @@ jobs:
         run: cargo clippy --all-targets --all-features -- -D warnings
         env:
           RUSTC_BOOTSTRAP: 1
-      
+
       - name: Crate Release Dry Run
         run: cargo release --no-tag --workspace --no-push --allow-branch '*' --registry UefiRust
+        env:
+          RUSTC_BOOTSTRAP: 1
 
       - name: 🧪 Run Tests 🧪
         run: cargo make coverage


### PR DESCRIPTION
## Description

Crate Release Dry Run task requires `RUSTC_BOOTSTRAP: 1` to be set. If not, the builds will fail.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

NA

## Integration Instructions

NA