### PR TITLE
core_locate_device_path: return InvalidParameter if device path is null

### DIFF
--- a/patina_dxe_core/src/protocols.rs
+++ b/patina_dxe_core/src/protocols.rs
@@ -690,6 +690,9 @@ pub fn core_locate_device_path(
     protocol: efi::Guid,
     device_path: *const r_efi::protocols::device_path::Protocol,
 ) -> Result<(*mut r_efi::protocols::device_path::Protocol, efi::Handle), EfiError> {
+    if device_path.is_null() {
+        return Err(EfiError::InvalidParameter);
+    }
     let device_path_protocol_guid = &r_efi::protocols::device_path::PROTOCOL_GUID as *const _ as *mut efi::Guid;
 
     let mut best_device: efi::Handle = core::ptr::null_mut();


### PR DESCRIPTION
## Description

If core_locate_device_path is provided a nullptr as the device path, a null pointer exception is hit in `remaining_device_path` function, as it's safety requirements are not upheld. This commit updates the logic in core_locate_device_path to return invalid parameter if the device path provided is a null pointer.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

SCTs not only stopped asserting, but now pass the previously asserting test case.

## Integration Instructions

N/A