### PR TITLE
Makefile.toml: Add `patina-test` task

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -5,8 +5,7 @@ default_to_workspace = false
 RUSTC_BOOTSTRAP = 1
 NO_STD_FLAGS = "--profile ${RUSTC_PROFILE} -Zbuild-std=core,compiler_builtins,alloc -Zbuild-std-features=compiler-builtins-mem -Zunstable-options --timings=html"
 STD_FLAGS = "--profile ${RUSTC_PROFILE} --features std"
-TEST_FLAGS = { value = "--features enable_patina_tests", condition = { env_not_set = ["TEST_FLAGS"] } }
-COV_FLAGS = { value = "--features enable_patina_tests --workspace --lcov --profile test --ignore-filename-regex .*test.*", condition = { env_not_set = ["COV_FLAGS"] } }
+COV_FLAGS = { value = "--workspace --lcov --profile test --ignore-filename-regex .*test.*", condition = { env_not_set = ["COV_FLAGS"] } }
 RUSTDOCFLAGS = "-D warnings -D missing_docs"
 
 [env.development]
@@ -133,10 +132,16 @@ clear = true
 run_task = [{ name = ["check_no_std", "check_std", "check_tests"], parallel = true }]
 
 [tasks.test]
-description = "Builds all rust tests in the workspace. Example `cargo make test`"
+description = "Runs tests with native cargo test behavior. Example `cargo make test` or `cargo make test -p package_name -- --nocapture`"
 clear = true
 command = "cargo"
-args = ["test", "@@split(INDIVIDUAL_PACKAGE_TARGETS, )", "@@split(TEST_FLAGS, )"]
+args = ["test", "@@split(CARGO_MAKE_TASK_ARGS,;)"]
+
+[tasks.patina-test]
+description = "Builds crates with Patina tests enabled. Example `cargo make patina-test`"
+clear = true
+command = "cargo"
+args = ["build", "@@split(INDIVIDUAL_PACKAGE_TARGETS, )", "@@split(STD_FLAGS, )", "--features", "enable_patina_tests"]
 dependencies = ["individual-package-targets"]
 
 [tasks.coverage]
@@ -277,6 +282,7 @@ dependencies = [
     "build-x64",
     "build-aarch64",
     "test",
+    "patina-test",
     "coverage",
     "fmt",
     "doc",

--- a/README.md
+++ b/README.md
@@ -98,10 +98,28 @@ cargo make -p release build-aarch64
 
 ## Test
 
-Use the test command to invoke a test build and execute all unit tests.
+- Run all unit tests in the workspace:
 
 ```shell
 cargo make test
+```
+
+- Run tests in an individual package:
+
+```shell
+cargo make test -p patina
+```
+
+Build on-platform tests in the workspace:
+
+```shell
+cargo make patina-test
+```
+
+- Build on-platform tests in an individual package:
+
+```shell
+cargo make patina-test -p patina
 ```
 
 ## Rust Version Updates

--- a/docs/src/background/rust_tools.md
+++ b/docs/src/background/rust_tools.md
@@ -112,12 +112,13 @@ The tools available with cargo make development simple and consistent across all
 
 ```bash
 # Standard cargo commands work universally
-cargo make check      # Fast compilation check
-cargo make build      # Full compilation
-cargo make test       # Run test suite
-cargo make doc        # Generate documentation
-cargo make cov        # Generate unit test code coverage
-cargo make deny       # Check for security and license compliance in dependencies
+cargo make check        # Fast compilation check
+cargo make build        # Full compilation
+cargo make test         # Run test suite
+cargo make patina-test  # Build with Patina test features enabled for on-platform tests
+cargo make doc          # Generate documentation
+cargo make cov          # Generate unit test code coverage
+cargo make deny         # Check for security and license compliance in dependencies
 
 cargo make all   # Run the same commands used in CI/CD
 ```


### PR DESCRIPTION
## Description

Right now, `cargo make test` does not support common test arguments
like `-p`:

```
  error: invalid character `;` in package name: `;patina`, the first
  character must be a Unicode XID start character (most letters or `_`)

  Error while executing command, exit code: 101
```

It is useful to only against test in a given package during
development. This change proposes `cargo make test` behaving similar
to `cargo test` so users don't have to know when to switch between
the two and can use `cargo make` as their common command root.

Now something like this works:

> `cargo make test -p patina_mm -- --nocapture`

---

In the course of changing the test command, this is also fixed:

`enable_patina_tests` is a feature that is used to build test code
to execute on platforms. It can be thought of conceptually like
UEFI application testing on a given platform. It is not related
to unit testing on a host machine.

This change removes the feature from the `test` command entirely
and builds code with that feature under its own `patina-test`
task using the underlying `build` command.

Also, not all crates support `enable_patina_tests`. Previously,
you'd run into errors like this even if individual crates were
supported in the test command if the crate didn't support the
feature:

```
error: the package 'patina_adv_logger' does not contain this feature:
enable_patina_tests
```

That feature can be enabled against all workspace:

```
cargo make patina-test
```

The `all` task now includes both `test` (for host-based tests) and
`patina-tests` (for building the on-platform tests).

`patina-test` can be run against an individual package that supports
the feature. For example:

```
cargo make patina-test -p patina_macro
```

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

- `cargo make test`
- `cargo make test -p patina_mm`
- `cargo make test -p patina_mm -- --nocapture`
- `cargo make patina-test`
- `cargo make patina-test -p patina_macro`
- `cargo make all`

## Integration Instructions

- No integration needed. But developers should review how each test command is used.