### PR TITLE
Beautify the Exception Handler Processing

### DIFF
--- a/core/patina_internal_cpu/src/interrupts.rs
+++ b/core/patina_internal_cpu/src/interrupts.rs
@@ -72,6 +72,46 @@ cfg_if::cfg_if! {
 /// specific interrupt type ID.
 pub type ExceptionType = usize;
 
+/// This macro pretty prints registers in groups of four per line.
+/// The expected input is a list of name, value pairs.
+#[macro_export]
+macro_rules! log_registers {
+    ( $( $name:expr, $value:expr ),+ $(,)? ) => {
+        let registers = [$(($name, $value),)+];
+        for chunk in registers.chunks(4) {
+            match chunk {
+                [c1, c2, c3, c4] => {
+                    log::error!(
+                        "{:>4}:  {:#018X}   {:>4}:  {:#018X}   {:>4}:  {:#018X}   {:>4}:  {:#018X}",
+                        c1.0, c1.1, c2.0, c2.1, c3.0, c3.1, c4.0, c4.1
+                    );
+                },
+                [c1, c2, c3] => {
+                    log::error!(
+                        "{:>4}:  {:#018X}   {:>4}:  {:#018X}   {:>4}:  {:#018X}",
+                        c1.0, c1.1, c2.0, c2.1, c3.0, c3.1
+                    );
+                },
+                [c1, c2] => {
+                    log::error!(
+                        "{:>4}:  {:#018X}   {:>4}:  {:#018X}",
+                        c1.0, c1.1, c2.0, c2.1,
+                    );
+                },
+                [c1] => {
+                    log::error!(
+                        "{:>4}:  {:#018X}",
+                        c1.0, c1.1
+                    );
+                },
+                _ => {
+                    log::error!("");
+                }
+            }
+        }
+    };
+}
+
 /// Trait for converting the architecture specific context structures into the
 /// UEFI System Context structure.
 pub(crate) trait EfiSystemContextFactory {
@@ -83,6 +123,9 @@ pub(crate) trait EfiSystemContextFactory {
 pub(crate) trait EfiExceptionStackTrace {
     /// Dump the stack trace for architecture specific context.
     fn dump_stack_trace(&self);
+
+    /// Dump system context registers for architecture specific context.
+    fn dump_system_context_registers(&self);
 }
 
 /// Trait for structs that implement and manage interrupts.

--- a/core/patina_internal_cpu/src/interrupts/aarch64.rs
+++ b/core/patina_internal_cpu/src/interrupts/aarch64.rs
@@ -6,14 +6,16 @@
 //!
 //! SPDX-License-Identifier: Apache-2.0
 //!
+use crate::log_registers;
 use patina::error::EfiError;
 use patina_pi::protocols::cpu_arch::EfiSystemContext;
 use patina_stacktrace::StackTrace;
 
+mod sysreg;
+
 cfg_if::cfg_if! {
     if #[cfg(all(target_os = "uefi", target_arch = "aarch64"))] {
         mod interrupt_manager;
-        mod sysreg;
         pub mod gic_manager;
         pub use interrupt_manager::InterruptsAarch64;
         use core::arch::asm;
@@ -37,6 +39,24 @@ impl super::EfiExceptionStackTrace for ExceptionContextAArch64 {
         if let Err(err) = unsafe { StackTrace::dump_with(self.elr, self.sp) } {
             log::error!("StackTrace: {err}");
         }
+    }
+
+    fn dump_system_context_registers(&self) {
+        log::error!("Exception Registers:");
+        log_registers!("ESR", self.esr, "ELR", self.elr, "SPSR", self.spsr, "FAR", self.far,);
+
+        log::error!("");
+
+        log::error!("General-Purpose Registers:");
+        log_registers!(
+            "x0", self.x0, "x1", self.x1, "x2", self.x2, "x3", self.x3, "x4", self.x4, "x5", self.x5, "x6", self.x6,
+            "x7", self.x7, "x8", self.x8, "x9", self.x9, "x10", self.x10, "x11", self.x11, "x12", self.x12, "x13",
+            self.x13, "x14", self.x14, "x15", self.x15, "x16", self.x16, "x17", self.x17, "x18", self.x18, "x19",
+            self.x19, "x20", self.x20, "x21", self.x21, "x22", self.x22, "x23", self.x23, "x24", self.x24, "x25",
+            self.x25, "x26", self.x26, "x27", self.x27, "x28", self.x28, "fp", self.fp, "lr", self.lr, "sp", self.sp
+        );
+
+        log::debug!("Full Context: {self:#X?}");
     }
 }
 

--- a/core/patina_internal_cpu/src/interrupts/aarch64/sysreg.rs
+++ b/core/patina_internal_cpu/src/interrupts/aarch64/sysreg.rs
@@ -3,6 +3,7 @@
 // See LICENSE-APACHE and LICENSE-MIT for details.
 
 /// Reads and returns the value of the given aarch64 system register.
+#[allow(unused_macros)]
 macro_rules! read_sysreg {
     ($name:ident) => {
         {
@@ -16,9 +17,11 @@ macro_rules! read_sysreg {
         }
     }
 }
+#[allow(unused_imports)]
 pub(crate) use read_sysreg;
 
 /// Writes the given value to the given aarch64 system register.
+#[allow(unused_macros)]
 macro_rules! write_sysreg {
     ($name:ident, $value:expr) => {
         {
@@ -44,4 +47,5 @@ macro_rules! write_sysreg {
         }
     };
 }
+#[allow(unused_imports)]
 pub(crate) use write_sysreg;

--- a/core/patina_internal_cpu/src/interrupts/exception_handling.rs
+++ b/core/patina_internal_cpu/src/interrupts/exception_handling.rs
@@ -9,6 +9,7 @@
 //!
 
 use patina::error::EfiError;
+use patina_paging::page_allocator::PageAllocator;
 use patina_pi::protocols::cpu_arch::EfiExceptionType;
 use spin::rwlock::RwLock;
 
@@ -106,11 +107,22 @@ extern "efiapi" fn exception_handler(exception_type: usize, context: &mut Except
             handler.handle_interrupt(exception_type, context);
         }
         HandlerType::None => {
-            log::error!("Unhandled Exception! 0x{exception_type:x}");
-            log::error!("Exception Context: {context:#x?}");
+            log::error!("Unhandled Exception! {exception_type:#X}");
+            log::error!("");
+            context.dump_system_context_registers();
+            log::error!("");
             context.dump_stack_trace();
-            panic!("Unhandled Exception! 0x{exception_type:x}");
+            panic!("Unhandled Exception! {exception_type:#X}");
         }
+    }
+}
+
+#[allow(dead_code)]
+pub(crate) struct FaultAllocator {}
+
+impl PageAllocator for FaultAllocator {
+    fn allocate_page(&mut self, _align: u64, _size: u64, _contiguous: bool) -> patina_paging::PtResult<u64> {
+        Err(patina_paging::PtError::OutOfResources)
     }
 }
 

--- a/core/patina_internal_cpu/src/interrupts/null.rs
+++ b/core/patina_internal_cpu/src/interrupts/null.rs
@@ -26,6 +26,7 @@ impl super::EfiSystemContextFactory for ExceptionContextNull {
 
 impl super::EfiExceptionStackTrace for ExceptionContextNull {
     fn dump_stack_trace(&self) {}
+    fn dump_system_context_registers(&self) {}
 }
 
 /// A function that does nothing as this is a null implementation.

--- a/core/patina_internal_cpu/src/interrupts/x64.rs
+++ b/core/patina_internal_cpu/src/interrupts/x64.rs
@@ -7,6 +7,7 @@
 //! SPDX-License-Identifier: Apache-2.0
 //!
 
+use crate::log_registers;
 use core::arch::asm;
 use patina::error::EfiError;
 use patina_pi::protocols::cpu_arch::EfiSystemContext;
@@ -35,6 +36,43 @@ impl super::EfiExceptionStackTrace for ExceptionContextX64 {
         if let Err(err) = unsafe { StackTrace::dump_with(self.rip, self.rsp) } {
             log::error!("StackTrace: {err}");
         }
+    }
+
+    fn dump_system_context_registers(&self) {
+        log::error!("Control Registers:");
+        log_registers!(
+            "CR0",
+            self.cr0,
+            "CR2",
+            self.cr2,
+            "CR3",
+            self.cr3,
+            "CR4",
+            self.cr4,
+            "RIP",
+            self.rip,
+            "CS",
+            self.cs,
+            "SS",
+            self.ss,
+            "DS",
+            self.ds,
+            "RSP",
+            self.rsp,
+            "RFLAGS",
+            self.rflags
+        );
+
+        log::error!("");
+
+        log::error!("General-Purpose Registers:");
+        log_registers!(
+            "RAX", self.rax, "RBX", self.rbx, "RCX", self.rcx, "RDX", self.rdx, "RSI", self.rsi, "RDI", self.rdi,
+            "RBP", self.rbp, "R8", self.r8, "R9", self.r9, "R10", self.r10, "R11", self.r11, "R12", self.r12, "R13",
+            self.r13, "R14", self.r14, "R15", self.r15
+        );
+
+        log::debug!("Full Context: {self:#X?}");
     }
 }
 


### PR DESCRIPTION
## Description

This change makes several updates to the exception handlers for x64 and aarch64:
- Add an AARCH64 synchronous exception handler to dump more granular information, particularly about instruction/data aborts
- Print register dumps in arch specific and generic handlers more concisely, printing multiple registers per line and only useful registers (except at debug error level)
- Dump the page table for the failing address in a page fault instead only using query; this provides much more information.

A couple notes:
- This is somewhat subjective, so happy to take additional feedback
- Doing log::error(""); between lines instead of `\n` inside of another print makes the log look better, with adv logger, because the error string gets appended on the front of the former, but not the latter, making the output look strange.
- Other ARM64 synchronous exception types can be added, but instruction/data aborts are some of the most common and there is easily obtainable information that is useful to retrieve. As time goes on, we could certainly extend it. I am not attempting to replace existing external software that translates the ESR for you. Just getting information we can't otherwise get.

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Tested by injecting faults on Q35 and SBSA and seeing the exception messages.

## Integration Instructions

N/A.
