### PR TITLE
Integrate uefi-sdk v3.0.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ rust-version = "1.83.0"
 
 [workspace.dependencies]
 section_extractor = { version = "10" }
-uefi_sdk = { version = "2" }
+uefi_sdk = { version = "3" }
 uefi_cpu = { version = "10" }
 uefi_debugger = { version = "10" }
 uefi_corosensei = { version = "0.1", default-features = false }

--- a/adv_logger/src/component.rs
+++ b/adv_logger/src/component.rs
@@ -147,7 +147,7 @@ mod tests {
     use core::mem::size_of;
 
     use mu_pi::hob::{header::Hob, GuidHob, GUID_EXTENSION};
-    use uefi_sdk::serial::UartNull;
+    use uefi_sdk::serial::uart::UartNull;
 
     use super::*;
 

--- a/adv_logger/src/lib.rs
+++ b/adv_logger/src/lib.rs
@@ -26,14 +26,14 @@
 //! # use core::ffi::c_void;
 //! use adv_logger::{component::AdvancedLoggerComponent, logger::AdvancedLogger};
 //!
-//! static LOGGER: AdvancedLogger<uefi_sdk::serial::UartNull> = AdvancedLogger::new(
+//! static LOGGER: AdvancedLogger<uefi_sdk::serial::uart::UartNull> = AdvancedLogger::new(
 //!      uefi_sdk::log::Format::Standard,
 //!      &[("goblin", log::LevelFilter::Off), ("uefi_depex_lib", log::LevelFilter::Off)],
 //!      log::LevelFilter::Trace,
-//!      uefi_sdk::serial::UartNull{},
+//!      uefi_sdk::serial::uart::UartNull{},
 //! );
 //!
-//! static ADV_LOGGER: AdvancedLoggerComponent<uefi_sdk::serial::UartNull> = AdvancedLoggerComponent::new(&LOGGER);
+//! static ADV_LOGGER: AdvancedLoggerComponent<uefi_sdk::serial::uart::UartNull> = AdvancedLoggerComponent::new(&LOGGER);
 //!
 //! fn _start(physical_hob_list: *const c_void) {
 //!     log::set_logger(&LOGGER).map(|()| log::set_max_level(log::LevelFilter::Trace)).unwrap();


### PR DESCRIPTION
## Description

Includes changes for the uart path being modified as a breaking change in v3.0.0.

Note: Will pick up changes from the `uefi-core` v10.0.1 release that match the
      UART path changes.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

- `cargo make all`

## Integration Instructions

- N/A