### PR TITLE
patina_sdk: PageAllocation: Do not drop uninitialized memory

### DIFF
--- a/sdk/patina_sdk/src/component/service/memory.rs
+++ b/sdk/patina_sdk/src/component/service/memory.rs
@@ -552,13 +552,13 @@ impl PageAllocation {
 
     /// Converts the allocation and leaks the memory as a mutable `T`.
     ///
-    /// This function is similar to [Box::lea] in terms of caller responsibility for memory
+    /// This function is similar to [Box::leak] in terms of caller responsibility for memory
     /// management. Dropping the returned reference will cause a memory leak.
     ///
     /// # Returns
     ///
     /// - `None` if the size of the value is larger than the allocation.
-    /// - `Some(&T)` of the initialized value.
+    /// - `Some(&mut T)` of the initialized value.
     ///
     #[must_use]
     pub fn try_leak_as<'a, T>(mut self, value: T) -> Option<&'a mut T> {


### PR DESCRIPTION
## Description

This commit does the following two things:

1. Brings the user interface for leaking to be similar to [Box::leak](https://doc.rust-lang.org/std/boxed/struct.Box.html#method.leak) which is to say we no longer require the lifetime of the leaked data to be `static`, but still clearly state that dropping the reference will result in a memory leak.

2. Similar to #622 and the issue #621, when filling a slice, the existing memory is treated as initialized and is thus dropped when replaced with the default value. #622 resolved the issue in `into_boxed_slice` but did not fix `leak_as_slice`, which this commit resolves by moving the logic of `into_boxed_slice` into `leak_as_slice` then re-using `leak_as_slice` in `into_boxed_slice`

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [x] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

CI passes

## Integration Instructions

N/A
