### PR TITLE
Move to `patina-mtrr` and `patina-paging` crates

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -3,8 +3,8 @@ patina-fw = { index = "sparse+https://pkgs.dev.azure.com/patina-fw/artifacts/_pa
 
 [patch.crates-io]
 dxe_core = { path = "core/dxe_core" }
-mtrr = { registry = "patina-fw", version = "0" }
-paging = { registry = "patina-fw", version = "4" }
+patina-mtrr = { registry = "patina-fw", version = "0" }
+patina-paging = { registry = "patina-fw", version = "5" }
 section_extractor = { path = "core/section_extractor" }
 stacktrace = { path = "core/stacktrace" }
 uefi_collections = { path = "core/uefi_collections" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,10 +33,10 @@ lazy_static = { version = "^1" }
 linked_list_allocator = { version = "^0.10" }
 linkme = { version = "^0.3.29" }
 log = { version = "0.4", default-features = false }
-mtrr = { version = "0.1.1", registry = "patina-fw" }
 mu_pi = { version = "5.2.3" }
 mu_rust_helpers = { version = "3.0.1" }
-paging = { version = "4.0.1", registry = "patina-fw" }
+patina-paging = { version = "5.0.0", registry = "patina-fw" }
+patina-mtrr = { version = "0.1.2", registry = "patina-fw" }
 proc-macro2 = { version = "1" }
 quote = { version = "1" }
 r-efi = { version = "5.0.0", default-features = false }

--- a/core/dxe_core/Cargo.toml
+++ b/core/dxe_core/Cargo.toml
@@ -35,7 +35,7 @@ linked_list_allocator = { workspace = true }
 log = { workspace = true }
 mu_pi = { workspace = true }
 mu_rust_helpers = { workspace = true }
-paging = { workspace = true }
+patina-paging = { workspace = true }
 r-efi = { workspace = true }
 scroll = {workspace = true, features = ["derive"]}
 spin = { workspace = true }

--- a/core/dxe_core/src/gcd.rs
+++ b/core/dxe_core/src/gcd.rs
@@ -15,7 +15,7 @@ use mu_pi::{
     dxe_services::{GcdIoType, GcdMemoryType},
     hob::{self, Hob, HobList, PhaseHandoffInformationTable, ResourceDescriptorV2},
 };
-use paging::MemoryAttributes;
+use patina_paging::MemoryAttributes;
 use r_efi::efi;
 use uefi_sdk::base::{align_down, align_up};
 use uefi_sdk::error::EfiError;

--- a/core/dxe_core/src/gcd/spin_locked_gcd.rs
+++ b/core/dxe_core/src/gcd/spin_locked_gcd.rs
@@ -25,7 +25,7 @@ use crate::{
     allocator::DEFAULT_ALLOCATION_STRATEGY, ensure, error, events::EVENT_DB, protocol_db, protocol_db::INVALID_HANDLE,
     tpl_lock, GCD,
 };
-use paging::{page_allocator::PageAllocator, MemoryAttributes, PageTable, PtError, PtResult};
+use patina_paging::{page_allocator::PageAllocator, MemoryAttributes, PageTable, PtError, PtResult};
 use uefi_cpu::paging::create_cpu_paging;
 
 use mu_pi::hob::{Hob, HobList};

--- a/core/uefi_cpu/Cargo.toml
+++ b/core/uefi_cpu/Cargo.toml
@@ -22,7 +22,7 @@ log = { workspace = true }
 r-efi = { workspace = true }
 uefi_sdk = { workspace = true }
 spin = { workspace = true, features = ["rwlock"] }
-paging = { workspace = true }
+patina-paging = { workspace = true }
 mu_pi = { workspace = true }
 cfg-if = { workspace = true }
 stacktrace = { workspace = true }
@@ -32,7 +32,7 @@ x86_64 = { workspace = true, features = [
     "instructions",
     "abi_x86_interrupt",
 ] }
-mtrr = { workspace = true }
+patina-mtrr = { workspace = true }
 
 [target.'cfg(all(target_arch="aarch64"))'.dependencies]
 arm-gic = { workspace = true }

--- a/core/uefi_cpu/src/interrupts/x64/interrupt_manager.rs
+++ b/core/uefi_cpu/src/interrupts/x64/interrupt_manager.rs
@@ -10,8 +10,8 @@
 use core::arch::global_asm;
 use lazy_static::lazy_static;
 use mu_pi::protocols::cpu_arch::EfiSystemContext;
-use paging::page_allocator::PageAllocator;
-use paging::{MemoryAttributes, PageTable, PagingType};
+use patina_paging::page_allocator::PageAllocator;
+use patina_paging::{MemoryAttributes, PageTable, PagingType};
 use stacktrace::StackTrace;
 use uefi_sdk::base::SIZE_4GB;
 use uefi_sdk::base::{UEFI_PAGE_MASK, UEFI_PAGE_SIZE};
@@ -308,14 +308,14 @@ fn interpret_gp_fault_exception_data(exception_data: u64) {
 }
 
 fn get_fault_attributes(cr2: u64, cr3: u64, paging_type: PagingType) -> Option<MemoryAttributes> {
-    let pt = unsafe { paging::x64::X64PageTable::from_existing(cr3, FaultAllocator {}, paging_type).ok()? };
+    let pt = unsafe { patina_paging::x64::X64PageTable::from_existing(cr3, FaultAllocator {}, paging_type).ok()? };
     pt.query_memory_region(cr2 & !(UEFI_PAGE_MASK as u64), UEFI_PAGE_SIZE as u64).ok()
 }
 
 pub struct FaultAllocator {}
 
 impl PageAllocator for FaultAllocator {
-    fn allocate_page(&mut self, _align: u64, _size: u64, _contiguous: bool) -> paging::PtResult<u64> {
+    fn allocate_page(&mut self, _align: u64, _size: u64, _contiguous: bool) -> patina_paging::PtResult<u64> {
         unimplemented!()
     }
 }

--- a/core/uefi_cpu/src/paging/aarch64.rs
+++ b/core/uefi_cpu/src/paging/aarch64.rs
@@ -9,11 +9,11 @@
 //! SPDX-License-Identifier: BSD-2-Clause-Patent
 //!
 use alloc::boxed::Box;
-use paging::aarch64::AArch64PageTable;
-use paging::PagingType;
-use paging::{MemoryAttributes, PageTable, PtError};
+use patina_paging::aarch64::AArch64PageTable;
+use patina_paging::PagingType;
+use patina_paging::{MemoryAttributes, PageTable, PtError};
 
-use paging::page_allocator::PageAllocator;
+use patina_paging::page_allocator::PageAllocator;
 use r_efi::efi;
 
 #[cfg(test)]
@@ -68,7 +68,7 @@ pub fn create_cpu_aarch64_paging<A: PageAllocator + 'static>(
     page_allocator: A,
 ) -> Result<Box<dyn PageTable<ALLOCATOR = A>>, efi::Status> {
     Ok(Box::new(EfiCpuPagingAArch64 {
-        paging: AArch64PageTable::new(page_allocator, PagingType::AArch64PageTable4KB).unwrap(),
+        paging: AArch64PageTable::new(page_allocator, PagingType::Paging4Level).unwrap(),
     }))
 }
 

--- a/core/uefi_cpu/src/paging/null.rs
+++ b/core/uefi_cpu/src/paging/null.rs
@@ -9,9 +9,9 @@
 //! SPDX-License-Identifier: BSD-2-Clause-Patent
 //!
 use alloc::boxed::Box;
-use paging::{MemoryAttributes, PageTable, PtError};
+use patina_paging::{MemoryAttributes, PageTable, PtError};
 
-use paging::page_allocator::PageAllocator;
+use patina_paging::page_allocator::PageAllocator;
 use r_efi::efi;
 
 #[derive(Default)]

--- a/core/uefi_cpu/src/paging/x64.rs
+++ b/core/uefi_cpu/src/paging/x64.rs
@@ -9,16 +9,16 @@
 //! SPDX-License-Identifier: BSD-2-Clause-Patent
 //!
 use alloc::boxed::Box;
-use mtrr::create_mtrr_lib;
-use mtrr::error::MtrrError;
-use mtrr::structs::MtrrMemoryCacheType;
-use mtrr::Mtrr;
-use paging::page_allocator::PageAllocator;
-use paging::x64::X64PageTable;
-use paging::MemoryAttributes;
-use paging::PageTable;
-use paging::PagingType;
-use paging::PtError;
+use patina_mtrr::create_mtrr_lib;
+use patina_mtrr::error::MtrrError;
+use patina_mtrr::structs::MtrrMemoryCacheType;
+use patina_mtrr::Mtrr;
+use patina_paging::page_allocator::PageAllocator;
+use patina_paging::x64::X64PageTable;
+use patina_paging::MemoryAttributes;
+use patina_paging::PageTable;
+use patina_paging::PagingType;
+use patina_paging::PtError;
 use r_efi::efi;
 use uefi_sdk::error::EfiError;
 
@@ -173,7 +173,7 @@ fn mtrr_err_to_efi_status(err: MtrrError) -> EfiError {
 mod tests {
     use super::*;
     use mockall::mock;
-    use mtrr::{
+    use patina_mtrr::{
         error::MtrrResult,
         structs::{MtrrMemoryRange, MtrrSettings},
     };

--- a/core/uefi_debugger/Cargo.toml
+++ b/core/uefi_debugger/Cargo.toml
@@ -19,7 +19,7 @@ uefi_sdk = { workspace = true }
 uefi_cpu = { workspace = true }
 log = { workspace = true }
 spin = { workspace = true }
-paging = { workspace = true  }
+patina-paging = { workspace = true  }
 bitfield-struct = { workspace = true  }
 
 [dev-dependencies]

--- a/core/uefi_debugger/src/arch.rs
+++ b/core/uefi_debugger/src/arch.rs
@@ -14,7 +14,7 @@
 //!
 
 use gdbstub::target::ext::breakpoints;
-use paging::PageTable;
+use patina_paging::PageTable;
 use uefi_cpu::interrupts::ExceptionContext;
 
 use crate::ExceptionInfo;

--- a/core/uefi_debugger/src/arch/aarch64.rs
+++ b/core/uefi_debugger/src/arch/aarch64.rs
@@ -64,7 +64,7 @@ impl DebuggerArch for Aarch64Arch {
     const GDB_TARGET_XML: &'static str = r#"<?xml version="1.0"?><!DOCTYPE target SYSTEM "gdb-target.dtd"><target><architecture>aarch64</architecture><xi:include href="registers.xml"/></target>"#;
     const GDB_REGISTERS_XML: &'static str = include_str!("xml/aarch64_registers.xml");
 
-    type PageTable = paging::aarch64::AArch64PageTable<memory::DebugPageAllocator>;
+    type PageTable = patina_paging::aarch64::AArch64PageTable<memory::DebugPageAllocator>;
 
     #[inline(always)]
     fn breakpoint() {
@@ -221,10 +221,10 @@ impl DebuggerArch for Aarch64Arch {
         // TODO: Check for EL1?
         let ttbr0_el2 = read_sysreg!("ttbr0_el2");
         unsafe {
-            paging::aarch64::AArch64PageTable::from_existing(
+            patina_paging::aarch64::AArch64PageTable::from_existing(
                 ttbr0_el2,
                 memory::DebugPageAllocator {},
-                paging::PagingType::AArch64PageTable4KB,
+                patina_paging::PagingType::Paging4Level,
             )
             .map_err(|_| ())
         }

--- a/core/uefi_debugger/src/arch/x64.rs
+++ b/core/uefi_debugger/src/arch/x64.rs
@@ -4,7 +4,7 @@ use gdbstub::{
     arch::{RegId, Registers},
     target::ext::breakpoints::WatchKind,
 };
-use paging::PagingType;
+use patina_paging::PagingType;
 use uefi_cpu::interrupts::ExceptionContext;
 
 use super::{DebuggerArch, UefiArchRegs};
@@ -29,7 +29,7 @@ impl DebuggerArch for X64Arch {
     const GDB_TARGET_XML: &'static str = r#"<?xml version="1.0"?><!DOCTYPE target SYSTEM "gdb-target.dtd"><target><architecture>i386:x86-64</architecture><xi:include href="registers.xml"/></target>"#;
     const GDB_REGISTERS_XML: &'static str = include_str!("xml/x64_registers.xml");
 
-    type PageTable = paging::x64::X64PageTable<memory::DebugPageAllocator>;
+    type PageTable = patina_paging::x64::X64PageTable<memory::DebugPageAllocator>;
 
     #[inline(always)]
     fn breakpoint() {
@@ -142,7 +142,8 @@ impl DebuggerArch for X64Arch {
         // SAFETY: The CR3 is currently being should be identity mapped and so
         // should point to a valid page table.
         unsafe {
-            paging::x64::X64PageTable::from_existing(cr3, memory::DebugPageAllocator {}, paging_type).map_err(|_| ())
+            patina_paging::x64::X64PageTable::from_existing(cr3, memory::DebugPageAllocator {}, paging_type)
+                .map_err(|_| ())
         }
     }
 

--- a/core/uefi_debugger/src/memory.rs
+++ b/core/uefi_debugger/src/memory.rs
@@ -9,7 +9,7 @@
 
 use core::ptr;
 
-use paging::{page_allocator::PageAllocator, MemoryAttributes, PageTable};
+use patina_paging::{page_allocator::PageAllocator, MemoryAttributes, PageTable};
 
 use crate::arch::DebuggerArch;
 
@@ -139,7 +139,7 @@ fn check_range_accessibility<P: PageTable>(page_table: &P, start_address: u64, l
 pub struct DebugPageAllocator {}
 
 impl PageAllocator for DebugPageAllocator {
-    fn allocate_page(&mut self, _align: u64, _size: u64, _is_root: bool) -> paging::PtResult<u64> {
+    fn allocate_page(&mut self, _align: u64, _size: u64, _is_root: bool) -> patina_paging::PtResult<u64> {
         panic!("Should not allocate page tables from the debugger!");
     }
 }
@@ -153,7 +153,7 @@ mod tests {
     use gdbstub::target::ext::breakpoints;
     use mockall::predicate::*;
     use mockall::*;
-    use paging::{MemoryAttributes, PtResult};
+    use patina_paging::{MemoryAttributes, PtResult};
 
     mock! {
         pub MemPageTable {}
@@ -208,7 +208,7 @@ mod tests {
         mock_page_table
             .expect_query_memory_region()
             .times(2)
-            .returning(|_, _| Err(paging::PtError::InvalidMemoryRange));
+            .returning(|_, _| Err(patina_paging::PtError::InvalidMemoryRange));
 
         let result = check_range_accessibility(&mock_page_table, 0, 0x1000);
         result.expect_err("Should have return a failure.");
@@ -232,7 +232,7 @@ mod tests {
         mock_page_table
             .expect_query_memory_region()
             .times(1)
-            .returning(|_, _| Err(paging::PtError::InvalidMemoryRange));
+            .returning(|_, _| Err(patina_paging::PtError::InvalidMemoryRange));
 
         let result = check_range_accessibility(&mock_page_table, 0x800, 0x3000);
         assert!(result.expect("Failed to check range access.") == 0x1800);
@@ -269,7 +269,9 @@ mod tests {
         let ctx = MockMemDebuggerArch::get_page_table_context();
         ctx.expect().returning(|| {
             let mut mock_page_table = MockMemPageTable::new();
-            mock_page_table.expect_query_memory_region().returning(|_, _| Err(paging::PtError::InvalidMemoryRange));
+            mock_page_table
+                .expect_query_memory_region()
+                .returning(|_, _| Err(patina_paging::PtError::InvalidMemoryRange));
             Ok(mock_page_table)
         });
 


### PR DESCRIPTION
## Description

- Updates to `patina-` prefixed crates in `patina-fw` feed
- Updates paths as necessary
- Integrates breaking changes in the v5.0.0 `patina-paging` release

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

- `cargo make all`

## Integration Instructions

- Use the `patina-mtrr` and `patina-paging` crates from the `patina-fw` registry.