### PR TITLE
debugger: Add descriptions to custom monitor commands

### DIFF
--- a/core/patina_debugger/src/dbg_target/monitor.rs
+++ b/core/patina_debugger/src/dbg_target/monitor.rs
@@ -60,7 +60,7 @@ impl ext::monitor_cmd::MonitorCmd for PatinaTarget {
                 let _ = buf.write_str("External commands:\n");
                 if let Some(state) = self.system_state.try_lock() {
                     for cmd in state.monitor_commands.iter() {
-                        let _ = write!(buf, "{}\t", cmd.command);
+                        let _ = writeln!(buf, "    {} - {}", cmd.command, cmd.description);
                     }
                 };
             }

--- a/core/patina_debugger/src/debugger.rs
+++ b/core/patina_debugger/src/debugger.rs
@@ -373,12 +373,17 @@ impl<T: SerialIO> Debugger for PatinaDebugger<T> {
         }
     }
 
-    fn add_monitor_command(&'static self, command: &'static str, callback: crate::MonitorCommandFn) {
+    fn add_monitor_command(
+        &'static self,
+        command: &'static str,
+        description: &'static str,
+        callback: crate::MonitorCommandFn,
+    ) {
         if !self.enabled() {
             return;
         }
 
-        self.system_state.lock().add_monitor_command(command, callback);
+        self.system_state.lock().add_monitor_command(command, description, callback);
     }
 }
 

--- a/core/patina_debugger/src/lib.rs
+++ b/core/patina_debugger/src/lib.rs
@@ -42,7 +42,7 @@
 //!     patina_debugger::set_debugger(&DEBUGGER);
 //!
 //!     // Setup a custom monitor command for this platform.
-//!     patina_debugger::add_monitor_command("my_command", |args, writer| {
+//!     patina_debugger::add_monitor_command("my_command", "Description of my_command", |args, writer| {
 //!         // Parse the arguments from _args, which is a SplitWhitespace iterator.
 //!         let _ = write!(writer, "Executed my_command with args: {:?}", args);
 //!     });
@@ -147,7 +147,7 @@ trait Debugger: Sync {
     fn poll_debugger(&'static self);
 
     /// Adds a monitor command to the debugger.
-    fn add_monitor_command(&'static self, cmd: &'static str, function: MonitorCommandFn);
+    fn add_monitor_command(&'static self, cmd: &'static str, description: &'static str, function: MonitorCommandFn);
 }
 
 #[derive(Debug)]
@@ -237,15 +237,15 @@ pub fn enabled() -> bool {
 /// ## Example
 ///
 /// ```rust
-/// patina_debugger::add_monitor_command("my_command", |args, writer| {
+/// patina_debugger::add_monitor_command("my_command", "Description of my_command", |args, writer| {
 ///     // Parse the arguments from _args, which is a SplitWhitespace iterator.
 ///     let _ = write!(writer, "Executed my_command with args: {:?}", args);
 /// });
 /// ```
 ///
-pub fn add_monitor_command(cmd: &'static str, function: MonitorCommandFn) {
+pub fn add_monitor_command(cmd: &'static str, description: &'static str, function: MonitorCommandFn) {
     if let Some(debugger) = DEBUGGER.get() {
-        debugger.add_monitor_command(cmd, function);
+        debugger.add_monitor_command(cmd, description, function);
     }
 }
 

--- a/core/patina_debugger/src/system.rs
+++ b/core/patina_debugger/src/system.rs
@@ -25,8 +25,13 @@ impl SystemState {
         SystemState { modules: Modules::new(), monitor_commands: Vec::new() }
     }
 
-    pub fn add_monitor_command(&mut self, command: &'static str, callback: MonitorCommandFn) {
-        let _monitor = MonitorCallback { command, callback };
+    pub fn add_monitor_command(
+        &mut self,
+        command: &'static str,
+        description: &'static str,
+        callback: MonitorCommandFn,
+    ) {
+        let _monitor = MonitorCallback { command, description, callback };
         cfg_if::cfg_if! {
             if #[cfg(feature = "alloc")] {
                 self.monitor_commands.push(_monitor);
@@ -125,6 +130,8 @@ impl Modules {
 pub(crate) struct MonitorCallback {
     /// The monitor command string that triggers the callback.
     pub command: &'static str,
+    /// The description of the monitor command.
+    pub description: &'static str,
     /// The callback function that will be invoked when the command is executed.
     /// See [MonitorCommandFn] for more details on the function signature.
     pub callback: MonitorCommandFn,
@@ -182,10 +189,11 @@ mod tests {
     fn test_handle_monitor_command() {
         let mut system_state = SystemState::new();
         let command = "test_command";
+        let description = "This is a test command";
         let callback: MonitorCommandFn = |args, out| {
             let _ = writeln!(out, "Executed with args: {:?}", args.collect::<Vec<_>>());
         };
-        system_state.add_monitor_command(command, callback);
+        system_state.add_monitor_command(command, description, callback);
 
         let mut out = String::new();
         let args = &mut "arg1 arg2".split_whitespace();

--- a/patina_dxe_core/src/config_tables/debug_image_info_table.rs
+++ b/patina_dxe_core/src/config_tables/debug_image_info_table.rs
@@ -172,7 +172,7 @@ pub(crate) fn initialize_debug_image_info_table(system_table: &mut EfiSystemTabl
     // Set the system table address for the debugger.
     DBG_SYSTEM_TABLE_POINTER_ADDRESS.store(address as u64, Ordering::Relaxed);
 
-    patina_debugger::add_monitor_command("system_table_ptr", |_, out| {
+    patina_debugger::add_monitor_command("system_table_ptr", "Prints the system table pointer", |_, out| {
         let address = DBG_SYSTEM_TABLE_POINTER_ADDRESS.load(Ordering::Relaxed);
         let _ = write!(out, "{:x}", address);
     });

--- a/patina_dxe_core/src/lib.rs
+++ b/patina_dxe_core/src/lib.rs
@@ -263,11 +263,7 @@ where
 
         // Add custom monitor commands to the debugger before initializing so that
         // they are available in the initial breakpoint.
-        patina_debugger::add_monitor_command("version", |_, out| {
-            let _ = out.write_str(concat!("Patina DXE Core v", env!("CARGO_PKG_VERSION")));
-        });
-
-        patina_debugger::add_monitor_command("gcd", |_, out| {
+        patina_debugger::add_monitor_command("gcd", "Prints the GCD", |_, out| {
             let _ = write!(out, "GCD -\n{}", GCD);
         });
 


### PR DESCRIPTION
## Description

Adds descriptions to custom monitor commands and cleans up the help print for the added commands.

Removed the version command as it is redundant with `?`

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Tested on Q35

## Integration Instructions

N/A
