### PR TITLE
.github: Re-enable cargo release dry-run

### DIFF
--- a/.github/workflows/CiWorkflow.yml
+++ b/.github/workflows/CiWorkflow.yml
@@ -104,11 +104,10 @@ jobs:
         env:
           RUSTC_BOOTSTRAP: 1
 
-      # Commenting below to allow the PR# 425 to pass CI.
-      # - name: Crate Release Dry Run
-      #   run: cargo release --no-tag --workspace --no-push --allow-branch '*' --registry patina-fw
-      #   env:
-      #     RUSTC_BOOTSTRAP: 1
+      - name: Crate Release Dry Run
+        run: cargo release --no-tag --workspace --no-push --allow-branch '*' --registry patina-fw
+        env:
+          RUSTC_BOOTSTRAP: 1
 
       - name: 🧪 Run Tests 🧪
         run: cargo make coverage

--- a/.github/workflows/ReleaseWorkflow.yml
+++ b/.github/workflows/ReleaseWorkflow.yml
@@ -72,11 +72,10 @@ jobs:
       - name: Login to Registry
         run: cargo login "${{ secrets.PATINA_FW_TOKEN }}" --registry patina-fw
 
-      # Commenting below to allow the PR# 425 to skip below dry run for one off release.
-      # - name: Cargo Release Dry Run
-      #   run: cargo release ${{ steps.release_tag.outputs.tag }} --no-tag --workspace --registry patina-fw
-      #   env:
-      #     RUSTC_BOOTSTRAP: 1
+      - name: Cargo Release Dry Run
+        run: cargo release ${{ steps.release_tag.outputs.tag }} --no-tag --workspace --registry patina-fw
+        env:
+          RUSTC_BOOTSTRAP: 1
 
       - name: Cargo Release
         run: cargo release ${{ steps.release_tag.outputs.tag }} -x --no-tag --no-confirm --workspace --registry patina-fw


### PR DESCRIPTION
## Description

.github: Re-enable cargo release dry-run which were disabled during the crate rename PR(#425). 

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

NA

## Integration Instructions

NA