### PR TITLE
patina_debugger: Improve the info (monitor ?) response

### DIFF
--- a/core/patina_debugger/src/arch/aarch64.rs
+++ b/core/patina_debugger/src/arch/aarch64.rs
@@ -97,6 +97,7 @@ impl DebuggerArch for Aarch64Arch {
                 | EC_DATA_ABORT_CURRENT_EL => ExceptionType::AccessViolation(context.far as usize),
                 _ => ExceptionType::Other(exception_class),
             },
+            instruction_pointer: context.elr,
         }
     }
 

--- a/core/patina_debugger/src/arch/x64.rs
+++ b/core/patina_debugger/src/arch/x64.rs
@@ -53,6 +53,7 @@ impl DebuggerArch for X64Arch {
                 14 => ExceptionType::AccessViolation(context.cr2 as usize),
                 _ => ExceptionType::Other(exception_type),
             },
+            instruction_pointer: context.rip,
             context: *context,
         }
     }

--- a/core/patina_debugger/src/dbg_target/monitor.rs
+++ b/core/patina_debugger/src/dbg_target/monitor.rs
@@ -71,8 +71,14 @@ impl ext::monitor_cmd::MonitorCmd for PatinaTarget {
             Some("?") => {
                 let _ = write!(
                     self.monitor_buffer,
-                    "Patina Rust Debugger.\nException Type: {:x?}",
-                    self.exception_info.exception_type
+                    concat!(
+                        "Patina Rust Debugger ",
+                        env!("CARGO_PKG_VERSION"),
+                        "\n",
+                        "Instruction Pointer: {:#X}\n",
+                        "Exception Type: {}\n"
+                    ),
+                    self.exception_info.instruction_pointer, self.exception_info.exception_type
                 );
             }
             Some("disablechecks") => {

--- a/core/patina_debugger/src/lib.rs
+++ b/core/patina_debugger/src/lib.rs
@@ -248,17 +248,18 @@ pub fn add_monitor_command(cmd: &'static str, function: MonitorCommandFn) {
 }
 
 /// Exception information for the debugger.
-#[derive(Debug)]
 #[allow(dead_code)]
 struct ExceptionInfo {
     /// The type of exception that occurred.
     pub exception_type: ExceptionType,
+    /// The instruction pointer address.
+    pub instruction_pointer: u64,
     /// The system context at the time of the exception.
     pub context: ExceptionContext,
 }
 
 /// Exception type information.
-#[derive(Debug, PartialEq, Eq)]
+#[derive(PartialEq, Eq)]
 #[allow(dead_code)]
 enum ExceptionType {
     /// A break due to a completed instruction step.
@@ -271,4 +272,18 @@ enum ExceptionType {
     GeneralProtectionFault(u64),
     /// A break due to an exception type not handled by the debugger. The exception type is provided.
     Other(u64),
+}
+
+impl core::fmt::Display for ExceptionType {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            ExceptionType::Step => write!(f, "Debug Step"),
+            ExceptionType::Breakpoint => write!(f, "Breakpoint"),
+            ExceptionType::AccessViolation(addr) => write!(f, "Access Violation at {:#X}", addr),
+            ExceptionType::GeneralProtectionFault(data) => {
+                write!(f, "General Protection Fault. Exception data: {:#X}", data)
+            }
+            ExceptionType::Other(exception_type) => write!(f, "Unknown. Architecture code: {:#X}", exception_type),
+        }
+    }
 }


### PR DESCRIPTION
## Description

Adds instruction address and clarifies the exception type info. This is invoked by calling `!uefiext.info` or `!uefiext.monitor ?` in windbgx.

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Tested on Q35

## Integration Instructions

N/A
