### PR TITLE
image.rs: Make .rdata sections read only

### DIFF
--- a/dxe_core/src/image.rs
+++ b/dxe_core/src/image.rs
@@ -41,8 +41,6 @@ pub const EFI_IMAGE_SUBSYSTEM_EFI_RUNTIME_DRIVER: u16 = 12;
 
 pub const ENTRY_POINT_STACK_SIZE: usize = 0x100000;
 
-const INIT_READ_DATA: u32 = section_table::IMAGE_SCN_CNT_INITIALIZED_DATA | section_table::IMAGE_SCN_MEM_READ;
-
 // dummy function used to initialize PrivateImageData.entry_point.
 #[cfg(not(tarpaulin_include))]
 extern "efiapi" fn unimplemented_entry_point(
@@ -367,7 +365,7 @@ fn apply_image_memory_protections(pe_info: &UefiPeInfo, private_info: &PrivateIm
         }
 
         if section.characteristics & section_table::IMAGE_SCN_MEM_WRITE == 0
-            && ((section.characteristics & INIT_READ_DATA) == INIT_READ_DATA)
+            && ((section.characteristics & section_table::IMAGE_SCN_MEM_READ) == section_table::IMAGE_SCN_MEM_READ)
         {
             attributes |= efi::MEMORY_RO;
         }


### PR DESCRIPTION
## Description

If an initialized data section is readable and not writable set the RO attribute on that section.

This is meant to set .rdata sections as RO:

<img width="400" alt="rdata section" src="https://github.com/user-attachments/assets/bb2c7fca-53ab-4a41-b886-d76d21388098" />

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

- QEMU boot to EFI shell and Windows

## Integration Instructions

- N/A