### PR TITLE
patina_sdk: PageAllocation: Do not call `Drop` on unitialized memory

### DIFF
--- a/sdk/patina_sdk/src/component/service/memory.rs
+++ b/sdk/patina_sdk/src/component/service/memory.rs
@@ -948,12 +948,18 @@ mod tests {
     #[test]
     fn test_into_boxed_slice_will_call_drop_properly() {
         static DROP_COUNT: AtomicUsize = AtomicUsize::new(0);
+        static COUNT: AtomicUsize = AtomicUsize::new(0);
 
-        #[derive(Default)]
         struct MyStruct(usize);
         impl MyStruct {
             fn value(&self) -> usize {
                 self.0
+            }
+        }
+
+        impl Default for MyStruct {
+            fn default() -> Self {
+                MyStruct(COUNT.fetch_add(1, std::sync::atomic::Ordering::SeqCst))
             }
         }
 
@@ -972,7 +978,7 @@ mod tests {
 
             let mut i = 0;
             boxed_slice.iter().for_each(|item| {
-                assert_eq!(item.value(), 0, "Default value of MyStruct should be zero");
+                assert_eq!(item.value(), i, "Default value of MyStruct should be {i}");
                 i += 1;
             });
         }


### PR DESCRIPTION
## Description

As referenced in #621, when filling the slice for `into_boxed_slice`, the value being replaced (which is uninitialized) has it's `Drop` implementation called because the function believes the data is initialized. This commit updates the logic to use MaybeUninit, so that when the value is inserted, the replaced, uninitialized data, does not have it's `Drop` implementation called

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [x] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Failing test that detected this is now passing.

## Integration Instructions

N/A
