### PR TITLE
Make copyrights consistent

### DIFF
--- a/components/patina_adv_logger/bin/bin.rs
+++ b/components/patina_adv_logger/bin/bin.rs
@@ -2,7 +2,7 @@
 //!
 //! ## License
 //!
-//! Copyright (C) Microsoft Corporation. All rights reserved.
+//! Copyright (c) Microsoft Corporation.
 //!
 //! SPDX-License-Identifier: Apache-2.0
 //!

--- a/components/patina_adv_logger/src/component.rs
+++ b/components/patina_adv_logger/src/component.rs
@@ -5,7 +5,7 @@
 //!
 //! ## License
 //!
-//! Copyright (C) Microsoft Corporation. All rights reserved.
+//! Copyright (c) Microsoft Corporation.
 //!
 //! SPDX-License-Identifier: Apache-2.0
 //!

--- a/components/patina_adv_logger/src/integration_test.rs
+++ b/components/patina_adv_logger/src/integration_test.rs
@@ -6,7 +6,7 @@
 //!
 //! ## License
 //!
-//! Copyright (C) Microsoft Corporation. All rights reserved.
+//! Copyright (c) Microsoft Corporation.
 //!
 //! SPDX-License-Identifier: Apache-2.0
 //!

--- a/components/patina_adv_logger/src/lib.rs
+++ b/components/patina_adv_logger/src/lib.rs
@@ -46,7 +46,7 @@
 //!
 //! ## License
 //!
-//! Copyright (C) Microsoft Corporation. All rights reserved.
+//! Copyright (c) Microsoft Corporation.
 //!
 //! SPDX-License-Identifier: Apache-2.0
 //!

--- a/components/patina_adv_logger/src/logger.rs
+++ b/components/patina_adv_logger/src/logger.rs
@@ -5,7 +5,7 @@
 //!
 //! ## License
 //!
-//! Copyright (C) Microsoft Corporation. All rights reserved.
+//! Copyright (c) Microsoft Corporation.
 //!
 //! SPDX-License-Identifier: Apache-2.0
 //!

--- a/components/patina_adv_logger/src/memory_log.rs
+++ b/components/patina_adv_logger/src/memory_log.rs
@@ -5,7 +5,7 @@
 //!
 //! ## License
 //!
-//! Copyright (C) Microsoft Corporation. All rights reserved.
+//! Copyright (c) Microsoft Corporation.
 //!
 //! SPDX-License-Identifier: Apache-2.0
 //!

--- a/components/patina_adv_logger/src/parser.rs
+++ b/components/patina_adv_logger/src/parser.rs
@@ -2,7 +2,7 @@
 //!
 //! ## License
 //!
-//! Copyright (C) Microsoft Corporation. All rights reserved.
+//! Copyright (c) Microsoft Corporation.
 //!
 //! SPDX-License-Identifier: Apache-2.0
 //!

--- a/components/patina_adv_logger/src/protocol.rs
+++ b/components/patina_adv_logger/src/protocol.rs
@@ -2,7 +2,7 @@
 //!
 //! ## License
 //!
-//! Copyright (C) Microsoft Corporation. All rights reserved.
+//! Copyright (c) Microsoft Corporation.
 //!
 //! SPDX-License-Identifier: Apache-2.0
 //!

--- a/components/patina_mm/src/component.rs
+++ b/components/patina_mm/src/component.rs
@@ -6,7 +6,7 @@
 //!
 //! ## License
 //!
-//! Copyright (C) Microsoft Corporation. All rights reserved.
+//! Copyright (c) Microsoft Corporation.
 //!
 //! SPDX-License-Identifier: Apache-2.0
 //!

--- a/components/patina_performance/src/component.rs
+++ b/components/patina_performance/src/component.rs
@@ -2,7 +2,7 @@
 //!
 //! ## License
 //!
-//! Copyright (C) Microsoft Corporation. All rights reserved.
+//! Copyright (c) Microsoft Corporation.
 //!
 //! SPDX-License-Identifier: Apache-2.0
 //!

--- a/components/patina_performance/src/component/performance.rs
+++ b/components/patina_performance/src/component/performance.rs
@@ -4,7 +4,7 @@
 //!
 //! ## License
 //!
-//! Copyright (C) Microsoft Corporation. All rights reserved.
+//! Copyright (c) Microsoft Corporation.
 //!
 //! SPDX-License-Identifier: Apache-2.0
 //!

--- a/components/patina_performance/src/lib.rs
+++ b/components/patina_performance/src/lib.rs
@@ -24,7 +24,7 @@
 //!
 //! ## License
 //!
-//! Copyright (C) Microsoft Corporation. All rights reserved.
+//! Copyright (c) Microsoft Corporation.
 //!
 //! SPDX-License-Identifier: Apache-2.0
 //!

--- a/components/patina_samples/src/function_component.rs
+++ b/components/patina_samples/src/function_component.rs
@@ -4,7 +4,7 @@
 //!
 //! ## License
 //!
-//! Copyright (C) Microsoft Corporation. All rights reserved.
+//! Copyright (c) Microsoft Corporation.
 //!
 //! SPDX-License-Identifier: Apache-2.0
 //!

--- a/components/patina_samples/src/lib.rs
+++ b/components/patina_samples/src/lib.rs
@@ -4,7 +4,7 @@
 //!
 //! ## License
 //!
-//! Copyright (C) Microsoft Corporation. All rights reserved.
+//! Copyright (c) Microsoft Corporation.
 //!
 //! SPDX-License-Identifier: Apache-2.0
 //!

--- a/components/patina_samples/src/struct_component.rs
+++ b/components/patina_samples/src/struct_component.rs
@@ -4,7 +4,7 @@
 //!
 //! ## License
 //!
-//! Copyright (C) Microsoft Corporation. All rights reserved.
+//! Copyright (c) Microsoft Corporation.
 //!
 //! SPDX-License-Identifier: Apache-2.0
 //!

--- a/core/patina_internal_collections/benches/bench_add.rs
+++ b/core/patina_internal_collections/benches/bench_add.rs
@@ -23,7 +23,7 @@
 //!
 //! ## License
 //!
-//! Copyright (C) Microsoft Corporation. All rights reserved.
+//! Copyright (c) Microsoft Corporation.
 //!
 //! SPDX-License-Identifier: Apache-2.0
 //!

--- a/core/patina_internal_collections/benches/bench_delete.rs
+++ b/core/patina_internal_collections/benches/bench_delete.rs
@@ -23,7 +23,7 @@
 //!
 //! ## License
 //!
-//! Copyright (C) Microsoft Corporation. All rights reserved.
+//! Copyright (c) Microsoft Corporation.
 //!
 //! SPDX-License-Identifier: Apache-2.0
 //!

