### PR TITLE
Add rustc feature gate tracking issue requirements

### DIFF
--- a/.github/ISSUE_TEMPLATE/rustc_feature_gate.yml
+++ b/.github/ISSUE_TEMPLATE/rustc_feature_gate.yml
@@ -25,6 +25,14 @@ body:
       placeholder: "generic_associated_types"
     validations:
       required: true
+  - type: input
+    id: feature_link
+    attributes:
+      label: Unstable rustc feature issue link
+      description: The link to the unstable rust feature tracking issue (github).
+      placeholder: https://github.com/rust-lang/rfcs/pull/1598
+    validations:
+      required: true
   - type: checkboxes
     id: status
     attributes:

--- a/docs/src/dev/unstable.md
+++ b/docs/src/dev/unstable.md
@@ -10,7 +10,8 @@ and unstable state, such as: being largely no-std, implementing and using its ow
 and unsafe operations. Below are the guiding principles and practices for working with unstable Rust features in
 Patina.
 
-You can always track all active unstable rustc [feature usage](https://github.com/OpenDevicePartnership/patina/issues?q=is%3Aissue%20state%3Aopen%20label%3Astate%3Arustc-feature-gate).
+All active rustc feature usage is tracked with the [`state:rustc-feature-gate`](https://github.com/OpenDevicePartnership/patina/issues?q=is%3Aissue%20state%3Aopen%20label%3Astate%3Arustc-feature-gate)
+label.
 
 ## When Unstable Rust Features May Be Used
 


### PR DESCRIPTION

## Description

Updates the documentation to clarify the process and requirements for introducing and tracking unstable rustc feature usage in the Patina project. Specifically, this includes the need for an active and maintained tracking issue for each unstable feature used. This tracking issue should remain open until the feature usage is rejected, stabilized, or removed from the codebase.

The tracking issue, specifically marked with the label `rustc-feature-gate`, allows maintainers to easily monitor and manage the lifecycle of unstable rustc features within the project. It also provides a single place for tracking justification and usage of such features.

Having an overall tracking issue for each unstable feature was requested via #749 but it does not close it.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [x] Includes documentation?

## How This Was Tested

CI and validated the issue template renders properly.

## Integration Instructions

The `rustc-feature-gate` label needs to be created.
