### PR TITLE
Readme: Add badging

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,6 @@
 [![commit]][_commit]
 [![ci]][_ci]
 
-
 This repository hosts the Patina project - a Rust implementation of UEFI firmware.
 
 The goal of this project is to serve as a replacement for core UEFI firmware components so they are written in Pure


### PR DESCRIPTION
## Description

Adds the following badging:

1. Crates.io version
2. Commits since last release
3. current CI Status

Please note that the Crates.io version badge will not properly display until we perform our first release and the other two badges will not properly display until we go pubic.

Closes #26. The codecov percentage wil be moved to another task, which I will create and self assign, to start pubishing coverage results to codecov once we go public.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

N/A

## Integration Instructions

N/A