### PR TITLE
FixedSizeBlockAllocator: Do not panic when an allocation fails due to not having enough resources.

### DIFF
--- a/patina_dxe_core/src/allocator/fixed_size_block_allocator.rs
+++ b/patina_dxe_core/src/allocator/fixed_size_block_allocator.rs
@@ -801,8 +801,14 @@ unsafe impl Allocator for SpinLockedFixedSizeBlockAllocator {
                         self.handle,
                         None,
                     )
-                    .map_err(|_| {
-                        debug_assert!(false);
+                    .map_err(|err| {
+                        log::error!(
+                            "Allocator Expansion via GCD failed: [{:?}], {{ Bytes: {:#x}, Alignment: {:#x}, Page Count: {:#x} }}",
+                            err,
+                            allocation_size,
+                            required_alignment,
+                            required_pages,
+                        );
                         AllocError
                     })?;
 


### PR DESCRIPTION
## Description

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

SCT tests previously failing as descrived in #671 and #673 no longer assert

## Integration Instructions

N/A
