### PR TITLE
Temporarily use goblin 0.9.3-hotfix.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ crc32fast = { version = "1.4", default-features = false }
 fallible-streaming-iterator = { version = "0.1.9" }
 fixedbitset = { version = "^0.5", default-features = false }
 gdbstub = { version = "0.7.3", default-features = false }
-goblin = { version = "^0.9", default-features = false }
+goblin = { version = "0.9.3-hotfix.1", default-features = false, registry = "patina-fw" }
 lazy_static = { version = "^1" }
 linked_list_allocator = { version = "^0.10" }
 linkme = { version = "^0.3.29" }


### PR DESCRIPTION
## Description

Based on this commit which is currently the goblin/master tip:

https://github.com/m4b/goblin/commit/bc33409ad60500576329a08bd11279c597dbea88

Hotfix in the patina-fw registry is temporarily used until https://github.com/m4b/goblin/commit/f06b768709d8f83cc662558bf503815413941240 is released.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

- `cargo make all`

## Integration Instructions

N/A