### PR TITLE
patina_internal_collections: Update function signature

### DIFF
--- a/core/patina_internal_collections/src/bst.rs
+++ b/core/patina_internal_collections/src/bst.rs
@@ -169,7 +169,7 @@ where
 
     /// Searches for a value in the tree, returning a mutable reference to it if it exists.
     ///
-    /// Returns `Some(&D)` if the value was found.
+    /// Returns `Some(&mut D)` if the value was found.
     ///
     /// Returns `None` if the value was not found.
     ///
@@ -182,8 +182,7 @@ where
     /// The caller must ensure that the mutable reference is not used to modify any value that
     /// affects the value of the key.
     ///
-    #[allow(clippy::mut_from_ref)]
-    pub unsafe fn get_mut(&self, key: &D::Key) -> Option<&mut D> {
+    pub unsafe fn get_mut(&mut self, key: &D::Key) -> Option<&mut D> {
         match self.get_node(key) {
             Some(node) => {
                 let ptr = node.as_mut_ptr();

--- a/core/patina_internal_collections/src/rbt.rs
+++ b/core/patina_internal_collections/src/rbt.rs
@@ -179,7 +179,7 @@ where
 
     /// Searches for a value in the tree, returning a mutable reference to it if it exists.
     ///
-    /// Returns `Some(&D)` if the value was found.
+    /// Returns `Some(&mut D)` if the value was found.
     ///
     /// Returns `None` if the value was not found.
     ///
@@ -192,8 +192,7 @@ where
     /// The caller must ensure that the mutable reference is not used to modify any value that
     /// affects the value of the key.
     ///
-    #[allow(clippy::mut_from_ref)]
-    pub unsafe fn get_mut(&self, key: &D::Key) -> Option<&mut D> {
+    pub unsafe fn get_mut(&mut self, key: &D::Key) -> Option<&mut D> {
         match self.get_node(key) {
             Some(node) => Some(unsafe { &mut (*node.as_mut_ptr()).data }),
             None => None,


### PR DESCRIPTION
## Description

Updates the function signature of `get_mut` in both `bst.rs` and `rbt.rs` to take a mutable reference to self. This change aligns with Rust's safety principles, ensuring that mutable access to the data structure is properly managed.

This should be considered a bug fix, as the previous signature was invalid and could cause UB. No internal usage of `get_mut` being called with an immutable reference was found, however.

closes #704

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

CI passes. Platform compiles. While this was a bug that clippy caught, but it was not being actively misused.

## Integration Instructions

N/A
