### PR TITLE
patina_samples: Follow Patina component layout conventions

### DIFF
--- a/components/patina_samples/src/component.rs
+++ b/components/patina_samples/src/component.rs
@@ -1,0 +1,12 @@
+//! Sample Component Implementations
+//!
+//! This module contains example component implementations demonstrating various
+//! Patina component patterns.
+//!
+//! ## License
+//!
+//! Copyright (c) Microsoft Corporation.
+//!
+//! SPDX-License-Identifier: Apache-2.0
+//!
+pub mod hello_world;

--- a/components/patina_samples/src/component/hello_world.rs
+++ b/components/patina_samples/src/component/hello_world.rs
@@ -1,6 +1,6 @@
-//! A Hello world component implementation example using a struct component.
+//! Hello World Component Examples
 //!
-//! A simple component implementation used to demonstrate how to build a component.
+//! This module demonstrates basic component implementations using both struct and enum types.
 //!
 //! ## License
 //!

--- a/components/patina_samples/src/lib.rs
+++ b/components/patina_samples/src/lib.rs
@@ -1,6 +1,12 @@
-//! Hello World Sample Components
+//! Sample Patina Components
 //!
-//! A simple component used for demonstration.
+//! This crate provides example component implementations demonstrating various
+//! Patina component patterns and usage models.
+//!
+//! ## Examples
+//!
+//! - [`component::hello_world::HelloStruct`]: Demonstrates a struct-based component with default entry point
+//! - [`component::hello_world::GreetingsEnum`]: Demonstrates an enum-based component with custom entry point
 //!
 //! ## License
 //!
@@ -11,6 +17,4 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 #![feature(coverage_attribute)]
 
-mod struct_component;
-
-pub use struct_component::{GreetingsEnum, HelloStruct};
+pub mod component;


### PR DESCRIPTION
## Description

Updates the crate to follow Patina component conventions as described in RFC `0009-standardize-component-crate`.

This also positions the crate to more cleanly support new samples being added in the future.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

- `cargo make all`
- `cargo make doc-open` to review `patina_samples` documentation

## Integration Instructions

Access the currently provided samples with the following paths:

- `component::hello_world::HelloStruct`
- `component::hello_world::GreetingsEnum`