### PR TITLE
patina_dxe_core: Prevent empty component dispatch warning messages

### DIFF
--- a/patina_dxe_core/src/lib.rs
+++ b/patina_dxe_core/src/lib.rs
@@ -377,24 +377,30 @@ where
     }
 
     fn display_components_not_dispatched(&self) {
-        let name_len = "name".len();
-        let param_len = "failed_param".len();
+        if !self.components.is_empty() {
+            let name_len = "name".len();
+            let param_len = "failed_param".len();
 
-        let max_name_len = self.components.iter().map(|c| c.metadata().name().len()).max().unwrap_or(name_len);
-        let max_param_len = self
-            .components
-            .iter()
-            .map(|c| c.metadata().failed_param().map(|s| s.len()).unwrap_or(0))
-            .max()
-            .unwrap_or(param_len);
+            let max_name_len = self.components.iter().map(|c| c.metadata().name().len()).max().unwrap_or(name_len);
+            let max_param_len = self
+                .components
+                .iter()
+                .map(|c| c.metadata().failed_param().map(|s| s.len()).unwrap_or(0))
+                .max()
+                .unwrap_or(param_len);
 
-        log::warn!("Components not dispatched:");
-        log::warn!("{:-<max_name_len$} {:-<max_param_len$}", "", "");
-        log::warn!("{:<max_name_len$} {:<max_param_len$}", "name", "failed_param");
+            log::warn!("Components not dispatched:");
+            log::warn!("{:-<max_name_len$} {:-<max_param_len$}", "", "");
+            log::warn!("{:<max_name_len$} {:<max_param_len$}", "name", "failed_param");
 
-        for component in &self.components {
-            let metadata = component.metadata();
-            log::warn!("{:<max_name_len$} {:<max_param_len$}", metadata.name(), metadata.failed_param().unwrap_or(""));
+            for component in &self.components {
+                let metadata = component.metadata();
+                log::warn!(
+                    "{:<max_name_len$} {:<max_param_len$}",
+                    metadata.name(),
+                    metadata.failed_param().unwrap_or("")
+                );
+            }
         }
     }
 


### PR DESCRIPTION
## Description

If all components are dispatched, some empty warning messagees are printed intended to be the header for the list of components that were not dispatched. This change prevents those messages to prevent someone reading the log from being confused about potentially undispatched components.

The below messages are shown when all components are dispatched.

---

**BEFORE**

```
INFO - Finished Dispatching Local Drivers
WARN - Components not dispatched:
WARN - ---- ------------
WARN - name failed_param
INFO - Depex evaluation complete, scheduled 1 drivers
```

---

**AFTER**

```
INFO - Finished Dispatching Local Drivers
INFO - Depex evaluation complete, scheduled 1 drivers
```

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

- Q35 and physical platform boot with no components skipped
- Q35 and physical platform boot with a component skipped

## Integration Instructions

N/A