### PR TITLE
RFC Amendment: Feature and major branch update [Rebase & FF]

### DIFF
--- a/docs/src/rfc/text/0015-patina-release-process.md
+++ b/docs/src/rfc/text/0015-patina-release-process.md
@@ -30,6 +30,7 @@ This RFC proposes a process for releasing Patina crates.
   - Initial draft of RFC amendment to include PR title requirements for PRs into feature and major branches.
   - Add a note in the Branching section that the "major" branch process has not been adopted by the project
     yet at this time.
+  - Add guidance in the Branching section for merging a feature branch into the main branch.
 
 ## Motivation
 
@@ -303,6 +304,39 @@ Regardless of feature details, the criteria to merge into `main` are consistent:
    > demonstrate how a platform is expected to integrate the feature, and have been tested locally including OS boot
    > with the feature enabled. The patina-qemu PR must be completed and merged as soon as possible after the feature
    > branch is merged into the `main` branch in the patina repository.
+
+#### Guidance for Merging a Feature Branch into `main`
+
+There are two distinct phases in feature branch development:
+
+1. Work on the feature branch
+2. Merging that work into the `main` branch
+
+Once a change is ready to merge to `main`, the following suggestions are made (but not required):
+
+1. Lock the feature branch - At this time, the feature branch has served its purpose and is no longer a development
+   target. Feature effort should focus on the merge into `main`.
+
+   > If you do not have permission to lock the feature branch, simply request that the branch be locked in a PR comment
+   > in the PR into the `main` branch.
+2. Locally create a new branch ("main PR branch") from the feature branch.
+   - For example: `git checkout -b feature/feature1_main feature/feature1`
+   - Rebase this branch onto the latest `main`
+3. Prepare the "main PR branch" as needed for a clean merge into `main`.
+   - The history and contents DO NOT need to match the feature branch. The feature branch was a mechanism to control
+     feature development complexity and stabilization. It has no bearing on the process into `main` which is the same
+     as for any change, including those that do not originate from a feature branch.
+   - Consider:
+     - Whether to split commits up so they are easier to review but will be squashed when the PR is merged into a
+       single commit.
+     - Whether to split commits up and/or rearrange the overall feature branch history so it can more cleanly go into
+       the main branch as a Rebase & FF style PR where the commits are reflected in `main` in the exact way they are in
+       the "main PR branch".
+
+     > Note: In most cases, history will be cleanest and most logical in `main` NOT being the same as the code was
+     > developed in the feature branch. Just like when code is developed locally and made ready for a PR into `main`,
+     > it must be cleaned up.
+4. Continue to manage the "main PR branch" and do not make changes to the original feature branch.
 
 ## Unresolved Questions
 


### PR DESCRIPTION
## Description

Two main amendments to the RFC:

---

**RFC Amendment: Add non-main PR title conventions**

Adds conventions for pull request titles to the Branching section in the Patina Release Process RFC.

These are meant to make it easier when viewing pull requests to:

1. Determine which are targeting or targeted `main`
2. Filter to those PRs for a specific branch/feature

A note is also added that the `major` branch process for breaking changes is not adopted in the project yet at this time.

---

**RFC Amendment: Add feature branch merge guidance**

Adds guidance to the Branching section on merging feature branches into the `main` branch.

---

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [x] Includes documentation?

## How This Was Tested

- `cargo make all`
- markdownlint check

## Integration Instructions

- N/A