### PR TITLE
Rename markdownlint file

### DIFF
--- a/.github/workflows/CiWorkflow.yml
+++ b/.github/workflows/CiWorkflow.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Markdown Linting
         uses: avto-dev/markdown-lint@v1.5.0
         with:
-          config: markdownlint.yml
+          config: .markdownlint.yml
           args: "**/*.md"
 
       - name: 🛠️ Download Rust Tools 🛠️

--- a/.markdownlint.yml
+++ b/.markdownlint.yml
@@ -1,4 +1,4 @@
-# @file markdownlint.yml
+# @file .markdownlint.yml
 #
 # markdownlint configuration file
 #


### PR DESCRIPTION
## Description

Update the file name to match the expected default name by the `DavidAnson.vscode-markdownlint` VS Code plugin so the rules are applied automatically.

> Rules can be enabled, disabled, and customized by creating a
> JSON file named .markdownlint.jsonc/.markdownlint.json or a YAML
> file named .markdownlint.yaml/.markdownlint.yml or a JavaScript
> file named .markdownlint.cjs in any directory of a project.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

- Use markdownlint plugin locally without further configuration.

## Integration Instructions

Rename `markdownlint.yml` to `.markdownlint.yml`.