### PR TITLE
Update arm-gic to 0.5.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,8 @@ publish = ["patina-fw"]
 
 [workspace.dependencies]
 alloc-no-stdlib = { version = "~2.0" }
-arm-gic = { version = "^0.1.2" }
+arm-gic = { version = "0.5" }
+safe-mmio = { version = "0.2.5" }
 bitfield-struct = { version = "0.10" }
 brotli-decompressor = { version = "4.0.0", default-features = false }
 cfg-if = { version = "1" }

--- a/core/patina_internal_cpu/Cargo.toml
+++ b/core/patina_internal_cpu/Cargo.toml
@@ -31,6 +31,7 @@ patina_mtrr = { workspace = true }
 
 [target.'cfg(all(target_arch="aarch64"))'.dependencies]
 arm-gic = { workspace = true }
+safe-mmio = {workspace = true }
 
 [dev-dependencies]
 x86_64 = { workspace = true, features = [

--- a/core/patina_internal_cpu/src/interrupts/aarch64/gic_manager.rs
+++ b/core/patina_internal_cpu/src/interrupts/aarch64/gic_manager.rs
@@ -1,7 +1,10 @@
-use arm_gic::gicv3::{GicV3, IntId, Trigger, registers::GICD};
-use core::ptr::{addr_of, addr_of_mut, write_volatile};
+use arm_gic::{
+    IntId, Trigger,
+    gicv3::{GicV3, InterruptGroup},
+};
 use patina_sdk::error::EfiError;
 use r_efi::efi;
+use safe_mmio::field;
 
 use crate::interrupts::aarch64::sysreg::{read_sysreg, write_sysreg};
 
@@ -68,19 +71,6 @@ pub fn get_system_gic_version() -> GicVersion {
     GicVersion::ArmGicV2
 }
 
-/// Get the maximum interrupt number supported by the GIC.
-///
-/// # Safety
-///
-/// This function reads the GICD_TYPER register, which is set during core
-/// initialization and is not expected to change during runtime.
-///
-pub unsafe fn get_max_interrupt_number(gicd: *mut GICD) -> u32 {
-    let max_num = unsafe { addr_of!((*gicd).typer).read_volatile() & 0x1f };
-
-    if max_num == 0x1f { 1020 } else { (max_num + 1) * 32 }
-}
-
 pub fn get_mpidr() -> u64 {
     unsafe { read_sysreg!(mpidr_el1) }
 }
@@ -99,7 +89,7 @@ pub fn set_binary_point_reg(value: u64) {
 /// initialized during core initialization and not expected to change during
 /// runtime.
 ///
-pub unsafe fn gic_initialize(gicd_base: *mut u64, gicr_base: *mut u64) -> Result<GicV3, EfiError> {
+pub unsafe fn gic_initialize<'a>(gicd_base: *mut u64, gicr_base: *mut u64) -> Result<GicV3<'a>, EfiError> {
     let gic_v = get_system_gic_version();
     if gic_v == GicVersion::ArmGicV2 {
         debug_assert!(false, "GICv2 is not supported");
@@ -110,71 +100,57 @@ pub unsafe fn gic_initialize(gicd_base: *mut u64, gicr_base: *mut u64) -> Result
     // Enable affinity routing and non-secure group 1 interrupts.
     // Enable gic cpu interface
     // Enable gic distributor
-    let mut gic_v3 = unsafe { GicV3::new(gicd_base, gicr_base) };
-    gic_v3.setup();
+    let mut gic_v3 = unsafe { GicV3::new(gicd_base as _, gicr_base as _, 1, false) };
+    gic_v3.setup(0);
 
     // Disable all interrupts and set priority to 0x80.
-    let max_int = unsafe { get_max_interrupt_number(gic_v3.gicd_ptr()) };
-    for i in 0..max_int {
-        if i < 16 {
-            gic_v3.enable_interrupt(IntId::sgi(i), false);
-            gic_v3.set_interrupt_priority(IntId::sgi(i), 0x80);
-        } else if i < 32 {
-            gic_v3.enable_interrupt(IntId::ppi(i - 16), false);
-            gic_v3.set_interrupt_priority(IntId::ppi(i - 16), 0x80);
-        } else {
-            gic_v3.enable_interrupt(IntId::spi(i - 32), false);
-            gic_v3.set_interrupt_priority(IntId::spi(i - 32), 0x80);
-        }
+    gic_v3.enable_all_interrupts(false);
+    for i in IntId::private() {
+        gic_v3.set_interrupt_priority(i, Some(0), 0x80);
     }
-
-    // Route the SPIs to the primary CPU. SPIs start at the INTID 32
-    // MuChange - SPIs per the GICv3 spec start at line 32, but the previous code
-    // relied on irouter to be a value different than the spec that
-    // skipped those first 32 lines.
-    let cpu_target = get_mpidr() & (0xFF0000FFFF);
-    for i in 0..(max_int - 32) {
-        unsafe {
-            let irouter_ptr = addr_of_mut!((*gic_v3.gicd_ptr()).irouter[i as usize]);
-            write_volatile(irouter_ptr, cpu_target);
-        }
+    for spi in 0..gic_v3.typer().num_spis() {
+        gic_v3.set_interrupt_priority(IntId::spi(spi), None, 0x80);
     }
-
     // Set binary point reg to 0x7 (no preemption)
     set_binary_point_reg(0x7);
-
     // Set priority mask reg to 0xff to allow all priorities through
     GicV3::set_priority_mask(0xff);
-
     Ok(gic_v3)
 }
 
-pub struct AArch64InterruptInitializer {
-    pub gic_v3: GicV3,
+pub struct AArch64InterruptInitializer<'a> {
+    pub gic_v3: GicV3<'a>,
 }
 
-impl AArch64InterruptInitializer {
+impl AArch64InterruptInitializer<'_> {
+    fn source_to_intid(interrupt_source: u64) -> Result<IntId, efi::Status> {
+        let int_id: u32 = interrupt_source.try_into().map_err(|_| efi::Status::INVALID_PARAMETER)?;
+        Ok(match int_id {
+            x if x < IntId::SGI_COUNT => IntId::sgi(x),
+            x if x < IntId::SGI_COUNT + IntId::PPI_COUNT => IntId::ppi(x - IntId::SGI_COUNT),
+            x => IntId::spi(x - IntId::SGI_COUNT + IntId::PPI_COUNT),
+        })
+    }
+
     pub fn enable_interrupt_source(&mut self, interrupt_source: u64) -> efi::Status {
-        let int_id = if interrupt_source < 16 {
-            IntId::sgi(interrupt_source.try_into().unwrap())
-        } else if interrupt_source < 32 {
-            IntId::ppi((interrupt_source - 16).try_into().unwrap())
+        let int_id = if let Ok(int_id) = Self::source_to_intid(interrupt_source) {
+            int_id
         } else {
-            IntId::spi((interrupt_source - 32).try_into().unwrap())
+            return efi::Status::INVALID_PARAMETER;
         };
-        self.gic_v3.enable_interrupt(int_id, true);
+
+        self.gic_v3.enable_interrupt(int_id, Some(0), true);
+
         efi::Status::SUCCESS
     }
 
     pub fn disable_interrupt_source(&mut self, interrupt_source: u64) -> efi::Status {
-        let int_id = if interrupt_source < 16 {
-            IntId::sgi(interrupt_source.try_into().unwrap())
-        } else if interrupt_source < 32 {
-            IntId::ppi((interrupt_source - 16).try_into().unwrap())
+        let int_id = if let Ok(int_id) = Self::source_to_intid(interrupt_source) {
+            int_id
         } else {
-            IntId::spi((interrupt_source - 32).try_into().unwrap())
+            return efi::Status::INVALID_PARAMETER;
         };
-        self.gic_v3.enable_interrupt(int_id, false);
+        self.gic_v3.enable_interrupt(int_id, Some(0), false);
         efi::Status::SUCCESS
     }
 
@@ -182,27 +158,22 @@ impl AArch64InterruptInitializer {
         let index = (interrupt_source / 32) as usize;
         let bit = 1 << (interrupt_source % 32);
 
-        // SAFETY: We know that `gic_v3.gic_v3.gicd` is a valid and unique pointer to the registers of a
-        // GIC distributor interface, and `gic_v3.gic_v3.sgi` to the SGI and PPI registers of a GIC
-        // redistributor interface.
-        unsafe {
-            if interrupt_source < 32 {
-                addr_of_mut!((*self.gic_v3.sgi_ptr()).isenabler0).read_volatile() & bit != 0
-            } else {
-                addr_of_mut!((*self.gic_v3.gicd_ptr()).isenabler[index]).read_volatile() & bit != 0
-            }
+        if interrupt_source < 32 {
+            let mut sgi = self.gic_v3.sgi_ptr(0);
+            field!(sgi, isenabler0).read() & bit != 0
+        } else {
+            let mut gicd = self.gic_v3.gicd_ptr();
+            field!(gicd, isenabler).get(index).unwrap().read() & bit != 0
         }
     }
 
     pub fn end_of_interrupt(&self, interrupt_source: u64) -> efi::Status {
-        let int_id = if interrupt_source < 16 {
-            IntId::sgi(interrupt_source.try_into().unwrap())
-        } else if interrupt_source < 32 {
-            IntId::ppi((interrupt_source - 16).try_into().unwrap())
+        let int_id = if let Ok(int_id) = Self::source_to_intid(interrupt_source) {
+            int_id
         } else {
-            IntId::spi((interrupt_source - 32).try_into().unwrap())
+            return efi::Status::INVALID_PARAMETER;
         };
-        GicV3::end_interrupt(int_id);
+        GicV3::end_interrupt(int_id, InterruptGroup::Group1);
         efi::Status::SUCCESS
     }
 
@@ -210,35 +181,26 @@ impl AArch64InterruptInitializer {
         let index = (interrupt_source / 16) as usize;
         let bit = 1 << (interrupt_source % 16);
 
-        // SAFETY: We know that `gic_v3.gic_v3.gicd` is a valid and unique pointer to the registers of a
-        // GIC distributor interface, and `gic_v3.gic_v3.sgi` to the SGI and PPI registers of a GIC
-        // redistributor interface.
-        let level = unsafe {
-            if interrupt_source < 32 {
-                addr_of_mut!((*self.gic_v3.sgi_ptr()).icfgr[index]).read_volatile() & bit == 0
-            } else {
-                addr_of_mut!((*self.gic_v3.gicd_ptr()).icfgr[index]).read_volatile() & bit == 0
-            }
+        let level = if interrupt_source < 32 {
+            let mut sgi = self.gic_v3.sgi_ptr(0);
+            field!(sgi, icfgr).get(index).unwrap().read() & bit != 0
+        } else {
+            let mut gicd = self.gic_v3.gicd_ptr();
+            field!(gicd, icfgr).get(index).unwrap().read() & bit != 0
         };
 
         if level { Trigger::Level } else { Trigger::Edge }
     }
 
     pub fn set_trigger_type(&mut self, interrupt_source: u64, trigger_type: Trigger) -> Result<(), EfiError> {
-        let int_id = if interrupt_source < 16 {
-            IntId::sgi(interrupt_source.try_into().unwrap())
-        } else if interrupt_source < 32 {
-            IntId::ppi((interrupt_source - 16).try_into().unwrap())
-        } else {
-            IntId::spi((interrupt_source - 32).try_into().unwrap())
-        };
+        let int_id = Self::source_to_intid(interrupt_source)?;
 
-        self.gic_v3.set_trigger(int_id, trigger_type);
+        self.gic_v3.set_trigger(int_id, Some(0), trigger_type);
 
         Ok(())
     }
 
-    pub fn new(gic_v3: GicV3) -> Self {
+    pub fn new(gic_v3: GicV3<'static>) -> Self {
         AArch64InterruptInitializer { gic_v3 }
     }
 }

--- a/patina_dxe_core/src/hw_interrupt_protocol.rs
+++ b/patina_dxe_core/src/hw_interrupt_protocol.rs
@@ -4,13 +4,14 @@ use alloc::boxed::Box;
 use alloc::vec;
 use alloc::vec::Vec;
 use core::ffi::c_void;
-use patina_internal_cpu::interrupts::gic_manager::{
-    AArch64InterruptInitializer, get_max_interrupt_number, gic_initialize,
-};
+use patina_internal_cpu::interrupts::gic_manager::{AArch64InterruptInitializer, gic_initialize};
 use patina_internal_cpu::interrupts::{ExceptionContext, InterruptHandler, InterruptManager};
 use r_efi::efi;
 
-use arm_gic::gicv3::{GicV3, Trigger};
+use arm_gic::{
+    Trigger,
+    gicv3::{GicV3, InterruptGroup},
+};
 use patina_sdk::boot_services::{BootServices, StandardBootServices};
 use patina_sdk::component::{params::Config, service::Service};
 use patina_sdk::error::Result;
@@ -306,12 +307,12 @@ impl From<HardwareInterrupt2TriggerType> for Trigger {
 
 struct HwInterruptProtocolHandler {
     handlers: TplMutex<Vec<Option<HwInterruptHandler>>>,
-    aarch64_int: TplMutex<AArch64InterruptInitializer>,
+    aarch64_int: TplMutex<AArch64InterruptInitializer<'static>>,
 }
 
 impl InterruptHandler for HwInterruptProtocolHandler {
     fn handle_interrupt(&'static self, exception_type: usize, context: &mut ExceptionContext) {
-        let int_id = GicV3::get_and_acknowledge_interrupt();
+        let int_id = GicV3::get_and_acknowledge_interrupt(InterruptGroup::Group1);
         if int_id.is_none() {
             // The special interrupt do not need to be acknowledged
             return;
@@ -335,7 +336,7 @@ impl InterruptHandler for HwInterruptProtocolHandler {
         if let Some(handler) = self.handlers.lock()[raw_value as usize] {
             handler(raw_value as u64, context);
         } else {
-            GicV3::end_interrupt(int_id);
+            GicV3::end_interrupt(int_id, InterruptGroup::Group1);
             log::error!("Unhandled Exception! 0x{:x}", exception_type);
             log::error!("Exception Context: {:#x?}", context);
             panic! {"Unhandled Exception! 0x{:x}", exception_type};
@@ -344,7 +345,7 @@ impl InterruptHandler for HwInterruptProtocolHandler {
 }
 
 impl HwInterruptProtocolHandler {
-    pub fn new(handlers: Vec<Option<HwInterruptHandler>>, aarch64_int: AArch64InterruptInitializer) -> Self {
+    pub fn new(handlers: Vec<Option<HwInterruptHandler>>, aarch64_int: AArch64InterruptInitializer<'static>) -> Self {
         Self {
             handlers: TplMutex::new(efi::TPL_HIGH_LEVEL, handlers, "Hardware Interrupt Lock"),
             aarch64_int: TplMutex::new(efi::TPL_HIGH_LEVEL, aarch64_int, "AArch64 GIC Lock"),
@@ -385,13 +386,14 @@ pub(crate) fn install_hw_interrupt_protocol(
     gic_bases: Config<GicBases>,
     boot_services: StandardBootServices,
 ) -> Result<()> {
-    let mut gic_v3 = unsafe {
+    log::info!("GICv3 initializing {:x?}", (gic_bases.0, gic_bases.1));
+    let gic_v3 = unsafe {
         gic_initialize(gic_bases.0 as _, gic_bases.1 as _).inspect_err(|_| log::error!("Failed to initialize GICv3"))?
     };
     log::info!("GICv3 initialized");
 
-    let max_int = unsafe { get_max_interrupt_number(gic_v3.gicd_ptr()) as usize };
-    let handlers = vec![None; max_int];
+    let max_int = gic_v3.typer().num_spis();
+    let handlers = vec![None; max_int as usize];
     let aarch64_int = AArch64InterruptInitializer::new(gic_v3);
 
     // Prepare context for the v1 interrupt handler


### PR DESCRIPTION
## Description

Updates patina AARCH64 GIC support to use 0.5.0 of arm-gic crate. There have been significant API changes since arm-gic crate was first integrated. This PR brings patina up to the latest API. In the course of integrating this, found and filed the following bug to upstream (thanks, @kuqin12 ): [https://github.com/google/arm-gic/issues/67](https://github.com/google/arm-gic/issues/67). This issue is not fatal to operation but will cause error messages on systems with GIC RAS features enabled. 

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Built and tested boot on an AARCH64 hardware platform. 

## Integration Instructions

N/A