--- a/core/patina_internal_collections/benches/bench_search.rs
+++ b/core/patina_internal_collections/benches/bench_search.rs
@@ -23,7 +23,7 @@
 //!
 //! ## License
 //!
-//! Copyright (C) Microsoft Corporation. All rights reserved.
+//! Copyright (c) Microsoft Corporation.
 //!
 //! SPDX-License-Identifier: Apache-2.0
 //!

--- a/core/patina_internal_collections/src/bst.rs
+++ b/core/patina_internal_collections/src/bst.rs
@@ -2,7 +2,7 @@
 //!
 //! ## License
 //!
-//! Copyright (C) Microsoft Corporation. All rights reserved.
+//! Copyright (c) Microsoft Corporation.
 //!
 //! SPDX-License-Identifier: Apache-2.0
 //!

--- a/core/patina_internal_collections/src/lib.rs
+++ b/core/patina_internal_collections/src/lib.rs
@@ -53,7 +53,7 @@
 //!
 //! ## License
 //!
-//! Copyright (C) Microsoft Corporation. All rights reserved.
+//! Copyright (c) Microsoft Corporation.
 //!
 //! SPDX-License-Identifier: Apache-2.0
 //!

--- a/core/patina_internal_collections/src/node.rs
+++ b/core/patina_internal_collections/src/node.rs
@@ -2,7 +2,7 @@
 //!
 //! ## License
 //!
-//! Copyright (C) Microsoft Corporation. All rights reserved.
+//! Copyright (c) Microsoft Corporation.
 //!
 //! SPDX-License-Identifier: Apache-2.0
 //!

--- a/core/patina_internal_collections/src/rbt.rs
+++ b/core/patina_internal_collections/src/rbt.rs
@@ -2,7 +2,7 @@
 //!
 //! ## License
 //!
-//! Copyright (C) Microsoft Corporation. All rights reserved.
+//! Copyright (c) Microsoft Corporation.
 //!
 //! SPDX-License-Identifier: Apache-2.0
 //!

--- a/core/patina_internal_collections/src/sorted_slice.rs
+++ b/core/patina_internal_collections/src/sorted_slice.rs
@@ -2,7 +2,7 @@
 //!
 //! ## License
 //!
-//! Copyright (C) Microsoft Corporation. All rights reserved.
+//! Copyright (c) Microsoft Corporation.
 //!
 //! SPDX-License-Identifier: Apache-2.0
 //!

--- a/core/patina_internal_cpu/src/cpu.rs
+++ b/core/patina_internal_cpu/src/cpu.rs
@@ -6,7 +6,7 @@
 //!
 //! ## License
 //!
-//! Copyright (C) Microsoft Corporation. All rights reserved.
+//! Copyright (c) Microsoft Corporation.
 //!
 //! SPDX-License-Identifier: Apache-2.0
 //!

--- a/core/patina_internal_cpu/src/cpu/aarch64.rs
+++ b/core/patina_internal_cpu/src/cpu/aarch64.rs
@@ -2,7 +2,7 @@
 //!
 //! ## License
 //!
-//! Copyright (C) Microsoft Corporation. All rights reserved.
+//! Copyright (c) Microsoft Corporation.
 //!
 //! SPDX-License-Identifier: Apache-2.0
 //!

--- a/core/patina_internal_cpu/src/cpu/aarch64/cpu.rs
+++ b/core/patina_internal_cpu/src/cpu/aarch64/cpu.rs
@@ -2,7 +2,7 @@
 //!
 //! ## License
 //!
-//! Copyright (C) Microsoft Corporation. All rights reserved.
+//! Copyright (c) Microsoft Corporation.
 //!
 //! SPDX-License-Identifier: Apache-2.0
 //!

--- a/core/patina_internal_cpu/src/cpu/null.rs
+++ b/core/patina_internal_cpu/src/cpu/null.rs
@@ -2,7 +2,7 @@
 //!
 //! ## License
 //!
-//! Copyright (C) Microsoft Corporation. All rights reserved.
+//! Copyright (c) Microsoft Corporation.
 //!
 //! SPDX-License-Identifier: Apache-2.0
 //!

--- a/core/patina_internal_cpu/src/cpu/x64.rs
+++ b/core/patina_internal_cpu/src/cpu/x64.rs
@@ -2,7 +2,7 @@
 //!
 //! ## License
 //!
-//! Copyright (C) Microsoft Corporation. All rights reserved.
+//! Copyright (c) Microsoft Corporation.
 //!
 //! SPDX-License-Identifier: Apache-2.0
 //!

--- a/core/patina_internal_cpu/src/cpu/x64/cpu.rs
+++ b/core/patina_internal_cpu/src/cpu/x64/cpu.rs
@@ -2,7 +2,7 @@
 //!
 //! ## License
 //!
-//! Copyright (C) Microsoft Corporation. All rights reserved.
+//! Copyright (c) Microsoft Corporation.
 //!
 //! SPDX-License-Identifier: Apache-2.0
 //!

--- a/core/patina_internal_cpu/src/cpu/x64/gdt.rs
+++ b/core/patina_internal_cpu/src/cpu/x64/gdt.rs
@@ -2,7 +2,7 @@
 //!
 //! ## License
 //!
-//! Copyright (C) Microsoft Corporation. All rights reserved.
+//! Copyright (c) Microsoft Corporation.
 //!
 //! SPDX-License-Identifier: Apache-2.0
 //!

--- a/core/patina_internal_cpu/src/interrupts.rs
+++ b/core/patina_internal_cpu/src/interrupts.rs
@@ -10,7 +10,7 @@
 //!
 //! ## License
 //!
-//! Copyright (C) Microsoft Corporation. All rights reserved.
+//! Copyright (c) Microsoft Corporation.
 //!
 //! SPDX-License-Identifier: Apache-2.0
 //!

--- a/core/patina_internal_cpu/src/interrupts/aarch64.rs
+++ b/core/patina_internal_cpu/src/interrupts/aarch64.rs
@@ -2,7 +2,7 @@
 //!
 //! ## License
 //!
-//! Copyright (C) Microsoft Corporation. All rights reserved.
+//! Copyright (c) Microsoft Corporation.
 //!
 //! SPDX-License-Identifier: Apache-2.0
 //!

--- a/core/patina_internal_cpu/src/interrupts/aarch64/interrupt_manager.rs
+++ b/core/patina_internal_cpu/src/interrupts/aarch64/interrupt_manager.rs
@@ -2,7 +2,7 @@
 //!
 //! ## License
 //!
