### PR TITLE
Makefile.tom: Add `cspell` to `all`

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -271,6 +271,7 @@ args = ["bench", "@@split(CARGO_MAKE_TASK_ARGS,;)"]
 description = "Run all tasks for PR readiness."
 dependencies = [
     "deny",
+    "cspell",
     "clippy",
     "build",
     "build-x64",


### PR DESCRIPTION
## Description

Include spell checking as part of the `all` task.

The CI workflow uses `streetsidesoftware/cspell-action`. This will run spell check again in the CI workflow in `cargo make all`, but I don't think that's a big deal. This catches spelling errors locally to better reflect all CI testing.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

- `cargo make all`

## Integration Instructions

- N/A