### PR TITLE
RFC: Firmware Performance Component

### DIFF
--- a/docs/src/rfc/text/0000-firmware-performance-dxe.md
+++ b/docs/src/rfc/text/0000-firmware-performance-dxe.md
@@ -52,7 +52,7 @@ The new `FirmwarePerformanceDxe` component will cover remaining performance func
 
 The Rust `FirmwarePerformanceDxe` component closely follows the design of the `FirmwarePerformanceDxe` driver in C.
 
-The primary functionality of the C `FirmwarePerformancedxe` driver is encapsulated in
+The primary functionality of the C `FirmwarePerformanceDxe` driver is encapsulated in
 the `FirmwarePerformanceDxeEntryPoint`, which registers the necessary FPDT status code listener
 and sets up two event callbacks for `EndOfDxe` and `ExitBootServices`.
 


### PR DESCRIPTION
## Description
This RFC proposes a Rust-based `FirmwarePerformanceDxe` component that replaces the existing C implementation
responsible for installing and managing UEFI firmware performance tables, specifically the FBPT and FPDT.
The new component initializes during DXE dispatch and handles tasks such as
installing the FPDT, publishing the FBPT, recording ExitBootServices timings, and registering the FPDT status code listener.

Current RFC State: **Draft**

tracks issue #467 

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?
