### PR TITLE
Cargo.toml: Update paging to v4

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,7 @@ log = { version = "^0.4", default-features = false }
 mockall = "0.13.0"
 mu_pi = { version = "^5.2" }
 mu_rust_helpers = { version = "2" }
-paging = { version = "2" }
+paging = { version = "4" }
 rand = "^0.8"
 r-efi = { version = "^5.2.0", default-features = false }
 scroll = { version = "^0.12", default-features = false, features = ["derive"] }


### PR DESCRIPTION
## Description

Allows build with dependencies already using v4.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

- `cargo make all`

## Integration Instructions

- Use `paging` v4