### PR TITLE
patina_sdk: Add size check to page allocation's into_raw_ptr

### DIFF
--- a/patina_dxe_core/src/memory_manager.rs
+++ b/patina_dxe_core/src/memory_manager.rs
@@ -214,12 +214,12 @@ fn memory_manager_allocations_test(mm: Service<dyn MemoryManager>) -> patina_sdk
     let result = mm.allocate_pages(1, AllocationOptions::new());
     u_assert!(result.is_ok(), "Failed to allocate single page.");
     let allocation = result.unwrap();
-    let address = allocation.into_raw_ptr::<u8>() as usize;
+    let address = allocation.into_raw_ptr::<u8>().unwrap() as usize;
     let result = unsafe { mm.free_pages(address, 1) };
     u_assert!(result.is_ok(), "Failed to free page.");
     let result = mm.allocate_pages(1, AllocationOptions::new().with_strategy(PageAllocationStrategy::Address(address)));
     u_assert!(result.is_ok(), "Failed to allocate page by address");
-    u_assert_eq!(result.unwrap().into_raw_ptr::<u8>() as usize, address, "Failed to allocate correct address");
+    u_assert_eq!(result.unwrap().into_raw_ptr::<u8>().unwrap() as usize, address, "Failed to allocate correct address");
 
     // Allocate an aligned address.
     const TEST_ALIGNMENT: usize = 0x400000;
@@ -227,7 +227,7 @@ fn memory_manager_allocations_test(mm: Service<dyn MemoryManager>) -> patina_sdk
     u_assert!(result.is_ok(), "Failed to allocate single aligned pages.");
     let allocation = result.unwrap();
     u_assert_eq!(allocation.page_count(), 8);
-    let address = allocation.into_raw_ptr::<u8>() as usize;
+    let address = allocation.into_raw_ptr::<u8>().unwrap() as usize;
     u_assert_eq!(address % TEST_ALIGNMENT, 0, "Allocated page not correctly aligned.");
     let result = unsafe { mm.free_pages(address, 8) };
     u_assert!(result.is_ok(), "Failed to free page.");
@@ -261,7 +261,7 @@ fn memory_manager_attributes_test(mm: Service<dyn MemoryManager>) -> patina_sdk:
     let result = mm.allocate_pages(1, AllocationOptions::new());
     u_assert!(result.is_ok(), "Failed to allocate single page.");
     let allocation = result.unwrap();
-    let address = allocation.into_raw_ptr::<u8>() as usize;
+    let address = allocation.into_raw_ptr::<u8>().unwrap() as usize;
     let result = mm.get_page_attributes(address, 1);
     u_assert!(result.is_ok(), "Failed to get original page attributes.");
     let (access, caching) = result.unwrap();


### PR DESCRIPTION
## Description

Other routines in the Memory Manager API will return `None` in the event that the type of the pointer does not fit into the allocated pages. This moves that logic down to the ptr so that all returnes will do size checks. A `into_raw_ptr_unchecked` could be added in the future if a truely unchecked version is needed.

This change additionally removes the `try_` prefixes as the panic versions no longer exist, and this makes the interfaces more consistent.

CLOSES: #620 

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

- [x] Q35 with patina tests
- [x] Unit tests

## Integration Instructions

Update usage to remote `try_` prefix and handle option from `into_raw_ptr`
