### PR TITLE
Use new `patina_mtrr` and `patina_paging` crate names

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -3,8 +3,8 @@ patina-fw = { index = "sparse+https://pkgs.dev.azure.com/patina-fw/artifacts/_pa
 
 [patch.crates-io]
 dxe_core = { path = "core/dxe_core" }
-patina-mtrr = { registry = "patina-fw", version = "0" }
-patina-paging = { registry = "patina-fw", version = "5" }
+patina_mtrr = { registry = "patina-fw", version = "1" }
+patina_paging = { registry = "patina-fw", version = "6" }
 section_extractor = { path = "core/section_extractor" }
 stacktrace = { path = "core/stacktrace" }
 uefi_collections = { path = "core/uefi_collections" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,8 +35,8 @@ linkme = { version = "^0.3.29" }
 log = { version = "0.4", default-features = false }
 mu_pi = { version = "5.2.3" }
 mu_rust_helpers = { version = "3.0.1" }
-patina-paging = { version = "5.0.0", registry = "patina-fw" }
-patina-mtrr = { version = "0.1.2", registry = "patina-fw" }
+patina_paging = { version = "6.0.0", registry = "patina-fw" }
+patina_mtrr = { version = "1.0.0", registry = "patina-fw" }
 proc-macro2 = { version = "1" }
 quote = { version = "1" }
 r-efi = { version = "5.0.0", default-features = false }

--- a/core/dxe_core/Cargo.toml
+++ b/core/dxe_core/Cargo.toml
@@ -35,7 +35,7 @@ linked_list_allocator = { workspace = true }
 log = { workspace = true }
 mu_pi = { workspace = true }
 mu_rust_helpers = { workspace = true }
-patina-paging = { workspace = true }
+patina_paging = { workspace = true }
 r-efi = { workspace = true }
 scroll = {workspace = true, features = ["derive"]}
 spin = { workspace = true }

--- a/core/uefi_cpu/Cargo.toml
+++ b/core/uefi_cpu/Cargo.toml
@@ -22,7 +22,7 @@ log = { workspace = true }
 r-efi = { workspace = true }
 uefi_sdk = { workspace = true }
 spin = { workspace = true, features = ["rwlock"] }
-patina-paging = { workspace = true }
+patina_paging = { workspace = true }
 mu_pi = { workspace = true }
 cfg-if = { workspace = true }
 stacktrace = { workspace = true }
@@ -32,7 +32,7 @@ x86_64 = { workspace = true, features = [
     "instructions",
     "abi_x86_interrupt",
 ] }
-patina-mtrr = { workspace = true }
+patina_mtrr = { workspace = true }
 
 [target.'cfg(all(target_arch="aarch64"))'.dependencies]
 arm-gic = { workspace = true }

--- a/core/uefi_debugger/Cargo.toml
+++ b/core/uefi_debugger/Cargo.toml
@@ -19,7 +19,7 @@ uefi_sdk = { workspace = true }
 uefi_cpu = { workspace = true }
 log = { workspace = true }
 spin = { workspace = true }
-patina-paging = { workspace = true  }
+patina_paging = { workspace = true  }
 bitfield-struct = { workspace = true  }
 
 [dev-dependencies]


### PR DESCRIPTION
## Description

We decided to change the crate names from the hyphenated name (e.g. `patina-mtrr`) to one with an underscore (e.g. `patina_mtrr`) for consistency with other Patina crate names.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

- `cargo make all`

## Integration Instructions

- Patina MTRR and Paging crate names are now `patina-mtrr` and `patina-paging`