### PR TITLE
Update Display Impl for GCD

### DIFF
--- a/dxe_core/src/gcd/spin_locked_gcd.rs
+++ b/dxe_core/src/gcd/spin_locked_gcd.rs
@@ -2383,8 +2383,16 @@ impl SpinLockedGcd {
 
 impl Display for SpinLockedGcd {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        writeln!(f, "{:?}", self.memory.try_lock())?;
-        writeln!(f, "{:?}", self.io.try_lock())?;
+        if let Some(gcd) = self.memory.try_lock() {
+            writeln!(f, "{}", gcd)?;
+        } else {
+            writeln!(f, "Locked: {:?}", self.memory.try_lock())?;
+        }
+        if let Some(gcd) = self.io.try_lock() {
+            writeln!(f, "{}", gcd)?;
+        } else {
+            writeln!(f, "Locked: {:?}", self.io.try_lock())?;
+        }
         Ok(())
     }
 }


### PR DESCRIPTION
## Description

Updates display implementation for SpinLockedGcd to actually dump the GCD.

Before:
```
18:00:59.229 : INFO - GCD - After memory init:
18:00:59.245 : Some(GCD { maximum_address: 1099511627776, memory_blocks: Some(Rbt { capacity: 4096, len: 29, height: 11 }) })
18:00:59.245 : Some(IoGCD { maximum_address: 65536, io_blocks: None })
```
After:
```
01:07:15.851 : INFO - GCD - After memory init:
01:07:15.867 : GCDMemType Range                             Capabilities     Attributes       ImageHandle      DeviceHandle
01:07:15.867 : ========== ================================= ================ ================ ================ ================
01:07:15.883 : NonExist   0000000000000000-00000000000fffff 0000000000000000 0000000000000000 0x00000000000000 0x00000000000000
01:07:15.883 : MMIO       0000000000100000-000000004fffffff c700000000027001 0000000000000001 0x00000000000000 0x00000000000000
01:07:15.899 : NonExist   0000000050000000-0000000053ffffff 0000000000000000 0000000000000000 0x00000000000000 0x00000000000000
01:07:15.915 : MMIO       0000000054000000-000000007fffffff c700000000027001 0000000000000001 0x00000000000000 0x00000000000000
```

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

See above log dumps.

## Integration Instructions

N/A
