### PR TITLE
patina_dxe_core: Prevent spurious test failures

### DIFF
--- a/patina_dxe_core/src/dispatcher.rs
+++ b/patina_dxe_core/src/dispatcher.rs
@@ -524,6 +524,13 @@ pub fn display_discovered_not_dispatched() {
     }
 }
 
+/// Reset the dispatcher context to a clean default state for testing.
+/// Note: This function should only be called from tests to ensure clean state between test runs.
+#[cfg(test)]
+pub(crate) fn reset_dispatcher_context_for_tests() {
+    *DISPATCHER_CONTEXT.lock() = DispatcherContext::new();
+}
+
 extern "efiapi" fn core_fw_vol_event_protocol_notify(_event: efi::Event, _context: *mut c_void) {
     //Note: runs at TPL_CALLBACK
     match PROTOCOL_DB.locate_handles(Some(firmware_volume_block::PROTOCOL_GUID)) {

--- a/patina_dxe_core/src/test_support.rs
+++ b/patina_dxe_core/src/test_support.rs
@@ -91,6 +91,11 @@ pub(crate) unsafe fn init_test_protocol_db() {
     PROTOCOL_DB.init_protocol_db();
 }
 
+/// Reset the dispatcher context to default empty state.
+pub(crate) fn reset_dispatcher_context() {
+    crate::dispatcher::reset_dispatcher_context_for_tests();
+}
+
 pub(crate) fn build_test_hob_list(mem_size: u64) -> *const c_void {
     let mem = unsafe { get_memory(mem_size as usize) };
     let mem_base = mem.as_mut_ptr() as u64;


### PR DESCRIPTION
## Description

Three dispatcher tests in dxe_services.rs added in 1d9a702 were failing intermittently when run in parallel. The tests call `dispatch()` which depends on the `DISPATCHER_CONTEXT` global static, but the dxe_services.rs test helper did not reset this context between test runs, causing tests to inherit leftover state from previous tests which could cause tests to fail depending on test dispatch order.

This change adds a function called `reset_dispatcher_context_for_tests` to dispatcher.rs to use in the dxe_services.rs test setup to clean state for all dispatch-related tests. It also cleans up repeated functions called throughout unit tests in `dxe_services`.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [x] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Tested by running:

`cargo test --lib --package patina_dxe_core test_dispatch`

In sets of 10 runs 10 times in a row. Before this change failure rate was an average of 60%, after 0%.

## Integration Instructions

- N/A