### PR TITLE
Bug: runtime/fv tests fail when run independently - reset global state to fix

### DIFF
--- a/patina_dxe_core/src/fv.rs
+++ b/patina_dxe_core/src/fv.rs
@@ -1435,6 +1435,8 @@ mod tests {
             }
             assert!(PRIVATE_FV_DATA.lock().fv_information.is_empty());
 
+            PRIVATE_FV_DATA.lock().section_extractor = Some(Box::new(patina_section_extractor::BrotliSectionExtractor));
+
             let mut fv_interface = Box::from(mu_pi::protocols::firmware_volume::Protocol {
                 get_volume_attributes: fv_get_volume_attributes,
                 set_volume_attributes: fv_set_volume_attributes,

--- a/patina_dxe_core/src/runtime.rs
+++ b/patina_dxe_core/src/runtime.rs
@@ -290,7 +290,8 @@ mod tests {
     fn with_locked_state<F: Fn() + std::panic::RefUnwindSafe>(f: F) {
         test_support::with_global_lock(|| {
             unsafe {
-                test_support::init_test_gcd(Some(0x100000));
+                test_support::init_test_gcd(None);
+                test_support::reset_allocators();
                 test_support::init_test_protocol_db();
             }
             f();


### PR DESCRIPTION
## Description

The `test_fv_special_section_read()` fv test fail when not executed in below order
- `fv::tests::test_fv_init_core`
- `fv::tests::test_fv_special_section_read` <-- rely on above test for the `section_extractor`

Below tests rely on prior tests allocator state
- `runtime::tests::test_convert_pointer`
- `runtime::tests::init_should_initialize_convert_pointer_and_set_virtual_address_map`

---

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [x] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

- `cargo test fv::tests::test_fv_special_section_read` 
- `cargo test runtime::tests::test_convert_pointer` 
- `cargo test runtime::tests::init_should_initialize_convert_pointer_and_set_virtual_address_map`

## Integration Instructions

NA