-//! Copyright (C) Microsoft Corporation. All rights reserved.
+//! Copyright (c) Microsoft Corporation.
 //!
 //! SPDX-License-Identifier: Apache-2.0
 //!

--- a/core/patina_internal_cpu/src/interrupts/null.rs
+++ b/core/patina_internal_cpu/src/interrupts/null.rs
@@ -2,7 +2,7 @@
 //!
 //! ## License
 //!
-//! Copyright (C) Microsoft Corporation. All rights reserved.
+//! Copyright (c) Microsoft Corporation.
 //!
 //! SPDX-License-Identifier: Apache-2.0
 //!

--- a/core/patina_internal_cpu/src/interrupts/null/interrupt_manager.rs
+++ b/core/patina_internal_cpu/src/interrupts/null/interrupt_manager.rs
@@ -2,7 +2,7 @@
 //!
 //! ## License
 //!
-//! Copyright (C) Microsoft Corporation. All rights reserved.
+//! Copyright (c) Microsoft Corporation.
 //!
 //! SPDX-License-Identifier: Apache-2.0
 //!

--- a/core/patina_internal_cpu/src/interrupts/x64.rs
+++ b/core/patina_internal_cpu/src/interrupts/x64.rs
@@ -2,7 +2,7 @@
 //!
 //! ## License
 //!
-//! Copyright (C) Microsoft Corporation. All rights reserved.
+//! Copyright (c) Microsoft Corporation.
 //!
 //! SPDX-License-Identifier: Apache-2.0
 //!

--- a/core/patina_internal_cpu/src/interrupts/x64/interrupt_handler.asm
+++ b/core/patina_internal_cpu/src/interrupts/x64/interrupt_handler.asm
@@ -1,7 +1,7 @@
 #
 # Exception entry point logic for X64.
 #
-# Copyright (C) Microsoft Corporation. All rights reserved.
+# Copyright (c) Microsoft Corporation.
 #
 # SPDX-License-Identifier: Apache-2.0
 #

--- a/core/patina_internal_cpu/src/interrupts/x64/interrupt_manager.rs
+++ b/core/patina_internal_cpu/src/interrupts/x64/interrupt_manager.rs
@@ -2,7 +2,7 @@
 //!
 //! ## License
 //!
-//! Copyright (C) Microsoft Corporation. All rights reserved.
+//! Copyright (c) Microsoft Corporation.
 //!
 //! SPDX-License-Identifier: Apache-2.0
 //!

--- a/core/patina_internal_cpu/src/lib.rs
+++ b/core/patina_internal_cpu/src/lib.rs
@@ -4,7 +4,7 @@
 //!
 //! ## License
 //!
-//! Copyright (C) Microsoft Corporation. All rights reserved.
+//! Copyright (c) Microsoft Corporation.
 //!
 //! SPDX-License-Identifier: Apache-2.0
 //!

--- a/core/patina_internal_cpu/src/paging.rs
+++ b/core/patina_internal_cpu/src/paging.rs
@@ -4,7 +4,7 @@
 //!
 //! ## License
 //!
-//! Copyright (C) Microsoft Corporation. All rights reserved.
+//! Copyright (c) Microsoft Corporation.
 //!
 //! SPDX-License-Identifier: Apache-2.0
 //!

--- a/core/patina_internal_cpu/src/paging/aarch64.rs
+++ b/core/patina_internal_cpu/src/paging/aarch64.rs
@@ -4,7 +4,7 @@
 //!
 //! ## License
 //!
-//! Copyright (C) Microsoft Corporation. All rights reserved.
+//! Copyright (c) Microsoft Corporation.
 //!
 //! SPDX-License-Identifier: Apache-2.0
 //!

--- a/core/patina_internal_cpu/src/paging/null.rs
+++ b/core/patina_internal_cpu/src/paging/null.rs
@@ -4,7 +4,7 @@
 //!
 //! ## License
 //!
-//! Copyright (C) Microsoft Corporation. All rights reserved.
+//! Copyright (c) Microsoft Corporation.
 //!
 //! SPDX-License-Identifier: Apache-2.0
 //!

--- a/core/patina_internal_cpu/src/paging/x64.rs
+++ b/core/patina_internal_cpu/src/paging/x64.rs
@@ -4,7 +4,7 @@
 //!
 //! ## License
 //!
-//! Copyright (C) Microsoft Corporation. All rights reserved.
+//! Copyright (c) Microsoft Corporation.
 //!
 //! SPDX-License-Identifier: Apache-2.0
 //!

--- a/core/patina_internal_depex/src/lib.rs
+++ b/core/patina_internal_depex/src/lib.rs
@@ -4,7 +4,7 @@
 //!
 //! ## License
 //!
-//! Copyright (C) Microsoft Corporation. All rights reserved.
+//! Copyright (c) Microsoft Corporation.
 //!
 //! SPDX-License-Identifier: Apache-2.0
 //!

--- a/core/patina_internal_device_path/src/lib.rs
+++ b/core/patina_internal_device_path/src/lib.rs
@@ -4,7 +4,7 @@
 //!
 //! ## License
 //!
-//! Copyright (C) Microsoft Corporation. All rights reserved.
+//! Copyright (c) Microsoft Corporation.
 //!
 //! SPDX-License-Identifier: Apache-2.0
 //!

--- a/core/patina_stacktrace/src/error.rs
+++ b/core/patina_stacktrace/src/error.rs
@@ -2,7 +2,7 @@
 //!
 //! ## License
 //!
-//! Copyright (C) Microsoft Corporation. All rights reserved.
+//! Copyright (c) Microsoft Corporation.
 //!
 //! SPDX-License-Identifier: Apache-2.0
 use core::fmt;

--- a/patina_dxe_core/examples/std.rs
+++ b/patina_dxe_core/examples/std.rs
@@ -2,7 +2,7 @@
 //!
 //! ## License
 //!
-//! Copyright (C) Microsoft Corporation. All rights reserved.
+//! Copyright (c) Microsoft Corporation.
 //!
 //! SPDX-License-Identifier: Apache-2.0
 //!

--- a/patina_dxe_core/src/allocator.rs
+++ b/patina_dxe_core/src/allocator.rs
@@ -2,7 +2,7 @@
 //!
 //! ## License
 //!
-//! Copyright (C) Microsoft Corporation. All rights reserved.
+//! Copyright (c) Microsoft Corporation.
 //!
 //! SPDX-License-Identifier: Apache-2.0
 //!

--- a/patina_dxe_core/src/allocator/fixed_size_block_allocator.rs
+++ b/patina_dxe_core/src/allocator/fixed_size_block_allocator.rs
@@ -5,7 +5,7 @@
 //!
 //! ## License
 //!
