### PR TITLE
provide a bit! macro to match make setting a particular bit easy.

### DIFF
--- a/sdk/patina_sdk/src/base.rs
+++ b/sdk/patina_sdk/src/base.rs
@@ -11,7 +11,7 @@
 use num_traits;
 use r_efi::efi;
 
-use crate::{bit, error::EfiError};
+use crate::error::EfiError;
 
 pub mod guid;
 


### PR DESCRIPTION
## Description

We unfortunately cannot directly match C's `#define` functionality as it is type-less, and const definitions in rust require a type. To resolve this, we instead make a macro that does the left shifting for you, allowing you to specify the underlying binary type (u32, i32, etc).

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

CI

## Integration Instructions

N/A
