### PR TITLE
Set RUSTC_BOOTSTRAP for rust analyzer tests

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -9,4 +9,7 @@
     "."
   ],
   "rust-analyzer.cargo.targetDir": true,
+  "rust-analyzer.runnables.extraEnv": {
+    "RUSTC_BOOTSTRAP": "1"
+  },
 }


### PR DESCRIPTION
## Description

Bootstrap is not generally needed anymore, but to use the "Run test" or "Debug" options that are available through rust analyzer, it needs to be set for that environment. 

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

N/A

## Integration Instructions

N/A