-//! Copyright (C) Microsoft Corporation. All rights reserved.
+//! Copyright (c) Microsoft Corporation.
 //!
 //! SPDX-License-Identifier: Apache-2.0
 //!

--- a/patina_dxe_core/src/allocator/uefi_allocator.rs
+++ b/patina_dxe_core/src/allocator/uefi_allocator.rs
@@ -4,7 +4,7 @@
 //!
 //! ## License
 //!
-//! Copyright (C) Microsoft Corporation. All rights reserved.
+//! Copyright (c) Microsoft Corporation.
 //!
 //! SPDX-License-Identifier: Apache-2.0
 //!

--- a/patina_dxe_core/src/config_tables/memory_attributes_table.rs
+++ b/patina_dxe_core/src/config_tables/memory_attributes_table.rs
@@ -2,7 +2,7 @@
 //!
 //! ## License
 //!
-//! Copyright (C) Microsoft Corporation. All rights reserved.
+//! Copyright (c) Microsoft Corporation.
 //!
 //! SPDX-License-Identifier: Apache-2.0
 //!

--- a/patina_dxe_core/src/cpu_arch_protocol.rs
+++ b/patina_dxe_core/src/cpu_arch_protocol.rs
@@ -2,7 +2,7 @@
 //!
 //! ## License
 //!
-//! Copyright (C) Microsoft Corporation. All rights reserved.
+//! Copyright (c) Microsoft Corporation.
 //!
 //! SPDX-License-Identifier: Apache-2.0
 //!

--- a/patina_dxe_core/src/dispatcher.rs
+++ b/patina_dxe_core/src/dispatcher.rs
@@ -2,7 +2,7 @@
 //!
 //! ## License
 //!
-//! Copyright (C) Microsoft Corporation. All rights reserved.
+//! Copyright (c) Microsoft Corporation.
 //!
 //! SPDX-License-Identifier: Apache-2.0
 //!

--- a/patina_dxe_core/src/driver_services.rs
+++ b/patina_dxe_core/src/driver_services.rs
@@ -2,7 +2,7 @@
 //!
 //! ## License
 //!
-//! Copyright (C) Microsoft Corporation. All rights reserved.
+//! Copyright (c) Microsoft Corporation.
 //!
 //! SPDX-License-Identifier: Apache-2.0
 //!

--- a/patina_dxe_core/src/dxe_services.rs
+++ b/patina_dxe_core/src/dxe_services.rs
@@ -2,7 +2,7 @@
 //!
 //! ## License
 //!
-//! Copyright (C) Microsoft Corporation. All rights reserved.
+//! Copyright (c) Microsoft Corporation.
 //!
 //! SPDX-License-Identifier: Apache-2.0
 //!

--- a/patina_dxe_core/src/event_db.rs
+++ b/patina_dxe_core/src/event_db.rs
@@ -4,7 +4,7 @@
 //!
 //! ## License
 //!
-//! Copyright (C) Microsoft Corporation. All rights reserved.
+//! Copyright (c) Microsoft Corporation.
 //!
 //! SPDX-License-Identifier: Apache-2.0
 //!

--- a/patina_dxe_core/src/events.rs
+++ b/patina_dxe_core/src/events.rs
@@ -2,7 +2,7 @@
 //!
 //! ## License
 //!
-//! Copyright (C) Microsoft Corporation. All rights reserved.
+//! Copyright (c) Microsoft Corporation.
 //!
 //! SPDX-License-Identifier: Apache-2.0
 //!

--- a/patina_dxe_core/src/filesystems.rs
+++ b/patina_dxe_core/src/filesystems.rs
@@ -2,7 +2,7 @@
 //!
 //! ## License
 //!
-//! Copyright (C) Microsoft Corporation. All rights reserved.
+//! Copyright (c) Microsoft Corporation.
 //!
 //! SPDX-License-Identifier: Apache-2.0
 //!

--- a/patina_dxe_core/src/fv.rs
+++ b/patina_dxe_core/src/fv.rs
@@ -2,7 +2,7 @@
 //!
 //! ## License
 //!
-//! Copyright (C) Microsoft Corporation. All rights reserved.
+//! Copyright (c) Microsoft Corporation.
 //!
 //! SPDX-License-Identifier: Apache-2.0
 //!

--- a/patina_dxe_core/src/gcd.rs
+++ b/patina_dxe_core/src/gcd.rs
@@ -2,7 +2,7 @@
 //!
 //! ## License
 //!
-//! Copyright (C) Microsoft Corporation. All rights reserved.
+//! Copyright (c) Microsoft Corporation.
 //!
 //! SPDX-License-Identifier: Apache-2.0
 //!

--- a/patina_dxe_core/src/gcd/io_block.rs
+++ b/patina_dxe_core/src/gcd/io_block.rs
@@ -2,7 +2,7 @@
 //!
 //! ## License
 //!
-//! Copyright (C) Microsoft Corporation. All rights reserved.
+//! Copyright (c) Microsoft Corporation.
 //!
 //! SPDX-License-Identifier: Apache-2.0
 //!

--- a/patina_dxe_core/src/gcd/memory_block.rs
+++ b/patina_dxe_core/src/gcd/memory_block.rs
@@ -2,7 +2,7 @@
 //!
 //! ## License
 //!
-//! Copyright (C) Microsoft Corporation. All rights reserved.
+//! Copyright (c) Microsoft Corporation.
 //!
 //! SPDX-License-Identifier: Apache-2.0
 //!

--- a/patina_dxe_core/src/gcd/spin_locked_gcd.rs
+++ b/patina_dxe_core/src/gcd/spin_locked_gcd.rs
@@ -2,7 +2,7 @@
 //!
 //! ## License
 //!
-//! Copyright (C) Microsoft Corporation. All rights reserved.
+//! Copyright (c) Microsoft Corporation.
 //!
 //! SPDX-License-Identifier: Apache-2.0
 //!

--- a/patina_dxe_core/src/image.rs
+++ b/patina_dxe_core/src/image.rs
@@ -2,7 +2,7 @@
 //!
 //! ## License
 //!
-//! Copyright (C) Microsoft Corporation. All rights reserved.
+//! Copyright (c) Microsoft Corporation.
 //!
 //! SPDX-License-Identifier: Apache-2.0
 //!

--- a/patina_dxe_core/src/lib.rs
+++ b/patina_dxe_core/src/lib.rs
@@ -19,7 +19,7 @@
 //!
 //! ## License
 //!
-//! Copyright (C) Microsoft Corporation. All rights reserved.
+//! Copyright (c) Microsoft Corporation.
 //!
 //! SPDX-License-Identifier: Apache-2.0
 //!

