### PR TITLE
Update `patina_sdk` refernces to the `patina` crate in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,9 +176,9 @@ Various crates have benchmarks setup that can be executed using the `cargo make 
 will be passed along to the bench command:
 
 ```cmd
-cargo make bench -p patina_sdk
-cargo make bench -p patina_sdk --bench bench_component
-cargo make bench -p patina_sdk --bench bench_component -- with_component
+cargo make bench -p patina
+cargo make bench -p patina --bench bench_component
+cargo make bench -p patina --bench bench_component -- with_component
 ```
 
 Benchmarks utilize the [criterion](https://crates.io/crates/criterion) benchmarking library, so if new benchmarks are

--- a/docs/src/component/requirements.md
+++ b/docs/src/component/requirements.md
@@ -148,7 +148,7 @@ The below is a list of requirements for the crate, but it does not prevent addit
 2. `component` module: This module may optionally exist if the crate produces a component. It must contain the publicly
    importable component(s) for the crate.
 3. `config` module: This module may optionally exist if the component consumes configuration data that is registered
-   with the platform via `.with_config` and this config is not accessible via `patina_sdk` or elsewhere.
+   with the platform via `.with_config` and this config is not accessible via the `patina` crate or elsewhere.
 4. `error` module: This module may optionally exist if a `service` module is present and the public Service's interface
    contains custom errors.
 5. `hob` module: This module may optionally exist if a new guided HOB type has been created for this component. The
@@ -158,7 +158,7 @@ The below is a list of requirements for the crate, but it does not prevent addit
    exists elsewhere, the crate should consume that definition instead of making their own.
 6. `service` module: This module may optionally exist if the crate produces a service implementation that can be
    directly instantiated and passed to the core with the `.with_service` method. If the service trait defintion is not
-   accessible via `patina_sdk` or another crate, then the public defintion should also be defined in this module.
+   accessible via `patina` or another crate, then the public defintion should also be defined in this module.
 
 **Note**: Type re-exports are allowed, and can be re-exported in the same locations as would a public new type for
 your crate.

--- a/docs/src/components/patina_performance.md
+++ b/docs/src/components/patina_performance.md
@@ -32,11 +32,11 @@ Core::default()
  .with_config(patina_performance::config::PerfConfig {
      enable_component: true,
      enabled_measurements: {
-        patina_sdk::performance::Measurement::DriverBindingStart         // Adds driver binding start measurements.
-        | patina_sdk::performance::Measurement::DriverBindingStop        // Adds driver binding stop measurements.
-        | patina_sdk::performance::Measurement::DriverBindingSupport     // Adds driver binding support measurements.
-        | patina_sdk::performance::Measurement::LoadImage                // Adds load image measurements.
-        | patina_sdk::performance::Measurement::StartImage               // Adds start image measurements.
+        patina::performance::Measurement::DriverBindingStart         // Adds driver binding start measurements.
+        | patina::performance::Measurement::DriverBindingStop        // Adds driver binding stop measurements.
+        | patina::performance::Measurement::DriverBindingSupport     // Adds driver binding support measurements.
+        | patina::performance::Measurement::LoadImage                // Adds load image measurements.
+        | patina::performance::Measurement::StartImage               // Adds start image measurements.
      }
  })
  .with_component(patina_performance::component::Performance))

--- a/docs/src/dev/code_organization.md
+++ b/docs/src/dev/code_organization.md
@@ -25,7 +25,7 @@ graph TD
   B --> H[Section Extractor]
   B --> I[Stacktrace]
 
-  C --> J[**patina_sdk** - SDK library]
+  C --> J[**patina** - SDK library]
   J --> K[Common Types and Definitions]
   J --> L[Boot Services]
   J --> M[Runtime Services]

--- a/docs/src/dev/testing.md
+++ b/docs/src/dev/testing.md
@@ -26,8 +26,8 @@ which extends standard assertions to create a colorful diff.
 
 Benchmarking is another way to write tests. Instead of caring about code passing for failing certain requirements, you
 are instead investigating the performance of certain regions of code. Patina uses the [criterion](https://crates.io/crates/criterion)
-crate for benchmarking, so one should follow it's documentation when writing benchmarks. Multiple crates (including
-patina_sdk and patina_internal_collections) also have some benchmark examples to follow.
+crate for benchmarking, so one should follow it's documentation when writing benchmarks. Multiple crates (including the
+patina and patina_internal_collections crates) also have some benchmark examples to follow.
 
 Benchmark results are shown on the command line, but graphics are available in the `target/criterion` folder.
 

--- a/docs/src/dev/testing/platform.md
+++ b/docs/src/dev/testing/platform.md
@@ -1,22 +1,22 @@
 # Platform Testing
 
-Platform testing is supported through the `patina_sdk::test` module, which provides a testing framework similar to
+Platform testing is supported through the `patina::test` module, which provides a testing framework similar to
 the typical Rust testing framework. The key difference is that instead of tests being collected and executed on the
-host system, they are collected and executed via a component (`patina_sdk::test::TestRunner`) provided by the same
+host system, they are collected and executed via a component (`patina::test::TestRunner`) provided by the same
 crate. The platform must register this component with the Patina DXE Core, which will then dispatch the component
 to run all registered tests.
 
-> **Note:** The most up-to-date documentation on the `patina_sdk::test` module can be found on
-> [crates.io](https://crates.io/crates/patina_sdk). For convenience, some high-level concepts are summarized below.
+> **Note:** The most up-to-date documentation on the `patina::test` module can be found on
+> [crates.io](https://crates.io/crates/patina). For convenience, some high-level concepts are summarized below.
 
 ## Writing On-Platform Tests
 
 Writing a test to be run on-platform is as simple as setting the `patina_test` attribute on a function with the
 following interface, where `...` can be any number of parameters that implement the `Param` trait from
-`patina_sdk::component::*`:
+`patina::component::*`:
 
 ```rust
