### PR TITLE
chore: Release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "2"
 members = ["components/*", "core/*", "sdk/*", "patina_dxe_core"]
 
 [workspace.package]
-version = "6.2.1"
+version = "7.0.0"
 license = "BSD-2-Clause-Patent"
 edition = "2024"
 rust-version = "1.89"
@@ -32,19 +32,20 @@ log = { version = "0.4", default-features = false }
 mu_pi = { version = "6.0.0" }
 mu_rust_helpers = { version = "3.0.1" }
 num-traits = { version = "0.2", default-features = false }
-patina_debugger = { version = "6.2.1", path = "core/patina_debugger", registry = "patina-fw" }
-patina_internal_collections = { version = "6.2.1", path = "core/patina_internal_collections", default-features = false, registry = "patina-fw" }
-patina_internal_cpu = { version = "6.2.1", path = "core/patina_internal_cpu", registry = "patina-fw" }
-patina_internal_depex = { version = "6.2.1", path = "core/patina_internal_depex", registry = "patina-fw" }
-patina_internal_device_path = { version = "6.2.1", path = "core/patina_internal_device_path", registry = "patina-fw" }
+patina_debugger = { version = "7.0.0", path = "core/patina_debugger", registry = "patina-fw" }
+patina_internal_collections = { version = "7.0.0", path = "core/patina_internal_collections", default-features = false, registry = "patina-fw" }
+patina_internal_cpu = { version = "7.0.0", path = "core/patina_internal_cpu", registry = "patina-fw" }
+patina_internal_depex = { version = "7.0.0", path = "core/patina_internal_depex", registry = "patina-fw" }
+patina_internal_device_path = { version = "7.0.0", path = "core/patina_internal_device_path", registry = "patina-fw" }
 patina_lzma_rs = { version = "0.3.1", default-features = false, registry = "patina-fw" }
 patina_mtrr = { version = "1.0.0", registry = "patina-fw" }
 patina_paging = { version = "8", registry = "patina-fw" }
-patina_performance = { version = "6.2.1", path = "components/patina_performance", registry = "patina-fw" }
-patina_sdk = { version = "6.2.1", path = "sdk/patina_sdk", registry = "patina-fw" }
-patina_ffs = { version = "6.2.1", path = "sdk/patina_ffs"}
-patina_sdk_macro = { version = "6.2.1", path = "sdk/patina_sdk_macro", registry = "patina-fw" }
-patina_stacktrace = { version = "6.2.1", path = "core/patina_stacktrace", registry = "patina-fw" }
+patina_performance = { version = "7.0.0", path = "components/patina_performance", registry = "patina-fw" }
+patina_sdk = { version = "7.0.0", path = "sdk/patina_sdk", registry = "patina-fw" }
+patina_ffs = { version = "7.0.0", path = "sdk/patina_ffs", registry = "patina-fw" }
+patina_ffs_extractors = { version = "7.0.0", path = "sdk/patina_ffs_extractors", registry = "patina-fw" }
+patina_sdk_macro = { version = "7.0.0", path = "sdk/patina_sdk_macro", registry = "patina-fw" }
+patina_stacktrace = { version = "7.0.0", path = "core/patina_stacktrace", registry = "patina-fw" }
 proc-macro2 = { version = "1" }
 quote = { version = "1" }
 r-efi = { version = "5.0.0", default-features = false }


### PR DESCRIPTION
## Description

Updates the crate version via `cargo-release` but also manually updates the Cargo.toml file to add the `patina_ffs_extractors` crate and re-target `patina-fw` registry for `patina_ffs` and `patina_ffs_extractors`.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

N/A

## Integration Instructions

N/A
