### PR TITLE
dxe_core: Point to Reallocated Table in Dbg Image Info

### DIFF
--- a/patina_dxe_core/src/config_tables/debug_image_info_table.rs
+++ b/patina_dxe_core/src/config_tables/debug_image_info_table.rs
@@ -222,6 +222,7 @@ pub(crate) fn core_new_debug_image_info_entry(
         metadata_table.slice = new_boxed_slice;
 
         metadata_table.actual_table_size = new_table_size;
+        metadata_table.table.efi_debug_image_info_table = metadata_table.slice.as_ptr();
     }
 
     // size here is last_index + 1


### PR DESCRIPTION
## Description

Currently, the debug image info table updates the Rust slice pointer to a newly reallocated table, but does not update the UEFI defined structure to point to the new table, as a result the old table gets freed and the table in memory (discovered by the debugger) points to garbage.

This correctly points the in memory UEFI spec defined structure to point to the new table.

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Tested on Q35 when the SCTs caused the image count to go above the initial table size. This resolved the issue of the debug extension not being able to load image symbols.

## Integration Instructions

N/A.
