### PR TITLE
Increase stack space for AARCH64 synchronous exceptions.

### DIFF
--- a/core/patina_internal_cpu/src/interrupts/aarch64/exception_handler.asm
+++ b/core/patina_internal_cpu/src/interrupts/aarch64/exception_handler.asm
@@ -91,10 +91,10 @@
 
   .global sp_el0_end
 
-# Stack for SP_EL0 of 0x2000 bytes. Also set to 8KB aligned, which corresponds to BIT13.
+# Stack for SP_EL0 of 0x10000 bytes. Also set to 8KB aligned, which corresponds to BIT13.
   .align 13
 sp_el0_start:
-  .space 0x2000
+  .space 0x10000
 sp_el0_end:
 
   .section .text


### PR DESCRIPTION
## Description

The current implementation for the aarch64 exception handler reserves 8K of stack for exceptions where the stack pointer may have been corrupted at the time of exception. In practice (especially when optimizations are disabled) this is not enough for all use cases, in particular when the debugger is active. 

This PR increases the space for the alternate stack to 64K. 

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Fixes debugger behavior on aarch64 platform used for test.

## Integration Instructions

N/A
