### PR TITLE
.github: Provide ability to skip cargo release dry run

### DIFF
--- a/.github/workflows/CiWorkflow.yml
+++ b/.github/workflows/CiWorkflow.yml
@@ -105,6 +105,7 @@ jobs:
           RUSTC_BOOTSTRAP: 1
 
       - name: Crate Release Dry Run
+        if: ${{ !contains(github.event.pull_request.body, '(skip cargo release dry run)') }}
         run: cargo release --no-tag --workspace --no-push --allow-branch '*' --registry patina-fw
         env:
           RUSTC_BOOTSTRAP: 1

--- a/.github/workflows/ReleaseWorkflow.yml
+++ b/.github/workflows/ReleaseWorkflow.yml
@@ -72,7 +72,19 @@ jobs:
       - name: Login to Registry
         run: cargo login "${{ secrets.PATINA_FW_TOKEN }}" --registry patina-fw
 
+      - name: Check Skip Cargo Release
+        id: check_skip_dry_run
+        run: |
+          if [[ "${{ github.event.release.body }}" == *"(skip cargo release dry run)"* ]]; then
+            echo "skip=true" >> $GITHUB_OUTPUT
+            echo "Skipping cargo release as requested in release description"
+          else
+            echo "skip=false" >> $GITHUB_OUTPUT
+          fi
+        shell: bash
+
       - name: Cargo Release Dry Run
+        if: steps.check_skip_dry_run.outputs.skip != 'true'
         run: cargo release ${{ steps.release_tag.outputs.tag }} --no-tag --workspace --registry patina-fw
         env:
           RUSTC_BOOTSTRAP: 1


### PR DESCRIPTION
## Description

By adding "`(skip cargo release dry run)`" in a PR description, cargo release dry run will not be run in the CI workflow in the PR gate. Also, the "Publish Release" workflow will not run the dry run if that text is in the release description (the PR description is rolled into the release notes automatically). This means adding "`(skip cargo release dry run)`" to the PR description will skip cargo release dry run in both workflows and make it auditable that was done per the descriptions.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Verified the `cargo release` dry run step is not in the CI and release workflows when the text is present.

## Integration Instructions

N/A