### PR TITLE
Remove `cpp` and `cpp-legacy` from cspell dictionaries

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -7,6 +7,6 @@ replace-with = "UefiRust"
 [net]
 git-fetch-with-cli = true
 
-# This tells cargo to consider the MSV of rust for our crate vs our depencencies
+# This tells cargo to consider the MSV of rust for our crate vs our dependencies.
 [resolver]
 incompatible-rust-versions = "fallback"

--- a/core/dxe_core/src/gcd/spin_locked_gcd.rs
+++ b/core/dxe_core/src/gcd/spin_locked_gcd.rs
@@ -2472,7 +2472,7 @@ impl SpinLockedGcd {
                         _ => descriptor.length as usize,
                     };
 
-                    // set_memory_space_attributes will set both the GCD and paging atrributes
+                    // set_memory_space_attributes will set both the GCD and paging attributes
                     match self.set_memory_space_attributes(
                         address,
                         size,

--- a/cspell.yml
+++ b/cspell.yml
@@ -10,8 +10,6 @@ version: "0.2"
 language: en
 dictionaries:
   - "companies"
-  - "cpp"
-  - "cpp-legacy"
   - "java"
   - "makefile"
   - "python"
@@ -31,17 +29,21 @@ caseSensitive: false
 allowCompoundWords: true
 words:
   - aarch
-  - BASECORE
+  - acpibase
+  - addrs
+  - armasm
+  - basecore
   - bitfield
   - bitor
   - bitvec
-  - BNDLDX
-  - BNDSTX
+  - bndldx
+  - bndstx
   - brotli
+  - cdecl
   - cdrom
   - cforce
   - civac
-  - CLFLUSH
+  - clflush
   - clfsh
   - cntfrq
   - cntpct
@@ -57,6 +59,8 @@ words:
   - depex
   - dereferenceable
   - descs
+  - distros
+  - dllcharacteristics
   - dnested
   - docsrs
   - dxecore
@@ -65,11 +69,18 @@ words:
   - edkii
   - efiapi
   - eficall
+  - efierror
+  - eflags
+  - entrancy
   - fnent
   - fvmain
-  - FXRSTOR
-  - FXSAVE
-  - GIGANTOR
+  - fxrstor
+  - fxsave
+  - gdbstub
+  - getsp
+  - gigantor
+  - gread
+  - gwrite
   - guids
   - hlength
   - hresult
@@ -83,95 +94,106 @@ words:
   - keccak
   - keyid
   - linkme
+  - longjmp
   - lshift
   - mawau
-  - MAWAU
   - maxnp
   - mdbook
   - mdscr
   - mfence
-  - MKTME
+  - mktme
   - mmram
-  - MMTRR
+  - mmtrr
   - morerelia
   - mpidr
   - msdia
   - mtrr
-  - Mtrr
-  - MTRR
-  - MTRRCAP
+  - mtrr
+  - mtrrcap
   - mtrrlib
   - mtrrs
-  - Mtrrs
-  - MTRRs
   - mult
   - nanos
   - nestedfv
   - nologo
+  - nomem
   - nshst
   - ntdll
   - oleaut
   - opinfo
-  - Oppermann
+  - oppermann
   - oprom
   - oslar
   - oslsr
   - ospke
   - pacibsp
-  - PCIEXBAR
+  - pccard
+  - pciexbar
   - pdata
-  - Physbase
-  - PHYSBASE
-  - Physmask
-  - PHYSMASK
+  - philipp
+  - pemfile
+  - physbase
+  - physmask
   - pointee
+  - pread
   - prefetchwt
-  - PREFETCHWT
   - psapi
   - ptable
   - pterror
+  - pwrite
   - pytool
   - qwords
   - rdmsr
-  - RDPKRU
+  - rdpkru
   - rdtsc
   - rebox
+  - reentrancy
+  - regsvr
+  - reloc
   - repr
   - retval
   - rshift
   - rustc
   - rustfmt
+  - rustls
+  - rwlock
   - sbsa
   - sctlr
   - smbus
   - smcport
-  - SMRAM
+  - smiport
+  - smram
   - stosq
   - structs
-  - SWMMIs
-  - TESTCODE
+  - swmmis
+  - testcode
   - tiano
+  - tianocore
   - tttracer
   - typer
   - uefi
   - uefi's
-  - Unaccepte
+  - uintn
+  - unaccepte
   - uncacheable
-  - Uncacheable
   - uncontained
   - unrecovered
+  - unregisters
+  - unspec
   - upvote
   - vcvarsamd
   - vcvarsarm
   - vmalle
   - vpopcntdq
-  - VPOPCNTDQ
+  - vpopcntdq
   - wakeup
   - wbinvd
+  - webpki
+  - windbg
   - windbgx
   - withf
-  - WRMSR
-  - WRPKRU
+  - wrmsr
+  - wrpkru
   - x'xxxzzzzz
   - x'xxzzzzzz
   - xdata

--- a/docs/src/dxe_core/dispatcher.md
+++ b/docs/src/dxe_core/dispatcher.md
@@ -3,7 +3,7 @@
 This portion of the core deals with discovering and executing drivers found in firmware volumes as ordered by their
 dependencies. The Rust DXE Core dispatcher generally aligns with the requirements laid out in the UEFI Platform
 Initialization Spec for the [DXE Dispatcher](https://uefi.org/specs/PI/1.8A/V2_DXE_Dispatcher.html), with the exception
-of APRIORI file support.
+of a priori file support.
 
 ## Dispatcher Initialization
 
@@ -171,8 +171,8 @@ the DEPEX operators and capabilities specified in the UEFI Platform Initializati
 
 ## A Priori File
 
-```admonish warning title="No APRIORI Support"
-The Rust DXE Core does not presently provide support for APRIORI file control of dispatch order for drivers.
+```admonish warning title="No A Priori Support"
+The Rust DXE Core does not presently provide support for a priori file control of dispatch order for drivers.
 ```
 
 The *a priori* file was introduced in the Platform Initialization (PI) Specification to provide additional flexibility

--- a/docs/src/patina.md
+++ b/docs/src/patina.md
@@ -167,7 +167,7 @@ Right now, those include:
 
 In the above high-level diagram, the Rust DXE Core takes system data input in the form of HOBs in the same way as the
 C DXE Core. The green box indicates that the core is written in Rust, while purple indicates that DXE drivers may be
-written either in C or Rust. Organge indicates code that is still written in C. For example, the UEFI Boot Services
+written either in C or Rust. Orange indicates code that is still written in C. For example, the UEFI Boot Services
 table and services themselves are largely written in pure Rust. The UEFI Runtime Services table itself has a Rust
 definition but many of the services are still implemented in C so it is orange.
 

--- a/docs/src/rfc/text/0001-guided-hob-to-hob-param.md
+++ b/docs/src/rfc/text/0001-guided-hob-to-hob-param.md
@@ -127,7 +127,7 @@ impl<'h, H: FromHob + 'static> Iterator for HobIter<'h, H> {
 struct Storage {
     hob_parsers: BTreeMap<Guid, fn(&[u8], &mut Storage)>,
     hobs: SparseVec<Vec<Box<dyn Any>>>,
-    hob_indicies: BTreeMap<TypeId, usize>,
+    hob_indices: BTreeMap<TypeId, usize>,
 }
 
 impl Storage {

--- a/docs/src/rfc/text/0006-patina-repo.md
+++ b/docs/src/rfc/text/0006-patina-repo.md
@@ -147,7 +147,7 @@ There are a lot of strategies for assigning crates to repositories.
 
 In particular, the repo defines focus for its content and purpose - the revision history, versioning, documentation,
 crate-specific workflows, maintainers, policies, etc. This RFC proposes that Patina encompass more of the content into
-a single location improving developer ergonomics and simplifying logistics of managing code withiin the project.
+a single location improving developer ergonomics and simplifying logistics of managing code within the project.
 
 ## Alternatives
 

--- a/sdk/uefi_sdk/src/component/hob.rs
+++ b/sdk/uefi_sdk/src/component/hob.rs
@@ -34,7 +34,7 @@
 //!
 //! impl FromHob for MyComplexHobStruct {
 //!     const HOB_GUID: r_efi::efi::Guid = r_efi::efi::Guid::from_fields(0, 0, 0, 0, 0, &[0; 6]);
-//!     
+//!
 //!    fn parse(bytes: &[u8]) -> Self {
 //!        Self::default() // Simple for example
 //!    }
@@ -124,7 +124,7 @@ pub use uefi_sdk_macro::FromHob;
 /// An immutable Hob value registered with [Storage] via the [FromHob] trait.
 ///
 /// The underlying datum of this type is a slice. The first element of the slice can be directly accessed by
-/// derefencing the struct. The entire slice can be iterated over using the [Hob::iter] method or the [IntoIterator]
+/// dereferencing the struct. The entire slice can be iterated over using the [Hob::iter] method or the [IntoIterator]
 /// trait.
 ///
 /// ## Example

--- a/sdk/uefi_sdk/src/component/service/memory.rs
+++ b/sdk/uefi_sdk/src/component/service/memory.rs
@@ -255,7 +255,7 @@ pub trait MemoryManager {
 }
 
 /// The `AllocationOptions` structure allows for the caller to  specify
-/// additional contraints on the allocation. This can be used to specify the type
+/// additional constraints on the allocation. This can be used to specify the type
 /// of memory to allocate, alignment requirements, and allocation strategy. Users
 /// should always start with `AllocationOptions::new()` and then call the `.with_`
 /// functions to set the options they wish to use. see [`AllocationOptions::new()`]

--- a/sdk/uefi_sdk/src/component/storage.rs
+++ b/sdk/uefi_sdk/src/component/storage.rs
@@ -206,7 +206,7 @@ pub struct Storage {
     /// A container for all [Hob](super::hob::Hob) datums.
     hobs: SparseVec<Vec<Box<dyn Any>>>,
     /// a map to convert from TypeId to a hob index.
-    hob_indicies: BTreeMap<TypeId, usize>,
+    hob_indices: BTreeMap<TypeId, usize>,
     // Standard Boot Services.
     boot_services: StandardBootServices,
     // Standard Runtime Services.
@@ -229,7 +229,7 @@ impl Storage {
             service_indices: BTreeMap::new(),
             hob_parsers: BTreeMap::new(),
             hobs: SparseVec::new(),
-            hob_indicies: BTreeMap::new(),
+            hob_indices: BTreeMap::new(),
             boot_services: StandardBootServices::new_uninit(),
             runtime_services: StandardRuntimeServices::new_uninit(),
         }
@@ -377,8 +377,8 @@ impl Storage {
 
     /// Gets the global id of a service, registering it if it does not exist.
     pub(crate) fn get_or_register_hob(&mut self, id: TypeId) -> usize {
-        let idx = self.hob_indicies.len();
-        let idx = self.hob_indicies.entry(id).or_insert(idx);
+        let idx = self.hob_indices.len();
+        let idx = self.hob_indices.entry(id).or_insert(idx);
         if self.hobs.get(*idx).is_none() {
             self.hobs.insert(*idx, Vec::new());
         }
@@ -400,7 +400,7 @@ impl Storage {
 
     /// Attempts to retrieve a HOB datum from the storage.
     pub fn get_hob<T: FromHob>(&self) -> Option<Hob<T>> {
-        let id = self.hob_indicies.get(&TypeId::of::<T>())?;
+        let id = self.hob_indices.get(&TypeId::of::<T>())?;
         self.hobs.get(*id).and_then(|hob| {
             if hob.is_empty() {
                 return None;


### PR DESCRIPTION
## Description

Add word exceptions needed. Fix some spelling errors hidden behind the dictionaries.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

- `cargo make cspell`

## Integration Instructions

- N/A