### PR TITLE
.github/action.yml: Fix cache key expansion

### DIFF
--- a/.github/actions/rust-tool-cache/action.yml
+++ b/.github/actions/rust-tool-cache/action.yml
@@ -27,7 +27,7 @@ runs:
         path: |
           ~/.cargo/bin/
           ~/.rustup/toolchains/
-        key: ${{ runner.os }}-rust-tools-${{ hashFiles('${{ inputs.rust-toolchain-file }}') }}
+        key: ${{ runner.os }}-rust-tools-${{ hashFiles(inputs.rust-toolchain-file) }}
 
     # Installs the toolchain specified in the rust-toolchain.toml file if rustup >= 1.28.0
     #


### PR DESCRIPTION
## Description

The cache key is getting truncated due to double template expansion, so it looks like this in an action log:

```
Run actions/cache@v4
  with:
    path: ~/.cargo/bin/
  ~/.rustup/toolchains/

    key: Linux-rust-tools-
    enableCrossOsArchive: false
    fail-on-cache-miss: false
    lookup-only: false
```

This causes the cache to get hit when it shouldn't. In this case, causing a change in `rust-toolchain.toml` to get missed in the file hash calculation.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

- Tested the workflow on a fork and saw the cache key is resolved as expected (e.g. "`Linux-rust-tools-64374eb3836192205d8b657e5f0a81999d29c54659eb9b2a59ac29c0ab8f9d44`").

## Integration Instructions

- N/A