### PR TITLE
Update Patina repo documentation (first pass for mono repo)

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -7,5 +7,5 @@
 blank_issues_enabled: false
 contact_links:
   - name: 📃 Documentation
-    url: https://OpenDevicePartnership.github.io/uefi-dxe-core/
+    url: https://OpenDevicePartnership.github.io/patina/
     about: Goals, principles, repo layout, build instructions, and more.

--- a/.github/workflows/CiWorkflow.yml
+++ b/.github/workflows/CiWorkflow.yml
@@ -46,7 +46,7 @@ jobs:
           args: "**/*.md"
 
       - name: 🛠️ Download Rust Tools 🛠️
-        uses: OpenDevicePartnership/uefi-dxe-core/.github/actions/rust-tool-cache@main
+        uses: OpenDevicePartnership/patina/.github/actions/rust-tool-cache@main
 
       - name: 📖 Build Book 📖
         run: mdbook build ${{ inputs.mdbook-path }}
@@ -68,7 +68,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: 🛠️ Download Rust Tools 🛠️
-        uses: OpenDevicePartnership/uefi-dxe-core/.github/actions/rust-tool-cache@main
+        uses: OpenDevicePartnership/patina/.github/actions/rust-tool-cache@main
 
       - name: Setup Cred Provider
         if: runner.os == 'Linux'

--- a/.github/workflows/ReleaseWorkflow.yml
+++ b/.github/workflows/ReleaseWorkflow.yml
@@ -30,7 +30,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: 🛠️ Download Rust Tools 🛠️
-        uses: OpenDevicePartnership/uefi-dxe-core/.github/actions/rust-tool-cache@main
+        uses: OpenDevicePartnership/patina/.github/actions/rust-tool-cache@main
 
       - name: Get Release Tag
         id: release_tag

--- a/.github/workflows/publish-mdbook.yml
+++ b/.github/workflows/publish-mdbook.yml
@@ -32,7 +32,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: 🛠️ Download Rust Tools 🛠️
-        uses: OpenDevicePartnership/uefi-dxe-core/.github/actions/rust-tool-cache@main
+        uses: OpenDevicePartnership/patina/.github/actions/rust-tool-cache@main
 
       - name: 📄 Build Documentation 📄
         run: mdbook build docs

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -60,7 +60,7 @@ representative at an online or offline event.
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
 reported to the community leaders responsible for enforcement at
-odpadmin@microsoft.com.
+<odpadmin@microsoft.com>.
 All complaints will be reviewed and investigated promptly and fairly.
 
 All community leaders are obligated to respect the privacy and security of the

--- a/README.md
+++ b/README.md
@@ -1,46 +1,47 @@
 
-# Rust DXE Core
+# Patina
 
