### PR TITLE
patina: test: Update how tests are executed

### DIFF
--- a/sdk/patina/src/lib.rs
+++ b/sdk/patina/src/lib.rs
@@ -45,7 +45,6 @@ pub mod performance;
 pub mod pi;
 pub mod runtime_services;
 pub mod serial;
-#[coverage(off)]
 pub mod test;
 pub mod tpl_mutex;
 pub mod uefi_protocol;


### PR DESCRIPTION
## Description

Recent changes to how tests were executed and filtered with the `enable_patina_test` feature resulted in almost no testing actually being performed for the functionality. This pull-request updates how we test the `patina-test` logic, so that it does not rely on the `enable_patina_test` feature being enabled. 

It does this in two parts:

1. Creates a second static collection of patina-tests that only collects fake patina-tests from the local file.
1. Splits the main logic of `TestRunner` into two parts. The first collects the patina-tests, and the second runs the patina-tests. This allowed us properly test the patina-test execution process by passing in our second static collection of controlled patina-tests.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [x] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

CI

## Integration Instructions

N/A