### PR TITLE
Add pdbhelper.dll to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 *.profraw
 Cargo.lock
 docs/book/
+**/pdbhelper.dll


### PR DESCRIPTION
## Description

pdbhelper.dll is generated by the stack trace resolver script and is not intended to be tracked by version control. Ignore it.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Doesn't show up in git status any longer

## Integration Instructions

N/A.
