### PR TITLE
Remove unused btreemap_alloc feature

### DIFF
--- a/patina_dxe_core/src/lib.rs
+++ b/patina_dxe_core/src/lib.rs
@@ -31,7 +31,6 @@
 #![feature(alloc_error_handler)]
 #![feature(c_variadic)]
 #![feature(allocator_api)]
-#![feature(btreemap_alloc)]
 #![feature(slice_ptr_get)]
 #![feature(coverage_attribute)]
 


### PR DESCRIPTION
## Description

PR #769 removed the functionality using this feature. Due to this, the feature can be removed.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

N/A

## Integration Instructions

N/A
