### PR TITLE
Make copy of device path in LoadImage for loaded image protocol

### DIFF
--- a/patina_dxe_core/src/image.rs
+++ b/patina_dxe_core/src/image.rs
@@ -994,11 +994,12 @@ pub fn core_load_image(
     }
 
     if let Some(path) = fixed_file_path {
-        let copy = Box::into_raw(
-            copy_device_path_to_boxed_slice(path).map_err(|status| EfiError::status_to_result(status).unwrap_err())?,
-        ) as *mut efi::protocols::device_path::Protocol;
-
-        image_info.file_path = copy;
+        if !path.is_null() {
+            image_info.file_path = Box::into_raw(
+                copy_device_path_to_boxed_slice(path)
+                    .map_err(|status| EfiError::status_to_result(status).unwrap_err())?,
+            ) as *mut efi::protocols::device_path::Protocol;
+        }
     }
 
     let mut private_info = core_load_pe_image(image_to_load.as_ref(), image_info)


### PR DESCRIPTION
## Description

This change makes a copy of the device path in the `LoadImage` function for the loaded image protocol. This is not explicitly state for loaded_image_protocol, but is mentioned for the required by the UEFI specification for `EFI_LOADED_IMAGE_DEVICE_PATH_PROTOCOL`.

This specifically revolves a use after free issue that presented in the shell which happend to overwrite a device path when it was re-allocated this memory while the pointer was still in the loaded image protocol. Whenever this protocol is next inspected it can cause unexpected behavior. Specifically, the `dh` command would cause the device to get stuck in a loop trying to parse the invalid path and eventually assert.

Relevant UEFI Description:

![image](https://github.com/user-attachments/assets/a1cb9ca0-360c-430d-835c-40d0812d4b40)

This is also done by the C Core:

![image](https://github.com/user-attachments/assets/ec6d33e2-5a31-43b2-908f-62c712ec341b)

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Tested on Q35

## Integration Instructions

N/A
