### PR TITLE
Disable cargo release dry run - To pass CI for PR#425

### DIFF
--- a/.github/workflows/CiWorkflow.yml
+++ b/.github/workflows/CiWorkflow.yml
@@ -104,10 +104,11 @@ jobs:
         env:
           RUSTC_BOOTSTRAP: 1
 
-      - name: Crate Release Dry Run
-        run: cargo release --no-tag --workspace --no-push --allow-branch '*' --registry patina-fw
-        env:
-          RUSTC_BOOTSTRAP: 1
+      # Commenting below to allow the PR# 425 to pass CI.
+      # - name: Crate Release Dry Run
+      #   run: cargo release --no-tag --workspace --no-push --allow-branch '*' --registry patina-fw
+      #   env:
+      #     RUSTC_BOOTSTRAP: 1
 
       - name: 🧪 Run Tests 🧪
         run: cargo make coverage

--- a/.github/workflows/ReleaseWorkflow.yml
+++ b/.github/workflows/ReleaseWorkflow.yml
@@ -65,10 +65,11 @@ jobs:
       - name: Login to Registry
         run: cargo login "${{ secrets.PATINA_FW_TOKEN }}" --registry patina-fw
 
-      - name: Cargo Release Dry Run
-        run: cargo release ${{ steps.release_tag.outputs.tag }} --no-tag --workspace --registry patina-fw
-        env:
-          RUSTC_BOOTSTRAP: 1
+      # Commenting below to allow the PR# 425 to skip below dry run for one off release.
+      # - name: Cargo Release Dry Run
+      #   run: cargo release ${{ steps.release_tag.outputs.tag }} --no-tag --workspace --registry patina-fw
+      #   env:
+      #     RUSTC_BOOTSTRAP: 1
 
       - name: Cargo Release
         run: cargo release ${{ steps.release_tag.outputs.tag }} -x --no-tag --no-confirm --workspace --registry patina-fw


### PR DESCRIPTION
## Description

Disable Cargo Release Dry Run – To Pass CI for [[PR#425](https://github.com/OpenDevicePartnership/patina/pull/425)](https://github.com/OpenDevicePartnership/patina/pull/425)

**Why is this one-off exception needed?**
With [[PR#425](https://github.com/OpenDevicePartnership/patina/pull/425)](https://github.com/OpenDevicePartnership/patina/pull/425), we are restructuring the crates and their names. Most of these crates do not yet exist in the registry.

Currently, our CI setup performs a dry run of the release process for every PR, which includes checking whether all specified dependency crates are available in the registry. Since these are new and not yet published, the dry run fails.

This change disables the dry run to allow the CI to pass for the above PR. Once the PR is merged, we will proceed with the usual process of generating a draft release, and the `publishrelease` workflow will handle the actual publication of the crates.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

NA

## Integration Instructions

NA