### PR TITLE
RFC: ESRT

### DIFF
--- a/docs/src/rfc/rejected/0023-esrt.md
+++ b/docs/src/rfc/rejected/0023-esrt.md
@@ -1,0 +1,488 @@
+# RFC: `ESRT (EFI System Resource Table)`
+
+This RFC proposes a Rust-based interface for managing the EFI System Resource Table (ESRT), safely
+encapsulating the `ESRT_MANAGEMENT_PROTOCOL` functionality from the UEFI specification behind an
+idiomatic Rust service. It introduces an `EsrtRecords` trait for registering, updating, removing,
+and publishing ESRT entries that describe updatable firmware resources. The design focuses on:
+(1) preserving required UEFI semantics, (2) reducing memory‑unsafe patterns inherent in the C
+protocol, and (3) enforcing a minimal, future‑extensible surface for firmware update tracking.
+
+## Change Log
+
+- 2025-10-14: Initial RFC created.
+- 2025-10-17: Updated based on PR review feedback:
+  - Fixed version validation logic to validate individual field correctness rather than enforce incorrect
+    LSV ≤ FwVersion relationship
+  - Restored automatic FMP synchronization feature to maintain EDK2 compatibility (removed from rejected alternatives)
+  - Clarified platform configuration defaults to reference specific EDK2 PCD values (32 entries for both FMP and Non-FMP)
+  - Added configurable auto-lock behavior with secure default (auto_lock_at_ready_to_boot option, defaults to true)
+  - Enhanced EsrtConfiguration documentation with clear references to EDK2 PCDs and security recommendations
+  - Changed capsule_flags from raw u32 to type-safe CapsuleFlags enum for better API design
+  - Added VendorDefined variant to LastAttemptStatus enum with range-validated VendorStatusCode wrapper
+  - Added design rationale for using private component configuration for capacity limits and ESRT-specific settings
+- 2025-11-03: RFC rejected during Final Comment Period:
+  - Added rejection summary documenting community decision to reject standalone ESRT component
+  - Community consensus favors integrated FMP/ESRT approach over standalone ESRT service
+
+## Motivation
+
+The EFI System Resource Table (ESRT) provides a standardized mechanism for firmware to communicate
+information about updatable system resources to the operating system. This includes system firmware,
+device firmware, and UEFI drivers that can be updated through the UEFI UpdateCapsule mechanism. This
+RFC proposes a pure Rust interface for existing ESRT capabilities, replacing the C-based implementations
+while preserving the semantics and behavior specified in the UEFI specification.
+
+**Compatibility Definition**:
+
+1. **Functional Equivalence**: The Rust implementation provides all functionality required by `ESRT_MANAGEMENT_PROTOCOL`
+2. **Semantic Preservation**: Operations maintain the same behavior, constraints, and error conditions as specified in UEFI
+3. **Data Format Compliance**: ESRT table structures conform exactly to the UEFI specification
+4. **Interface Transformation**: C-style function pointers, raw pointers, and u32 constants are replaced with idiomatic
+   Rust traits, ownership, type safety, and strongly-typed enums
+5. **Interoperability**: The implementation can produce C-compatible protocol bindings when needed for legacy component integration
+
+This approach provides a simpler, safer Rust-based interface while maintaining required ESRT functionality and
+ensuring that the resulting firmware behavior aligns with UEFI specification requirements. By using Rust-native
+types (enums for firmware types and status codes, Guid instead of raw arrays), the API prevents entire classes
+of errors at compile time that would be runtime errors in C.
+
+### Scope
+
+The `EsrtRecords` service implements equivalent functionality for the following protocol:
+
+- `ESRT_MANAGEMENT_PROTOCOL`
+  - `RegisterEsrtEntry`
+  - `UpdateEsrtEntry`
+  - `UnRegisterEsrtEntry`
+  - `GetEsrtEntry`
+  - `SyncEsrtFmp`
+  - `LockEsrtRepository`
+
+Additionally, the service provides ESRT table publication to the UEFI Configuration Table for OS visibility.
+
+## Technology Background
+
+The EFI System Resource Table (ESRT) provides a standardized mechanism for firmware to communicate
+updatable resource information to the operating system. The ESRT contains entries describing firmware
+resources (system firmware, device firmware, UEFI drivers) with version information, update status,
+and rollback protection metadata. See UEFI Specification 2.11, Section 23.4 for complete details.
+
+ESRT resources originate from two sources:
+
+- **FMP (Firmware Management Protocol)**: Dynamic resources from FMP protocol instances
+- **Non-FMP**: Static resources registered by platform code
+
+The UEFI Forum Specifications define the ESRT Management Protocol for managing entries:
+[ESRT_MANAGEMENT_PROTOCOL](https://github.com/tianocore/edk2/blob/master/MdeModulePkg/Include/Protocol/EsrtManagement.h)
+
+## Goals
+
+Create an idiomatic Rust API for ESRT-related protocols (*see [Motivation - Scope](#scope)*).
+
+## Requirements
+
+1. The API should provide all necessary ESRT functionality as a service to components
+2. The API should utilize Rust best practices, particularly memory safety and error handling
+3. The ESRT service should produce protocols equivalent to the current C implementations, preserving existing C functionality
+4. Support both FMP-based and Non-FMP resource registration
+5. Provide automatic FMP synchronization to discover dynamic firmware resources
+6. Enable repository locking to prevent modifications after platform initialization
+7. Publish ESRT table to UEFI Configuration Table for OS consumption
+
+## Unresolved Questions
+
+None at this time.
+
+## Prior Art (Existing PI C Implementation)
+
+This Patina-based ESRT implementation follows the ESRT Management Protocol as implemented in EDK2.
+In C, `ESRT_PRIVATE_DATA` provides the core management structure with separate locks for FMP and
+Non-FMP repositories. Entries are stored in UEFI variables (`EsrtFmp` and `EsrtNonFmp`) and the
+driver publishes the consolidated table to the Configuration Table on the Ready To Boot event.
+
+Key C implementation patterns preserved:
+
+- Separate variable storage for FMP and Non-FMP entries
+- Lock-protected repository access
+- Entry-level granularity for all operations
+- Automatic FMP synchronization on Ready To Boot event
+- Ready To Boot event for table publication
+
+### Dependencies on C Protocols
+
+While the final outcome should be a purely Rust-based interface, the current implementation depends on:
+
+- `FirmwareManagementProtocol` for FMP enumeration
+
+Note: RuntimeServices and BootServices are natively provided by Patina and do not require C FFI.
+
+## Alternatives
+
+### Memory Safety Considerations
+
+**Security-First Approach**: This implementation prioritizes memory safety and specification compliance.
+All ESRT entry operations validate input data before modification to prevent corruption of the firmware
+update metadata that the OS relies upon.
+
+#### Entry Validation Safety Model
+
+The service validates all ESRT entries before accepting them into the repository:
+
+1. **FwClass Uniqueness**: Prevents duplicate GUIDs within the same repository (FMP or Non-FMP)
+2. **Firmware Type Validation**: Ensures FwType is one of the valid values (System/Device/Driver)
+3. **Version Field Validation**: Ensures version fields are valid (non-zero LowestSupportedFwVersion, proper version encoding)
+4. **Repository Capacity**: Enforces maximum entry limits to prevent unbounded growth
+   - **Security Rationale**: Protects against memory exhaustion attacks and ensures predictable memory usage
+   - **EDK2 Compatibility**: Default limits (32 entries each) match existing EDK2 PCD defaults, maintaining
+     established platform expectations and tested deployment patterns
+   - **Legitimate Use Case Analysis**: While limits could theoretically block platforms with >32 updatable
+     components, this represents an extreme edge case. Current EDK2 implementations successfully operate
+     with these limits across diverse platforms. Platforms requiring higher limits can configure them
+     during component instantiation.
+   - **Bad Actor Prevention**: Unbounded entry creation could exhaust available memory, corrupt UEFI
+     variable storage, or cause boot failures. Limits provide a safety boundary for both accidental
+     and malicious scenarios.
+   - **Configuration Placement**: Max values use private component configuration since they are component-specific
+     resource allocation parameters, following Patina's pattern for internal capacity constraints
+
+### Alternative Design Choices
+
+The design prioritizes memory safety through:
+
+- **Entry Validation**: FwClass uniqueness, firmware type validation, version consistency checks, capacity limits
+- **Repository Separation**: Separate FMP/Non-FMP storage preserves trust boundaries and lifecycle management
+  - **Trust Boundaries**: Platform-controlled Non-FMP entries vs dynamically discovered FMP entries from third-party drivers
+  - **Lifecycle Management**: Non-FMP entries persist across boots, FMP entries are re-discovered each boot
+  - **EDK2 Compatibility**: Matches existing EDK2 architecture with separate `EsrtFmp` and `EsrtNonFmp` variables
+  - **Operational Benefits**: Independent capacity limits, separate locking semantics, and clear ownership models
+- **Write Protection**: `lock_repository()` prevents post-initialization modifications
+
+### Rejected Alternatives
+
+**Single Unified Repository**: Rejected because it loses the trust boundary between platform and third-party code,
+complicates synchronization, and creates a single point of failure. While removing the callback-based FMP collection
+might suggest a unified approach, the fundamental differences in data sources (platform-controlled vs dynamic discovery),
+persistence models (permanent vs per-boot), and trust levels still justify separate storage domains. The complexity
+of dual repositories is offset by clearer ownership semantics and compatibility with existing EDK2 patterns.
+
+**In-Memory Storage**: Rejected because `LastAttemptVersion`/`LastAttemptStatus` must persist across reboots
+per UEFI specification requirements.
+
+**Bulk Entry Operations**: Rejected due to complexity in partial failure handling and atomicity. Entry-level
+operations match UEFI semantics and can be wrapped if needed.
+
+## Rust Code Design
+
+### Component Architecture
+
+The ESRT service follows Patina's component/service pattern:
+
+```rust
+#[derive(IntoComponent, IntoService)]
+#[service(dyn EsrtRecords)]
+pub struct EsrtManager {
+    // Internal state for entry management
+}
+```
+
+The service is registered using the Commands pattern in the component entry point. During initialization,
+the component registers a Ready To Boot event handler to automatically publish the ESRT table:
+
+```rust
+fn entry_point(
+    mut self,
+    config: EsrtConfiguration,
+    mut commands: Commands,
+    boot_services: Service<dyn BootServices>,
+) -> Result<()> {
+    // Initialize repositories with configured capacities
+    
+    // Register Ready To Boot event handler to publish ESRT table
+    boot_services.create_event_ex(
+        EventType::NOTIFY_SIGNAL,
+        Tpl::CALLBACK,
+        Some(ready_to_boot_callback),
+        event_context,
+        &EVENT_GROUP_READY_TO_BOOT,
+    )?;
+    
+    commands.add_service(self);
+    Ok(())
+}
+```
+
+Platforms can configure ESRT capacity limits and locking behavior:
+
+```rust
+pub struct EsrtConfiguration {
+    /// Maximum FMP entries in cache repository. Default: 32 (matches EDK2 PcdMaxFmpEsrtCacheNum)
+    pub max_fmp_entries: u32,
+    /// Maximum Non-FMP entries in cache repository. Default: 32 (matches EDK2 PcdMaxNonFmpEsrtCacheNum)
+    pub max_non_fmp_entries: u32,
+    /// Whether to automatically lock repository at Ready To Boot. Default: true (recommended for security)
+    /// When true, lock_repository() is automatically called unless explicitly called earlier by platform
+    /// When false, repository remains unlocked unless platform explicitly calls lock_repository()
+    pub auto_lock_at_ready_to_boot: bool,
+}
+```
+
+**Design Note on Configuration Structure**: The capacity limits (`max_fmp_entries`, `max_non_fmp_entries`) are
+placed in the component's private configuration rather than shared public configuration since these values are
+component-specific resource allocation parameters, consumed only by the ESRT component during initialization.
+This follows Patina's pattern where private configuration is used for component-specific, hardcoded settings
+that don't require coordination between multiple components, while public `Config<T>` is reserved for values
+that may be consumed or mutated by multiple components before being locked.
+
+### Service Overview
+
+The ESRT component exposes one primary capability: a resource entry service that collects firmware
+resource metadata, stores it persistently, and (on demand) publishes a consolidated ESRT table as a UEFI Configuration Table.
+
+Key responsibilities:
+
+- **Entry Registration**: Accept Non-FMP entries from platform code with validation
+- **Entry Updates**: Modify existing entries (typically LastAttemptVersion/Status after updates)
+- **Entry Removal**: Remove Non-FMP entries that are no longer applicable
+- **Automatic FMP Synchronization**: Automatically enumerate FMP instances and update FMP repository on Ready To Boot
+  event (before lock)
+- **Repository Locking**: Prevent modifications after platform initialization, with configurable automatic locking at
+  Ready To Boot after FMP synchronization (default: enabled for security)
+- **Automatic Table Publication**: Register Ready To Boot event handler to publish consolidated ESRT after FMP sync and lock
+
+### Public Interaction Pattern (High Level)
+
+1. Platform code registers Non-FMP entries for system firmware resources
+2. Platform may update entries to reflect firmware update attempts
+3. Platform calls `lock_repository()` before Ready To Boot (optional - unless disabled via configuration,
+   repository automatically locks at Ready To Boot after FMP synchronization)
+4. On Ready To Boot event, service automatically:
+   a. Synchronizes FMP instances into FMP repository
+   b. Locks repository (if `auto_lock_at_ready_to_boot` is true and not already locked)
+   c. Publishes consolidated ESRT table to Configuration Table
+5. OS reads ESRT from Configuration Table to determine updatable resources
+
+Error surfaces (design‑relevant):
+
+- Duplicate FwClass GUID in registration
+- Repository full (capacity exhausted)
+- Entry not found on update/unregister
+- Repository locked (write-protected)
+
+### Safety Boundary
+
+The service uses Rust-native types with strong typing and validation. ESRT entries are represented
+as Rust structs with enforced invariants, eliminating memory-unsafe patterns from C-style raw data
+manipulation. Type-safe enums represent firmware types and status codes, preventing invalid values
+at compile time.
+
+## Guide-Level Explanation
+
+Platform components receive the ESRT service as a parameter and use it to manage firmware resource
+metadata throughout the boot process. The ESRT table is automatically published on the Ready To Boot
+event - platforms do not need to call `publish_table()` explicitly.
+
+```rust
+use patina::component::service::Service;
+
+fn platform_init(esrt: Service<dyn EsrtRecords>) -> Result<()> {
+    // Register system firmware resource
+    let system_fw = SystemResourceEntry {
+        fw_class: SYSTEM_FIRMWARE_GUID,
+        fw_type: FirmwareType::SystemFirmware,
+        fw_version: 0x00010002,
+        lowest_supported_fw_version: 0x00010000,
+        capsule_flags: CapsuleFlags::PERSIST_ACROSS_RESET,
+        last_attempt_version: 0,
+        last_attempt_status: LastAttemptStatus::Success,
+    };
+    esrt.register_entry(&system_fw)?;
+
+    // Update entry after firmware update attempt
+    let mut entry = esrt.get_entry(&SYSTEM_FIRMWARE_GUID)?;
+    entry.last_attempt_version = new_version;
+    entry.last_attempt_status = LastAttemptStatus::Success;
+    esrt.update_entry(&entry)?;
+
+    // Lock before OS handoff (optional - unless disabled via configuration, repository auto-locks at Ready To Boot)
+    esrt.lock_repository()?;
+    
+    // FMP instances are automatically discovered and synchronized on Ready To Boot event
+    // Table will be automatically published on Ready To Boot event
+
+    Ok(())
+}
+```
+
+## Appendix A: Public API Summary
+
+This appendix lists only the externally visible, intentionally supported surface. Internal helper types
+(variable storage, repository structures, FFI glue) are intentionally excluded.
+
+### Private Component Configuration
+
+```rust
+pub struct EsrtConfiguration {
+    /// Maximum FMP entries in cache repository. Default: 32 (matches EDK2 PcdMaxFmpEsrtCacheNum)
+    pub max_fmp_entries: u32,
+    /// Maximum Non-FMP entries in cache repository. Default: 32 (matches EDK2 PcdMaxNonFmpEsrtCacheNum)
+    pub max_non_fmp_entries: u32,
+    /// Whether to automatically lock repository at Ready To Boot. Default: true (recommended for security)
+    /// When true, lock_repository() is automatically called unless explicitly called earlier by platform
+    /// When false, repository remains unlocked unless platform explicitly calls lock_repository()
+    pub auto_lock_at_ready_to_boot: bool,
+}
+```
+
+Note: This configuration is passed directly to the component during instantiation as private configuration,
+not through the public `Config<T>` system, since these are component-specific settings not shared with other components.
+
+### Core Types
+
+```rust
+/// Firmware resource entry
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SystemResourceEntry {
+    pub fw_class: Guid,
+    pub fw_type: FirmwareType,
+    pub fw_version: u32,
+    pub lowest_supported_fw_version: u32,
+    pub capsule_flags: CapsuleFlags,
+    pub last_attempt_version: u32,
+    pub last_attempt_status: LastAttemptStatus,
+}
+
+/// Firmware type classification
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FirmwareType {
+    Unknown,
+    SystemFirmware,
+    DeviceFirmware,
+    UefiDriver,
+}
+
+/// Capsule flags for firmware update behavior
+/// Provides type-safe access to standard UEFI capsule flags while allowing OEM-specific values
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CapsuleFlags {
+    // Implementation details omitted - provides variants for standard flags:
+    // PERSIST_ACROSS_RESET, POPULATE_SYSTEM_TABLE, INITIATE_RESET
+    // and support for OEM-specific flag values
+}
+
+/// Last update attempt status
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LastAttemptStatus {
+    Success,
+    ErrorUnsuccessful,
+    ErrorInsufficientResources,
+    ErrorIncorrectVersion,
+    ErrorInvalidFormat,
+    ErrorAuthError,
+    ErrorPowerEventAc,
+    ErrorPowerEventBattery,
+    ErrorUnsatisfiedDependencies,
+    /// Vendor-defined status codes (valid range: 0x1000-0x3FFF)
+    VendorDefined(VendorStatusCode),
+    // Additional standard status codes per UEFI spec
+}
+
+/// Wrapper for vendor-defined LastAttemptStatus codes to enforce valid ranges
+/// Similar to CustomMemoryType pattern used in EfiMemoryType::OemMemoryType
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct VendorStatusCode {
+    // Implementation details omitted - ensures status codes are within 
+    // UEFI-defined vendor range (0x1000-0x3FFF)
+    // Private field prevents direct construction with invalid values
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum EsrtError {
+    InvalidParameter,
+    NotFound,
+    AlreadyExists,
+    OutOfResources,
+    WriteProtected,
+    RepositoryCorrupt,
+}
+```
+
+### Service Trait (Stable Surface)
+
+```rust
+pub trait EsrtRecords {
+    /// Register a Non-FMP entry (platform-provided firmware resource)
+    fn register_entry(&self, entry: &SystemResourceEntry) -> Result<(), EsrtError>;
+    
+    /// Update an existing entry (FMP or Non-FMP)
+    fn update_entry(&self, entry: &SystemResourceEntry) -> Result<(), EsrtError>;
+    
+    /// Unregister a Non-FMP entry
+    fn unregister_entry(&self, fw_class: &Guid) -> Result<(), EsrtError>;
+    
+    /// Retrieve an entry by FwClass GUID
+    fn get_entry(&self, fw_class: &Guid) -> Result<SystemResourceEntry, EsrtError>;
+    
+    /// Lock both repositories to prevent further modifications
+    fn lock_repository(&self) -> Result<(), EsrtError>;
+}
+```
+
+Notes:
+
+- `register_entry` and `unregister_entry` only work with Non-FMP entries
+- `update_entry` and `get_entry` work with both FMP and Non-FMP entries
+- All operations return `EsrtError::WriteProtected` if called after `lock_repository()`
+- FMP instances are automatically discovered and synchronized on Ready To Boot event (before auto-lock)
+- ESRT table automatically published to Configuration Table on Ready To Boot event (after lock)
+- Table published using ESRT GUID (B122A263-3661-4F68-9929-78F8B0D62180)
+- `SystemResourceEntry` converted to C-compatible `EFI_SYSTEM_RESOURCE_ENTRY` format internally
+- `CapsuleFlags` provides type-safe access to standard UEFI capsule flags while allowing OEM-specific values
+- Component registers Ready To Boot event handler during initialization using `boot_services.create_event_ex()`
+- Ready To Boot event handler executes in this order: (1) FMP sync, (2) auto-lock (if configured), (3) table publication
+- By default (when `auto_lock_at_ready_to_boot` is true), repository automatically locks after FMP synchronization if
+  `lock_repository()` hasn't been called explicitly
+- When `auto_lock_at_ready_to_boot` is false, repository remains unlocked unless platform explicitly calls `lock_repository()`
+
+## Appendix B: UEFI Specification Reference
+
+The ESRT is defined in the UEFI Specification:
+
+- **UEFI Specification 2.11**, Section 23.4 - EFI System Resource Table
+
+Key specification requirements:
+
+- ESRT must be published to Configuration Table before OS handoff
+- Each entry's FwClass GUID must be unique within the table
+- FwResourceVersion must be set to 1 (current specification version)
+- LastAttemptStatus must persist across reboots
+- Table memory should be allocated as ACPI Reclaim or Runtime Services data
+
+## Rejection Summary
+
+This RFC was rejected during the Final Comment Period based on community feedback that questioned the fundamental
+need for a standalone ESRT component in Patina.
+
+### Key Rejection Reasons
+
+1. **Lack of Justification for Standalone Component**: The community consensus was that there is insufficient
+   justification for creating a standalone ESRT management component. Most platforms in practice use `EsrtFmpDxe`
+   rather than `EsrtDxe` from EDK2, indicating that ESRT functionality should be tightly coupled with Firmware
+   Management Protocol (FMP) implementation.
+
+2. **Architectural Coupling Concerns**: The proposed ESRT component would be tightly coupled to FMP functionality,
+   requiring FMP protocol publication to operate properly. This tight coupling suggests that ESRT functionality
+   would be better integrated directly into a future FMP component rather than maintained as a separate service.
+
+3. **Platform Migration Burden**: Disconnecting ESRT from FMP would introduce complexity and require
+   platform-specific customizations that increase the cost of adoption. The community prioritized maintaining
+   compatibility with existing EDK2 patterns where ESRT and FMP are integrated.
+
+### Future Considerations
+
+The community agreed that ESRT functionality should be reconsidered as part of a comprehensive FMP component design.
+A future RFC will propose an integrated FMP/ESRT solution that addresses firmware update management holistically
+rather than treating ESRT as a standalone concern.
+
+**Note**: This RFC remains available for reference and may inform future FMP component design decisions. The
+technical design patterns and Rust safety considerations documented here may be applicable to future firmware
+management implementations.


### PR DESCRIPTION
## Description

Status: Rejected

Proposes a new EsrtRecords service for managing the EFI System Resource Table (ESRT) with Rust-native types and memory safety guarantees.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [x] Includes documentation?

## How This Was Tested

N/A

## Integration Instructions

N/A