--- a/patina_dxe_core/src/memory_attributes_protocol.rs
+++ b/patina_dxe_core/src/memory_attributes_protocol.rs
@@ -2,7 +2,7 @@
 //!
 //! ## License
 //!
-//! Copyright (C) Microsoft Corporation. All rights reserved.
+//! Copyright (c) Microsoft Corporation.
 //!
 //! SPDX-License-Identifier: Apache-2.0
 //!

--- a/patina_dxe_core/src/memory_manager.rs
+++ b/patina_dxe_core/src/memory_manager.rs
@@ -2,7 +2,7 @@
 //!
 //! ## License
 //!
-//! Copyright (C) Microsoft Corporation. All rights reserved.
+//! Copyright (c) Microsoft Corporation.
 //!
 //! SPDX-License-Identifier: Apache-2.0
 //!

--- a/patina_dxe_core/src/misc_boot_services.rs
+++ b/patina_dxe_core/src/misc_boot_services.rs
@@ -2,7 +2,7 @@
 //!
 //! ## License
 //!
-//! Copyright (C) Microsoft Corporation. All rights reserved.
+//! Copyright (c) Microsoft Corporation.
 //!
 //! SPDX-License-Identifier: Apache-2.0
 //!

--- a/patina_dxe_core/src/pecoff.rs
+++ b/patina_dxe_core/src/pecoff.rs
@@ -2,7 +2,7 @@
 //!
 //! ## License
 //!
-//! Copyright (C) Microsoft Corporation. All rights reserved.
+//! Copyright (c) Microsoft Corporation.
 //!
 //! SPDX-License-Identifier: Apache-2.0
 //!

--- a/patina_dxe_core/src/pecoff/error.rs
+++ b/patina_dxe_core/src/pecoff/error.rs
@@ -2,7 +2,7 @@
 //!
 //! ## License
 //!
-//! Copyright (C) Microsoft Corporation. All rights reserved.
+//! Copyright (c) Microsoft Corporation.
 //!
 //! SPDX-License-Identifier: Apache-2.0
 //!

--- a/patina_dxe_core/src/pecoff/relocation.rs
+++ b/patina_dxe_core/src/pecoff/relocation.rs
@@ -2,7 +2,7 @@
 //!
 //! ## License
 //!
-//! Copyright (C) Microsoft Corporation. All rights reserved.
+//! Copyright (c) Microsoft Corporation.
 //!
 //! SPDX-License-Identifier: Apache-2.0
 //!

--- a/patina_dxe_core/src/pecoff/resource_directory.rs
+++ b/patina_dxe_core/src/pecoff/resource_directory.rs
@@ -2,7 +2,7 @@
 //!
 //! ## License
 //!
-//! Copyright (C) Microsoft Corporation. All rights reserved.
+//! Copyright (c) Microsoft Corporation.
 //!
 //! SPDX-License-Identifier: Apache-2.0
 //!

--- a/patina_dxe_core/src/protocol_db.rs
+++ b/patina_dxe_core/src/protocol_db.rs
@@ -4,7 +4,7 @@
 //!
 //! ## License
 //!
-//! Copyright (C) Microsoft Corporation. All rights reserved.
+//! Copyright (c) Microsoft Corporation.
 //!
 //! SPDX-License-Identifier: Apache-2.0
 //!

--- a/patina_dxe_core/src/protocols.rs
+++ b/patina_dxe_core/src/protocols.rs
@@ -2,7 +2,7 @@
 //!
 //! ## License
 //!
-//! Copyright (C) Microsoft Corporation. All rights reserved.
+//! Copyright (c) Microsoft Corporation.
 //!
 //! SPDX-License-Identifier: Apache-2.0
 //!

--- a/patina_dxe_core/src/runtime.rs
+++ b/patina_dxe_core/src/runtime.rs
@@ -2,7 +2,7 @@
 //!
 //! ## License
 //!
-//! Copyright (C) Microsoft Corporation. All rights reserved.
+//! Copyright (c) Microsoft Corporation.
 //!
 //! SPDX-License-Identifier: Apache-2.0
 //!

--- a/patina_dxe_core/src/systemtables.rs
+++ b/patina_dxe_core/src/systemtables.rs
@@ -4,7 +4,7 @@
 //!
 //! ## License
 //!
-//! Copyright (C) Microsoft Corporation. All rights reserved.
+//! Copyright (c) Microsoft Corporation.
 //!
 //! SPDX-License-Identifier: Apache-2.0
 //!

--- a/patina_dxe_core/src/test_support.rs
+++ b/patina_dxe_core/src/test_support.rs
@@ -4,7 +4,7 @@
 //!
 //! ## License
 //!
-//! Copyright (C) Microsoft Corporation. All rights reserved.
+//! Copyright (c) Microsoft Corporation.
 //!
 //! SPDX-License-Identifier: Apache-2.0
 //!

--- a/patina_dxe_core/src/tpl_lock.rs
+++ b/patina_dxe_core/src/tpl_lock.rs
@@ -4,7 +4,7 @@
 //!
 //! ## License
 //!
