### PR TITLE
.github: Add issue triager

### DIFF
--- a/.github/advanced-issue-labeler.yml
+++ b/.github/advanced-issue-labeler.yml
@@ -1,0 +1,47 @@
+# Defines the mappings between GitHub issue responses and labels applied to the issue.
+#
+# IMPORTANT: Only use labels defined in the .github/Labels.yml file in this repo.
+#
+# Copyright (c) Microsoft Corporation.
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+# For more information, see:
+# https://github.com/redhat-plumbers-in-action/advanced-issue-labeler
+
+policy:
+  - section:
+
+    # Issue Template - Urgency Dropdown
+    - id: ['urgency']
+      block-list: []
+      label:
+        - name: 'urgency:low'
+          keys: ['Low']
+        - name: 'urgency:medium'
+          keys: ['Medium']
+        - name: 'urgency:high'
+          keys: ['High']
+
+    # Issue Template - Fix Owner Dropdown
+    - id: ['fix_owner', 'request_owner']
+      block-list: []
+      label:
+        - name: 'state:needs-owner'
+          keys: [
+            'Someone else needs to fix it',
+            'Someone else needs to make the change',
+            'Someone else needs to implement the feature'
+            ]
+        - name: 'state:needs-triage'
+          keys: [
+            'Someone else needs to fix it',
+            'Someone else needs to make the change',
+            'Someone else needs to implement the feature'
+            ]
+
+    # Issue Template - Needs Maintainer Feedback Dropdown
+    - id: ['needs_maintainer_feedback']
+      block-list: []
+      label:
+        - name: 'state:needs-maintainer-feedback'
+          keys: ['Maintainer feedback requested']

--- a/.github/workflows/IssueTriager.yml
+++ b/.github/workflows/IssueTriager.yml
@@ -1,0 +1,57 @@
+# This workflow assists with initial triage of new issues by applying
+# labels based on data provided in the issue.
+#
+# Configuration file that maps issue form input values to labels:
+#   advanced-issue-labeler.yml
+#
+# Copyright (c) Microsoft Corporation.
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+# For more information, see:
+# https://github.com/stefanbuck/github-issue-parser
+# https://github.com/redhat-plumbers-in-action/advanced-issue-labeler
+
+name: Issue Triage Workflow
+
+on:
+  workflow_call:
+
+jobs:
+  triage_issues:
+    name: Triage Issues
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      issues: write
+
+    strategy:
+      matrix:
+        template: [ bug_report.yml, documentation_request.yml, feature_request.yml, unstable_feature.yml ]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Parse Issue Form
+        uses: stefanbuck/github-issue-parser@v3
+        id: issue-parser
+        with:
+          issue-body: ${{ github.event.issue.body }}
+          template-path: .github/ISSUE_TEMPLATE/${{ matrix.template }}
+
+      - name: Apply Labels from Triage
+        uses: redhat-plumbers-in-action/advanced-issue-labeler@v2
+        with:
+          issue-form: ${{ steps.issue-parser.outputs.jsonString }}
+          template: ${{ matrix.template }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Update Assignee
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          FIX_OWNER: ${{ steps.issue-parser.outputs.issueparser_fix_owner }}
+        run: |
+          if [[ $FIX_OWNER == "I will fix it" ]] || [[ $FIX_OWNER == "I will make the change" ]] || [[ $FIX_OWNER == "I will implement the feature" ]]
+          then
+            gh issue edit ${{ github.event.issue.html_url }} --add-assignee ${{ github.event.issue.user.login }}
+          fi

--- a/.github/workflows/triage-issues.yml
+++ b/.github/workflows/triage-issues.yml
@@ -1,0 +1,21 @@
+# This workflow assists with initial triage of new issues by applying
+# labels based on data provided in the issue.
+#
+# Copyright (c) Microsoft Corporation.
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+
+name: Initial Triage for New Issue
+
+on:
+  issues:
+    types: [ opened ]
+
+jobs:
+  triage:
+    permissions:
+      contents: read
+      issues: write
+
+    uses: ./.github/workflows/IssueTriager.yml
+    secrets: inherit


### PR DESCRIPTION
## Description

Adds a GitHub workflow to "triage" issues when they are initially submitted. This includes applying labels based on content in the issue.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

- Verified expected labels are added on patina fork

## Integration Instructions

- N/A