### PR TITLE
Makefile: Move `cargo doc --open` to `cargo make doc-open`

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -211,6 +211,13 @@ dependencies = ["individual-package-targets"]
 description = "Builds all rust documentation in the workspace. Example `cargo make doc`"
 env = { RUSTDOCFLAGS = "-D warnings"}
 command = "cargo"
+args = ["doc", "@@split(INDIVIDUAL_PACKAGE_TARGETS, )", "--features", "doc"]
+
+[tasks.doc-open]
+description = "Builds all rust documentation in the workspace and opens the documentation. Example `cargo make doc-open`"
+env = { RUSTDOCFLAGS = "-D warnings"}
+clear = true
+command = "cargo"
 args = ["doc", "@@split(INDIVIDUAL_PACKAGE_TARGETS, )", "--features", "doc", "--open"]
 
 [tasks.clippy]

--- a/README.md
+++ b/README.md
@@ -48,7 +48,8 @@ at <https://OpenDevicePartnership.github.io/patina/>, however this documentation
 `mdbook serve docs` to self host the getting started book.
 
 You can also generate API documentation for the project using `cargo make doc`. This will eventually be hosted on
-docs.rs once we begin uploading to crates.io.
+docs.rs once we begin uploading to crates.io. You can have the documentation opened in your browser by running
+`cargo make doc-open`.
 
 ## First-Time Tool Setup Instructions
 


### PR DESCRIPTION
## Description

Closes #451 

Allows `cargo make all` to use `cargo make doc` which doesn't open the Web browser with documentation when running the command.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

- `cargo make doc`
- `cargo make doc-open`
- `cargo make all`

## Integration Instructions

Review the readme to understand what command to use for your use case.