### PR TITLE
patina_debugger: Remove initial breakpoint configurability.

### DIFF
--- a/core/patina_debugger/src/debugger.rs
+++ b/core/patina_debugger/src/debugger.rs
@@ -102,11 +102,7 @@ impl<T: SerialIO> PatinaDebugger<T> {
             log_policy: DebuggerLoggingPolicy::SuspendLogging,
             no_transport_init: false,
             exception_types: SystemArch::DEFAULT_EXCEPTION_TYPES,
-            config: spin::RwLock::new(DebuggerConfig {
-                enabled: false,
-                initial_break: false,
-                initial_break_timeout: 0,
-            }),
+            config: spin::RwLock::new(DebuggerConfig { enabled: false, initial_break: true, initial_break_timeout: 0 }),
             internal: Mutex::new(DebuggerInternal { gdb_buffer: None, gdb: None }),
             system_state: Mutex::new(SystemState::new()),
         }
@@ -148,22 +144,16 @@ impl<T: SerialIO> PatinaDebugger<T> {
         self
     }
 
-    /// Configure the debugger.
+    /// Enables the debugger.
     ///
-    /// Allows runtime configuration of some of the debugger settings.
+    /// Allows runtime enablement of the debugger. This should be called before the Patina
+    /// core is invoked.
     ///
     /// Enabled - Whether the debugger is enabled, and will install itself into the system.
     ///
-    /// Initial Break - Whether the debugger should break on initialization.
-    ///
-    /// Initial Break Timeout - A duration in seconds for the debugger to wait for a connection.
-    /// 0 indicates no timeout and will wait indefinitely
-    ///
-    pub fn configure(&self, enabled: bool, _initial_break: bool, _initial_break_timeout: u32) {
+    pub fn enable(&self, enabled: bool) {
         let mut config = self.config.write();
         config.enabled = enabled;
-        // Intentionally ignoring initial_break config until configuration is thought out.
-        config.initial_break = true;
     }
 
     /// Enters the debugger from an exception.

--- a/core/patina_debugger/src/lib.rs
+++ b/core/patina_debugger/src/lib.rs
@@ -35,8 +35,7 @@
 //! fn entry() {
 //!
 //!     // Configure the debugger. This is used for dynamic configuration of the debugger.
-//!     // For static configuration use the with_config method on construction.
-//!     DEBUGGER.configure(true, true, 0);
+//!     DEBUGGER.enable(true);
 //!
 //!     // Set the global debugger instance. This can only be done once.
 //!     patina_debugger::set_debugger(&DEBUGGER);

--- a/docs/src/dev/debugging.md
+++ b/docs/src/dev/debugging.md
@@ -88,9 +88,8 @@ ERROR - ************************************
 This means the debugger is waiting for a connection. If you do not see this hang,
 then confirm that the debugger is enabled and installed prior to calling the core.
 
-You can also enable the debugger at runtime using the `Configure` routine, but use caution.
-Runtime enablement can skip the initial breakpoint and may cause security issues. For development,
-prefer force enablement.
+You can also enable the debugger at runtime using the `enable` routine, but use caution.
+Dynamic enablement should be carefully thought through to ensure proper platform security.
 
 ### Step 4: Verify the transport
 

--- a/docs/src/dev/debugging.md
+++ b/docs/src/dev/debugging.md
@@ -90,6 +90,7 @@ then confirm that the debugger is enabled and installed prior to calling the cor
 
 You can also enable the debugger at runtime using the `enable` routine, but use caution.
 Dynamic enablement should be carefully thought through to ensure proper platform security.
+See the [Security Considerations section](#security-considerations) for more details.
 
 ### Step 4: Verify the transport
 
@@ -127,6 +128,16 @@ if patina_debugger::enabled() {
 
 As an aside, `patina_debugger::breakpoint()` can be useful to placing in other locations
 of interest while debugging to ensure you catch a specific function or scenario.
+
+### Security Considerations
+
+When enabling the debugger through any runtime enablement mechanism, it is critical
+that the platform consider the security impacts. The platform should be certain
+that the configuration or policy that is used to enable the debugger comes from
+an authenticated source and that the enablement of the debugger is properly captured
+in the TPM measurements through the appropriate `EV_EFI_ACTION` measurement **BEFORE**
+enabling the debugger. Allowing the debugger to be dynamically enabled in production
+in an unauthenticated or unmeasured way would be a significant security bypass.
 
 ## Debugger Functionality
 


### PR DESCRIPTION
## Description

The `configure` function in PatinaDebugger currently allows the platform to dynamically enable the debugger without the initial breakpoint. Currently this input is ignored as having the debugger enable in a silent configuration can be potentially dangerous for having the debugger enabled without notice in non-development scenarios. This removes this option and changes `configure` to `enable` for clarity.

Not marking as breaking as the configure function is not currently used.

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

N/A

## Integration Instructions

N/A
