### PR TITLE
deny.toml: Drop patina-fw registry

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -100,12 +100,7 @@ ignore = false
 # One or more private registries that you might publish crates to, if a crate
 # is only published to private registries, and ignore is true, the crate will
 # not have its license(s) checked
-#
-# This public registry was published to prior to moving to crates.io. It is left
-# here until the crates.io transition has stabilized.
-registries = [
-    "sparse+https://pkgs.dev.azure.com/patina-fw/artifacts/_packaging/temporary/Cargo/index/",
-]
+registries = []
 
 # This section is considered when running `cargo deny check bans`.
 # More documentation about the 'bans' section can be found here:
@@ -197,13 +192,9 @@ unknown-git = "deny"
 # if not specified. If it is specified but empty, no registries are allowed.
 # allow-registry = ["registry+https://github.com/rust-lang/crates.io-index"]
 # List of URLs for allowed Git repositories
-#
-# This public registry was published to prior to moving to crates.io. It is left
-# here until the crates.io transition has stabilized.
 allow-git = []
 allow-registry = [
     "registry+https://github.com/rust-lang/crates.io-index",
-    "sparse+https://pkgs.dev.azure.com/patina-fw/artifacts/_packaging/temporary/Cargo/index/",
 ]
 
 [sources.allow-org]


### PR DESCRIPTION
## Description

Now that the transition from patina-fw to crates.io is complete, drop the patina-fw registry from deny.toml.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

- `cargo make deny`
- `cargo make all`

## Integration Instructions

- N/A