### PR TITLE
RFC: Remove `FunctionComponent` Component implementation

### DIFF
--- a/docs/src/rfc/text/0016-remove-function-component.md
+++ b/docs/src/rfc/text/0016-remove-function-component.md
@@ -6,7 +6,7 @@ A request for comments regarding the removal of the `FunctionComponent` implemen
 ## Change Log
 
 - 2025-09-15: Initial RFC created.
-- 2026-09-24: Finialize RFC.
+- 2026-09-24: Finalize RFC.
 
 ## Motivation
 


### PR DESCRIPTION
## Description

RFC to remove the `FunctionComponent` implementation so that only structures (with or without internal state) can be used as a component

Current RFC State: FCP

