### PR TITLE
Fix UB in `memory_log::tests::create_fill_check_test`

### DIFF
--- a/components/patina_adv_logger/src/memory_log.rs
+++ b/components/patina_adv_logger/src/memory_log.rs
@@ -385,9 +385,9 @@ mod tests {
 
     #[test]
     fn create_fill_check_test() {
-        let buff_box = Box::new([0_u8; 0x10000]);
-        let buffer = buff_box.as_ref();
-        let address = buffer as *const u8 as PhysicalAddress;
+        let mut buff_box = Box::new([0_u64; 0x2000]);
+        let buffer = buff_box.as_mut();
+        let address = buffer as *mut u64 as PhysicalAddress;
         let len = buffer.len() as u32;
 
         let log = unsafe { AdvLoggerInfo::initialize_memory_log(address, len) };


### PR DESCRIPTION
## Description

- Type needs 8 byte alignment, ensure that by using `u64` instead of `u8` which Miri will complain about.
- Make sure the memory is considered mutable by marking the references and underlying `Box` as such.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

`cargo miri` before and after

## Integration Instructions

n/a
