### PR TITLE
Temporarily disable setting read-only sections

### DIFF
--- a/dxe_core/src/image.rs
+++ b/dxe_core/src/image.rs
@@ -8,7 +8,6 @@
 //!
 use alloc::{boxed::Box, collections::BTreeMap, string::String, vec, vec::Vec};
 use core::{convert::TryInto, ffi::c_void, mem::transmute, slice::from_raw_parts};
-use goblin::pe::section_table;
 use mu_pi::hob::{Hob, HobList};
 use r_efi::efi;
 use uefi_device_path::{copy_device_path_to_boxed_slice, device_path_node_count, DevicePathWalker};
@@ -364,11 +363,12 @@ fn apply_image_memory_protections(pe_info: &UefiPeInfo, private_info: &PrivateIm
             attributes = efi::MEMORY_RO;
         }
 
-        if section.characteristics & section_table::IMAGE_SCN_MEM_WRITE == 0
-            && ((section.characteristics & section_table::IMAGE_SCN_MEM_READ) == section_table::IMAGE_SCN_MEM_READ)
-        {
-            attributes |= efi::MEMORY_RO;
-        }
+        // TODO: Reenable after https://github.com/OpenDevicePartnership/uefi-dxe-core/issues/365 is resolved
+        // if section.characteristics & section_table::IMAGE_SCN_MEM_WRITE == 0
+        //     && ((section.characteristics & section_table::IMAGE_SCN_MEM_READ) == section_table::IMAGE_SCN_MEM_READ)
+        // {
+        //     attributes |= efi::MEMORY_RO;
+        // }
 
         // each section starts at image_base + virtual_address, per PE/COFF spec.
         let section_base_addr = (private_info.image_info.image_base as u64) + (section.virtual_address as u64);


### PR DESCRIPTION
## Description

Commit 30fa804 made sections in a PE/COFF image that are not writable but readable to have the read-only attribute set. While this has successfully booted to Windows on QEMU and no issues have been encountered in UEFI images, it does fail on physical Intel platforms, at least in some cases.

That is being tracked in:
https://github.com/OpenDevicePartnership/uefi-dxe-core/issues/365

To allow physical platforms to release the code is temporarily commented. It is left in the codebase as a reminder that it should be followed up on after the issue is closed.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

- QEMU Windows boot
- Intel physical platform Windows boot

## Integration Instructions

N/A