### PR TITLE
Coverage: Generate lcov file for local tooling

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -6,7 +6,7 @@ RUSTC_BOOTSTRAP = 1
 NO_STD_FLAGS = "--profile ${RUSTC_PROFILE} -Zbuild-std=core,compiler_builtins,alloc -Zbuild-std-features=compiler-builtins-mem -Zunstable-options --timings=html"
 STD_FLAGS = "--profile ${RUSTC_PROFILE} --features std"
 TEST_FLAGS = { value = "--features enable_patina_tests", condition = { env_not_set = ["TEST_FLAGS"] } }
-COV_FLAGS = { value = "--features enable_patina_tests --workspace --out html --out xml --exclude-files **/tests/* --exclude-files **/benches/* --exclude patina_test_macro", condition = { env_not_set = ["COV_FLAGS"] } }
+COV_FLAGS = { value = "--features enable_patina_tests --workspace --out html --out xml --out lcov --exclude-files **/tests/* --exclude-files **/benches/* --exclude patina_test_macro", condition = { env_not_set = ["COV_FLAGS"] } }
 RUSTDOCFLAGS = "-D warnings -D missing_docs"
 
 [env.development]


### PR DESCRIPTION
## Description

Local tooling such as coverage gutters can read lcov files and directly highlihgt coverage in vscode . Automatically generating this file helps automate using this tool with no extra bootstrapping.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

N/A
## Integration Instructions

N/A
