### PR TITLE
dxe_core: Parse guided HOB to `Hob<T>`

### DIFF
--- a/dxe_core/src/lib.rs
+++ b/dxe_core/src/lib.rs
@@ -107,7 +107,7 @@ pub mod test_support;
 
 use core::{ffi::c_void, ptr, str::FromStr};
 
-use alloc::{boxed::Box, collections::BTreeMap, vec::Vec};
+use alloc::{boxed::Box, vec::Vec};
 use gcd::SpinLockedGcd;
 use mu_pi::{
     fw_fs,
@@ -116,7 +116,7 @@ use mu_pi::{
     status_code::{EFI_PROGRESS_CODE, EFI_SOFTWARE_DXE_CORE, EFI_SW_DXE_CORE_PC_HANDOFF_TO_NEXT},
 };
 use protocols::PROTOCOL_DB;
-use r_efi::efi::{self, Guid};
+use r_efi::efi;
 use uefi_sdk::{
     boot_services::StandardBootServices,
     component::{Component, IntoComponent, Storage},


### PR DESCRIPTION
## Description

Parses guided HOBs to `Hob<T>` per [RFC 0001](https://github.com/OpenDevicePartnership/uefi-dxe-core/pull/349).

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Tested usage of `Hob<T>` in a working Component.

## Integration Instructions

N/A, components written to consume `Hob<T>` will now be executed as they will be available.
