### PR TITLE
Bug: MAT tests fail when run independently - reset global state to fix

### DIFF
--- a/patina_dxe_core/src/allocator.rs
+++ b/patina_dxe_core/src/allocator.rs
@@ -1004,6 +1004,12 @@ pub fn install_memory_services(bs: &mut efi::BootServices) {
     bs.get_memory_map = get_memory_map;
 }
 
+// Resets the ALLOCATOR map to empty and resets the static allocators for test purposes.
+#[cfg(test)]
+pub(crate) unsafe fn reset_allocators() {
+    ALLOCATORS.lock().reset();
+}
+
 #[cfg(test)]
 mod tests {
 

--- a/patina_dxe_core/src/test_support.rs
+++ b/patina_dxe_core/src/test_support.rs
@@ -77,6 +77,11 @@ pub(crate) unsafe fn init_test_gcd(size: Option<usize>) {
     .unwrap();
 }
 
+/// Resets the ALLOCATOR map to empty and resets the static allocators
+pub(crate) unsafe fn reset_allocators() {
+    crate::allocator::reset_allocators()
+}
+
 /// Reset and re-initialize the protocol database to default empty state.
 pub(crate) unsafe fn init_test_protocol_db() {
     PROTOCOL_DB.reset();


### PR DESCRIPTION
## Description

The current MAT tests fail when not executed in below order:
- `test memory_attributes_table::tests::test_mat_init`
- `test memory_attributes_table::tests::test_memory_attributes_table_generation`

**Repro:** `cargo test memory_attributes_table::tests::test_memory_attributes_table_generation`
**Root Cause:**
**Case 1:** `test_mat_init()` followed by `test_memory_attributes_table_generation()`

* `test_mat_init()` clears and populates:

```
| #   | MAT Entries           | Test                |
| --- | --------------------- | ------------------- |
| #1  | RUNTIME_SERVICES_DATA | system_table_init() |
```

* Then, `test_memory_attributes_table_generation()` clears and populates:

```
| #   | MAT Entries           | Allocated Pages       | Test        |
| --- | --------------------- | --------------------- | ----------- |
| #1  | RUNTIME_SERVICES_DATA | RUNTIME_SERVICES_DATA | test        |
| #2  | RUNTIME_SERVICES_CODE | RUNTIME_SERVICES_CODE | test        |
| ... | ....                  | ...                   |             |
| #9  | RUNTIME_SERVICES_DATA | RUNTIME_SERVICES_DATA | test        |
| #10 | RUNTIME_SERVICES_CODE | RUNTIME_SERVICES_CODE | test        |
| #11 | - missing             | -                     | -           |
```

Here, entry #11 is **not** added by `system_table_init()` due to hidden state in
allocator from the previous test. This results in only 10 MAT entries. The test
incorrectly assumes that when the MAT entries match the allocated pages, It
checks the entry attributes and succeed

**Case 2:** Only `test_memory_attributes_table_generation()` is run

* This test clears and populates:

```
| #   | MAT Entries           | Allocated Pages       | Test                |
| --- | --------------------- | --------------------- | ------------------- |
| #1  | RUNTIME_SERVICES_DATA | RUNTIME_SERVICES_DATA | test                |
| #2  | RUNTIME_SERVICES_CODE | RUNTIME_SERVICES_CODE | test                |
| ... | ...                   | ...                   |                     |
| #9  | RUNTIME_SERVICES_DATA | RUNTIME_SERVICES_DATA | test                |
| #10 | RUNTIME_SERVICES_CODE | RUNTIME_SERVICES_CODE | test                |
| #11 | RUNTIME_SERVICES_DATA | -                     | system_table_init() |
```

Here, entry #11 **is** added by `system_table_init()` because no hidden state
exists from prior tests. The test incorrectly assumes the first entry was added
by `system_table_init()` and skips it. It then fails when comparing mismatched
types - attempting to compare a Runtime Services Data page with a Runtime
Services Code MAT entry.

**Fix:** Clearing hidden state in the allocator makes the tests independent. In
Rust, tests are expected to be independent by default. Any interdependent logic
must be consolidated into a single test case.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [x] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

`cargo test memory_attributes_table::tests::test_memory_attributes_table_generation`

## Integration Instructions

NA
