### PR TITLE
Generate lcov and html coverage reports

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -5,7 +5,7 @@ default_to_workspace = false
 RUSTC_BOOTSTRAP = 1
 NO_STD_FLAGS = "--profile ${RUSTC_PROFILE} -Zbuild-std=core,compiler_builtins,alloc -Zbuild-std-features=compiler-builtins-mem -Zunstable-options --timings=html"
 STD_FLAGS = "--profile ${RUSTC_PROFILE} --features std"
-COV_FLAGS = { value = "--workspace --lcov --profile test --ignore-filename-regex .*test.*", condition = { env_not_set = ["COV_FLAGS"] } }
+COV_FLAGS = { value = "--workspace --profile test --ignore-filename-regex .*test.*", condition = { env_not_set = ["COV_FLAGS"] } }
 RUSTDOCFLAGS = "-D warnings -D missing_docs"
 
 [env.development]
@@ -150,13 +150,32 @@ private = true
 command = "cargo"
 args = ["generate-lockfile"]
 
-[tasks.coverage]
-description = "Build and run all tests and calculate coverage."
+[tasks.coverage-collect]
+description = "Run tests and collect coverage data without generating reports."
 install_crate = false
 clear = true
 command = "cargo"
-args = ["llvm-cov", "@@split(COV_FLAGS, )", "--output-path", "${CARGO_MAKE_WORKSPACE_WORKING_DIRECTORY}/target/lcov.info"]
+args = ["llvm-cov", "@@split(COV_FLAGS, )", "--no-report"]
 dependencies = ["individual-package-targets"]
+
+[tasks.coverage-lcov]
+description = "Generate an LCOV coverage report from collected data."
+install_crate = false
+clear = true
+command = "cargo"
+args = ["llvm-cov", "report", "--lcov", "--output-path", "${CARGO_MAKE_WORKSPACE_WORKING_DIRECTORY}/target/lcov.info"]
+
+[tasks.coverage-html]
+description = "Generate an HTML coverage report from collected data."
+install_crate = false
+clear = true
+command = "cargo"
+args = ["llvm-cov", "report", "--html", "--output-dir", "${CARGO_MAKE_WORKSPACE_WORKING_DIRECTORY}/target/coverage"]
+
+[tasks.coverage]
+description = "Build and run all tests and calculate coverage (runs test once and generates LCOV and HTML reports)."
+dependencies = ["coverage-collect", "coverage-lcov", "coverage-html"]
+clear = true
 
 [tasks.coverage-filter]
 description = "Generates the coverage filter to ignore coverage data for other packages."

--- a/docs/src/background/rust_tools.md
+++ b/docs/src/background/rust_tools.md
@@ -603,17 +603,17 @@ mod tests {
 
 **Configuration in Patina**:
 
-```toml
-# Makefile.toml - Coverage with failure thresholds
-[tasks.coverage-fail-package]
-command = "cargo"
-args = ["llvm-cov", "--package", "${PACKAGE}", "--fail-under-lines", "80",
-        "--ignore-filename-regex", "${PACKAGE_COVERAGE_FILTER}"]
+Patina has several tasks defined in `Makefile.toml` to collect coverage data and generate reports in different formats:
 
+- `cargo make coverage-collect`: Runs tests and collects coverage data without generating reports. This allows
+  multiple report formats to be generated from the same data efficiently.
+- `cargo make coverage-lcov`: Generates an LCOV coverage report from the collected data.
+- `cargo make coverage-html`: Generates an HTML coverage report from the collected data.
+
+```toml
 [tasks.coverage]
-command = "cargo"
-args = ["llvm-cov", "@@split(COV_FLAGS, )", "--output-path",
-        "${CARGO_MAKE_WORKSPACE_WORKING_DIRECTORY}/target/lcov.info"]
+description = "Build and run all tests and calculate coverage (generates both LCOV and HTML outputs efficiently)."
+dependencies = ["coverage-collect", "coverage-lcov", "coverage-html"]
 ```
 
 > Note: Patina previously used [`tarpaulin`](https://github.com/xd009642/tarpaulin) for coverage, but switched to

--- a/docs/src/dev/testing.md
+++ b/docs/src/dev/testing.md
@@ -43,9 +43,9 @@ must have CI that fails if any code added to the repository has less than 80% co
 whole is below 80% coverage.
 
 By default, cargo-llvm-cov will produced an lcov report, which is easily consumable in various processing tools like
-[Coverage Gutters](https://marketplace.visualstudio.com/items?itemName=ryanluker.vscode-coverage-gutters). To view the
-report in HTML format, `cargo llvm-cov report --html` can be run to generate the report from the already produced lcov
-report.
+[Coverage Gutters](https://marketplace.visualstudio.com/items?itemName=ryanluker.vscode-coverage-gutters). The
+`cargo make coverage` command in Patina also produces an HTML report. This is available in the
+`target/coverage/html` folder.
 
 ```mermaid
 ---


### PR DESCRIPTION
## Description

Currently, only lcov reports are generated by default. However, HTML reports provide nice, simple visualization of coverage data. While the HTML report can be generated manually today, it can also be generated efficiently in the `coverage` task without users having to understand (1) that the command is available and (2) how to use it to generate the HTML report.

Coverage data will be calculated once and then both reports will be generated from that data. Individual cargo-make tasks can be run as desired if only report type is needed in a given flow or development scenario. However, the main use case remains `cargo make coverage` which will now generate both reports.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

- `cargo make coverage`
- `cargo make coverage-collect`
- `cargo make coverage-lcov`
- `cargo make coverage-html`

## Integration Instructions

- N/A - Impacts local repo developer operations