-This repository contains a Pure Rust DXE Core.
+This repository hosts the Patina project - a Rust implementation of UEFI firmware.
+
+The goal of this project is to serve as a replacement for core UEFI firmware components so they are written in Pure
+Rust as opposed to Rust wrappers around core implementation still written in C.
 
 ## Background
 
 There have been various [instances of advocacy](https://msrc-blog.microsoft.com/2019/11/07/using-rust-in-windows/) for
 building system level software in [Rust](https://www.rust-lang.org/).
 
-This repository contains a Rust DXE Core [UEFI](https://uefi.org/) firmware implementation. We plan to enable an
+This repository contains a Rust [UEFI](https://uefi.org/) firmware implementation called Patina. We plan to enable an
 incremental migration of today's firmware components largely written in C to Rust starting with the core. The primary
 objective for this effort is to improve the security and stability of system firmware by leveraging the memory safety
 offered by Rust while retaining similar boot performance.
 
 ## Important Notes
 
-This repository is still considered to be in a "beta" stage and not recommended for production platforms at this time.
-
-Platform testing and integration feedback is very welcome.
+This repository is still considered to be in a "beta" stage at this time. Platform testing and integration feedback
+is very welcome.
 
 Before making pull requests at a minimum, run:
 
-- `cargo clippy -- -D warnings`
-- `cargo fmt --all`
+- `cargo make all`
 
 ## Performing a Release
 
-Below is the information required to perform a release that publishes to the internal UefiRust feed:
+Below is the information required to perform a release to the external registry.
 
-1. Review the current draft release on the github repo: [Releases](https://github.com/OpenDevicePartnership/uefi-dxe-core/releases)
+1. Review the current draft release on the github repo: [Releases](https://github.com/OpenDevicePartnership/patina/releases)
    a. If something is incorrect, update it in the draft release
    b. If you need to manually change the version, make sure you update the associated git tag value in the draft release
 2. Publish the release
 3. Monitor the publish release workflow that is automatically triggered on the release being published:
-   [Publish Release Workflow](https://github.com/OpenDevicePartnership/uefi-dxe-core/actions/workflows/publish-release.yml)
+   [Publish Release Workflow](https://github.com/OpenDevicePartnership/patina/actions/workflows/publish-release.yml)
 4. Once completed successfully, click on the  "Notify Branch Creation Step" and click the provided link to create the
    PR to update all versions in all Cargo.toml files across the repository.
 
 ## Documentation
 
 We have "Getting Started" documentation located in this repository at `docs/*`. The latest documentation can be found
-at <https://OpenDevicePartnership.github.io/uefi-dxe-core/>, however this documentation can also be self-hosted via
+at <https://OpenDevicePartnership.github.io/patina/>, however this documentation can also be self-hosted via
 ([mdbook](https://github.com/rust-lang/mdBook)). Once you all dependencies installed as specified below, you can run
 `mdbook serve docs` to self host the getting started book.
 
@@ -67,30 +68,11 @@ automatically installed with `rustup toolchain install`, the tools in the `[tool
 are not. At a minimum, you should download `cargo-make` and `cargo-tarpaulin`, however it is suggested that you
 download all tools in the `[tools]` section of the `rust-toolchain.toml`.
 
-### DXE Core Goals
-
-1. Construction of a bare-metal "kernel (DXE core)" to dispatch from `DxeIpl`.
-   1. Log output over a basic subsystem such as serial I/O.
-   2. Integrable into a UEFI build as a replacement for `DxeMain` with observable debug output.
-   3. Greater than 80% unit test coverage across all code compiled into the DXE Core.
-   4. A "monolithic" DXE environment that encapsulates functionality distributed across separate EFI modules today.
-      This is accomplished with an internal dispatcher to the binary that executes individual components linked during
-      platform integration and given to the common Rust DXE Core interface when the platform builds its version of
-      Rust DXE Core.
-   5. In addition to internal Rust component dispatch, UEFI driver dispatch - FVs and FFS files in the firmware ROM.
-   6. No direct dependencies on PEI except PI abstracted structures.
-
-2. Support for CPU interrupts/exception handlers.
-
-3. Support for paging and heap allocation.
-
-4. UEFI memory protections that implement best known practices and drive memory protections in UEFI firmware forward.
-
 ## Build
 
 **The order of arguments is important in these commands.**
 
-### Building uefi-dxe-core Crates
+### Building Crates
 
 The following commands build all crates with one of our three supported targets: `x86_64-unknown-uefi`,
 `aarch64-unknown-uefi`, and your host system target triple. The default compilation mode is `development`, but you can
@@ -102,23 +84,6 @@ easily switch modes with the `-p` flag.
 - Release Compilation (aarch64-unknown-uefi): `cargo make -p release build-aarch64`
 - Release Compilation (x86_64-unknown-uefi): `cargo make -p release build-x64`
 - Release Compilation (host system): `cargo make -p release build`
-
-### Building a Host Executable DXE Core
-
-DXE Core can also run directly on the host using the standard library in place of some firmware services in a pure
-firmware environment.
-
-- Host (Standard Library) DXE Core Build: `cargo make build-bin`
-
-#### Running the Host Executable
-
-While the executable can be run directly out of the `/target/<debug/release>` directory, it can easily be run with the
-following command:
-
-- `cargo make run-bin`
-
-> Note: This will currently launch the DXE Core, but some additional changes are needed for it to fully operate in
-> `std` mode.
 
 ## Test
 

--- a/core/dxe_core/README.md
+++ b/core/dxe_core/README.md
@@ -1,73 +1,9 @@
 
 # Rust DXE Core
 
-This repository contains a Pure Rust DXE Core.
+This crate contains a Pure Rust DXE Core.
 
-## Background
-
-There have been various [instances of advocacy](https://msrc-blog.microsoft.com/2019/11/07/using-rust-in-windows/) for
-building system level software in [Rust](https://www.rust-lang.org/).
-
-This repository contains a Rust DXE Core [UEFI](https://uefi.org/) firmware implementation. We plan to enable an
-incremental migration of today's firmware components largely written in C to Rust starting with the core. The primary
-objective for this effort is to improve the security and stability of system firmware by leveraging the memory safety
-offered by Rust while retaining similar boot performance.
-
-## Important Notes
-
-This repository is still considered to be in a "beta" stage and not recommended for production platforms at this time.
-
-Platform testing and integration feedback is very welcome.
-
-Before making pull requests at a minimum, run:
-
-- `cargo clippy -- -D warnings`
-- `cargo fmt --all`
-
-## Performing a Release
-
-Below is the information required to perform a release that publishes to the internal UefiRust feed:
-
-1. Review the current draft release on the github repo: [Releases](https://github.com/OpenDevicePartnership/uefi-dxe-core/releases)
-   a. If something is incorrect, update it in the draft release
-   b. If you need to manually change the version, make sure you update the associated git tag value in the draft release
-2. Publish the release
-3. Monitor the publish release workflow that is automatically triggered on the release being published:
-   [Publish Release Workflow](https://github.com/OpenDevicePartnership/uefi-dxe-core/actions/workflows/publish-release.yml)
-4. Once completed successfully, click on the  "Notify Branch Creation Step" and click the provided link to create the
-   PR to update all versions in all Cargo.toml files across the repository.
-
-## Documentation
-
-We have "Getting Started" documentation located in this repository at `docs/*`. The latest documentation can be found
-at <https://OpenDevicePartnership.github.io/uefi-dxe-core/>, however this documentation can also be self-hosted via
-([mdbook](https://github.com/rust-lang/mdBook)). Once you all dependencies installed as specified below, you can run
-`mdbook serve docs` to self host the getting started book.
-
-You can also generate API documentation for the project using `cargo make doc`. This will eventually be hosted on
-docs.rs once we begin uploading to crates.io.
-
-## First-Time Tool Setup Instructions
-
-The following instructions install Rust.
-
-1. Download and install rust/cargo from [Getting Started - Rust Programming Language (rust-lang.org)](https://www.rust-lang.org/learn/get-started).
-   > `rustup-init` installs the toolchain and utilities.
-
-2. Make sure it's working - restart a shell after install and make sure the tools are in your path:
-
-   \>`cargo --version`
-
-3. Install toolchain specified in `rust-toolchain.toml`
-
-   \>`rustup toolchain install`
-
-4. While the specific toolchains and components specified in `[toolchain]` section of the `rust-toolchain.toml` are
-automatically installed with `rustup toolchain install`, the tools in the `[tools]` section, such as `cargo-make`
-are not. At a minimum, you should download `cargo-make` and `cargo-tarpaulin`, however it is suggested that you
-download all tools in the `[tools]` section of the `rust-toolchain.toml`.
-
-### DXE Core Goals
+## DXE Core Goals
 
 1. Construction of a bare-metal "kernel (DXE core)" to dispatch from `DxeIpl`.
    1. Log output over a basic subsystem such as serial I/O.
@@ -86,64 +22,7 @@ download all tools in the `[tools]` section of the `rust-toolchain.toml`.
 
 4. UEFI memory protections that implement best known practices and drive memory protections in UEFI firmware forward.
 
-## Build
-
-**The order of arguments is important in these commands.**
-
-### Building uefi-dxe-core Crates
-
-The following commands build all crates with one of our three supported targets: `x86_64-unknown-uefi`,
-`aarch64-unknown-uefi`, and your host system target triple. The default compilation mode is `development`, but you can
-easily switch modes with the `-p` flag.
-
-- Development Compilation (aarch64-unknown-uefi): `cargo make build-aarch64`
-- Development Compilation (x86_64-unknown-uefi): `cargo make build-x64`
-- Development Compilation (host system): `cargo make build`
-- Release Compilation (aarch64-unknown-uefi): `cargo make -p release build-aarch64`
-- Release Compilation (x86_64-unknown-uefi): `cargo make -p release build-x64`
-- Release Compilation (host system): `cargo make -p release build`
-
-### Building a Host Executable DXE Core
-
-DXE Core can also run directly on the host using the standard library in place of some firmware services in a pure
-firmware environment.
-
-- Host (Standard Library) DXE Core Build: `cargo make build-bin`
-
-#### Running the Host Executable
-
-While the executable can be run directly out of the `/target/<debug/release>` directory, it can easily be run with the
-following command:
-
-- `cargo make run-bin`
-
-> Note: This will currently launch the DXE Core, but some additional changes are needed for it to fully operate in
-> `std` mode.
-
-## Test
-
-- `cargo make test`
-
-## Coverage
-
-A developer can easily generate coverage data with the below commands. A developer can specify a single package
-to generate coverage for by adding the package name after the command.
-
-- `cargo make coverage`
-- `cargo make coverage dxe_core`
-
-Another set of commands are available that can  generate coverage data, but is generally only used for CI.
-This command runs coverage on each package individually, filtering out any results outside of the package,
-and will fail if the code coverage percentage is less than 75%.
-
-- `cargo make coverage-fail`
-- `cargo make coverage-fail dxe_core`
-
-## Notes
-
-1. This project uses `RUSTC_BOOSTRAP=1` environment variable due to internal requirements
-   1. This puts us in parity with the nightly features that exist on the toolchain targeted
-   2. The `nightly` toolchain may be used in place of this
+For more information, refer to [Setting up the DXE Core](https://sturdy-adventure-nv32gqw.pages.github.io/integrate/dxe_core.html).
 
 ## Contributing
 

--- a/core/dxe_core/src/lib.rs
+++ b/core/dxe_core/src/lib.rs
@@ -1,7 +1,7 @@
 //! DXE Core
 //!
 //! A pure rust implementation of the UEFI DXE Core. Please review the getting started documentation at
-//! <https://OpenDevicePartnership.github.io/uefi-dxe-core/> for more information.
+//! <https://OpenDevicePartnership.github.io/patina/> for more information.
 //!
 //! ## Examples
 //!

--- a/core/stacktrace/README.md
+++ b/core/stacktrace/README.md
@@ -28,12 +28,12 @@ PS C:\> .\resolve_stacktrace.ps1 -StackTrace "
 
 Output:
   # Source Path                                                           Child-SP         Return Address   Call Site
-  0 [C:\r\uefi-core\stacktrace\src\x64\tests\collateral\x64.c     @   63] 00000057261FFAE0 00007FFC9AC910E5 x64!func1+25
-  1 [C:\r\uefi-core\stacktrace\src\x64\tests\collateral\x64.c     @   72] 00000057261FFB10 00007FFC9AC9115E x64!func2+15
-  2 [C:\r\uefi-core\stacktrace\src\x64\tests\collateral\x64.c     @   84] 00000057261FFB50 00007FFC9AC911E8 x64!func3+1E
-  3 [C:\r\uefi-core\stacktrace\src\x64\tests\collateral\x64.c     @   96] 00000057261FFB90 00007FFC9AC9125F x64!func4+28
-  4 [C:\r\uefi-core\stacktrace\src\x64\tests\collateral\x64.c     @  109] 00000057261FFBD0 00007FF6D3557236 x64!StartCallStack+1F
-  5 [C:\r\uefi-core\stacktrace\src\x64\tests\unwind_test_full.rs  @   98] 00000057261FFC10 00007FFCC4BDE8D7 stacktrace-cf486b9b613e51dc!static unsigned int stacktrace::x64::tests::unwind_test_full::call_stack_thread(union enum2$<winapi::ctypes::c_void> *)+56
+  0 [C:\r\patina\core\stacktrace\src\x64\tests\collateral\x64.c     @   63] 00000057261FFAE0 00007FFC9AC910E5 x64!func1+25
+  1 [C:\r\patina\core\stacktrace\src\x64\tests\collateral\x64.c     @   72] 00000057261FFB10 00007FFC9AC9115E x64!func2+15
+  2 [C:\r\patina\core\stacktrace\src\x64\tests\collateral\x64.c     @   84] 00000057261FFB50 00007FFC9AC911E8 x64!func3+1E
+  3 [C:\r\patina\core\stacktrace\src\x64\tests\collateral\x64.c     @   96] 00000057261FFB90 00007FFC9AC9125F x64!func4+28
+  4 [C:\r\patina\core\stacktrace\src\x64\tests\collateral\x64.c     @  109] 00000057261FFBD0 00007FF6D3557236 x64!StartCallStack+1F
+  5 [C:\r\patina\core\stacktrace\src\x64\tests\unwind_test_full.rs  @   98] 00000057261FFC10 00007FFCC4BDE8D7 stacktrace-cf486b9b613e51dc!static unsigned int stacktrace::x64::tests::unwind_test_full::call_stack_thread(union enum2$<winapi::ctypes::c_void> *)+56
   6 [Failed to load PDB file (HRESULT: 0x806D0005)                      ] 00000057261FFC70 00007FFCC6B7FBCC kernel32+2E8D7
   7 [Failed to load PDB file (HRESULT: 0x806D0005)                      ] 00000057261FFCA0 0000000000000000 ntdll+34521
 ```

--- a/core/stacktrace/resolve_stacktrace/resolve_stacktrace.ps1
+++ b/core/stacktrace/resolve_stacktrace/resolve_stacktrace.ps1
@@ -29,12 +29,12 @@
 #
 # Output:
 # # Source Path                                                           Child-SP         Return Address   Call Site
-# 0 [C:\r\uefi-core\stacktrace\src\x64\tests\collateral\x64.c     @   63] 00000057261FFAE0 00007FFC9AC910E5 x64!func1+25
-# 1 [C:\r\uefi-core\stacktrace\src\x64\tests\collateral\x64.c     @   72] 00000057261FFB10 00007FFC9AC9115E x64!func2+15
-# 2 [C:\r\uefi-core\stacktrace\src\x64\tests\collateral\x64.c     @   84] 00000057261FFB50 00007FFC9AC911E8 x64!func3+1E
-# 3 [C:\r\uefi-core\stacktrace\src\x64\tests\collateral\x64.c     @   96] 00000057261FFB90 00007FFC9AC9125F x64!func4+28
-# 4 [C:\r\uefi-core\stacktrace\src\x64\tests\collateral\x64.c     @  109] 00000057261FFBD0 00007FF6D3557236 x64!StartCallStack+1F
-# 5 [C:\r\uefi-core\stacktrace\src\x64\tests\unwind_test_full.rs  @   98] 00000057261FFC10 00007FFCC4BDE8D7 stacktrace-cf486b9b613e51dc!static unsigned int stacktrace::x64::tests::unwind_test_full::call_stack_thread(union enum2$<winapi::ctypes::c_void> *)+56
+# 0 [C:\r\patina\core\stacktrace\src\x64\tests\collateral\x64.c     @   63] 00000057261FFAE0 00007FFC9AC910E5 x64!func1+25
+# 1 [C:\r\patina\core\stacktrace\src\x64\tests\collateral\x64.c     @   72] 00000057261FFB10 00007FFC9AC9115E x64!func2+15
+# 2 [C:\r\patina\core\stacktrace\src\x64\tests\collateral\x64.c     @   84] 00000057261FFB50 00007FFC9AC911E8 x64!func3+1E
+# 3 [C:\r\patina\core\stacktrace\src\x64\tests\collateral\x64.c     @   96] 00000057261FFB90 00007FFC9AC9125F x64!func4+28
+# 4 [C:\r\patina\core\stacktrace\src\x64\tests\collateral\x64.c     @  109] 00000057261FFBD0 00007FF6D3557236 x64!StartCallStack+1F
+# 5 [C:\r\patina\core\stacktrace\src\x64\tests\unwind_test_full.rs  @   98] 00000057261FFC10 00007FFCC4BDE8D7 stacktrace-cf486b9b613e51dc!static unsigned int stacktrace::x64::tests::unwind_test_full::call_stack_thread(union enum2$<winapi::ctypes::c_void> *)+56
 # 6 [Failed to load PDB file (HRESULT: 0x806D0005)                      ] 00000057261FFC70 00007FFCC6B7FBCC kernel32+2E8D7
 # 7 [Failed to load PDB file (HRESULT: 0x806D0005)                      ] 00000057261FFCA0 0000000000000000 ntdll+34521
 #

--- a/core/stacktrace/src/lib.rs
+++ b/core/stacktrace/src/lib.rs
@@ -28,12 +28,12 @@
 //!
 //! Output:
 //! # Source Path                                                           Child-SP         Return Address   Call Site
-//! 0 [C:\r\uefi-core\stacktrace\src\x64\tests\collateral\x64.c     @   63] 00000057261FFAE0 00007FFC9AC910E5 x64!func1+25
-//! 1 [C:\r\uefi-core\stacktrace\src\x64\tests\collateral\x64.c     @   72] 00000057261FFB10 00007FFC9AC9115E x64!func2+15
-//! 2 [C:\r\uefi-core\stacktrace\src\x64\tests\collateral\x64.c     @   84] 00000057261FFB50 00007FFC9AC911E8 x64!func3+1E
-//! 3 [C:\r\uefi-core\stacktrace\src\x64\tests\collateral\x64.c     @   96] 00000057261FFB90 00007FFC9AC9125F x64!func4+28
-//! 4 [C:\r\uefi-core\stacktrace\src\x64\tests\collateral\x64.c     @  109] 00000057261FFBD0 00007FF6D3557236 x64!StartCallStack+1F
-//! 5 [C:\r\uefi-core\stacktrace\src\x64\tests\unwind_test_full.rs  @   98] 00000057261FFC10 00007FFCC4BDE8D7 stacktrace-cf486b9b613e51dc!static unsigned int stacktrace::x64::tests::unwind_test_full::call_stack_thread(union enum2$<winapi::ctypes::c_void> *)+56
+//! 0 [C:\r\patina\core\stacktrace\src\x64\tests\collateral\x64.c     @   63] 00000057261FFAE0 00007FFC9AC910E5 x64!func1+25
+//! 1 [C:\r\patina\core\stacktrace\src\x64\tests\collateral\x64.c     @   72] 00000057261FFB10 00007FFC9AC9115E x64!func2+15
+//! 2 [C:\r\patina\core\stacktrace\src\x64\tests\collateral\x64.c     @   84] 00000057261FFB50 00007FFC9AC911E8 x64!func3+1E
+//! 3 [C:\r\patina\core\stacktrace\src\x64\tests\collateral\x64.c     @   96] 00000057261FFB90 00007FFC9AC9125F x64!func4+28
+//! 4 [C:\r\patina\core\stacktrace\src\x64\tests\collateral\x64.c     @  109] 00000057261FFBD0 00007FF6D3557236 x64!StartCallStack+1F
+//! 5 [C:\r\patina\core\stacktrace\src\x64\tests\unwind_test_full.rs  @   98] 00000057261FFC10 00007FFCC4BDE8D7 stacktrace-cf486b9b613e51dc!static unsigned int stacktrace::x64::tests::unwind_test_full::call_stack_thread(union enum2$<winapi::ctypes::c_void> *)+56
 //! 6 [Failed to load PDB file (HRESULT: 0x806D0005)                      ] 00000057261FFC70 00007FFCC6B7FBCC kernel32+2E8D7
 //! 7 [Failed to load PDB file (HRESULT: 0x806D0005)                      ] 00000057261FFCA0 0000000000000000 ntdll+34521
 //! ```

--- a/core/uefi_performance/src/lib.rs
+++ b/core/uefi_performance/src/lib.rs
@@ -312,7 +312,7 @@ extern "efiapi" fn create_performance_measurement(
                 let record = GuidQwordStringEventRecord::new(perf_id, 0, timestamp, guid, address as u64, &module_name);
                 _ = FBPT.lock().add_record(record);
             }
-            // TODO something to do if address is not 0 need example to continue development. (https://github.com/OpenDevicePartnership/uefi-dxe-core/issues/194)
+            // TODO something to do if address is not 0 need example to continue development. (https://github.com/OpenDevicePartnership/patina/issues/194)
         }
         PerfId::PERF_EVENT_SIGNAL_START
         | PerfId::PERF_EVENT_SIGNAL_END
@@ -573,16 +573,16 @@ fn get_module_info_from_handle(
         let _image_bytes = unsafe {
             slice::from_raw_parts(loaded_image.image_base as *const _ as *const u8, loaded_image.image_size as usize)
         };
-        // TODO: Find Module name in handle (image_bytes) (https://github.com/OpenDevicePartnership/uefi-dxe-core/issues/187).
+        // TODO: Find Module name in handle (image_bytes) (https://github.com/OpenDevicePartnership/patina/issues/187).
 
         return Ok((None, guid));
     }
 
     // Method 2 - Get the name string from ComponentName2
-    // TODO: https://github.com/OpenDevicePartnership/uefi-dxe-core/issues/192
+    // TODO: https://github.com/OpenDevicePartnership/patina/issues/192
 
     // Method 3 - Get the name string from FFS UI Section.
-    // TODO: https://github.com/OpenDevicePartnership/uefi-dxe-core/issues/193
+    // TODO: https://github.com/OpenDevicePartnership/patina/issues/193
 
     Ok((None, guid))
 }

--- a/docs/src/concepts.md
+++ b/docs/src/concepts.md
@@ -26,7 +26,7 @@ silicon vendor specific reasons.
 in the rust implementation, we split the `LibraryClasses` concept into two distinct concepts -
 [Traits](https://blog.rust-lang.org/2015/05/11/traits.html) for abstractions and [Crates](https://doc.rust-lang.org/book/ch07-01-packages-and-crates.html)
 for code reuse. To learn how to effectively use Traits and Crates to represent EDKII
-LibraryClasses, Please review the [Abstractions](dev/abstractions.md) and [Code reuse](dev/reuse.md)
+LibraryClasses, Please review the [Abstractions](dev/principles/abstractions.md) and [Code reuse](dev/principles/reuse.md)
 sections of the Best Practices Chapter.
 
 ``` admonish important

--- a/docs/src/dev/other.md
+++ b/docs/src/dev/other.md
@@ -14,12 +14,11 @@ Below is a currated list of resources to help get you started with rust developm
 
 ## Repositories
 
-Other repositories related to the uefi-dxe-core project.
+Other repositories related to the patina project.
 
 | Repository | Description |
 |------------|-------------|
-| [uefi-dxe-core](https://github.com/OpenDevicePartnership/uefi-dxe-core) | The pure-rust implementation of the UEFI DXE Core. |
-| [uefi-core](https://github.com/OpenDevicePartnership/uefi-core) | Abstraction point implementations, such as for CPU initialization, serial writing, logging, etc. |
+| [patina](https://github.com/OpenDevicePartnership/patina) | The pure-rust implementation of the UEFI DXE Core. |
 | [mtrr](https://github.com/OpenDevicePartnership/mtrr) | Memory Type Range Registers for x86_64. |
 | [paging](https://github.com/OpenDevicePartnership/paging) | Paging implementation. |
 | [r-efi](https://github.com/r-efi/r-efi) | UEFI reference specification protocol constants and definitions. |

--- a/docs/src/dev/principles.md
+++ b/docs/src/dev/principles.md
@@ -1,4 +1,4 @@
 # Best Practices
 
 The following sections provide some of the core principles and best practices to follow when
-developing UEFI modules, libraries, or the DXE Core in rust.
+developing in Patina.

--- a/docs/src/dev/principles/config.md
+++ b/docs/src/dev/principles/config.md
@@ -1,6 +1,6 @@
 # Config in Code
 
-In EDKII, configuration of libraries and components was managed through PCDs due to the fact that
+In EDK II, configuration of libraries and components was managed through PCDs due to the fact that
 all modules were compiled separately, making it difficult to share configuration. With the pure
 rust dxe core, drivers and the dxe core are being compiled together in a monolithic nature. This
 allows for configuration to be done in code, during the instantiation process of each individual

--- a/docs/src/dev/principles/reuse.md
+++ b/docs/src/dev/principles/reuse.md
@@ -1,6 +1,6 @@
 # Code Reuse
 
-In EDKII, code re-use was done using the `LibraryClasses` build concept. In rust, we do **not** use
+In EDK II, code re-use was done using the `LibraryClasses` build concept. In rust, we do **not** use
 rust `Traits` for code-reuse. Instead we use rust `Crates`. See some of the generic reading here:
 
 - [Packages and Crates](https://doc.rust-lang.org/book/ch07-00-managing-growing-projects-with-packages-crates-and-modules.html)

--- a/docs/src/driver/interface.md
+++ b/docs/src/driver/interface.md
@@ -24,7 +24,7 @@ expects that a `Self::entry_point(self, ...) -> uefi_sdk::error::Result<()> { ..
 function definition can be any number of parameters twho support dependency injection as shown below. The function
 name can be overwritten with the attribute macro `#[entry_point(path = path::to::func)]` on the same struct.
 
-See [Samples](https://github.com/OpenDevicePartnership/uefi-dxe-core/tree/main/sample_components) or [Examples](#examples)
+See [Samples](https://github.com/OpenDevicePartnership/patina/tree/main/sample_components) or [Examples](#examples)
 for examples of basic components using these two methods.
 
 Due to this, developing a component is as simple as writing a function whose parameters are a part of the below list of

--- a/docs/src/dxe_core/testing.md
+++ b/docs/src/dxe_core/testing.md
@@ -1,7 +1,7 @@
 # DXE Core Testing
 
 Writing DXE Core tests follows all the same principles defined in the [Testing](../dev/testing.md) chapter, so if you
-have not reviewed it yet, please do so before continuing. One of the reasons that [uefi-dxe-core](https://github.com/OpenDevicePartnership/uefi-dxe-core)
+have not reviewed it yet, please do so before continuing. One of the reasons that [patina](https://github.com/OpenDevicePartnership/patina)
 is split into multiple crates and merged the the `dxe_core` umbrella crate is to support code separation and ease of
 unit testing. Support crates (in the `crates/*` folder) should not contain any static data used by the core. Instead,
 they should provide the generic implementation details that the core uses to function. This simplifies unit tests, code
@@ -18,7 +18,7 @@ static pieces of data that are referenced throughout the codebase. Since unit te
 that multiple tests may be manipulating this static data at the same time. This will lead to either dead-locks, panics,
 or the static data being in an unexpected state for the test.
 
-To help with this issue in the dxe_core crate, a [test_support](https://github.com/OpenDevicePartnership/uefi-dxe-core/blob/main/dxe_core/src/test_support.rs)
+To help with this issue in the dxe_core crate, a [test_support](https://github.com/OpenDevicePartnership/patina/blob/main/dxe_core/src/test_support.rs)
 module was added to make writing tests more convenient. The most important functionality in the module is the
 `with_global_lock` function which takes your test closure / function as a parameter. This function locks a private
 global mutex, ensuring you have exclusive access to all statics within the dxe_core.

--- a/docs/src/integrate/compile_local.md
+++ b/docs/src/integrate/compile_local.md
@@ -1,7 +1,7 @@
-# Compiling through EDKII
+# Compiling through EDK II
 
 This section will walk you through adding a rust crate to your existing platform repository so
-that it can be compiled via the existing EDKII build system.
+that it can be compiled via the existing EDK II build system.
 
 ## Create the crate
 

--- a/docs/src/rfc/text/0001-guided-hob-to-hob-param.md
+++ b/docs/src/rfc/text/0001-guided-hob-to-hob-param.md
@@ -17,6 +17,7 @@ registering itself with the core, and instead moves the parsing to the core.
   guided HOB, and to be able to remove the need to register HOBs with the core. Update `HobConfig` to `FromHob`.
   Remove `with_hob_config`.
 - 2025-04-15: Move `parse_hobs` logic into core, so components with access to `Storage` from using `parse_hobs`
+- 2025-05-08 - Amendment: Remove references to the now deprecated `uefi-sdk` repo
 
 ## Motivation
 
@@ -34,7 +35,7 @@ This proposal will use the existing `Storage` logic from the `uefi_sdk` to store
 
 1. Enable a simple interface for component dependency injectable configuration to be produced via a guided HOB in the
    HOB list
-2. Create core / uefi-sdk `T`'s for standard spec-defined guided HOBs that are available to component that wants it.
+2. Create `T`'s for standard spec-defined guided HOBs that are available to component that wants it.
 
 ## Requirements
 

--- a/docs/src/rfc/text/0002-memory-management-interface.md
+++ b/docs/src/rfc/text/0002-memory-management-interface.md
@@ -2,16 +2,17 @@
 
 To support scaling both within the core and throughout Components, stable APIs
 must be created for all functionality provided by the core. This RFC proposes the
-creation of a `MemoryManager` trait within uefi-sdk to act as the common interface
-for all externally available memory APIs.
+creation of a `MemoryManager` trait to act as the common interface for all externally
+available memory APIs.
 
 ## Change Log
 
-- 2024-04-06: Initial RFC created.
-- 2024-04-07: Changes AllocationOptions to not use implementation defined defaults.
-- 2024-04-07: Further clarification on the `HeapAllocator` type.
-- 2024-04-09: Removed HeapAllocator, added more details on other types.
-- 2024-04-14: Removed panic wrappers for PageAllocation, added slice wrappers.
+- 2025-04-06: Initial RFC created.
+- 2025-04-07: Changes AllocationOptions to not use implementation defined defaults.
+- 2025-04-07: Further clarification on the `HeapAllocator` type.
+- 2025-04-09: Removed HeapAllocator, added more details on other types.
+- 2025-04-14: Removed panic wrappers for PageAllocation, added slice wrappers.
+- 2025-05-08 - Amendment: Remove references to the now deprecated `uefi-sdk` repo
 
 ## Motivation
 
@@ -23,7 +24,7 @@ can used as an initial testbed for these services.
 
 This design assumes the presence and use of the Component and Service model within the
 dependency injection-based dispatch of rust-based extensions to the core binary. More
-details on this model can be found in the [Component Model](https://github.com/OpenDevicePartnership/uefi-dxe-core/blob/main/docs/src/dxe_core/component_model.md)
+details on this model can be found in the [Component Model](https://github.com/OpenDevicePartnership/patina/blob/main/docs/src/dxe_core/component_model.md)
 document.
 
 ## Goals
@@ -87,9 +88,9 @@ consistency.
 
 ### Memory Manager Service
 
-The design proposal is to create a new trait definition in the uefi-sdk to implement
+The design proposal is to create a new trait definition in the SDK crate to implement
 core memory functionality called the `MemoryManager` trait. This RFC will not go into
-the details of the Service model, but information can be found in the [Component Model](https://github.com/OpenDevicePartnership/uefi-dxe-core/blob/main/docs/src/dxe_core/component_model.md)
+the details of the Service model, but information can be found in the [Component Model](https://github.com/OpenDevicePartnership/patina/blob/main/docs/src/dxe_core/component_model.md)
 document. This trait will be accessed through a `Service<dyn MemoryManager>` from external
 components and directly against the implementor within dxe-core itself. This trait will
 define functions for

--- a/docs/src/rfc/text/0004-move-cpu-into-core.md
+++ b/docs/src/rfc/text/0004-move-cpu-into-core.md
@@ -1,6 +1,6 @@
 # RFC: `Move CPU functionality into Patina Core`
 
-The struct(s) for configuring CPU specific functionality are currently exposed external to the uefi-dxe-core via the
+The struct(s) for configuring CPU specific functionality are currently exposed external to the patina via the
 `.with_cpu_init` and `.with_interrupt_manager` methods in the `Core` object to support the ability to (1) replace
 certain functionality based off of a platform's requirements and (2) replace cpu architecture specific functionality.
 As the Patina Core has evolved, we have noted that platforms do not need to customize this functionality; all platforms
@@ -17,6 +17,7 @@ Core to fine tune this logic for a given platform.
 - 2025-04-25: General update after a commit that removed some of the generics
 - 2025-04-28: Use `Config` for gic configuration
 - 2025-04-28: Split efi system table initialization into post-memory-init
+- 2025-05-08 - Amendment: Remove references to the now deprecated `uefi-sdk` repo
 
 ## Motivation
 
@@ -49,7 +50,7 @@ contains the functionality for all three of these trait interfaces and can be re
 ## Unresolved Questions
 
 1. Do we want to update the `Cpu` or `InterruptManager` trait interfaces?
-2. Do we want to move the `Cpu` or `InterruptManager` traits to another location (uefi-sdk)?
+2. Do we want to move the `Cpu` or `InterruptManager` traits to another location (the SDK)?
 
 ## Prior Art (Existing PI C Implementation)
 
@@ -145,7 +146,7 @@ where
     section_extractor: SectionExtractor,
     components: Vec<Box<dyn Component>>,
     storage: Storage,
-    _memory_state: core::marker::PhantomData<MemoryState>    
+    _memory_state: core::marker::PhantomData<MemoryState>
 }
 
 impl<SectionExtractor> Core<SectionExtractor, NoAlloc>
@@ -175,7 +176,7 @@ impl<SectionExtractor> Core<SectionExtractor, Alloc>
 where
     SectionExtractor: fw_fs::SectionExtractor + Default + Copy + 'static
 {
-    fn initialize_system_table(&self) -> Result<()> { 
+    fn initialize_system_table(&self) -> Result<()> {
 
         let cpu: Service<dyn Cpu> = storage.get_service().unwrap();
         let im: Service<dyn InterruptManager> = storage.get_service.unwrap();

--- a/sdk/uefi_test/README.md
+++ b/sdk/uefi_test/README.md
@@ -1,3 +1,3 @@
 # UEFI Test
 
-A Testing harness for registering and running unit tests on a UEFI platform that compiles with the `dxe_core`.
+A Testing harness for registering and running unit tests on a UEFI platform that compiles with the `core/dxe_core`.


### PR DESCRIPTION
## Description

Updates references to old repos and processes to those now used in the Patina "mono repo". Future updates will come to add more details (as opposed to patching old details and references) about working in the Patina repository and to reflect upcoming changes that will involve renaming crates.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [x] Includes documentation?

## How This Was Tested

- CI

## Integration Instructions

- N/A