### PR TITLE
Cargo.toml: Update scroll to v0.13

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,7 @@ patina_stacktrace = { version = "4.1.0", path = "core/patina_stacktrace", regist
 proc-macro2 = { version = "1" }
 quote = { version = "1" }
 r-efi = { version = "5.0.0", default-features = false }
-scroll = { version = "^0.12", default-features = false, features = ["derive"]}
+scroll = { version = "0.13", default-features = false, features = ["derive"]}
 spin = { version = "^0.9" }
 syn = { version = "2" }
 uart_16550 = { version = "^0.3.2" }


### PR DESCRIPTION
## Description

We use goblin 0.10 which has a dependency on scroll v0.13, however Patina specifies scroll v0.12. This leads to duplicate scroll versions being in the crate graph. This moves Patina to v0.13.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

- `cargo make all`

## Integration Instructions

- N/A