### PR TITLE
Set toolchain to 1.90 and fix issues with allocator_api and clippy.

### DIFF
--- a/components/patina_adv_logger/src/memory_log.rs
+++ b/components/patina_adv_logger/src/memory_log.rs
@@ -113,7 +113,9 @@ impl AdvancedLog<'static> {
     /// The caller is responsible for ensuring that the provided address is appropriately
     /// allocated and accessible.
     pub unsafe fn initialize_memory_log(address: efi::PhysicalAddress, length: u32) -> Option<Self> {
-        if length < size_of::<AdvLoggerInfo>() as u32 || address % core::mem::align_of::<AdvLoggerInfo>() as u64 != 0 {
+        if length < size_of::<AdvLoggerInfo>() as u32
+            || !address.is_multiple_of(core::mem::align_of::<AdvLoggerInfo>() as u64)
+        {
             return None;
         }
 

--- a/core/patina_internal_collections/src/lib.rs
+++ b/core/patina_internal_collections/src/lib.rs
@@ -58,7 +58,6 @@
 //! SPDX-License-Identifier: Apache-2.0
 //!
 #![no_std]
-#![feature(let_chains)]
 #![feature(coverage_attribute)]
 mod bst;
 mod node;

--- a/core/patina_internal_cpu/src/interrupts/x64/interrupt_manager.rs
+++ b/core/patina_internal_cpu/src/interrupts/x64/interrupt_manager.rs
@@ -46,7 +46,7 @@ lazy_static! {
         // means external caller cannot register for double fault call backs.
         // Fix it: Below line is excluded from std builds because rustc fails to
         //        compile with following error "offset is not a multiple of 16"
-        unsafe { idt.double_fault.set_handler_fn(double_fault_handler).set_stack_index(0) };
+        unsafe { idt.double_fault.set_handler_addr(VirtAddr::new(double_fault_handler as *const () as u64)).set_stack_index(0) };
 
         // Initialize the error code vectors. the x86_64 crate does not allow these
         // to be indexed.
@@ -113,11 +113,11 @@ impl InterruptManager for InterruptsX64 {}
 
 /// Handler for double faults.
 ///
-/// Handler for doubel faults that is configured to run as a direct interrupt
+/// Handler for double faults that is configured to run as a direct interrupt
 /// handler without using the normal handler assembly or stack. This is done to
 /// increase the diagnosability of faults in the interrupt handling code.
 ///
-extern "x86-interrupt" fn double_fault_handler(stack_frame: InterruptStackFrame, _error_code: u64) -> ! {
+extern "x86-interrupt" fn double_fault_handler(stack_frame: InterruptStackFrame, _error_code: u64) {
     panic!("EXCEPTION: DOUBLE FAULT\n{stack_frame:#x?}");
 }
 

--- a/core/patina_stacktrace/src/aarch64/runtime_function.rs
+++ b/core/patina_stacktrace/src/aarch64/runtime_function.rs
@@ -49,7 +49,7 @@ impl<'a> RuntimeFunction<'a> {
     }
 
     /// Parse the Unwind Info data pointed by RuntimeFunction
-    pub fn get_unwind_info(&self) -> StResult<UnwindInfo> {
+    pub fn get_unwind_info(&self) -> StResult<UnwindInfo<'_>> {
         UnwindInfo::parse(self.image_base, self.unwind_info, self.image_name)
             .map_err(|_| Error::UnwindInfoNotFound(self.image_name, self.image_base.as_ptr() as u64, self.unwind_info))
     }

--- a/patina_dxe_core/src/config_tables.rs
+++ b/patina_dxe_core/src/config_tables.rs
@@ -83,7 +83,8 @@ pub fn core_install_configuration_table(
                     //entry does not exist, we can't delete it. We have to put the original box back
                     //in the config table so it doesn't get dropped though. Pointer should be the same
                     //so we should not need to recompute CRC.
-                    system_table.configuration_table = Box::into_raw(cfg_table) as *mut efi::ConfigurationTable;
+                    system_table.configuration_table =
+                        Box::into_raw_with_allocator(cfg_table).0 as *mut efi::ConfigurationTable;
                     return Err(EfiError::NotFound);
                 }
             }
@@ -111,7 +112,7 @@ pub fn core_install_configuration_table(
         //when old_cfg_table goes out of scope at the end of the function.
         system_table.number_of_table_entries = new_table.len();
         let new_table = new_table.to_vec_in(&EFI_RUNTIME_SERVICES_DATA_ALLOCATOR).into_boxed_slice();
-        system_table.configuration_table = Box::into_raw(new_table) as *mut efi::ConfigurationTable;
+        system_table.configuration_table = Box::into_raw_with_allocator(new_table).0 as *mut efi::ConfigurationTable;
     }
     //since we modified the system table, re-calculate CRC.
     efi_system_table.checksum();

--- a/patina_dxe_core/src/dxe_services.rs
+++ b/patina_dxe_core/src/dxe_services.rs
@@ -448,7 +448,7 @@ pub fn init_dxe_services(system_table: &mut EfiSystemTable) {
 
     let _ = config_tables::core_install_configuration_table(
         dxe_services::DXE_SERVICES_TABLE_GUID,
-        Box::into_raw(dxe_system_table) as *mut c_void,
+        Box::into_raw_with_allocator(dxe_system_table).0 as *mut c_void,
         system_table,
     );
 }

--- a/patina_dxe_core/src/image.rs
+++ b/patina_dxe_core/src/image.rs
@@ -595,7 +595,7 @@ fn core_load_pe_image(
     let size = pe_info.size_of_image as usize;
 
     // the section alignment must be at least the size of a page
-    if alignment % UEFI_PAGE_SIZE != 0 || alignment == 0 {
+    if !alignment.is_multiple_of(UEFI_PAGE_SIZE) || alignment == 0 {
         log::error!(
             "core_load_pe_image_failed: section alignment of {alignment:#x?} is not a (non-zero) multiple of page size {UEFI_PAGE_SIZE:#x?}",
         );
@@ -604,7 +604,7 @@ fn core_load_pe_image(
     }
 
     // the size of the image must be a multiple of the section alignment per PE/COFF spec
-    if size % alignment != 0 {
+    if !size.is_multiple_of(alignment) {
         log::error!("core_load_pe_image_failed: size of image is not a multiple of the section alignment");
         debug_assert!(false);
         return Err(EfiError::LoadError);

--- a/patina_dxe_core/src/memory_manager.rs
+++ b/patina_dxe_core/src/memory_manager.rs
@@ -102,7 +102,7 @@ impl MemoryManager for CoreMemoryManager {
             return Err(MemoryError::InvalidPageCount);
         }
 
-        if address % UEFI_PAGE_SIZE != 0 {
+        if !address.is_multiple_of(UEFI_PAGE_SIZE) {
             return Err(MemoryError::UnalignedAddress);
         }
 
@@ -165,7 +165,7 @@ impl MemoryManager for CoreMemoryManager {
             return Err(MemoryError::InvalidPageCount);
         }
 
-        if address % UEFI_PAGE_SIZE != 0 {
+        if !address.is_multiple_of(UEFI_PAGE_SIZE) {
             return Err(MemoryError::UnalignedAddress);
         }
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "1.89.0"
+channel = "1.90.0"
 targets = ["x86_64-unknown-uefi", "aarch64-unknown-uefi"]
 components = ["rust-src", "clippy", "rustfmt", "rust-docs"]
 


### PR DESCRIPTION
## Description

Sets the toolchain to 1.90, fixes issues with allocator_api and clippy (none of which are expected to be functional/behavior changes). 

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Unit Tests and clippy check pass, confirmed boot on aarch64 hardware. 

## Integration Instructions

N/A
