### PR TITLE
Move license change history to docs

### DIFF
--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -67,4 +67,5 @@
 - [Performance Analysis](components/patina_performance.md)
 
 -----------
-[Contributors](misc/contributors.md)
+- [Contributors](misc/contributors.md)
+- [License](misc/license_history.md)

--- a/docs/src/misc/license_history.md
+++ b/docs/src/misc/license_history.md
@@ -1,10 +1,8 @@
-                              License-History.txt
-                              ===================
+# License History
 
 This file contains the history of Patina license changes.
 
-Key Dates
-----------
+## Key Dates
 
 * Project Inception: BSD-2-Clause-Patent License
 
@@ -18,4 +16,4 @@ Key Dates
   align with the Rust ecosystem and to provide additional protections and clarity for contributors and users.
 
   The change was made following the guidelines set forth in the project's governance documentation approved in
-  https://github.com/OpenDevicePartnership/governance/blob/main/rfc/0013-patina-apache-20-license.md.
+  [RFC: Apache 2.0 License for Patina](https://github.com/OpenDevicePartnership/governance/blob/main/rfc/0013-patina-apache-20-license.md).


### PR DESCRIPTION
## Description

Prevents the `License-History.txt` file from getting picked up in the GitHub UI with the main license file and consolidates info in documentation.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [x] Includes documentation?

## How This Was Tested

Review the change on a fork.

## Integration Instructions

- N/A