### PR TITLE
Remove outdated `with_section_extractor` documentation

### DIFF
--- a/docs/src/patina.md
+++ b/docs/src/patina.md
@@ -233,11 +233,12 @@ pub extern "efiapi" fn _start(physical_hob_list: *const c_void) -> ! {
     patina_debugger::set_debugger(&DEBUGGER);
 
     Core::default()
-        .with_section_extractor(patina_ffs_extractors::CompositeSectionExtractor::default()) // Section extractor can be customized or use default
-        .init_memory(physical_hob_list)                                                  // DXE Core initializes GCD with the HOB list
+        .init_memory(physical_hob_list)                                                 // DXE Core initializes GCD with the HOB list
+        .with_service(patina_ffs_extractors::CompositeSectionExtractor::default()) // A trait implementation that can be consumed by any component
         .with_component(adv_logger_component)                                            // The "advanced logger" Rust component is added for dispatch
         .start()
         .unwrap();
+}
 ```
 
 ``` admonish note


### PR DESCRIPTION
## Description

`with_section_extractor` method in the `Core` was replaced with `with_service` in 97680e5f897f2e259aeded59e496b1400f3b2bcb. When this happened, all documentation was also updated, however the single section being updated in this commit was missed.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [x] Includes documentation?

## How This Was Tested

N/A

## Integration Instructions

N/A
