### PR TITLE
Add Start Image ConnectController() Requirement

### DIFF
--- a/docs/src/dxe_core/images.md
+++ b/docs/src/dxe_core/images.md
@@ -138,6 +138,9 @@ flowchart TD
   style image2 fill:#caa
 ```
 
+See the following compatibility note -
+[ConnectController() Must Explicitly Be Called For Handles Created/Modified During Image Start](../integrate/patina_dxe_core_requirements.md#33-connectcontroller-must-explicitly-be-called-for-handles-createdmodified-during-image-start).
+
 ## Exiting an Image
 
 The `exit()` routine is used to transfer control from the image execution context back to the `core_start_image` context

--- a/docs/src/integrate/patina_dxe_core_requirements.md
+++ b/docs/src/integrate/patina_dxe_core_requirements.md
@@ -217,6 +217,16 @@ be able to accommodate that.
 
 Note: The Patina DXE Readiness Tool does not perform this check.
 
+#### 3.3 ConnectController() Must Explicitly Be Called For Handles Created/Modified During Image Start
+
+To maintain compatibility with UEFI drivers that are written to the EFI 1.02 Specification, the EDK II `StartImage()`
+implementation is extended to monitor the handle database before and after each image is started. If any handles are
+created or modified when an image is started, then `EFI_BOOT_SERVICES.ConnectController()` is called with the
+`Recursive` parameter set to `TRUE` for each of the newly created or modified handles before `StartImage()` returns.
+
+Patina does not implement this behavior. Images and platforms dependent on this behavior will need to be modified to
+explicitly call `ConnectController()` on any handles that they create or modify.
+
 ### 4. Known Limitations
 
 This section details requirements Patina currently has due to limitations in implementation, but that support will be


### PR DESCRIPTION
## Description

Explain a difference in behavior for connecting handles created or modified during image start between Patina and EDK II.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [x] Includes documentation?

## How This Was Tested

- `cargo make all`

## Integration Instructions

N/A