### PR TITLE
Docs: Document Stack Trace Flags Needed

### DIFF
--- a/core/patina_stacktrace/README.md
+++ b/core/patina_stacktrace/README.md
@@ -92,6 +92,10 @@ PE images:
 
 `RUSTFLAGS=-Cforce-unwind-tables`
 
+In order to preserve stack data about C binaries, this needs to be set in the platform DSC's build options section:
+
+`*_*_*_GENFW_FLAGS   = --keepexceptiontable`
+
 ## Supported Platforms
 
 - Hardware

--- a/cspell.yml
+++ b/cspell.yml
@@ -54,6 +54,7 @@ words:
   - fnent
   - gantt
   - gdbstub
+  - genfw
   - getrsp
   - getsp
   - granularities

--- a/docs/src/dxe_core/debugging.md
+++ b/docs/src/dxe_core/debugging.md
@@ -49,6 +49,23 @@ sequenceDiagram
   ExceptionHandler->>Patina: Return from exception
 ```
 
+## Prerequisites
+
+The debugger relies on exception table information being preserved in order to get an accurate stack trace. Two
+flags are needed to tell the toolchain to preserve this information, one for Rust, one for C code.
+
+Rust:
+
+This needs to be set in the environment variables for the build.
+
+`RUSTFLAGS=-Cforce-unwind-tables`
+
+C:
+
+This needs to be set in the platform DSC's build options section:
+
+`*_*_*_GENFW_FLAGS   = --keepexceptiontable`
+
 ## Structures
 
 The debugger consists of two high-level structures: the debugger struct itself and


### PR DESCRIPTION
## Description

This ensures consistent documentation between stacktrace and the debugger.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [x] Includes documentation?

## How This Was Tested

N/A.

## Integration Instructions

N/A.