-use patina_sdk::test::{Result, patina_test};
+use patina::test::{Result, patina_test};
 
 #[patina_test]
 fn my_test(...) -> Result { todo!() }
@@ -27,13 +27,13 @@ platform. Any function tagged with `#[patina_test]` will be collected and execut
 can filter out tests, but you should also be conscious of when tests should run. Using `cfg_attr` paired with the
 `skip` attribute is a great way to have tests ignored for reasons like host architecture or feature flags.
 
-> **Note:** `patina_sdk::test::Result` is simply `core::result::Result<(), &'static str>`, and you can use that
+> **Note:** `patina::test::Result` is simply `core::result::Result<(), &'static str>`, and you can use that
 > instead.
 
 This example shows how to use the `skip` attribute paired with `cfg_attr` to skip a test.
 
 ```rust
-use patina_sdk::boot_services::StandardBootServices;
+use patina::boot_services::StandardBootServices;
 
 #[patina_test]
 #[cfg_attr(target_arch = "aarch64", skip)]

--- a/docs/src/integrate/dxe_core.md
+++ b/docs/src/integrate/dxe_core.md
@@ -238,8 +238,8 @@ target (MMIO vs I/O space). Below are platform patterns.
 #### X86_64 Example (Q35)
 
 ```rust
-use patina_sdk::log::serial_logger::SerialLogger;
-use patina_sdk::serial::uart::Uart16550;
+use patina::log::serial_logger::SerialLogger;
+use patina::serial::uart::Uart16550;
 
 static LOGGER: SerialLogger<Uart16550> = SerialLogger::new(
     Uart16550::Io { base: 0x402 },  // <- Update this I/O port for your platform
@@ -249,8 +249,8 @@ static LOGGER: SerialLogger<Uart16550> = SerialLogger::new(
 #### AARCH64 Example (SBSA)
 
 ```rust
-use patina_sdk::log::serial_logger::SerialLogger;
-use patina_sdk::serial::uart::UartPl011;
+use patina::log::serial_logger::SerialLogger;
+use patina::serial::uart::UartPl011;
 
 static LOGGER: SerialLogger<UartPl011> = SerialLogger::new(
     UartPl011::new(0x6000_0000),  // <- Update this MMIO address for your platform
@@ -295,7 +295,7 @@ static DEBUGGER: patina_debugger::PatinaDebugger<UartPl011> =
 First, add the logger dependency to your Cargo.toml file in the crate:
 
 ```toml
-patina_sdk = "$(VERSION)"  # includes serial_logger
+patina = "$(VERSION)"  # includes serial_logger
 ```
 
 Next, update main.rs with the following:
@@ -303,8 +303,8 @@ Next, update main.rs with the following:
 ```rust
 use patina_dxe_core::Core;
 use patina_ffs_extractors::BrotliSectionExtractor;
-use patina_sdk::log::serial_logger::SerialLogger;
-use patina_sdk::serial::uart::Uart16550;
+use patina::log::serial_logger::SerialLogger;
+use patina::serial::uart::Uart16550;
 
 static LOGGER: SerialLogger<Uart16550> = SerialLogger::new(
     Uart16550::Io { base: 0x402 },
@@ -408,8 +408,8 @@ crate when supported by the target architecture.
 use core::{ffi::c_void, panic::PanicInfo};
 use patina_dxe_core::Core;
 use patina_ffs_extractors::BrotliSectionExtractor;
-use patina_sdk::log::serial_logger::SerialLogger;
-use patina_sdk::serial::uart::Uart16550;
+use patina::log::serial_logger::SerialLogger;
+use patina::serial::uart::Uart16550;
 use patina_stacktrace::StackTrace;
 extern crate alloc;
 

--- a/docs/src/patina.md
+++ b/docs/src/patina.md
@@ -191,7 +191,7 @@ definition but many of the services are still implemented in C so it is orange.
 - Support for [Enhanced Memory Protections](https://microsoft.github.io/mu/WhatAndWhy/enhancedmemoryprotection/).
 - Source-level debugging support.
 - Built-in Brotli and EFI decompression support.
-- Infrastructure (in the `patina_sdk::test` module) for on-platform execution of unit tests.
+- Infrastructure (in the `patina::test` module) for on-platform execution of unit tests.
 
 ``` admonish important
 The Patina DXE Core otherwise supports the normal responsibilities of a DXE Core except for the design restrictions
@@ -294,9 +294,9 @@ Three main types of testing are currently supported.
   state of the module. Only the external interfaces are being tested. Cargo will detect and run these tests with the
   same command as for unit tests. More information about integration tests are available in the
   [cargo book entry](https://doc.rust-lang.org/rust-by-example/testing/integration_testing.html).
-- **On-platform tests** are supported with code in a module called `patina_sdk::test` that provides a testing framework
+- **On-platform tests** are supported with code in a module called `patina::test` that provides a testing framework
   similar to the typical rust testing framework. The key difference is that instead of tests being collected and
-  executed on the host system, they are instead collected and executed via a component (`patina_sdk::test::TestRunner`)
+  executed on the host system, they are instead collected and executed via a component (`patina::test::TestRunner`)
   provided by the same crate. The platform must register this component with the `DXE core`. The DXE core will then
   dispatch this component, which will run all registered tests.
 


### PR DESCRIPTION
## Description

Closes #905 

With the refactor of `patina_sdk` to `patina`, the docs need to be updated.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [x] Includes documentation?

## How This Was Tested

- `cargo make all`
- `cargo make doc-open` and review docs locally

## Integration Instructions

- N/A