### PR TITLE
decompress: Bugfixes for SCT compliance

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ linked_list_allocator = { version = "^0.10" }
 linkme = { version = "^0.3.29" }
 log = { version = "0.4", default-features = false }
 mu_pi = { version = "6.0.0" }
-mu_rust_helpers = { version = "3.0.1" }
+mu_rust_helpers = { version = "3.0.2" }
 num-traits = { version = "0.2", default-features = false }
 patina_debugger = { version = "8.3.0", path = "core/patina_debugger", registry = "patina-fw" }
 patina_internal_collections = { version = "8.3.0", path = "core/patina_internal_collections", default-features = false, registry = "patina-fw" }

--- a/sdk/patina_sdk/src/uefi_protocol/decompress.rs
+++ b/sdk/patina_sdk/src/uefi_protocol/decompress.rs
@@ -64,7 +64,7 @@ impl EfiDecompressProtocol {
         // SAFETY: The data the pointer points to is at least 8 bytes long, as checked above.
         let compressed_size = unsafe { src.cast::<u32>().read_unaligned() };
 
-        if (src_size < compressed_size + 8) | compressed_size.checked_add(8).is_none() {
+        if (src_size < compressed_size + 8) || compressed_size.checked_add(8).is_none() {
             return efi::Status::INVALID_PARAMETER;
         }
 
@@ -95,7 +95,7 @@ impl EfiDecompressProtocol {
         let src = unsafe { core::slice::from_raw_parts(source_buffer as *const u8, source_size as usize) };
         let dst = unsafe { core::slice::from_raw_parts_mut(destination_buffer as *mut u8, destination_size as usize) };
 
-        match decompress_into_with_algo(src, dst, DecompressionAlgorithm::TianoDecompress) {
+        match decompress_into_with_algo(src, dst, DecompressionAlgorithm::UefiDecompress) {
             Ok(()) => efi::Status::SUCCESS,
             Err(_) => efi::Status::INVALID_PARAMETER,
         }


### PR DESCRIPTION
## Description

This commit provides three bugfixes to the UEFI decompression logic to be compliant with the decompress SCT tests:

1. return with EFI_SUCCESS if the decompressed size is zero.
2. Bugfix bitwise OR to logical OR when checking for integer overflow in `get_info`.
3. decompress using UefiDecompression algorithm instead of the TianoDecompression algorithm.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

decompress SCTs now pass

## Integration Instructions

N/A
