### PR TITLE
Remove `#[allow(static_mut_refs)]` macro usage

### DIFF
--- a/core/patina_internal_collections/benches/bench_delete.rs
+++ b/core/patina_internal_collections/benches/bench_delete.rs
@@ -66,7 +66,6 @@ where
     nums.into_iter().collect()
 }
 
-#[allow(static_mut_refs)]
 fn benchmark_delete_function(c: &mut Criterion) {
     let mut group = c.benchmark_group("delete");
     let nums = random_numbers::<u32>(0, 100_000);

--- a/sdk/patina_sdk/src/boot_services.rs
+++ b/sdk/patina_sdk/src/boot_services.rs
@@ -3114,7 +3114,6 @@ mod tests {
     }
 
     #[test]
-    #[allow(static_mut_refs)]
     fn test_copy_mem() {
         let boot_services = boot_services!(copy_mem = efi_copy_mem);
 
@@ -3137,7 +3136,6 @@ mod tests {
     }
 
     #[test]
-    #[allow(static_mut_refs)]
     fn test_set_mem() {
         let boot_services = boot_services!(set_mem = efi_set_mem);
 
@@ -3192,7 +3190,6 @@ mod tests {
             efi::Status::SUCCESS
         }
 
-        #[allow(static_mut_refs)]
         unsafe { boot_services.install_configuration_table(&GUID, &mut TABLE) }.unwrap();
     }
 


### PR DESCRIPTION
## Description

Removes the `#[allow(static_mut_refs)]` macro usage where it is no
longer applicable. This lint has been updated to only be applicable to
code that modifies static mutable references, rather than just anything
that accesses them.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

CI continues to pass

## Integration Instructions

N/A
