### PR TITLE
dxe_core: Print dxe_core version

### DIFF
--- a/dxe_core/src/lib.rs
+++ b/dxe_core/src/lib.rs
@@ -307,6 +307,8 @@ where
         mut self,
         physical_hob_list: *const c_void,
     ) -> Core<CpuInit, SectionExtractor, InterruptManager, InterruptBases, Alloc> {
+        log::info!("DXE Core Crate v{}", env!("CARGO_PKG_VERSION"));
+
         let _ = self.cpu_init.initialize();
         self.interrupt_manager.initialize().expect("Failed to initialize interrupt manager!");
 


### PR DESCRIPTION
## Description

To make it easier to trace and identify the dxe_core library version being used in a debug log, print it out at info level at the beginning of init_memory().

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

- Verified correct `dxe_core` library version is printed in serial log

  ```
  INFO - Advanced logger buffer initialized. Address = 0x000000007ebee000
  INFO - DXE Core Library v10.0.0
  INFO - Loaded GDT @ 0x7eb0ad60
  ```

## Integration Instructions

- N/A