### PR TITLE
Docs: Update Debugger Recommendations

### DIFF
--- a/docs/src/dev/debugging.md
+++ b/docs/src/dev/debugging.md
@@ -45,18 +45,25 @@ Example setup:
 
 ```rust
 #[cfg(feature = "enable_debugger")]
+const _ENABLE_DEBUGGER: bool = true;
+#[cfg(not(feature = "enable_debugger"))]
+const _ENABLE_DEBUGGER: bool = false;
+
+#[cfg(feature = "build_debugger")]
 static DEBUGGER: patina_debugger::PatinaDebugger<UartPl011> =
     patina_debugger::PatinaDebugger::new(UartPl011::new(0x6000_0000))
         .without_transport_init()
-        .with_force_enabled(true);
+        .with_force_enabled(_ENABLE_DEBUGGER);
 ```
 
 Debugging configuration is critical to proper functionality. Read the [Patina Debugger documentation](https://github.com/OpenDevicePartnership/patina/blob/main/core/patina_debugger/src/debugger.rs)
 for full configuration options.
 
-> Note: It is recommended to use a compile time feature flag to enable/disable the debugger, including instantiating the
+> Note: It is recommended to use a compile time feature flag to build the debugger, including instantiating the
 > static struct, as this saves significant file space when the debugger is not enabled. It has been shown to save
-> 60k - 200k of binary size depending on the platform.
+> 60k - 200k of binary size depending on the platform. Debug builds should default to having this feature flag enabled;
+> this helps to encourage debugger use and ensure that the platform FV is large enough to accommodate the debugger's
+> added size. A separate feature, as shown in the examples, may be used to enable the debugger.
 
 ### Step 2: Install the debugger
 
@@ -65,7 +72,7 @@ In the platform initialization routine, call `set_debugger` to install the debug
 it is available in the core.
 
 ```rust
-#[cfg(feature = "enable_debugger")]
+#[cfg(feature = "build_debugger")]
 patina_debugger::set_debugger(&DEBUGGER);
 ```
 
@@ -75,9 +82,8 @@ or active. Installing is a no-op without enablement.
 ### Step 3: Enable the debugger
 
 Enable the debugger at compile time by enabling the debugger feature, e.g. in the examples above this would be
-`cargo make build -- --features enable_debugger`. This causes Patina to
-break early and wait for the debugger. If successful, on boot you should see the following
-(if error logging is enabled) followed by a hang.
+`cargo make build --features enable_debugger`. This causes Patina to break early and wait for the debugger. If
+successful, on boot you should see the following (if error logging is enabled) followed by a hang.
 
 ```text
 ERROR - ************************************
@@ -135,9 +141,10 @@ When enabling the debugger through any runtime enablement mechanism, it is criti
 that the platform consider the security impacts. The platform should be certain
 that the configuration or policy that is used to enable the debugger comes from
 an authenticated source and that the enablement of the debugger is properly captured
-in the TPM measurements through the appropriate `EV_EFI_ACTION` measurement **BEFORE**
-enabling the debugger. Allowing the debugger to be dynamically enabled in production
-in an unauthenticated or unmeasured way would be a significant security bypass.
+in the TPM measurements (PCR7 is recommended) through the appropriate `EV_EFI_ACTION`
+measurement **BEFORE** enabling the debugger. Allowing the debugger to be dynamically
+enabled in production in an unauthenticated or unmeasured way would be a significant
+security bypass.
 
 ## Debugger Functionality
 

--- a/docs/src/integrate/dxe_core.md
+++ b/docs/src/integrate/dxe_core.md
@@ -264,9 +264,14 @@ Modify the `DEBUGGER` static to match your platform's debug serial infrastructur
 
 ```rust
 #[cfg(feature = "enable_debugger")]
+const _ENABLE_DEBUGGER: bool = true;
+#[cfg(not(feature = "enable_debugger"))]
+const _ENABLE_DEBUGGER: bool = false;
+
+#[cfg(feature = "build_debugger")]
 static DEBUGGER: patina_debugger::PatinaDebugger<Uart16550> =
     patina_debugger::PatinaDebugger::new(Uart16550::Io { base: 0x3F8 })  // <- Update for your platform
-        .with_force_enable(true)
+        .with_force_enable(_ENABLE_DEBUGGER)
         .with_log_policy(patina_debugger::DebuggerLoggingPolicy::FullLogging);
 ```
 
@@ -274,9 +279,14 @@ static DEBUGGER: patina_debugger::PatinaDebugger<Uart16550> =
 
 ```rust
 #[cfg(feature = "enable_debugger")]
+const _ENABLE_DEBUGGER: bool = true;
+#[cfg(not(feature = "enable_debugger"))]
+const _ENABLE_DEBUGGER: bool = false;
+
+#[cfg(feature = "build_debugger")]
 static DEBUGGER: patina_debugger::PatinaDebugger<UartPl011> =
     patina_debugger::PatinaDebugger::new(UartPl011::new(0x6000_0000))  // <- Update for your platform
-        .with_force_enable(true);
+        .with_force_enable(_ENABLE_DEBUGGER);
 ```
 
 #### Adding a Logger Example


### PR DESCRIPTION
## Description

This updates the patina docs to reflect that it is recommended to have a PCR7 measurement reflecting that the debugger is enabled and that for FV size considerations, it is recommended that debug builds have the debugger enabled to accommodate the size needs easily.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [x] Includes documentation?

## How This Was Tested

N/A.

## Integration Instructions

N/A.
