### PR TITLE
Makefile.toml: Update cargo vet task to only report unvetted deps

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -303,7 +303,8 @@ install_crate = false
 clear = true
 dependencies = ["generate-lockfile"]
 command = "cargo"
-args = ["vet"]
+args = ["vet", "--locked"]
+ignore_errors = true
 
 [tasks.all]
 description = "Run all tasks for PR readiness."

--- a/supply-chain/audits.toml
+++ b/supply-chain/audits.toml
@@ -333,6 +333,12 @@ user-id = 6743 # Ed Page (epage)
 start = "2022-10-21"
 end = "2026-10-06"
 
+[[trusted.toml_edit]]
+criteria = "safe-to-deploy"
+user-id = 6743 # Ed Page (epage)
+start = "2023-01-01"
+end = "2026-10-06"
+
 [[trusted.toml_parser]]
 criteria = "safe-to-deploy"
 user-id = 6743 # Ed Page (epage)


### PR DESCRIPTION
## Description

Prevent auto generated audit file updates.

Update the make task to not fail for unvetted dependencies. Another workflow will be added to enforce vetting on a more permissible basis.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

- `cargo make vet` locally

## Integration Instructions

- N/A