### PR TITLE
cspell: Update asm!(...); regex to support newlines

### DIFF
--- a/cspell.yml
+++ b/cspell.yml
@@ -21,7 +21,7 @@ ignorePaths:
   - "Makefile.toml"
   - "**/patina_debugger/src/arch/xml/**"
 # ignore hex numbers, asm blocks and patterns like xxxx'xxxxx used in describing bit patterns
-ignoreRegExpList: ["/0x[0-9a-fA-F]+/", "asm!\\([\\s\\S]*?\\);", ".*'x*"]
+ignoreRegExpList: ["/0x[0-9a-fA-F]+/", ".*asm!\\([\\s\\S]*?\\);", ".*'x*"]
 minWordLength: 5
 caseSensitive: false
 allowCompoundWords: true


### PR DESCRIPTION
## Description

The existing regex only matches if the entire `asm!(...);` macro is on the same line. The updated macro can now handle multi-line asm macros such as:

```rust
asm!(
   "...",
   "...",
);
```

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

ran `cargo make cspell` on code with a multi-line `asm!` macro and commands that would normally trigger a spell check did not.

## Integration Instructions

N/A
