### PR TITLE
mm_communicator: Remove comm buffer trace message

### DIFF
--- a/sdk/patina_sdk/src/component/service/mm_communicator.rs
+++ b/sdk/patina_sdk/src/component/service/mm_communicator.rs
@@ -160,21 +160,7 @@ impl MmCommunication for MmCommunicator {
         comm_buffer.set_message_info(recipient).map_err(|_| Status::CommBufferInitError)?;
         comm_buffer.set_message(data_buffer).map_err(|_| Status::CommBufferInitError)?;
 
-        log::trace!(
-            "Communicate buffer before MMI trigger => comm buffer [{}] size: {:#X} content:\n{:?}",
-            id,
-            comm_buffer.len(),
-            comm_buffer
-        );
-
         unsafe { sw_smi_trigger_service.trigger_sw_mmi(0xFF, 0).map_err(|_| Status::SwMmiFailed)? };
-
-        log::trace!(
-            "Communicate buffer after MMI trigger => comm buffer [{}] size: {:#X} content:\n{:?}",
-            id,
-            comm_buffer.len(),
-            comm_buffer
-        );
 
         Ok(comm_buffer.get_message())
     }

--- a/sdk/patina_sdk/src/component/service/sw_mmi_manager.rs
+++ b/sdk/patina_sdk/src/component/service/sw_mmi_manager.rs
@@ -79,7 +79,6 @@ impl SwMmiManager {
         }
 
         self.inner_config = config.clone();
-        log::info!("SwMmiManager initialized with config: {:?}", self.inner_config);
 
         commands.add_service(self);
 


### PR DESCRIPTION
## Description

Some platforms always have tracing on and this is noisy. Can be viewed in debugger if needed.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

- `cargo make all`

## Integration Instructions

- Comm buffer dump no longer present in trace level by default