### PR TITLE
patina-sdk: Make align* Functions More User Friendly

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ linkme = { version = "^0.3.29" }
 log = { version = "0.4", default-features = false }
 mu_pi = { version = "5.2.3" }
 mu_rust_helpers = { version = "3.0.1" }
+num-traits = { version = "0.2", default-features = false }
 patina_debugger = { version = "4.0.2", path = "core/patina_debugger", registry = "patina-fw" }
 patina_internal_collections = { version = "4.0.2", path = "core/patina_internal_collections", default-features = false, registry = "patina-fw" }
 patina_internal_cpu = { version = "4.0.2", path = "core/patina_internal_cpu", registry = "patina-fw" }

--- a/patina_dxe_core/src/gcd/spin_locked_gcd.rs
+++ b/patina_dxe_core/src/gcd/spin_locked_gcd.rs
@@ -2025,8 +2025,8 @@ impl SpinLockedGcd {
 
             // We need to use the virtual size for the section length, but
             // we cannot rely on this to be section aligned, as some compilers rely on the loader to align this
-            let aligned_virtual_size = match align_up(section.virtual_size as u64, pe_info.section_alignment as u64) {
-                Ok(size) => size,
+            let aligned_virtual_size = match align_up(section.virtual_size, pe_info.section_alignment) {
+                Ok(size) => size as u64,
                 Err(_) => {
                     panic!(
                         "Failed to align section size {:#x?} with alignment {:#x?}",
@@ -3983,7 +3983,7 @@ mod tests {
             assert_eq!(GCD.memory.lock().maximum_address, 0);
 
             let mem = unsafe { get_memory(MEMORY_BLOCK_SLICE_SIZE * 2) };
-            let address = align_up(mem.as_ptr() as u64, 0x1000).unwrap() as usize;
+            let address = align_up(mem.as_ptr() as usize, 0x1000).unwrap();
             GCD.init(48, 16);
             unsafe {
                 GCD.add_memory_space(

--- a/sdk/patina_sdk/Cargo.toml
+++ b/sdk/patina_sdk/Cargo.toml
@@ -25,6 +25,7 @@ cfg-if = { workspace = true }
 log = { workspace = true }
 r-efi = { workspace = true }
 mockall = { workspace = true, optional = true }
+num-traits = { workspace = true }
 fallible-streaming-iterator = { workspace = true }
 linkme = { workspace = true }
 scroll = { workspace = true }


### PR DESCRIPTION
## Description

Currently the align family of functions in the sdk requires u64s to be passed in, which often requires a pattern of my_usize as u64 getting passed in and the result of this being cast back to usize. This is needless, these functions can easily be generic.

In addition to this, these functions were passing back string errors which were universally being converted to EfiErrors. It was not using to return strings, instead return EfiErrors.

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Ran local tests as well as booted Windows on Q35 and SBSA.

## Integration Instructions

N/A. Existing users of the align functions don't need to change, but can change if they wish to make the usage simpler.
