### PR TITLE
Change the image handle for the EFI System Table Pointer structure to EfiRuntimeServicesData.

### DIFF
--- a/patina_dxe_core/src/config_tables/debug_image_info_table.rs
+++ b/patina_dxe_core/src/config_tables/debug_image_info_table.rs
@@ -143,7 +143,7 @@ pub(crate) fn initialize_debug_image_info_table(system_table: &mut EfiSystemTabl
         GcdMemoryType::SystemMemory,
         ALIGNMENT_SHIFT_4MB,
         UEFI_PAGE_SIZE,
-        protocol_db::DXE_CORE_HANDLE,
+        protocol_db::EFI_BOOT_SERVICES_DATA_ALLOCATOR_HANDLE,
         None,
     ) {
         Ok(address) => address,


### PR DESCRIPTION
## Description

This PR changes the image handle for the allocation for the EFI System Table Pointer structure to be EfiBootServicesData; the prior use of the DXE_CORE_HANDLE caused the region to appear as free in the memory map.

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Confirmed windows boot with the change, verified memory map by inspection.

## Integration Instructions

N/A