### PR TITLE
AdvLogger: Remove UB and improve parsing safety

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,6 +53,8 @@ uart_16550 = { version = "^0.3.2" }
 uefi_corosensei = { version = "0.1.3", default-features = false, registry = "patina-fw" }
 uuid = { version = "1.8", default-features = false }
 x86_64 = { version = "=0.15.2", default-features = false }
+zerocopy = { version = "0.8" }
+zerocopy-derive = { version = "0.8" }
 
 # dev dependencies
 criterion = { version = "^0.5" }

--- a/components/patina_adv_logger/Cargo.toml
+++ b/components/patina_adv_logger/Cargo.toml
@@ -20,6 +20,8 @@ mu_pi = { workspace = true }
 r-efi = { workspace = true }
 spin = { workspace = true }
 mu_rust_helpers = { workspace = true }
+zerocopy = { workspace = true }
+zerocopy-derive = { workspace = true }
 
 # Only used for CLI
 clap = { workspace = true, features = ['derive'], optional = true }

--- a/components/patina_adv_logger/bin/bin.rs
+++ b/components/patina_adv_logger/bin/bin.rs
@@ -39,7 +39,12 @@ fn main() -> io::Result<()> {
     let mut buffer = Vec::new();
     file.read_to_end(&mut buffer)?;
 
-    let parser = patina_adv_logger::parser::Parser::new(&buffer).with_entry_metadata(args.entry_metadata);
+    let mut parser = patina_adv_logger::parser::Parser::open(&buffer).map_err(|e| {
+        eprintln!("Error opening log data: {}", e);
+        io::Error::new(io::ErrorKind::InvalidData, e)
+    })?;
+
+    parser.configure_print_entry_metadata(args.entry_metadata);
     // Write to standard if no output file is specified.
     match args.output_path {
         Some(path) => {

--- a/components/patina_adv_logger/src/integration_test.rs
+++ b/components/patina_adv_logger/src/integration_test.rs
@@ -47,9 +47,11 @@ fn adv_logger_test(bs: StandardBootServices) -> patina_sdk::test::Result {
     u_assert_eq!(efi_status, efi::Status::SUCCESS, "adv_logger_test: Failed to write to the advanced logger protocol.");
 
     // Check that the strings were added to the log.
-    let log_info = unsafe { memory_log::AdvLoggerInfo::adopt_memory_log(protocol.log_info) };
-    u_assert!(log_info.is_some(), "adv_logger_test: Failed to adopt the memory log.");
-    let log_info = log_info.unwrap();
+    // SAFETY: We know this memory is safe and well structure as we just created it
+    //         using the counterpart functions.
+    let log = unsafe { memory_log::AdvancedLog::adopt_memory_log(protocol.log_info) };
+    u_assert!(log.is_some(), "adv_logger_test: Failed to adopt the memory log.");
+    let log_info = log.unwrap();
     let mut direct_found = false;
     let mut protocol_found = false;
     for entry in log_info.iter() {


### PR DESCRIPTION
## Description

Undefined behavior and safety improvements:
- Removes the undefined behavior by moving the log data into a UnsafeCell.
- More tightly binds buffer parsing by using data slice and `ZeroCopy` to perform data casting.

General Cleanup:
- Introduce the wrapper `AdvancedLog` type to abstract the entire log structure and routines.
- Simplified to use `LogEntry` for all intput and output of entries for `AdvancedLog`
- Allow for readonly version of log for parsing

CLOSES: #544 

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

- [x] Tested on QEMU
- [x] Unit tests
- [x] Integration Test
- [x] Manual parsing test


## Integration Instructions

N/A
