### PR TITLE
dxe_core: Add capabilities to EFI memory map descriptors

### DIFF
--- a/patina_dxe_core/src/config_tables/memory_attributes_table.rs
+++ b/patina_dxe_core/src/config_tables/memory_attributes_table.rs
@@ -144,7 +144,7 @@ pub fn core_install_memory_attributes_table() {
     }
 
     // get the GCD memory map descriptors and filter out the non-runtime sections
-    let desc_list = match get_memory_map_descriptors(None) {
+    let desc_list = match get_memory_map_descriptors(true) {
         Ok(descriptors) => descriptors,
         Err(_) => {
             log::error!("Failed to get memory map descriptors.");


### PR DESCRIPTION
## Description

This PR changes the behavior of `efi_get_memory_map` to return the capabilities and not the active attributes as this is required by the UEFI specification. Without this behavior failures can occur in Windows when the boot loader attempts to find allocatable memory that it wants to use uncached.

<img width="1223" height="108" alt="image" src="https://github.com/user-attachments/assets/7361d983-c2d9-48cc-a565-9f9cbde89e8b" />



- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

- [x] Q35 
- [x] SBSA
- [x] aarch64 platform

## Integration Instructions

N/A
