### PR TITLE
Docs: Add Recommendation to Use Debugger Feature Flag

### DIFF
--- a/docs/src/dev/debugging.md
+++ b/docs/src/dev/debugging.md
@@ -44,14 +44,19 @@ for examples.
 Example setup:
 
 ```rust
+#[cfg(feature = "enable_debugger")]
 static DEBUGGER: patina_debugger::PatinaDebugger<UartPl011> =
     patina_debugger::PatinaDebugger::new(UartPl011::new(0x6000_0000))
         .without_transport_init()
-        .with_force_enabled(false);
+        .with_force_enabled(true);
 ```
 
 Debugging configuration is critical to proper functionality. Read the [Patina Debugger documentation](https://github.com/OpenDevicePartnership/patina/blob/main/core/patina_debugger/src/debugger.rs)
 for full configuration options.
+
+> Note: It is recommended to use a compile time feature flag to enable/disable the debugger, including instantiating the
+> static struct, as this saves significant file space when the debugger is not enabled. It has been shown to save
+> 60k - 200k of binary size depending on the platform.
 
 ### Step 2: Install the debugger
 
@@ -60,6 +65,7 @@ In the platform initialization routine, call `set_debugger` to install the debug
 it is available in the core.
 
 ```rust
+#[cfg(feature = "enable_debugger")]
 patina_debugger::set_debugger(&DEBUGGER);
 ```
 
@@ -68,7 +74,8 @@ or active. Installing is a no-op without enablement.
 
 ### Step 3: Enable the debugger
 
-Enable the debugger at compile time with `.with_force_enabled(true)`. This causes Patina to
+Enable the debugger at compile time by enabling the debugger feature, e.g. in the examples above this would be
+`cargo make build -- --features enable_debugger`. This causes Patina to
 break early and wait for the debugger. If successful, on boot you should see the following
 (if error logging is enabled) followed by a hang.
 

--- a/docs/src/integrate/dxe_core.md
+++ b/docs/src/integrate/dxe_core.md
@@ -263,18 +263,20 @@ Modify the `DEBUGGER` static to match your platform's debug serial infrastructur
 #### X86_64 Example
 
 ```rust
+#[cfg(feature = "enable_debugger")]
 static DEBUGGER: patina_debugger::PatinaDebugger<Uart16550> =
     patina_debugger::PatinaDebugger::new(Uart16550::Io { base: 0x3F8 })  // <- Update for your platform
-        .with_force_enable(false)
+        .with_force_enable(true)
         .with_log_policy(patina_debugger::DebuggerLoggingPolicy::FullLogging);
 ```
 
 #### AARCH64 Example
 
 ```rust
+#[cfg(feature = "enable_debugger")]
 static DEBUGGER: patina_debugger::PatinaDebugger<UartPl011> =
     patina_debugger::PatinaDebugger::new(UartPl011::new(0x6000_0000))  // <- Update for your platform
-        .with_force_enable(false);
+        .with_force_enable(true);
 ```
 
 #### Adding a Logger Example


### PR DESCRIPTION
## Description

After analysis with cargo-bloat, it has been determined that the debugger, even when disabled, adds 60k - 200k of file size to a platform, depending on the platform. This updates the patina docs to recommend a feature flag to enable the debugger in order to save this space when it is not in use.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [x] Includes documentation?

## How This Was Tested

N/A.

## Integration Instructions

N/A.
