### PR TITLE
Remove TPL lock from uninstall_multiple_protocol_interfaces

### DIFF
--- a/patina_dxe_core/src/protocols.rs
+++ b/patina_dxe_core/src/protocols.rs
@@ -516,10 +516,6 @@ unsafe extern "C" fn install_multiple_protocol_interfaces(handle: *mut efi::Hand
 }
 
 unsafe extern "C" fn uninstall_multiple_protocol_interfaces(handle: efi::Handle, mut args: ...) -> efi::Status {
-    // See note in install_multiple_protocol_interfaces.
-    let tpl_mutex = TplMutex::new(efi::TPL_NOTIFY, (), "atomic_protocol_uninstall");
-    let _tpl_guard = tpl_mutex.lock();
-
     if handle.is_null() {
         return efi::Status::INVALID_PARAMETER;
     }


### PR DESCRIPTION
## Description

This removes the TPL lock from `uninstall_multiple_protocol_interfaces`. This brings the behavior of this function with respect to TPL in line with EDK2 C reference behavior. 

Acquiring the lock in unisntall_multiple_protocol_interfaces can lead to issues with drivers that are coded against the EDK2 behavior. 

An example of such an issue is in the FAT driver (https://github.com/tianocore/edk2/tree/master/FatPkg/EnhancedFatDxe) which attempts to acquire its own lock at TPL_CALLBACK as part of DriverBindingStop() functionality. This will trigger a TPL inversion if `uninstall_multiple-protocol_interfaces` is used to remove a BlockIo instance that is being used by the FAT driver - this will cause the FAT driver to be stopped while the TPL is NOTIFY and when it tries to acquire its own lock at TPL_CALLBACK a TPL inversion occurs. 


- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Functional testing with USB hot remove - prior to this change, USB hot remove will cause a TPL assert in FAT driver binding as described above. After this change, TPL assert in FAT driver no longer occurs. 

## Integration Instructions

N/A