-//! Copyright (C) Microsoft Corporation. All rights reserved.
+//! Copyright (c) Microsoft Corporation.
 //!
 //! SPDX-License-Identifier: Apache-2.0
 use core::{

--- a/sdk/patina_ffs_extractors/src/brotli.rs
+++ b/sdk/patina_ffs_extractors/src/brotli.rs
@@ -2,7 +2,7 @@
 //!
 //! ## License
 //!
-//! Copyright (C) Microsoft Corporation. All rights reserved.
+//! Copyright (c) Microsoft Corporation.
 //!
 //! SPDX-License-Identifier: Apache-2.0
 //!

--- a/sdk/patina_ffs_extractors/src/composite.rs
+++ b/sdk/patina_ffs_extractors/src/composite.rs
@@ -2,7 +2,7 @@
 //!
 //! ## License
 //!
-//! Copyright (C) Microsoft Corporation. All rights reserved.
+//! Copyright (c) Microsoft Corporation.
 //!
 //! SPDX-License-Identifier: Apache-2.0
 //!

--- a/sdk/patina_ffs_extractors/src/crc32.rs
+++ b/sdk/patina_ffs_extractors/src/crc32.rs
@@ -2,7 +2,7 @@
 //!
 //! ## License
 //!
-//! Copyright (C) Microsoft Corporation. All rights reserved.
+//! Copyright (c) Microsoft Corporation.
 //!
 //! SPDX-License-Identifier: Apache-2.0
 //!

--- a/sdk/patina_ffs_extractors/src/lib.rs
+++ b/sdk/patina_ffs_extractors/src/lib.rs
@@ -17,7 +17,7 @@
 //!
 //! ## License
 //!
-//! Copyright (C) Microsoft Corporation. All rights reserved.
+//! Copyright (c) Microsoft Corporation.
 //!
 //! SPDX-License-Identifier: Apache-2.0
 //!

--- a/sdk/patina_ffs_extractors/src/lzma.rs
+++ b/sdk/patina_ffs_extractors/src/lzma.rs
@@ -2,7 +2,7 @@
 //!
 //! ## License
 //!
-//! Copyright (C) Microsoft Corporation. All rights reserved.
+//! Copyright (c) Microsoft Corporation.
 //!
 //! SPDX-License-Identifier: Apache-2.0
 //!

--- a/sdk/patina_ffs_extractors/src/null.rs
+++ b/sdk/patina_ffs_extractors/src/null.rs
@@ -2,7 +2,7 @@
 //!
 //! ## License
 //!
-//! Copyright (C) Microsoft Corporation. All rights reserved.
+//! Copyright (c) Microsoft Corporation.
 //!
 //! SPDX-License-Identifier: Apache-2.0
 //!

--- a/sdk/patina_ffs_extractors/src/uefi_decompress.rs
+++ b/sdk/patina_ffs_extractors/src/uefi_decompress.rs
@@ -2,7 +2,7 @@
 //!
 //! ## License
 //!
-//! Copyright (C) Microsoft Corporation. All rights reserved.
+//! Copyright (c) Microsoft Corporation.
 //!
 //! SPDX-License-Identifier: Apache-2.0
 //!

--- a/sdk/patina_sdk/benches/bench_component.rs
+++ b/sdk/patina_sdk/benches/bench_component.rs
@@ -22,7 +22,7 @@
 //!
 //! ## License
 //!
-//! Copyright (C) Microsoft Corporation. All rights reserved.
+//! Copyright (c) Microsoft Corporation.
 //!
 //! SPDX-License-Identifier: Apache-2.0
 //!

--- a/sdk/patina_sdk/benches/bench_service.rs
+++ b/sdk/patina_sdk/benches/bench_service.rs
@@ -24,7 +24,7 @@
 //!
 //! ## License
 //!
-//! Copyright (C) Microsoft Corporation. All rights reserved.
+//! Copyright (c) Microsoft Corporation.
 //!
 //! SPDX-License-Identifier: Apache-2.0
 //!

--- a/sdk/patina_sdk/src/boot_services.rs
+++ b/sdk/patina_sdk/src/boot_services.rs
@@ -2,7 +2,7 @@
 //!
 //! ## License
 //!
-//! Copyright (C) Microsoft Corporation. All rights reserved.
+//! Copyright (c) Microsoft Corporation.
 //!
 //! SPDX-License-Identifier: Apache-2.0
 //!

--- a/sdk/patina_sdk/src/boot_services/allocation.rs
+++ b/sdk/patina_sdk/src/boot_services/allocation.rs
@@ -2,7 +2,7 @@
 //!
 //! ## License
 //!
-//! Copyright (C) Microsoft Corporation. All rights reserved.
+//! Copyright (c) Microsoft Corporation.
 //!
 //! SPDX-License-Identifier: Apache-2.0
 //!

--- a/sdk/patina_sdk/src/boot_services/boxed.rs
+++ b/sdk/patina_sdk/src/boot_services/boxed.rs
@@ -2,7 +2,7 @@
 //!
 //! ## License
 //!
-//! Copyright (C) Microsoft Corporation. All rights reserved.
+//! Copyright (c) Microsoft Corporation.
 //!
 //! SPDX-License-Identifier: Apache-2.0
 //!

--- a/sdk/patina_sdk/src/boot_services/c_ptr.rs
+++ b/sdk/patina_sdk/src/boot_services/c_ptr.rs
@@ -2,7 +2,7 @@
 //!
 //! ## License
 //!
-//! Copyright (C) Microsoft Corporation. All rights reserved.
+//! Copyright (c) Microsoft Corporation.
 //!
 //! SPDX-License-Identifier: Apache-2.0
 //!

--- a/sdk/patina_sdk/src/boot_services/event.rs
+++ b/sdk/patina_sdk/src/boot_services/event.rs
@@ -2,7 +2,7 @@
 //!
 //! ## License
 //!
-//! Copyright (C) Microsoft Corporation. All rights reserved.
+//! Copyright (c) Microsoft Corporation.
 //!
 //! SPDX-License-Identifier: Apache-2.0
 //!

--- a/sdk/patina_sdk/src/boot_services/global_allocator.rs
+++ b/sdk/patina_sdk/src/boot_services/global_allocator.rs
@@ -2,7 +2,7 @@
 //!
 //! ## License
 //!
-//! Copyright (C) Microsoft Corporation. All rights reserved.
+//! Copyright (c) Microsoft Corporation.
 //!
 //! SPDX-License-Identifier: Apache-2.0
 //!

--- a/sdk/patina_sdk/src/boot_services/protocol_handler.rs
+++ b/sdk/patina_sdk/src/boot_services/protocol_handler.rs
@@ -2,7 +2,7 @@
 //!
 //! ## License
 //!
-//! Copyright (C) Microsoft Corporation. All rights reserved.
+//! Copyright (c) Microsoft Corporation.
 //!
 //! SPDX-License-Identifier: Apache-2.0
 //!

--- a/sdk/patina_sdk/src/boot_services/tpl.rs
+++ b/sdk/patina_sdk/src/boot_services/tpl.rs
@@ -2,7 +2,7 @@
 //!
 //! ## License
 //!
-//! Copyright (C) Microsoft Corporation. All rights reserved.
+//! Copyright (c) Microsoft Corporation.
 //!
 //! SPDX-License-Identifier: Apache-2.0
 //!

--- a/sdk/patina_sdk/src/component.rs
+++ b/sdk/patina_sdk/src/component.rs
@@ -136,7 +136,7 @@
 //!
 //! ## License
 //!
-//! Copyright (C) Microsoft Corporation. All rights reserved.
+//! Copyright (c) Microsoft Corporation.
 //!
 //! SPDX-License-Identifier: Apache-2.0
 //!

--- a/sdk/patina_sdk/src/component/function_component.rs
+++ b/sdk/patina_sdk/src/component/function_component.rs
@@ -9,7 +9,7 @@
 //!
 //! ## License
 //!
-//! Copyright (C) Microsoft Corporation. All rights reserved.
+//! Copyright (c) Microsoft Corporation.
 //!
 //! SPDX-License-Identifier: Apache-2.0
 //!

--- a/sdk/patina_sdk/src/component/hob.rs
+++ b/sdk/patina_sdk/src/component/hob.rs
@@ -53,7 +53,7 @@
 //!
 //! ## License
 //!
-//! Copyright (C) Microsoft Corporation. All rights reserved.
+//! Copyright (c) Microsoft Corporation.
 //!
 //! SPDX-License-Identifier: Apache-2.0
 extern crate alloc;

--- a/sdk/patina_sdk/src/component/metadata.rs
+++ b/sdk/patina_sdk/src/component/metadata.rs
@@ -6,7 +6,7 @@
 //!
 //! ## License
 //!
-//! Copyright (C) Microsoft Corporation. All rights reserved.
+//! Copyright (c) Microsoft Corporation.
 //!
 //! SPDX-License-Identifier: Apache-2.0
 use core::fmt;

--- a/sdk/patina_sdk/src/component/params.rs
+++ b/sdk/patina_sdk/src/component/params.rs
@@ -90,7 +90,7 @@
 //!
 //! ## License
 //!
-//! Copyright (C) Microsoft Corporation. All rights reserved.
+//! Copyright (c) Microsoft Corporation.
 //!
 //! SPDX-License-Identifier: Apache-2.0
 //!

--- a/sdk/patina_sdk/src/component/service.rs
+++ b/sdk/patina_sdk/src/component/service.rs
@@ -111,7 +111,7 @@
 //!
 //! ## License
 //!
-//! Copyright (C) Microsoft Corporation. All rights reserved.
+//! Copyright (c) Microsoft Corporation.
 //!
 //! SPDX-License-Identifier: Apache-2.0
 //!

--- a/sdk/patina_sdk/src/component/service/memory.rs
+++ b/sdk/patina_sdk/src/component/service/memory.rs
@@ -25,7 +25,7 @@
 //!
 //! ## License
 //!
-//! Copyright (C) Microsoft Corporation. All rights reserved.
+//! Copyright (c) Microsoft Corporation.
 //!
 //! SPDX-License-Identifier: Apache-2.0
 //!

--- a/sdk/patina_sdk/src/component/storage.rs
+++ b/sdk/patina_sdk/src/component/storage.rs
@@ -2,7 +2,7 @@
 //!
 //! ## License
 //!
-//! Copyright (C) Microsoft Corporation. All rights reserved.
+//! Copyright (c) Microsoft Corporation.
 //!
 //! SPDX-License-Identifier: Apache-2.0
 //!

--- a/sdk/patina_sdk/src/component/struct_component.rs
+++ b/sdk/patina_sdk/src/component/struct_component.rs
@@ -21,7 +21,7 @@
 //!
 //! ## License
 //!
-//! Copyright (C) Microsoft Corporation. All rights reserved.
+//! Copyright (c) Microsoft Corporation.
 //!
 //! SPDX-License-Identifier: Apache-2.0
 //!

--- a/sdk/patina_sdk/src/error.rs
+++ b/sdk/patina_sdk/src/error.rs
@@ -2,7 +2,7 @@
 //!
 //! ## License
 //!
-//! Copyright (C) Microsoft Corporation. All rights reserved.
+//! Copyright (c) Microsoft Corporation.
 //!
 //! SPDX-License-Identifier: Apache-2.0
 //!

--- a/sdk/patina_sdk/src/log.rs
+++ b/sdk/patina_sdk/src/log.rs
@@ -31,7 +31,7 @@
 //!
 //! ## License
 //!
-//! Copyright (C) Microsoft Corporation. All rights reserved.
+//! Copyright (c) Microsoft Corporation.
 //!
 //! SPDX-License-Identifier: Apache-2.0
 //!

--- a/sdk/patina_sdk/src/log/serial_logger.rs
+++ b/sdk/patina_sdk/src/log/serial_logger.rs
@@ -2,7 +2,7 @@
 //!
 //! ## License
 //!
-//! Copyright (C) Microsoft Corporation. All rights reserved.
+//! Copyright (c) Microsoft Corporation.
 //!
 //! SPDX-License-Identifier: Apache-2.0
 //!

--- a/sdk/patina_sdk/src/performance/_smm.rs
+++ b/sdk/patina_sdk/src/performance/_smm.rs
@@ -6,7 +6,7 @@
 //!
 //! ## License
 //!
-//! Copyright (C) Microsoft Corporation. All rights reserved.
+//! Copyright (c) Microsoft Corporation.
 //!
 //! SPDX-License-Identifier: Apache-2.0
 //!

--- a/sdk/patina_sdk/src/performance/error.rs
+++ b/sdk/patina_sdk/src/performance/error.rs
@@ -2,7 +2,7 @@
 //!
 //! ## License
 //!
-//! Copyright (C) Microsoft Corporation. All rights reserved.
+//! Copyright (c) Microsoft Corporation.
 //!
 //! SPDX-License-Identifier: Apache-2.0
 use core::fmt::Display;

--- a/sdk/patina_sdk/src/performance/globals.rs
+++ b/sdk/patina_sdk/src/performance/globals.rs
@@ -2,7 +2,7 @@
 //!
 //! ## License
 //!
-//! Copyright (C) Microsoft Corporation. All rights reserved.
+//! Copyright (c) Microsoft Corporation.
 //!
 //! SPDX-License-Identifier: Apache-2.0
 //!

--- a/sdk/patina_sdk/src/performance/logging.rs
+++ b/sdk/patina_sdk/src/performance/logging.rs
@@ -2,7 +2,7 @@
 //!
 //! ## License
 //!
-//! Copyright (C) Microsoft Corporation. All rights reserved.
+//! Copyright (c) Microsoft Corporation.
 //!
 //! SPDX-License-Identifier: Apache-2.0
 //!

--- a/sdk/patina_sdk/src/performance/measurement.rs
+++ b/sdk/patina_sdk/src/performance/measurement.rs
@@ -2,7 +2,7 @@
 //!
 //! ## License
 //!
-//! Copyright (C) Microsoft Corporation. All rights reserved.
+//! Copyright (c) Microsoft Corporation.
 //!
 //! SPDX-License-Identifier: Apache-2.0
 //!

--- a/sdk/patina_sdk/src/performance/record.rs
+++ b/sdk/patina_sdk/src/performance/record.rs
@@ -2,7 +2,7 @@
 //!
 //! ## License
 //!
-//! Copyright (C) Microsoft Corporation. All rights reserved.
+//! Copyright (c) Microsoft Corporation.
 //!
 //! SPDX-License-Identifier: Apache-2.0
 //!

--- a/sdk/patina_sdk/src/performance/record/extended.rs
+++ b/sdk/patina_sdk/src/performance/record/extended.rs
@@ -2,7 +2,7 @@
 //!
 //! ## License
 //!
-//! Copyright (C) Microsoft Corporation. All rights reserved.
+//! Copyright (c) Microsoft Corporation.
 //!
 //! SPDX-License-Identifier: Apache-2.0
 //!

--- a/sdk/patina_sdk/src/performance/record/hob.rs
+++ b/sdk/patina_sdk/src/performance/record/hob.rs
@@ -2,7 +2,7 @@
 //!
 //! ## License
 //!
-//! Copyright (C) Microsoft Corporation. All rights reserved.
+//! Copyright (c) Microsoft Corporation.
 //!
 //! SPDX-License-Identifier: Apache-2.0
 //!

--- a/sdk/patina_sdk/src/performance/record/known.rs
+++ b/sdk/patina_sdk/src/performance/record/known.rs
@@ -3,7 +3,7 @@
 //!
 //! ## License
 //!
-//! Copyright (C) Microsoft Corporation. All rights reserved.
+//! Copyright (c) Microsoft Corporation.
 //!
 //! SPDX-License-Identifier: Apache-2.0
 //!

--- a/sdk/patina_sdk/src/performance/table.rs
+++ b/sdk/patina_sdk/src/performance/table.rs
@@ -3,7 +3,7 @@
 //!
 //! ## License
 //!
-//! Copyright (C) Microsoft Corporation. All rights reserved.
+//! Copyright (c) Microsoft Corporation.
 //!
 //! SPDX-License-Identifier: Apache-2.0
 //!

--- a/sdk/patina_sdk/src/serial/std.rs
+++ b/sdk/patina_sdk/src/serial/std.rs
@@ -2,7 +2,7 @@
 //!
 //! ## License
 //!
-//! Copyright (C) Microsoft Corporation. All rights reserved.
+//! Copyright (c) Microsoft Corporation.
 //!
 //! SPDX-License-Identifier: Apache-2.0
 //!

--- a/sdk/patina_sdk/src/test.rs
+++ b/sdk/patina_sdk/src/test.rs
@@ -68,7 +68,7 @@
 //!
 //! ## License
 //!
-//! Copyright (C) Microsoft Corporation. All rights reserved.
+//! Copyright (c) Microsoft Corporation.
 //!
 //! SPDX-License-Identifier: Apache-2.0
 //!

--- a/sdk/patina_sdk/src/test/__private_api.rs
+++ b/sdk/patina_sdk/src/test/__private_api.rs
@@ -5,7 +5,7 @@
 //!
 //! ## License
 //!
-//! Copyright (C) Microsoft Corporation. All rights reserved.
+//! Copyright (c) Microsoft Corporation.
 //!
 //! SPDX-License-Identifier: Apache-2.0
 //!

--- a/sdk/patina_sdk/src/tpl_mutex.rs
+++ b/sdk/patina_sdk/src/tpl_mutex.rs
@@ -2,7 +2,7 @@
 //!
 //! ## License
 //!
-//! Copyright (C) Microsoft Corporation. All rights reserved.
+//! Copyright (c) Microsoft Corporation.
 //!
 //! SPDX-License-Identifier: Apache-2.0
 //!

--- a/sdk/patina_sdk/src/uefi_protocol.rs
+++ b/sdk/patina_sdk/src/uefi_protocol.rs
@@ -2,7 +2,7 @@
 //!
 //! ## License
 //!
-//! Copyright (C) Microsoft Corporation. All rights reserved.
+//! Copyright (c) Microsoft Corporation.
 //!
 //! SPDX-License-Identifier: Apache-2.0
 //!

--- a/sdk/patina_sdk/src/uefi_protocol/device_path.rs
+++ b/sdk/patina_sdk/src/uefi_protocol/device_path.rs
@@ -4,7 +4,7 @@
 //!
 //! ## License
 //!
-//! Copyright (C) Microsoft Corporation. All rights reserved.
+//! Copyright (c) Microsoft Corporation.
 //!
 //! SPDX-License-Identifier: Apache-2.0
 //!

--- a/sdk/patina_sdk/src/uefi_protocol/performance_measurement.rs
+++ b/sdk/patina_sdk/src/uefi_protocol/performance_measurement.rs
@@ -4,7 +4,7 @@
 //!
 //! ## License
 //!
-//! Copyright (C) Microsoft Corporation. All rights reserved.
+//! Copyright (c) Microsoft Corporation.
 //!
 //! SPDX-License-Identifier: Apache-2.0
 //!

--- a/sdk/patina_sdk/src/uefi_protocol/status_code.rs
+++ b/sdk/patina_sdk/src/uefi_protocol/status_code.rs
@@ -6,7 +6,7 @@
 //!
 //! ## License
 //!
-//! Copyright (C) Microsoft Corporation. All rights reserved.
+//! Copyright (c) Microsoft Corporation.
 //!
 //! SPDX-License-Identifier: Apache-2.0
 //!

--- a/sdk/patina_sdk_macro/src/component_macro.rs
+++ b/sdk/patina_sdk_macro/src/component_macro.rs
@@ -2,7 +2,7 @@
 //!
 //! ## License
 //!
-//! Copyright (C) Microsoft Corporation. All rights reserved.
+//! Copyright (c) Microsoft Corporation.
 //!
 //! SPDX-License-Identifier: Apache-2.0
 //!

--- a/sdk/patina_sdk_macro/src/lib.rs
+++ b/sdk/patina_sdk_macro/src/lib.rs
@@ -2,7 +2,7 @@
 //!
 //! ## License
 //!
-//! Copyright (C) Microsoft Corporation. All rights reserved.
+//! Copyright (c) Microsoft Corporation.
 //!
 //! SPDX-License-Identifier: Apache-2.0
 //!

--- a/sdk/patina_sdk_macro/src/service_macro.rs
+++ b/sdk/patina_sdk_macro/src/service_macro.rs
@@ -2,7 +2,7 @@
 //!
 //! ## License
 //!
-//! Copyright (C) Microsoft Corporation. All rights reserved.
+//! Copyright (c) Microsoft Corporation.
 //!
 //! SPDX-License-Identifier: Apache-2.0
 //!

--- a/sdk/patina_sdk_macro/src/test_macro.rs
+++ b/sdk/patina_sdk_macro/src/test_macro.rs
@@ -5,7 +5,7 @@
 //!
 //! ## License
 //!
-//! Copyright (C) Microsoft Corporation. All rights reserved.
+//! Copyright (c) Microsoft Corporation.
 //!
 //! SPDX-License-Identifier: Apache-2.0
 //!


### PR DESCRIPTION
## Description

Files had been added to the repo with a mix of Microsoft copyright format. The correct format is:

> "Copyright (c) Microsoft Corporation."

Unrelated to the change, but the SPDX identifier is used so tools like GitHub license detection can parse the license.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

- `cargo make all`

## Integration Instructions

N/A