### PR TITLE
dxe_core: Move runtime event handling into runtime module

### DIFF
--- a/patina_dxe_core/src/allocator.rs
+++ b/patina_dxe_core/src/allocator.rs
@@ -36,7 +36,7 @@ use mu_pi::{
     hob::{self, EFiMemoryTypeInformation, Hob, HobList, MEMORY_TYPE_INFO_HOB_GUID},
 };
 use r_efi::{efi, system::TPL_HIGH_LEVEL};
-use uefi_allocator::UefiAllocator;
+pub use uefi_allocator::UefiAllocator;
 
 use patina_sdk::{
     base::{SIZE_4KB, UEFI_PAGE_MASK, UEFI_PAGE_SIZE},

--- a/patina_dxe_core/src/lib.rs
+++ b/patina_dxe_core/src/lib.rs
@@ -27,6 +27,7 @@
 #![feature(alloc_error_handler)]
 #![feature(c_variadic)]
 #![feature(allocator_api)]
+#![feature(btreemap_alloc)]
 #![feature(slice_ptr_get)]
 #![feature(coverage_attribute)]
 


### PR DESCRIPTION
## Description

This commit moves the handling of runtime events into the runtime.rs module and allocates them out of runtime memory. Runtime events, by definition and standard, are intended to be allocated in runtime memory and handled by a runtime driver. Since Patina handles the set_virtual_address_map itself, it must try to isolate that logic as much as possible from leveraging boot services resources.

This commit specifically resolves an issue on Windows where the set virtual address map is not called from the full firmware context. In this seperate context, the runtime services memory is mapped, but newer boot services data allocations may not be mapped. Moving the allocations to runtime memory works around potential access violations when traversing the tree that contains events that may have been allocated from a later heap.

CLOSES #337 

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Boot to Windows on Q35

## Integration Instructions

N/A
