### PR TITLE
Bugfix invalid "`" usage in javascript template string

### DIFF
--- a/.github/workflows/rust-version-check.yml
+++ b/.github/workflows/rust-version-check.yml
@@ -85,7 +85,7 @@ jobs:
             - [ ] All team members have sufficient review time for the change
             - [ ] CI/CD pipelines support the new Rust version
             - [ ] Documentation is updated if needed
-            - [ ] The `rust-version` field in Cargo.toml is updated if the minimum supported Rust version must change.
+            - [ ] The \`rust-version\` field in Cargo.toml is updated if the minimum supported Rust version must change.
               - See the "Updating the Minimum Supported Rust Version" section in the readme for more details.
             - [ ] The PR meets the requirements in the [Rust Version Update Policy](https://github.com/OpenDevicePartnership/patina/blob/main/README.md)
             ---
@@ -97,3 +97,4 @@ jobs:
               repo: context.repo.repo,
               body: comment
             });
+


### PR DESCRIPTION
## Description

We must escape the "`" usage in javascript template strings, to prevent the following error:

```
SyntaxError: Unexpected identifier 'rust'
    at new AsyncFunction (<anonymous>)
    at callAsyncFunction (/home/runner/work/_actions/actions/github-script/v7/dist/index.js:36187:16)
    at main (/home/runner/work/_actions/actions/github-script/v7/dist/index.js:36285:26)
    at /home/runner/work/_actions/actions/github-script/v7/dist/index.js:36260:1
    at /home/runner/work/_actions/actions/github-script/v7/dist/index.js:36317:3
    at Object.<anonymous> (/home/runner/work/_actions/actions/github-script/v7/dist/index.js:36320:12)
    at Module._compile (node:internal/modules/cjs/loader:1529:14)
    at Module._extensions..js (node:internal/modules/cjs/loader:1613:10)
    at Module.load (node:internal/modules/cjs/loader:1275:32)
    at Module._load (node:internal/modules/cjs/loader:1096:12)
Error: Unhandled error: SyntaxError: Unexpected identifier 'rust'
```

ref: https://github.com/OpenDevicePartnership/patina/actions/runs/17920730437

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

N/A

## Integration Instructions

N/A
