### PR TITLE
patina_internal_collections: Remove static mut usage

### DIFF
--- a/core/patina_internal_collections/benches/bench_delete.rs
+++ b/core/patina_internal_collections/benches/bench_delete.rs
@@ -95,7 +95,6 @@ fn benchmark_delete_function(c: &mut Criterion) {
     group.bench_function(BenchmarkId::new("bst", "32bit"), |b| {
         b.iter_batched_ref(
             || {
-
                 let mut bst: Bst<u32> = Bst::with_capacity(mem_u32());
                 for i in &nums {
                     bst.add(*i).unwrap();


### PR DESCRIPTION
## Description

Removes static mut usage during benchmarks by leaking the memory as needed

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

benchmarks continue to run

## Integration Instructions

N/A
