### PR TITLE
x86_64 cpu_init: Initialize / Configure FPU

### DIFF
--- a/core/patina_internal_cpu/src/cpu/x64/cpu.rs
+++ b/core/patina_internal_cpu/src/cpu/x64/cpu.rs
@@ -116,7 +116,7 @@ impl EfiCpuX64 {
                 temp = out(reg) _,
                 FPU_CONTROL_WORD = sym FPU_CONTROL_WORD,
                 MMX_CONTROL_WORD = sym MMX_CONTROL_WORD,
-                BIT9 = const 1 << 9,
+                BIT9 = const patina_sdk::bit!(9),
                 options(nostack, preserves_flags)
             );
         }


### PR DESCRIPTION
## Description

Initializes / configures the FPU by setting the x87 FPU Control Word and MXCSR Control Status Register to the required state per UEFI SCTs and existing C implementation.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Both SCTs now show the expected values for these two configurations, however one test is still failing as the precision sticky flag is being set to 1 somewhere in the BDS entry point before entering the Shell. This indicates that some type of floating-point math was performed where the result could not be accurately described by a given number and rounding occurred (example: `1.0 / 3.0`). This still needs to be further investigated, but the general configurations ignoring this bit is accurate (ref: #796)

## Integration Instructions

N/A
