### PR TITLE
dxe_core: Make Dev-dependencies set via path

### DIFF
--- a/dxe_core/Cargo.toml
+++ b/dxe_core/Cargo.toml
@@ -47,6 +47,10 @@ uefi_depex = { workspace = true}
 uefi_performance = { workspace = true }
 
 [dev-dependencies]
+# To avoid circular dependencies, cargo-release skips dev dependencies when evaluating the release order for
+# cargo-release, however they are still used when verifying the package is compileable. Any dev-dependency that is
+# local to the workspace should be added via `path` instead of `workspace = true` so that that it does not fail to
+# compile due to the dev-dependency not being published yet.
 sample_components = { path = "../sample_components" }
 section_extractor = { workspace = true }
 uefi_collections = { path = "../crates/uefi_collections" }


### PR DESCRIPTION
## Description

This is a solution specified via https://github.com/crate-ci/cargo-release/issues/829 for broken ordering when attempting to publish multiple crates in the repository.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

N/A

## Integration Instructions

N/A