### PR TITLE
Replace cargo test with nextest for better test runner UI and results

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -113,8 +113,7 @@ run_task = [{ name = ["check_no_std", "check_std"], parallel = true }]
 description = "Builds all rust tests in the workspace. Example `cargo make test`"
 clear = true
 command = "cargo"
-args = ["test", "@@split(INDIVIDUAL_PACKAGE_TARGETS, )", "@@split(TEST_FLAGS, )"]
-dependencies = ["individual-package-targets"]
+args = ["nextest", "run", "@@split(TEST_FLAGS, )", "${@}"]
 
 [tasks.coverage]
 description = "Build and run all tests and calculate coverage."

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -7,6 +7,7 @@ components = ["rust-src", "clippy", "rustfmt", "rust-docs"]
 [tools]
 cargo-deny = "^0.17"
 cargo-make = "0.37.21"
+cargo-nextest = "0.9.97"
 cargo-tarpaulin = "0.31.5"
 cargo-release = "0.25.12"
 mdbook = "0.4.40"


### PR DESCRIPTION
## Description

- Tests are still executed as `cargo make test` no change here!
- Makefile test task now uses [nexte.st](https://nexte.st/) which offers a much-improved test runner experience
- Provides more insightful test results
  - Including the number of tests executed
  - Test execution time
  - Improved execution speed
  - Call stack on failures
- Makefile test task is improved to directly accept any additional parameters like providing individual test names or `--nocapture` arguments etc.
   - ex: `cargo make test boot_services::test::test_open_protocol`
---
 
- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

![rust-optimized](https://github.com/user-attachments/assets/86f07813-d3db-4552-befa-ea98ccf59339)

## Integration Instructions

NA
