### PR TITLE
Docs: Add Memory Protection and Compatibility Mode Docs

### DIFF
--- a/docs/src/dxe_core/cpu.md
+++ b/docs/src/dxe_core/cpu.md
@@ -2,7 +2,5 @@
 
 ## Paging Implementation
 
-TBD
-
-Note: if renaming this section, please check for links in the documentation to
-[this](cpu.md#paging-implementation) and fix them up as well.
+See the [paging documentation](https://github.com/OpenDevicePartnership/paging/blob/main/docs/paging.md) for paging
+internals and [memory protection documentation](./memory_management.md#memory-protections) for memory protections.


### PR DESCRIPTION
## Description

This patch adds the theory of operation for memory protections and Compatibility Mode.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [x] Includes documentation?

## How This Was Tested

N/A.

## Integration Instructions

N/A.
