### PR TITLE
ParamFunction: Support Additional Self Types

### DIFF
--- a/sdk/patina_sdk/src/component/function_component.rs
+++ b/sdk/patina_sdk/src/component/function_component.rs
@@ -58,7 +58,7 @@ where
 
         let param_value = unsafe { Func::Param::get_param(param_state, storage) };
 
-        self.func.run((), param_value).map(|_| true)
+        self.func.run(&mut Some(()), param_value).map(|_| true)
     }
 
     /// Returns the metadata of the Component.

--- a/sdk/patina_sdk/src/test/__private_api.rs
+++ b/sdk/patina_sdk/src/test/__private_api.rs
@@ -117,7 +117,7 @@ where
 
         let param_value = unsafe { Func::Param::get_param(&param_state, storage) };
 
-        self.func.run((), param_value).map(|_| true)
+        self.func.run(&mut Some(()), param_value).map(|_| true)
     }
 }
 


### PR DESCRIPTION
## Description

This commit enhances the blanket `ParamFunction` trait implementation to support functions that take `&Self::In` and `&mut Self::In` in addition to `Self::In`.

What this translates to is that struct / enum components using the `#[derive(IntoComponent)]` macro can now define entry point functions that take `&self` or `&mut self` as their first parameter (in addition to `self`). This enhancement paves the way for future support of multi-callable dependency injectable types, including but not limited to components.

Additionally, this commit introduces a custom error message when a function is being used as a `ParamFunction` but does not meet the function signature requirements. This should help users quickly identify and rectify issues with their function signatures.

Improves the error message when the function you declare as your entry point does not meet the requirements of being a `ParamFunction`

<img width="768" height="248" alt="image" src="https://github.com/user-attachments/assets/a5b10014-5eb8-43db-bcea-4a69596ce847" />

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

CI continues to pass. Existing components continue to execute as expected.

## Integration Instructions

N/A - But users may now have functions with the interface `&self` or `&mut self`
