### PR TITLE
patina_debugger: Change x64 reset to use Reset Control Register

### DIFF
--- a/core/patina_debugger/src/arch/x64.rs
+++ b/core/patina_debugger/src/arch/x64.rs
@@ -129,9 +129,12 @@ impl DebuggerArch for X64Arch {
     }
 
     fn reboot() {
-        // Reset the system through the keyboard controller IO port.
+        // Reset the system through the Reset Control Register.
         unsafe {
-            asm!("cli", "out dx, al", in("dx") 0x64, in("al") 0xFE_u8);
+            asm!("cli",
+                 "out dx, al",
+                 in("dx") 0xCF9,
+                 in("al") 0x06_u8);
 
             // this is kept in a separate loop because we don't anticipate returning from this
             loop {


### PR DESCRIPTION
## Description

The keyboard controller port is legacy and not generally supported. This commit changes to use the CF9 Reset Control Register instead as it is broadly supported.

CLOSES #720 

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Tested on Q35

## Integration Instructions

N/A