### PR TITLE
Handle potentially unaligned pointers from FFI

### DIFF
--- a/core/patina_internal_device_path/src/lib.rs
+++ b/core/patina_internal_device_path/src/lib.rs
@@ -26,7 +26,8 @@ use r_efi::efi;
 ///
 /// ## Safety
 ///
-/// device_path input must be a valid pointer to a well-formed device path.
+/// device_path input must be a valid pointer (i.e. not null) that points to
+/// a well-formed device path that conforms to UEFI spec 2.11 section 10.
 ///
 /// ## Examples
 ///
@@ -75,6 +76,8 @@ pub fn device_path_node_count(
         return Err(efi::Status::INVALID_PARAMETER);
     }
     loop {
+        // Safety: caller must guarantee that device_path is a valid pointer to
+        // a well-formed device path as described in the function documentation above.
         let current_node = unsafe { current_node_ptr.read_unaligned() };
         let current_length: usize = u16::from_le_bytes(current_node.length).into();
         node_count += 1;

--- a/patina_dxe_core/src/config_tables.rs
+++ b/patina_dxe_core/src/config_tables.rs
@@ -25,6 +25,7 @@ extern "efiapi" fn install_configuration_table(table_guid: *mut efi::Guid, table
         return efi::Status::INVALID_PARAMETER;
     }
 
+    // Safety: caller must ensure that table_guid is a valid pointer. It is null-checked above.
     let table_guid = unsafe { table_guid.read_unaligned() };
 
     let mut st_guard = SYSTEM_TABLE.lock();

--- a/patina_dxe_core/src/cpu_arch_protocol.rs
+++ b/patina_dxe_core/src/cpu_arch_protocol.rs
@@ -88,6 +88,7 @@ extern "efiapi" fn get_interrupt_state(this: *const Protocol, state: *mut bool) 
     }
     interrupts::get_interrupt_state()
         .map(|interrupt_state| {
+            // Safety: caller must ensure that state is a valid pointer. It is null-checked above.
             unsafe {
                 state.write_unaligned(interrupt_state);
             }
@@ -140,6 +141,7 @@ extern "efiapi" fn get_timer_value(
 
     match result {
         Ok((value, period)) => {
+            // Safety: caller must ensure that timer_value and timer_period are valid pointers. They are null-checked above.
             unsafe {
                 timer_value.write_unaligned(value);
                 timer_period.write_unaligned(period);

--- a/patina_dxe_core/src/dxe_services.rs
+++ b/patina_dxe_core/src/dxe_services.rs
@@ -57,16 +57,19 @@ extern "efiapi" fn allocate_memory_space(
 
     let allocate_type = match gcd_allocate_type {
         dxe_services::GcdAllocateType::Address => {
+            // Safety: caller must ensure that base_address is a valid pointer. It is null-checked above.
             let desired_address = unsafe { base_address.read_unaligned() };
             gcd::AllocateType::Address(desired_address as usize)
         }
         dxe_services::GcdAllocateType::AnySearchBottomUp => gcd::AllocateType::BottomUp(None),
         dxe_services::GcdAllocateType::AnySearchTopDown => gcd::AllocateType::TopDown(None),
         dxe_services::GcdAllocateType::MaxAddressSearchBottomUp => {
+            // Safety: caller must ensure that base_address is a valid pointer. It is null-checked above.
             let limit = unsafe { base_address.read_unaligned() };
             gcd::AllocateType::BottomUp(Some(limit as usize))
         }
         dxe_services::GcdAllocateType::MaxAddressSearchTopDown => {
+            // Safety: caller must ensure that base_address is a valid pointer. It is null-checked above.
             let limit = unsafe { base_address.read_unaligned() };
             gcd::AllocateType::TopDown(Some(limit as usize))
         }
@@ -84,6 +87,7 @@ extern "efiapi" fn allocate_memory_space(
 
     match result {
         Ok(allocated_addr) => {
+            // Safety: caller must ensure that base_address is a valid pointer. It is null-checked above.
             unsafe { base_address.write_unaligned(allocated_addr as u64) };
             efi::Status::SUCCESS
         }
@@ -118,7 +122,9 @@ extern "efiapi" fn get_memory_space_descriptor(
 
     match core_get_memory_space_descriptor(base_address) {
         Err(err) => return err.into(),
-        Ok(target_descriptor) => unsafe {
+        Ok(target_descriptor) =>
+        // Safety: caller must ensure that descriptor is a valid pointer. It is null-checked above.
+        unsafe {
             descriptor.write_unaligned(target_descriptor);
         },
     }
@@ -205,7 +211,10 @@ extern "efiapi" fn get_memory_space_map(
     let buffer_size = descriptors.len() * mem::size_of::<dxe_services::MemorySpaceDescriptor>();
     match core_allocate_pool(efi::BOOT_SERVICES_DATA, buffer_size) {
         Err(err) => err.into(),
-        Ok(allocation) => unsafe {
+        Ok(allocation) =>
+        // Safety: caller must ensure that number_of_descriptors and memory_space_map are valid pointers. They are
+        // null-checked above.
+        unsafe {
             memory_space_map.write_unaligned(allocation as *mut dxe_services::MemorySpaceDescriptor);
             number_of_descriptors.write_unaligned(descriptors.len());
             slice::from_raw_parts_mut(memory_space_map.read_unaligned(), descriptors.len())
@@ -242,16 +251,19 @@ extern "efiapi" fn allocate_io_space(
 
     let allocate_type = match gcd_allocate_type {
         dxe_services::GcdAllocateType::Address => {
+            // Safety: caller must ensure that base_address is a valid pointer. It is null-checked above.
             let desired_address = unsafe { base_address.read_unaligned() };
             gcd::AllocateType::Address(desired_address as usize)
         }
         dxe_services::GcdAllocateType::AnySearchBottomUp => gcd::AllocateType::BottomUp(None),
         dxe_services::GcdAllocateType::AnySearchTopDown => gcd::AllocateType::TopDown(None),
         dxe_services::GcdAllocateType::MaxAddressSearchBottomUp => {
+            // Safety: caller must ensure that base_address is a valid pointer. It is null-checked above.
             let limit = unsafe { base_address.read_unaligned() };
             gcd::AllocateType::BottomUp(Some(limit as usize))
         }
         dxe_services::GcdAllocateType::MaxAddressSearchTopDown => {
+            // Safety: caller must ensure that base_address is a valid pointer. It is null-checked above.
             let limit = unsafe { base_address.read_unaligned() };
             gcd::AllocateType::TopDown(Some(limit as usize))
         }
@@ -269,6 +281,7 @@ extern "efiapi" fn allocate_io_space(
 
     match result {
         Ok(allocated_addr) => {
+            // Safety: caller must ensure that base_address is a valid pointer. It is null-checked above.
             unsafe { base_address.write_unaligned(allocated_addr as u64) };
             efi::Status::SUCCESS
         }
@@ -297,6 +310,10 @@ extern "efiapi" fn get_io_space_descriptor(
     base_address: efi::PhysicalAddress,
     descriptor: *mut dxe_services::IoSpaceDescriptor,
 ) -> efi::Status {
+    if descriptor.is_null() {
+        return efi::Status::INVALID_PARAMETER;
+    }
+
     //Note: this would be more efficient if it was done in the GCD; rather than retrieving all the descriptors and
     //searching them here. It is done this way for simplicity - it can be optimized if it proves too slow.
 
@@ -313,6 +330,7 @@ extern "efiapi" fn get_io_space_descriptor(
         descriptors.iter().find(|x| (x.base_address <= base_address) && (base_address < (x.base_address + x.length)));
 
     if let Some(target_descriptor) = target_descriptor {
+        // Safety: caller must ensure that descriptor is a valid pointer. It is null-checked above.
         unsafe { descriptor.write_unaligned(*target_descriptor) };
         efi::Status::SUCCESS
     } else {
@@ -341,7 +359,9 @@ extern "efiapi" fn get_io_space_map(
 
     match core_allocate_pool(efi::BOOT_SERVICES_DATA, buffer_size) {
         Err(err) => err.into(),
-        Ok(allocation) => unsafe {
+        Ok(allocation) =>
+        // Safety: caller must ensure that number_of_descriptors and io_space_map are valid pointers. They are null-checked above.
+        unsafe {
             io_space_map.write_unaligned(allocation as *mut dxe_services::IoSpaceDescriptor);
             number_of_descriptors.write_unaligned(descriptors.len());
             slice::from_raw_parts_mut(io_space_map.read_unaligned(), descriptors.len()).copy_from_slice(&descriptors);
@@ -361,6 +381,7 @@ extern "efiapi" fn schedule(firmware_volume_handle: efi::Handle, file_name: *con
     if file_name.is_null() {
         return efi::Status::INVALID_PARAMETER;
     }
+    // Safety: caller must ensure that file_name is a valid pointer. It is null-checked above.
     let file_name = unsafe { file_name.read_unaligned() };
 
     match core_schedule(firmware_volume_handle, &file_name) {
@@ -373,7 +394,7 @@ extern "efiapi" fn trust(firmware_volume_handle: efi::Handle, file_name: *const 
     if file_name.is_null() {
         return efi::Status::INVALID_PARAMETER;
     }
-
+    // Safety: caller must ensure that file_name is a valid pointer. It is null-checked above.
     let file_name = unsafe { file_name.read_unaligned() };
 
     match core_trust(firmware_volume_handle, &file_name) {
@@ -392,6 +413,7 @@ extern "efiapi" fn process_firmware_volume(
     }
 
     // construct a FirmwareVolume to verify sanity
+    // Safety: caller must ensure that firmware_volume_header is a valid pointer. It is null-checked above.
     let fv_slice = unsafe { slice::from_raw_parts(firmware_volume_header as *const u8, size) };
     if let Err(err) = VolumeRef::new(fv_slice) {
         return err.into();
@@ -404,6 +426,7 @@ extern "efiapi" fn process_firmware_volume(
         Err(err) => return err.into(),
     };
 
+    // Safety: caller must ensure that firmware_volume_handle is a valid pointer. It is null-checked above.
     unsafe {
         firmware_volume_handle.write_unaligned(handle);
     }

--- a/patina_dxe_core/src/fv.rs
+++ b/patina_dxe_core/src/fv.rs
@@ -71,7 +71,7 @@ extern "efiapi" fn fvb_get_attributes(
 
     match core_fvb_get_attributes(this) {
         Err(err) => return err.into(),
-        // SAFETY: caller must provide a valid pointer to receive the attributes. It is null-checked above.
+        // Safety: caller must provide a valid pointer to receive the attributes. It is null-checked above.
         Ok(fvb_attributes) => unsafe { attributes.write_unaligned(fvb_attributes) },
     };
 
@@ -115,7 +115,7 @@ extern "efiapi" fn fvb_get_physical_address(
         return efi::Status::NOT_FOUND;
     };
 
-    // SAFETY: caller must provide a valid pointer to receive the address. It is null-checked above.
+    // Safety: caller must provide a valid pointer to receive the address. It is null-checked above.
     unsafe { address.write_unaligned(fvb_data.physical_address) };
 
     efi::Status::SUCCESS
@@ -136,7 +136,7 @@ extern "efiapi" fn fvb_get_block_size(
         Ok((size, remaining_blocks)) => (size, remaining_blocks),
     };
 
-    // SAFETY: caller must provide valid pointers to receive the block size and number of blocks. They are null-checked above.
+    // Safety: caller must provide valid pointers to receive the block size and number of blocks. They are null-checked above.
     unsafe {
         block_size.write_unaligned(size);
         number_of_blocks.write_unaligned(remaining_blocks);
@@ -299,7 +299,7 @@ extern "efiapi" fn fv_get_volume_attributes(
         Ok(attrs) => attrs,
     };
 
-    // SAFETY: caller must provide a valid pointer to receive the attributes. It is null-checked above.
+    // Safety: caller must provide a valid pointer to receive the attributes. It is null-checked above.
     unsafe { fv_attributes.write_unaligned(fv_attributes_data) };
 
     efi::Status::SUCCESS

--- a/patina_dxe_core/src/hw_interrupt_protocol.rs
+++ b/patina_dxe_core/src/hw_interrupt_protocol.rs
@@ -134,6 +134,7 @@ impl<'a> EfiHardwareInterruptProtocol<'a> {
             hw_interrupt_protocol.hw_interrupt_handler.aarch64_int.lock().get_interrupt_source_state(interrupt_source);
         match enable {
             Ok(enable) => {
+                // Safety: caller must ensure that state is a valid pointer. It is null-checked above.
                 unsafe { state.write_unaligned(enable) }
                 efi::Status::SUCCESS
             }

--- a/patina_dxe_core/src/memory_attributes_protocol.rs
+++ b/patina_dxe_core/src/memory_attributes_protocol.rs
@@ -53,6 +53,7 @@ extern "efiapi" fn get_memory_attributes(
                 );
                 return efi::Status::NO_MAPPING;
             }
+            // Safety: caller must provide a valid pointer to receive the attributes. It is null-checked above.
             unsafe { attributes.write_unaligned(descriptor.attributes & efi::MEMORY_ACCESS_MASK) };
             efi::Status::SUCCESS
         }

--- a/patina_dxe_core/src/misc_boot_services.rs
+++ b/patina_dxe_core/src/misc_boot_services.rs
@@ -38,7 +38,7 @@ extern "efiapi" fn calculate_crc32(data: *mut c_void, data_size: usize, crc_32: 
     if data.is_null() || data_size == 0 || crc_32.is_null() {
         return efi::Status::INVALID_PARAMETER;
     }
-
+    // Safety: caller must ensure that data and crc_32 are valid pointers. They are null-checked above.
     unsafe {
         let buffer = from_raw_parts(data as *mut u8, data_size);
         crc_32.write_unaligned(crc32fast::hash(buffer));

--- a/patina_dxe_core/src/protocols.rs
+++ b/patina_dxe_core/src/protocols.rs
@@ -56,7 +56,7 @@ extern "efiapi" fn install_protocol_interface(
     if handle.is_null() || protocol.is_null() || interface_type != efi::NATIVE_INTERFACE {
         return efi::Status::INVALID_PARAMETER;
     }
-
+    // Safety: Caller must ensure that handle and protocol are valid pointers. They are null-checked above.
     let caller_handle = unsafe { handle.read_unaligned() };
     let caller_protocol = unsafe { protocol.read_unaligned() };
 
@@ -168,7 +168,7 @@ extern "efiapi" fn uninstall_protocol_interface(
         return efi::Status::INVALID_PARAMETER;
     }
 
-    // Safety: previously null-checked pointer.
+    // Safety: Caller must ensure that protocol is a valid pointer. It is null-checked above.
     let caller_protocol = unsafe { protocol.read_unaligned() };
 
     core_uninstall_protocol_interface(handle, caller_protocol, interface)
@@ -219,7 +219,7 @@ extern "efiapi" fn reinstall_protocol_interface(
         }
     }
 
-    // Safety: previously null-checked pointer.
+    // Safety: Caller must ensure that protocol is a valid pointer. It is null-checked above.
     let protocol = unsafe { protocol.read_unaligned() };
 
     // Call install to install the new interface and trigger any notifies
@@ -250,7 +250,7 @@ extern "efiapi" fn register_protocol_notify(
     if protocol.is_null() || registration.is_null() || !EVENT_DB.is_valid(event) {
         return efi::Status::INVALID_PARAMETER;
     }
-
+    // Safety: Caller must ensure that protocol is a valid pointer. It is null-checked above.
     match PROTOCOL_DB.register_protocol_notify(unsafe { protocol.read_unaligned() }, event) {
         Err(err) => err.into(),
         Ok(new_registration) => {
@@ -283,6 +283,7 @@ extern "efiapi" fn locate_handle(
             if protocol.is_null() {
                 return efi::Status::INVALID_PARAMETER;
             }
+            // Safety: Caller must ensure that protocol is a valid pointer. It is null-checked above.
             PROTOCOL_DB.locate_handles(Some(unsafe { protocol.read_unaligned() }))
         }
         _ => return efi::Status::INVALID_PARAMETER,
@@ -299,7 +300,9 @@ extern "efiapi" fn locate_handle(
             }
 
             list.shrink_to_fit();
+            // Safety: Caller must ensure that buffer_size is a valid pointer. It is null-checked above.
             let input_size = unsafe { buffer_size.read_unaligned() };
+            // Safety: Caller must ensure that buffer_size is a valid pointer. It is null-checked above.
             unsafe {
                 buffer_size.write_unaligned(list.len() * size_of::<efi::Handle>());
             }
@@ -310,7 +313,7 @@ extern "efiapi" fn locate_handle(
                 return efi::Status::INVALID_PARAMETER;
             }
 
-            //copy handle list into output buffer
+            // Caller must ensure that handle_buffer is valid for writes of list.len() handles. It is null-checked above.
             unsafe {
                 core::ptr::copy(
                     list.as_ptr() as *const u8,
@@ -351,7 +354,7 @@ extern "efiapi" fn open_protocol(
         return efi::Status::INVALID_PARAMETER;
     }
 
-    // Safety: previously null-checked pointer.
+    // Safety: Caller must ensure that protocol is a valid pointer. It is null-checked above.
     let protocol = unsafe { protocol.read_unaligned() };
 
     if interface.is_null() && attributes != efi::OPEN_PROTOCOL_TEST_PROTOCOL {
@@ -376,6 +379,7 @@ extern "efiapi" fn open_protocol(
                 && (x.attributes & efi::OPEN_PROTOCOL_EXCLUSIVE) == 0
                 && x.agent_handle != agent_handle
         }) {
+            // Safety: handles are validated above.
             unsafe {
                 if core_disconnect_controller(handle, usage.agent_handle, None).is_err() {
                     return efi::Status::ACCESS_DENIED;
@@ -387,6 +391,7 @@ extern "efiapi" fn open_protocol(
     match PROTOCOL_DB.add_protocol_usage(handle, protocol, agent_handle, controller_handle, attributes) {
         Err(EfiError::Unsupported) => {
             if !interface.is_null() {
+                // Safety: Caller must ensure that interface is a valid pointer if it is non-null.
                 unsafe { interface.write_unaligned(core::ptr::null_mut()) };
             }
             return efi::Status::UNSUPPORTED;
@@ -397,6 +402,7 @@ extern "efiapi" fn open_protocol(
                 .get_interface_for_handle(handle, protocol)
                 .expect("Already Started can't happen if protocol doesn't exist.");
             if !interface.is_null() {
+                // Safety: Caller must ensure that interface is a valid pointer if it is non-null.
                 unsafe { interface.write_unaligned(desired_interface) };
             }
             return efi::Status::ALREADY_STARTED;
@@ -412,6 +418,7 @@ extern "efiapi" fn open_protocol(
     };
 
     if attributes != efi::OPEN_PROTOCOL_TEST_PROTOCOL {
+        // Safety: Caller must ensure that interface is a valid pointer if it is non-null.
         unsafe { interface.write_unaligned(desired_interface) };
     }
     efi::Status::SUCCESS
@@ -443,6 +450,7 @@ extern "efiapi" fn close_protocol(
 
     match PROTOCOL_DB.remove_protocol_usage(
         handle,
+        // Safety: Caller must ensure that protocol is a valid pointer. It is null-checked above.
         unsafe { protocol.read_unaligned() },
         Some(agent_handle),
         controller_handle,
@@ -459,11 +467,12 @@ extern "efiapi" fn open_protocol_information(
     entry_buffer: *mut *mut efi::OpenProtocolInformationEntry,
     entry_count: *mut usize,
 ) -> efi::Status {
-    if protocol.is_null() {
+    if protocol.is_null() || entry_buffer.is_null() || entry_count.is_null() {
         return efi::Status::INVALID_PARAMETER;
     }
 
     let mut open_info: Vec<efi::OpenProtocolInformationEntry> =
+        // Safety: Caller must ensure that protocol is a valid pointer. It is null-checked above.
         match PROTOCOL_DB.get_open_protocol_information_by_protocol(handle, unsafe { protocol.read_unaligned() }) {
             Err(err) => return err.into(),
             Ok(info) => info.into_iter().map(efi::OpenProtocolInformationEntry::from).collect(),
@@ -475,7 +484,9 @@ extern "efiapi" fn open_protocol_information(
     //caller is supposed to free the entry buffer using FreePool, so we need to allocate it using allocate pool.
     match core_allocate_pool(efi::BOOT_SERVICES_DATA, buffer_size) {
         Err(err) => err.into(),
-        Ok(allocation) => unsafe {
+        Ok(allocation) =>
+        // Safety: Caller must ensure that entry_buffer and entry_count are valid pointers. They are null-checked above.
+        unsafe {
             entry_buffer.write_unaligned(allocation as *mut efi::OpenProtocolInformationEntry);
             entry_count.write_unaligned(open_info.len());
             core::ptr::copy(
@@ -603,6 +614,7 @@ extern "efiapi" fn protocols_per_handle(
     //caller is supposed to free the entry buffer using free pool, so we need to allocate it using allocate pool.
     match core_allocate_pool(efi::BOOT_SERVICES_DATA, ptr_buffer_size + guid_buffer_size) {
         Err(err) => err.into(),
+        // Safety: Caller must ensure that protocol_buffer and protocol_buffer_count are valid pointers. They are null-checked above.
         Ok(allocation) => unsafe {
             protocol_buffer.write_unaligned(allocation as *mut *mut efi::Guid);
             protocol_buffer_count.write_unaligned(protocol_list.len());
@@ -632,6 +644,7 @@ extern "efiapi" fn locate_handle_buffer(
 
     //EDK2 C reference code unconditionally sets no_handles and buffer to default values regardless of success or failure
     //of the function, and some callers expect this behavior (and don't check return status before using no_handles).
+    // Safety: Caller must ensure that no_handles and buffer are valid pointers. They are null-checked above.
     unsafe {
         no_handles.write_unaligned(0);
         buffer.write_unaligned(core::ptr::null_mut());
@@ -653,6 +666,7 @@ extern "efiapi" fn locate_handle_buffer(
             if protocol.is_null() {
                 return efi::Status::INVALID_PARAMETER;
             }
+            // Safety: Caller must ensure that protocol is a valid pointer. It is null-checked above.
             unsafe { PROTOCOL_DB.locate_handles(Some(protocol.read_unaligned())) }
         }
         _ => return efi::Status::INVALID_PARAMETER,
@@ -669,6 +683,7 @@ extern "efiapi" fn locate_handle_buffer(
         let buffer_size = handles.len() * size_of::<efi::Handle>();
         match core_allocate_pool(efi::BOOT_SERVICES_DATA, buffer_size) {
             Err(err) => err.into(),
+            // Safety: Caller must ensure that no_handles and buffer are valid pointers. They are null-checked above.
             Ok(allocation) => unsafe {
                 buffer.write_unaligned(allocation as *mut efi::Handle);
                 no_handles.write_unaligned(handles.len());
@@ -690,6 +705,7 @@ extern "efiapi" fn locate_protocol(
 
     if !registration.is_null() {
         if let Some(handle) = PROTOCOL_DB.next_handle_for_registration(registration) {
+            // Safety: Caller must ensure that protocol and interface are valid pointers. They are null-checked above.
             let i_face = PROTOCOL_DB
                 .get_interface_for_handle(handle, unsafe { protocol.read_unaligned() })
                 .expect("Protocol should exist on handle if it is returned for registration key.");
@@ -700,9 +716,11 @@ extern "efiapi" fn locate_protocol(
     } else {
         match PROTOCOL_DB.locate_protocol(unsafe { protocol.read_unaligned() }) {
             Err(err) => {
+                // Safety: Caller must ensure that interface is a valid pointer. It is null-checked above.
                 unsafe { interface.write_unaligned(core::ptr::null_mut()) };
                 return err.into();
             }
+            // Safety: Caller must ensure that interface is a valid pointer. It is null-checked above.
             Ok(i_face) => unsafe { interface.write_unaligned(i_face) },
         }
     }
@@ -756,11 +774,13 @@ extern "efiapi" fn locate_device_path(
     device_path: *mut *mut r_efi::protocols::device_path::Protocol,
     device: *mut efi::Handle,
 ) -> efi::Status {
+    // Safety: Caller must ensure that protocol, device_path, and device are valid pointers. They are null-checked below.
     if protocol.is_null() || device_path.is_null() || unsafe { device_path.read_unaligned() }.is_null() {
         return efi::Status::INVALID_PARAMETER;
     }
 
     let (best_remaining_path, best_device) =
+        // Safety: Caller must ensure that protocol and device_path are valid pointers. They are null-checked above.
         match core_locate_device_path(unsafe { protocol.read_unaligned() }, unsafe { device_path.read_unaligned() }) {
             Err(err) => return err.into(),
             Ok((path, device)) => (path, device),
@@ -768,6 +788,7 @@ extern "efiapi" fn locate_device_path(
     if device.is_null() {
         return efi::Status::INVALID_PARAMETER;
     }
+    // Safety: Caller must ensure that device_path and device are valid pointers. They are null-checked above.
     unsafe {
         device.write_unaligned(best_device);
         device_path.write_unaligned(best_remaining_path);


### PR DESCRIPTION
## Description

The UEFI spec does not clearly require that pointers passed to UEFI spec APIs (like AllocatePages) must be aligned. 
This pull request changes various FFI routines to assume that raw pointers passed to them may not be aligned. 

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Unit tests pass. On systems passing unaligned pointers to core routines, no longer observe crashes. Note: this doesn't constitute broad coverage of these changes; this was only observed with a subset of the routines in the real world. 

## Integration Instructions

N/A
