### PR TITLE
dxe_core: Pretty-print guid HOB guids

### DIFF
--- a/dxe_core/src/lib.rs
+++ b/dxe_core/src/lib.rs
@@ -467,13 +467,13 @@ where
                         parser_func(data, &mut self.storage);
                     }
                     None => {
-                        let (f0, f1, f2, f3, f4, &[f5,f6, f7, f8, f9, f10])
-                            = guid.name.as_fields();
-                        let name = alloc::format!(
-                            "{:08x}-{:04x}-{:04x}-{:02x}{:02x}-{:02x}{:02x}{:02x}{:02x}{:02x}{:02x}",
-                            f0, f1, f2, f3, f4, f5, f6, f7, f8, f9, f10
+                        let (f0, f1, f2, f3, f4, &[f5, f6, f7, f8, f9, f10]) = guid.name.as_fields();
+                        let name = alloc::format!("{f0:08x}-{f1:04x}-{f2:04x}-{f3:02x}{f4:02x}-{f5:02x}{f6:02x}{f7:02x}{f8:02x}{f9:02x}{f10:02x}");
+                        log::warn!(
+                            "No parser registered for HOB: GuidHob {{ {:?}, name: Guid {{ {} }} }}",
+                            guid.header,
+                            name
                         );
-                        log::warn!("No parser registered for HOB: GuidHob {{ {:?}, name: Guid {{ {} }} }}", guid.header, name);
                     }
                 }
             }


### PR DESCRIPTION
## Description

prints the guided HOB guid's in the same format specified via the derive macro for implementing a Hob Parser.

Example:

```
WARN - No parser registered for HOB: GuidHob { Hob { type: 4, length: 80, reserved: 0 }, name: Guid { 3def51c5-228f-481d-821b-32ec4df7d9c7 } }
WARN - No parser registered for HOB: GuidHob { Hob { type: 4, length: 280, reserved: 0 }, name: Guid { 8cfdb8c8-d6b2-40f3-8e97-02307cc98b7c } }
WARN - No parser registered for HOB: GuidHob { Hob { type: 4, length: 72, reserved: 0 }, name: Guid { 4c19049f-4137-4dd3-9c10-8b97a83ffdfa } }
WARN - No parser registered for HOB: GuidHob { Hob { type: 4, length: 32, reserved: 0 }, name: Guid { a160bf99-2aa4-4d7d-9993-899cb12df376 } }
WARN - No parser registered for HOB: GuidHob { Hob { type: 4, length: 40, reserved: 0 }, name: Guid { f34014c5-bcec-4f36-ada7-49fff5dd179f } }
WARN - No parser registered for HOB: GuidHob { Hob { type: 4, length: 48, reserved: 0 }, name: Guid { d4ffc718-fb82-4274-9afc-aa8b1eef5293 } }
WARN - No parser registered for HOB: GuidHob { Hob { type: 4, length: 48, reserved: 0 }, name: Guid { d4ffc718-fb82-4274-9afc-aa8b1eef5293 } }
```

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

qemuQ35 run produce the above example output

## Integration Instructions

N/A
