### PR TITLE
Add explicit check for image section alignment

### DIFF
--- a/dxe_core/src/image.rs
+++ b/dxe_core/src/image.rs
@@ -589,7 +589,11 @@ fn core_load_pe_image(
 
     // the section alignment must be at least the size of a page
     if alignment % UEFI_PAGE_SIZE != 0 || alignment == 0 {
-        log::error!("core_load_pe_image_failed: section alignment of {:#x?} is not a positive multiple of page size {:#x?}", alignment, UEFI_PAGE_SIZE);
+        log::error!(
+            "core_load_pe_image_failed: section alignment of {:#x?} is not a (non-zero) multiple of page size {:#x?}",
+            alignment,
+            UEFI_PAGE_SIZE
+        );
         debug_assert!(false);
         return Err(EfiError::LoadError);
     }


### PR DESCRIPTION
## Description

This change adds an explicit check to ensure that loaded images have a section alignment that is a multiple of one page. Without this explicit check any attempt to load an image with a section alignment that is not a multiple of one page will panic in `spin_locked_gcd.rs` due to an unaligned call to `SetMemoryAttributes()` with no indication the error stems from bad section alignment. Note that section aligned pages are a Patina requirement, as well as a requirement for the [Microsoft 3rd Party UEFI Certificate Authority memory migration](https://learn.microsoft.com/en-us/windows-hardware/drivers/bringup/uefi-ca-memory-mitigation-requirements).

- [x] Impacts functionality?
This change impacts the functionality of release builds. As of now, attempts to load an image with bad section alignment will result in the image being loaded without memory capabilities and attributes being appropriately set, which could lead to errors down the line. With this change, a load error is explicitly returned.

- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Booted images with page-aligned sections and non-page-aligned sections, ensuring that the check only indicates errors for images with bad section alignment.

## Integration Instructions

N/A