### PR TITLE
Mark libc with owner "rust-lang-owner" as safe to deploy

### DIFF
--- a/supply-chain/audits.toml
+++ b/supply-chain/audits.toml
@@ -107,9 +107,9 @@ end = "2026-03-24"
 
 [[trusted.libc]]
 criteria = "safe-to-deploy"
-user-id = 51017
-start = "2020-03-17"
-end = "2026-03-24"
+user-id = 55123 # rust-lang-owner
+start = "2024-08-15"
+end = "2026-10-09"
 
 [[trusted.linkme]]
 criteria = "safe-to-deploy"

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -280,10 +280,6 @@ criteria = "safe-to-run"
 version = "0.3.81"
 criteria = "safe-to-run"
 
-[[exemptions.libc]]
-version = "0.2.171"
-criteria = "safe-to-run"
-
 [[exemptions.libm]]
 version = "0.2.15"
 criteria = "safe-to-deploy"

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -112,6 +112,12 @@ user-id = 6743
 user-login = "epage"
 user-name = "Ed Page"
 
+[[publisher.libc]]
+version = "0.2.177"
+when = "2025-10-09"
+user-id = 55123
+user-login = "rust-lang-owner"
+
 [[publisher.linkme]]
 version = "0.3.35"
 when = "2025-09-28"
@@ -1076,12 +1082,6 @@ aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-ch
 who = "Erich Gubler <erichdongubler@gmail.com>"
 criteria = "safe-to-deploy"
 delta = "2.8.0 -> 2.11.4"
-aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
-
-[[audits.mozilla.audits.libc]]
-who = "Erich Gubler <erichdongubler@gmail.com>"
-criteria = "safe-to-deploy"
-delta = "0.2.171 -> 0.2.176"
 aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
 
 [[audits.mozilla.audits.num-conv]]


### PR DESCRIPTION
## Description

Cargo vet is currently failing for the newest version of libc.

cargo vet specifically states that mozilla trusts rust-lang-owner and to consider doing `cargo vet trust libc rust-lang-owner`, which is what this does.

Additionally removes the previous user-id for libc

<img width="755" height="73" alt="image" src="https://github.com/user-attachments/assets/646445b7-bb60-4e13-9b68-9631e5d73795" />

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

CI

## Integration Instructions

N/A
