### PR TITLE
[RFC]: Move CPU Init into Core

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,6 +66,3 @@ opt-level = 3
 
 [profile.test]
 opt-level = 0
-
-[patch.crates-io]
-uefi_cpu = { path = "C:\\src\\uefi-core\\uefi_cpu"}


### PR DESCRIPTION
RFC for moving the CPU initilization code into the core and instead exposing minimal configuration knobs as needed for platforms.

Current RFC State: FCP