### PR TITLE
Update to uefi_sdk version 6

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,10 +18,10 @@ edition = "2021"
 rust-version = "1.83.0"
 
 [workspace.dependencies]
-section_extractor = { version = "13" }
-uefi_sdk = { version = "5" }
-uefi_cpu = { version = "13" }
-uefi_debugger = { version = "13" }
+section_extractor = { version = "14" }
+uefi_sdk = { version = "6" }
+uefi_cpu = { version = "14" }
+uefi_debugger = { version = "14" }
 uefi_corosensei = { version = "0.1", default-features = false }
 
 adv_logger = { path = "adv_logger", version = "10" }


### PR DESCRIPTION
## Description

Updates uefi_sdk to version 6, which requires uefi_core to be updated to version 14

- [ ] Impacts functionality?
- [ ] Impacts security?
- [x] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

N/A

## Integration Instructions

When updating uefi-dxe-core to v15, consumers must also update uefi_sdk to v6 and uefi_core to v14
