### PR TITLE
patina: Add the BinaryGuid type

### DIFF
--- a/sdk/patina/src/lib.rs
+++ b/sdk/patina/src/lib.rs
@@ -21,7 +21,7 @@
 
 extern crate alloc;
 
-pub use base::guid::{Guid, GuidError, OwnedGuid};
+pub use base::guid::{BinaryGuid, Guid, GuidError, OwnedGuid};
 
 /// Common GUID constants
 pub mod guid_constants {


### PR DESCRIPTION
## Description

Closes #901 

Adds a new `BinaryGuid` type that can be directly used in C compatible binary structures in place of `r_efi::efi::Guid`.

The guid module documentation is updated to describe when to use this type versus the pre-existing Guid types.

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [x] Includes tests?
- [x] Includes documentation?

## How This Was Tested

- `cargo make all` (which includes unit tests)

## Integration Instructions

- No special integration is needed. Review the included documentation to understand how to use `BinaryGuid`.