### PR TITLE
SUMMARY.md: Fix some file references

### DIFF
--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -2,7 +2,8 @@
 
 [Introduction](introduction.md)
 [Core Concepts](concepts.md)
-[Code Organization](code_organization.md)
+[Code Organization](dev/code_organization.md)
+[Patina Background](patina.md)
 
 # Rust Development for UEFI
 


### PR DESCRIPTION
## Description

1. Point to the current location of `code_organization.md`
2. Add a `patina.md` link to SUMMARY.md so the page is available in the mdbook.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [x] Includes documentation?

## How This Was Tested

1. `mdbook watch`
2. `mdbook serve --open` -> Inspect the contents

## Integration Instructions

N/A