### PR TITLE
Ingest patina_paging version 7

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ patina_internal_cpu = { version = "1.0.0", path = "core/patina_internal_cpu", re
 patina_internal_depex = { version = "1.0.0", path = "core/patina_internal_depex", registry = "patina-fw" }
 patina_internal_device_path = { version = "1.0.0", path = "core/patina_internal_device_path", registry = "patina-fw" }
 patina_mtrr = { version = "1.0.0", registry = "patina-fw" }
-patina_paging = { version = "6.0.0", registry = "patina-fw" }
+patina_paging = { version = "7.0.0", registry = "patina-fw" }
 patina_performance = { version = "1.0.0", path = "components/patina_performance", registry = "patina-fw" }
 patina_sdk = { version = "1.0.0", path = "sdk/patina_sdk", registry = "patina-fw" }
 patina_sdk_macro = { version = "1.0.0", path = "sdk/patina_sdk_macro", registry = "patina-fw" }

--- a/core/patina_debugger/src/memory.rs
+++ b/core/patina_debugger/src/memory.rs
@@ -159,9 +159,6 @@ mod tests {
         pub MemPageTable {}
 
         impl PageTable for MemPageTable {
-            type ALLOCATOR = DebugPageAllocator;
-
-            fn borrow_allocator(&mut self) -> &mut DebugPageAllocator;
             fn map_memory_region(&mut self, address: u64, size: u64, attributes: MemoryAttributes) -> PtResult<()>;
             fn unmap_memory_region(&mut self, address: u64, size: u64) -> PtResult<()>;
             fn remap_memory_region(&mut self, address: u64, size: u64, attributes: MemoryAttributes) -> PtResult<()>;

--- a/core/patina_internal_cpu/src/paging/aarch64.rs
+++ b/core/patina_internal_cpu/src/paging/aarch64.rs
@@ -34,11 +34,6 @@ impl<P> PageTable for EfiCpuPagingAArch64<P>
 where
     P: PageTable,
 {
-    type ALLOCATOR = P::ALLOCATOR;
-    fn borrow_allocator(&mut self) -> &mut P::ALLOCATOR {
-        self.paging.borrow_allocator()
-    }
-
     fn map_memory_region(&mut self, address: u64, size: u64, attributes: MemoryAttributes) -> Result<(), PtError> {
         self.paging.map_memory_region(address, size, attributes)
     }
@@ -66,7 +61,7 @@ where
 
 pub fn create_cpu_aarch64_paging<A: PageAllocator + 'static>(
     page_allocator: A,
-) -> Result<Box<dyn PageTable<ALLOCATOR = A>>, efi::Status> {
+) -> Result<Box<dyn PageTable>, efi::Status> {
     Ok(Box::new(EfiCpuPagingAArch64 {
         paging: AArch64PageTable::new(page_allocator, PagingType::Paging4Level).unwrap(),
     }))
@@ -89,8 +84,6 @@ mod tests {
     mock! {
         PageTable {}
         impl PageTable for PageTable {
-            type ALLOCATOR = MockPageAllocator;
-            fn borrow_allocator(&mut self) -> &mut MockPageAllocator;
             fn map_memory_region(&mut self, address: u64, size: u64, attributes: MemoryAttributes) -> Result<(), PtError>;
             fn unmap_memory_region(&mut self, address: u64, size: u64) -> Result<(), PtError>;
             fn remap_memory_region(&mut self, address: u64, size: u64, attributes: MemoryAttributes) -> Result<(), PtError>;

--- a/core/patina_internal_cpu/src/paging/null.rs
+++ b/core/patina_internal_cpu/src/paging/null.rs
@@ -26,11 +26,6 @@ impl<A> PageTable for EfiCpuPagingNull<A>
 where
     A: PageAllocator,
 {
-    type ALLOCATOR = A;
-    fn borrow_allocator(&mut self) -> &mut A {
-        panic!("NullEfiCpuInit does not have a page allocator");
-    }
-
     fn map_memory_region(&mut self, _address: u64, _size: u64, _attributes: MemoryAttributes) -> Result<(), PtError> {
         Ok(())
     }
@@ -56,6 +51,6 @@ where
 
 pub fn create_cpu_null_paging<A: PageAllocator + 'static>(
     _page_allocator: A,
-) -> Result<Box<dyn PageTable<ALLOCATOR = A>>, efi::Status> {
+) -> Result<Box<dyn PageTable>, efi::Status> {
     Err(efi::Status::UNSUPPORTED)
 }

--- a/patina_dxe_core/src/gcd/spin_locked_gcd.rs
+++ b/patina_dxe_core/src/gcd/spin_locked_gcd.rs
@@ -1745,7 +1745,7 @@ pub struct SpinLockedGcd {
     memory: tpl_lock::TplMutex<GCD>,
     io: tpl_lock::TplMutex<IoGCD>,
     memory_change_callback: Option<MapChangeCallback>,
-    page_table: tpl_lock::TplMutex<Option<Box<dyn PageTable<ALLOCATOR = PagingAllocator<'static>>>>>,
+    page_table: tpl_lock::TplMutex<Option<Box<dyn PageTable>>>,
 }
 
 impl SpinLockedGcd {


### PR DESCRIPTION
## Description

Ingests the patina_paging and adjusts for braking changes that come with it. Primarily the removal of the `borrow_allocator` and `ALLOCATOR` definitions in the `PageTable` trait.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

- [x] Unit Tests
- [x] Q35 Boot
- [x] SBSA Boot

## Integration Instructions

N/A
