### PR TITLE
Integrate markdownlint-cli into cargo make all to validate documentation

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -236,6 +236,10 @@ args = ["fmt", "--all"]
 description = "Run cspell for spell checking." # npm install -g cspell@latest
 script = "cspell --quiet  --no-progress --no-summary  --dot --gitignore -e \"{.git/**,.github/**,.vscode/**}\" ."
 
+[tasks.markdownlint]
+description = "Run markdownlint for documentation linting." # npm install -g markdownlint-cli@latest
+script = "markdownlint '**/*.md' -c .markdownlint.yml --ignore target"
+
 [tasks.deny]
 description = "Run cargo deny."
 install_crate = false
@@ -249,6 +253,7 @@ dependencies = [
     "deny",
     "clippy",
     "cspell",
+    "markdownlint",
     "build",
     "build-x64",
     "build-aarch64",


### PR DESCRIPTION
## Description

Integrate markdownlint-cli into cargo make all to validate documentation

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

NA

## Integration Instructions

NA
