### PR TITLE
Continuous Integration: Upload Coverage Report

### DIFF
--- a/.github/workflows/CiWorkflow.yml
+++ b/.github/workflows/CiWorkflow.yml
@@ -125,11 +125,11 @@ jobs:
         run: cargo make doc
 
       - name: Upload Coverage Report
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          files: target/cobertura.xml
-          fail_ci_if_error: false # Expect it to fail while repository is private
+          files: target/lcov.info
+          fail_ci_if_error: true
 
       - name: Build std
         run: cargo make build

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 [![release]][_release]
 [![commit]][_commit]
 [![ci]][_ci]
+[![cov]][_cov]
 
 This repository hosts the Patina project - a Rust implementation of UEFI firmware.
 
@@ -237,3 +238,5 @@ directory.
 [_commit]: https://github.com/OpenDevicePartnership/patina/commits/main/
 [ci]: https://github.com/OpenDevicePartnership/patina/actions/workflows/ci-workflow.yml/badge.svg?branch=main&event=push
 [_ci]: https://github.com/OpenDevicePartnership/patina/actions/workflows/ci-workflow.yml
+[cov]: https://codecov.io/gh/OpenDevicePartnership/patina/graph/badge.svg?token=CWHWOUUGY6
+[_cov]: https://codecov.io/gh/OpenDevicePartnership/patina


### PR DESCRIPTION
## Description

Upload coverage report to Codecov during CI builds and merges into main. Adds Coverage badging which will display properly once the PR is merged and the Merge CI workflow finishes.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

CI - Validated coverage uploaded successfully. Viewable: https://app.codecov.io/github/OpenDevicePartnership/patina

## Integration Instructions

N/A
