### PR TITLE
patina_dxe_core: GCD: Only Map Page 0 If Existent in Compat Mode

### DIFF
--- a/patina_dxe_core/src/gcd/spin_locked_gcd.rs
+++ b/patina_dxe_core/src/gcd/spin_locked_gcd.rs
@@ -2548,11 +2548,13 @@ impl SpinLockedGcd {
         // always map page 0 if it exists in this system, as grub will attempt to read it for legacy boot structures
         // map it WB by default, because 0 is being used as the null page, it may not have gotten cache attributes
         // populated
-        if self.get_memory_descriptor_for_address(0).is_ok() {
+        if let Ok(descriptor) = self.get_memory_descriptor_for_address(0) {
             // set_memory_space_attributes will set both the GCD and paging attributes
-            if let Some(error) = self.set_memory_space_attributes(0, UEFI_PAGE_SIZE, efi::MEMORY_WB).err() {
-                log::error!("Failed to map page 0 for compat mode. Status: {:#x?}", error);
-                debug_assert!(false);
+            if descriptor.memory_type != dxe_services::GcdMemoryType::NonExistent {
+                if let Err(e) = self.set_memory_space_attributes(0, UEFI_PAGE_SIZE, efi::MEMORY_WB) {
+                    log::error!("Failed to map page 0 for compat mode. Status: {:#x?}", e);
+                    debug_assert!(false);
+                }
             }
         }
 


### PR DESCRIPTION
## Description

On some ARM64 platforms, page 0 is not a real address. This is anticipated by the GCD code and it intends to not map it in this case. However, the GCD envisions that page 0 will not exist in the GCD if this is the case, but on some platforms it will show up as NonExistent (as opposed to no descriptor).

This fixes the logic to not attempt to map page 0 if it does not exist in the GCD or if the type is non-existent.

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Tested on an ARM64 platform that was crashing when a non-existent page 0 was mapped. It was able to boot to Linux after the fix.

## Integration Instructions

N/A.
