### PR TITLE
Allow multiple HOB parsers per guided HOB

### DIFF
--- a/core/dxe_core/src/lib.rs
+++ b/core/dxe_core/src/lib.rs
@@ -283,18 +283,20 @@ where
     fn parse_hobs(&mut self) {
         for hob in self.hob_list.iter() {
             if let mu_pi::hob::Hob::GuidHob(guid, data) = hob {
-                match self.storage.get_hob_parser(&guid.name) {
-                    Some(parser_func) => {
+                let parser_funcs = self.storage.get_hob_parsers(&guid.name);
+                if parser_funcs.is_empty() {
+                    let (f0, f1, f2, f3, f4, &[f5, f6, f7, f8, f9, f10]) = guid.name.as_fields();
+                    let name = alloc::format!(
+                        "{f0:08x}-{f1:04x}-{f2:04x}-{f3:02x}{f4:02x}-{f5:02x}{f6:02x}{f7:02x}{f8:02x}{f9:02x}{f10:02x}"
+                    );
+                    log::warn!(
+                        "No parser registered for HOB: GuidHob {{ {:?}, name: Guid {{ {} }} }}",
+                        guid.header,
+                        name
+                    );
+                } else {
+                    for parser_func in parser_funcs {
                         parser_func(data, &mut self.storage);
-                    }
-                    None => {
-                        let (f0, f1, f2, f3, f4, &[f5, f6, f7, f8, f9, f10]) = guid.name.as_fields();
-                        let name = alloc::format!("{f0:08x}-{f1:04x}-{f2:04x}-{f3:02x}{f4:02x}-{f5:02x}{f6:02x}{f7:02x}{f8:02x}{f9:02x}{f10:02x}");
-                        log::warn!(
-                            "No parser registered for HOB: GuidHob {{ {:?}, name: Guid {{ {} }} }}",
-                            guid.header,
-                            name
-                        );
                     }
                 }
             }


### PR DESCRIPTION
## Description

Today, if multiple components register against the same HOB GUID, the subsequent HOB parsers will "overwrite" the earlier ones.

To allow independent components to both register parsers against the same HOB GUID, the HOB parser map now contains a set of maps to each unique type (`TypeId`) that registers a HOB parser so that they can parse the HOB however they intended without collision.

- [x] Impacts functionality?
- [ ] Impacts security?
- [x] Breaking change?
- [x] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

- `cargo make all`
  - Unit test with multiple parsers for the same HOB GUID
- QEMU boot with two components using different parsers for the same HOB GUID

## Integration Instructions

This is marked a breaking change because of the change to the `uefi_sdk::component::storage::Storage::get_hob_parser()` function signature:

- Before: `pub fn get_hob_parser(&self, guid: &Guid) -> Option<fn(&[u8], &mut Storage)>`
- After: `pub fn get_hob_parsers(&self, guid: &Guid) -> Vec<fn(&[u8], &mut Storage)>`