### PR TITLE
rust-version-check.yml: Only run on main

### DIFF
--- a/.github/workflows/rust-version-check.yml
+++ b/.github/workflows/rust-version-check.yml
@@ -10,6 +10,7 @@ name: Rust Version Change Detection
 
 on:
   pull_request:
+    branches: [main]
     types: [opened, synchronize]
     paths:
       - 'rust-toolchain.toml'


### PR DESCRIPTION
## Description

Add main branch trigger to prevent the worfklow from running when feature branches are targeted by PRs to merge main into the feature branch.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

- PR created to non-main branch on fork

## Integration Instructions

- N/A