### PR TITLE
RFC Amendment: Add feature branch merge criteria to release process

### DIFF
--- a/docs/src/rfc/text/0015-patina-release-process.md
+++ b/docs/src/rfc/text/0015-patina-release-process.md
@@ -259,7 +259,7 @@ merge.
 
 If necessary, a large feature can be broken down into phases where each phase has a clear goal and deliverable. Once
 a feature phase is complete, it is merged into `main` and the next phase can begin in a new feature branch. If the
-feature is broken down this way, consider whether the [unstable feature process](../dev/unstable_feature.md) should
+feature is broken down this way, consider whether the [unstable feature process](../../dev/unstable_feature.md) should
 be used.
 
 Regardless of feature details, the criteria to merge into `main` are consistent:


### PR DESCRIPTION
## Description

Resolves #743 

Status: FCP

Adds a section that describes the criteria for work on a feature branch to be merged to the main branch. 

The goal is to provide clarity so feature owners can plan how to organize their work to support the requirements and the process of adding new features is consistent over time for Patina consumers.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [x] Includes documentation?

## How This Was Tested

- `cargo make all`

## Integration Instructions

- N/A