### PR TITLE
patina::pi: Add missing public docs

### DIFF
--- a/sdk/patina/src/pi.rs
+++ b/sdk/patina/src/pi.rs
@@ -27,8 +27,6 @@
 //! reflect the degree of change.
 //!
 
-#![allow(missing_docs)]
-
 mod boot_mode;
 
 pub mod dxe_services;

--- a/sdk/patina/src/pi/dxe_services.rs
+++ b/sdk/patina/src/pi/dxe_services.rs
@@ -21,81 +21,130 @@ use r_efi::{
     system::TableHeader,
 };
 
+/// DXE Services Table GUID identifier
+///
+/// This GUID identifies the DXE Services Table in the EFI System Table
+/// Configuration Table array. The DXE Services Table provides services for
+/// managing the Global Coherency Domain memory and I/O space maps,
+/// and dispatcher functions for managing driver execution dependencies.
 pub const DXE_SERVICES_TABLE_GUID: Guid =
     Guid::from_fields(0x5ad34ba, 0x6f02, 0x4214, 0x95, 0x2e, &[0x4d, 0xa0, 0x39, 0x8e, 0x2b, 0xb9]);
 
-/// This service adds reserved memory system memory or memory mapped IO resources to the global coherency domain of the processor.
+/// Adds memory or memory-mapped I/O resources to the Global Coherency Domain (GCD)
+///
+/// This service adds reserved memory, system memory, or memory-mapped I/O resources
+/// to the Global Coherency Domain of the processor. The memory space being added
+/// must not overlap with any existing memory space in the GCD.
 ///
 /// # Documentation
 /// UEFI Platform Initialization Specification, Release 1.8, Section II-7.2.4.1
 pub type AddMemorySpace = extern "efiapi" fn(GcdMemoryType, PhysicalAddress, u64, u64) -> Status;
 
-/// This service allocates nonexistent memory reserved memory system memory or memory-mapped IO resources
-/// from the global coherency domain of the processor.
+/// Allocates memory space from the Global Coherency Domain (GCD)
+///
+/// This service allocates nonexistent memory, reserved memory, system memory,
+/// or memory-mapped I/O resources from the Global Coherency Domain of the processor.
+/// The allocation strategy is determined by the GcdAllocateType parameter.
 ///
 /// # Documentation
 /// UEFI Platform Initialization Specification, Release 1.8, Section II-7.2.4.2
 pub type AllocateMemorySpace =
     extern "efiapi" fn(GcdAllocateType, GcdMemoryType, usize, u64, *mut PhysicalAddress, Handle, Handle) -> Status;
 
+/// Frees memory space from the Global Coherency Domain (GCD)
+///
 /// This service frees nonexistent memory, reserved memory, system memory,
-/// or memory-mapped I/O resources from the global coherency domain of the processor.
+/// or memory-mapped I/O resources from the Global Coherency Domain of the processor.
+/// The freed memory becomes available for future allocation.
 ///
 /// # Documentation
 /// UEFI Platform Initialization Specification, Release 1.8, Section II-7.2.4.3
 pub type FreeMemorySpace = extern "efiapi" fn(PhysicalAddress, u64) -> Status;
 
-/// This service removes reserved memory, system memory,
-/// or memory-mapped I/O resources from the global coherency domain of the processor.
+/// Removes memory space from the Global Coherency Domain (GCD)
+///
+/// This service removes reserved memory, system memory, or memory-mapped I/O
+/// resources from the Global Coherency Domain of the processor. The removed
+/// region must not be currently allocated to any image or have any capabilities set.
 ///
 /// # Documentation
 /// UEFI Platform Initialization Specification, Release 1.8, Section II-7.2.4.4
 pub type RemoveMemorySpace = extern "efiapi" fn(PhysicalAddress, u64) -> Status;
 
-/// This service retrieves the descriptor for a memory region containing a specified address.
+/// Retrieves the memory space descriptor for a specified address from the
+/// Global Coherency Domain (GCD)
+///
+/// This service retrieves the descriptor for a memory region containing a
+/// specified address from the Global Coherency Domain memory space map.
 ///
 /// # Documentation
 /// UEFI Platform Initialization Specification, Release 1.8, Section II-7.2.4.5
 pub type GetMemorySpaceDescriptor = extern "efiapi" fn(PhysicalAddress, *mut MemorySpaceDescriptor) -> Status;
 
-/// This service modifies the attributes for a memory region in the global coherency domain of the processor.
+/// Sets memory space attributes in the Global Coherency Domain (GCD)
+///
+/// This service modifies the attributes for a memory region in the global
+/// coherency domain of the processor. Attributes control caching behavior
+/// and access permissions for the memory region.
 ///
 /// # Documentation
 /// UEFI Platform Initialization Specification, Release 1.8, Section II-7.2.4.6
 pub type SetMemorySpaceAttributes = extern "efiapi" fn(PhysicalAddress, u64, u64) -> Status;
 
-/// This service modifies the capabilities for a memory region in the global coherency domain of the processor.
+/// Sets memory space capabilities in the Global Coherency Domain (GCD)
+///
+/// This service modifies the capabilities for a memory region in the global
+/// coherency domain of the processor. Capabilities define which attributes
+/// are allowed to be set for the memory region.
 ///
 /// # Documentation
 /// UEFI Platform Initialization Specification, Release 1.8, Section II-7.2.4.7
 pub type SetMemorySpaceCapabilities = extern "efiapi" fn(PhysicalAddress, u64, u64) -> Status;
 
-/// Returns a map of the memory resources in the global coherency domain of the processor.
+/// Returns the Global Coherency Domain (GCD) memory space map
+///
+/// This service returns a map of all memory resources in the global coherency
+/// domain of the processor, including their types, attributes, and allocation status.
 ///
 /// # Documentation
 /// UEFI Platform Initialization Specification, Release 1.8, Section II-7.2.4.8
 pub type GetMemorySpaceMap = extern "efiapi" fn(*mut usize, *mut *mut MemorySpaceDescriptor) -> Status;
 
-/// This service adds reserved I/O, or I/O resources to the global coherency domain of the processor.
+/// Adds I/O space to the Global Coherency Domain (GCD)
+///
+/// This service adds reserved I/O or I/O resources to the global coherency
+/// domain of the processor. The I/O space being added must not overlap
+/// with any existing I/O space in the Global Coherency Domain.
 ///
 /// # Documentation
 /// UEFI Platform Initialization Specification, Release 1.8, Section II-7.2.4.9
 pub type AddIoSpace = extern "efiapi" fn(GcdIoType, PhysicalAddress, u64) -> Status;
 
-/// This service allocates nonexistent I/O, reserved I/O, or I/O resources from the global coherency domain of the processor.
+/// Allocates I/O space from the Global Coherency Domain (GCD)
+///
+/// This service allocates nonexistent I/O, reserved I/O, or I/O resources
+/// from the Global Coherency Domain of the processor. The allocation strategy
+/// is determined by the GcdAllocateType parameter.
 ///
 /// # Documentation
 /// UEFI Platform Initialization Specification, Release 1.8, Section II-7.2.4.10
 pub type AllocateIoSpace =
     extern "efiapi" fn(GcdAllocateType, GcdIoType, usize, u64, *mut PhysicalAddress, Handle, Handle) -> Status;
 
-/// This service frees nonexistent I/O, reserved I/O, or I/O resources from the global coherency domain of the processor.
+/// Frees I/O space from the Global Coherency Domain (GCD)
+///
+/// This service frees nonexistent I/O, reserved I/O, or I/O resources
+/// from the Global Coherency Domain of the processor. The freed I/O space
+/// becomes available for future allocation.
 ///
 /// # Documentation
 /// UEFI Platform Initialization Specification, Release 1.8, Section II-7.2.4.11
 pub type FreeIoSpace = extern "efiapi" fn(PhysicalAddress, u64) -> Status;
 
-/// This service removes reserved I/O, or I/O resources from the global coherency domain of the processor.
+/// Removes I/O space from the Global Coherency Domain (GCD)
+///
+/// This service removes reserved I/O or I/O resources from the global coherency
+/// domain of the processor. The removed I/O region must not be currently allocated.
 ///
 /// # Documentation
 /// UEFI Platform Initialization Specification, Release 1.8, Section II-7.2.4.12
@@ -107,76 +156,119 @@ pub type RemoveIoSpace = extern "efiapi" fn(PhysicalAddress, u64) -> Status;
 /// UEFI Platform Initialization Specification, Release 1.8, Section II-7.2.4.13
 pub type GetIoSpaceDescriptor = extern "efiapi" fn(PhysicalAddress, *mut IoSpaceDescriptor) -> Status;
 
-/// Returns a map of the I/O resources in the global coherency domain of the processor.
+/// Returns a map of the I/O resources in the Global Coherency Domain (GCD).
 ///
 /// # Documentation
 /// UEFI Platform Initialization Specification, Release 1.8, Section II-7.2.4.14
 pub type GetIoSpaceMap = extern "efiapi" fn(*mut usize, *mut *mut IoSpaceDescriptor) -> Status;
 
-/// Loads and executes DXE drivers from firmware volumes.
+/// Executes DXE drivers from firmware volumes
+///
+/// This service loads and executes DXE drivers from firmware volumes.
+/// The dispatcher uses dependency expressions to determine driver execution order.
 ///
 /// # Documentation
 /// UEFI Platform Initialization Specification, Release 1.8, Section II-7.3.1
 pub type Dispatch = extern "efiapi" fn() -> Status;
 
-/// Clears the Schedule on Request (SOR) flag for a component that is stored in a firmware volume.
+/// Schedules a firmware file for dispatch
+///
+/// This service clears the Schedule on Request (SOR) flag for a component
+/// that is stored in a firmware volume, allowing it to be dispatched.
 ///
 /// # Documentation
 /// UEFI Platform Initialization Specification, Release 1.8, Section II-7.3.2
 pub type Schedule = extern "efiapi" fn(Handle, *const Guid) -> Status;
 
-/// Promotes a file stored in a firmware volume from the untrusted to the trusted state.
-/// Only the Security Architectural Protocol can place a file in the untrusted state.
-/// A platform specific component may choose to use this service to promote a previously untrusted file to the trusted state.
+/// Promotes a firmware file from untrusted to trusted state
+///
+/// This service promotes a file stored in a firmware volume from the untrusted
+/// to the trusted state. Only the Security Architectural Protocol can place a file
+/// in the untrusted state initially.
 ///
 /// # Documentation
 /// UEFI Platform Initialization Specification, Release 1.8, Section II-7.3.3
 pub type Trust = extern "efiapi" fn(Handle, *const Guid) -> Status;
 
-/// Creates a firmware volume handle for a firmware volume that is present in system memory.
+/// Creates a firmware volume handle from system memory
+///
+/// This service creates a firmware volume handle for a firmware volume
+/// that is present in system memory, making it available to the DXE dispatcher.
 ///
 /// # Documentation
-/// UEFI Platform Initialization Specification, Release 1.8, Section II-7.3. II-59 (This one does not have a section)
+/// UEFI Platform Initialization Specification, Release 1.8, Section II-7.3.II-59 (This one does not have a section)
 pub type ProcessFirmwareVolume = extern "efiapi" fn(*const c_void, usize, *mut Handle) -> Status;
 
 #[repr(C)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
-/// `EFI_GCD_MEMORY_TYPE` in specification.
+/// Global Coherency Domain (GCD) memory types
+///
+/// Defines the types of memory regions that can exist in the Global Coherency Domain.
+/// Each memory region has a specific type that determines how it can be used by the system.
 pub enum GcdMemoryType {
-    /// A memory region that is visible to the boot processor.
-    /// However, there are no system components that are currently decoding this memory region.
+    /// Memory region with no active decoder
+    ///
+    /// A memory region that is visible to the boot processor but has no system
+    /// components currently decoding this memory region.
     #[default]
     NonExistent = 0,
-    /// A memory region that is visible to the boot processor.
-    /// This memory region is being decoded by a system component,
-    /// but the memory region is not considered to be either system memory or memory-mapped I/O.
+    /// Reserved memory region
+    ///
+    /// A memory region being decoded by a system component, but not considered
+    /// to be either system memory or memory-mapped I/O.
     Reserved,
-    /// A memory region that is visible to the boot processor.
-    /// A memory controller is currently decoding this memory region
-    /// and the memory controller is producing a tested system memory region that is available to the memory services.
+    /// System memory region
+    ///
+    /// A memory region decoded by a memory controller that produces tested
+    /// system memory available to the memory services.
     SystemMemory,
-    /// A memory region that is visible to the boot processor. This memory region is currently being decoded by a
-    /// component as memory-mapped I/O that can be used to access I/O devices in the platform.
+    /// Memory-mapped I/O region
+    ///
+    /// A memory region currently being decoded as memory-mapped I/O that can
+    /// be used to access I/O devices in the platform.
     MemoryMappedIo,
-    /// A memory region that is visible to the boot processor. This memory supports byte-addressable non-volatility.
+    /// Persistent memory region
+    ///
+    /// A memory region that supports byte-addressable non-volatility,
+    /// such as non-volatile dual in-line memory modules (NVDIMM).
     Persistent,
-    /// A memory region that provides higher reliability relative to other memory in the system.
-    /// If all memory has the same reliability, then this bit is not used.
+    /// High-reliability memory region
+    ///
+    /// A memory region that provides higher reliability relative to other memory
+    /// in the system. Used when memory has varying reliability characteristics.
     MoreReliable,
-    /// A memory region that is unaccepted. This region must be accepted before it can be converted to system memory.
+    /// Unaccepted memory region
+    ///
+    /// A memory region that is unaccepted and must be accepted before it can
+    /// be converted to system memory. Used in confidential computing environments.
     Unaccepted,
 }
 
 #[repr(C)]
 #[derive(Debug, Clone, Copy, Default)]
-/// `EFI_GCD_ALLOCATE_TYPE` in specification.
+/// Global Coherency Domain (GCD) allocation strategies
+///
+/// Defines the allocation strategies that can be used when allocating memory
+/// or I/O space from the Global Coherency Domain.
 pub enum GcdAllocateType {
     #[default]
+    /// Allocate any available address searching bottom-up
+    ///
+    /// Search for available space starting from the lowest addresses
     AnySearchBottomUp,
+    /// Allocate below a maximum address searching bottom-up
+    ///
+    /// Search for available space below a specified maximum address, starting from the bottom
     MaxAddressSearchBottomUp,
+    /// Allocate at a specific address
+    ///
+    /// Allocate at the exact address specified by the caller
     Address,
+    /// Search for memory from top down
     AnySearchTopDown,
+    /// Search for memory from specified max address top down
     MaxAddressSearchTopDown,
+    /// Maximum allocate type value
     MaxAllocateType,
 }
 
@@ -208,20 +300,28 @@ pub struct MemorySpaceDescriptor {
 
 #[repr(C)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
-/// `EFI_GCD_IO_TYPE` in specification.
+/// Global Coherency Domain (GCD) I/O space types
+///
+/// Defines the types of I/O regions that can exist in the Global Coherency Domain.
+/// Each I/O region has a specific type that determines how it can be accessed.
 pub enum GcdIoType {
-    /// An I/O region that is visible to the boot processor.
-    /// However, there are no system components that are currently decoding this I/O region.
+    /// I/O region with no active decoder
+    ///
+    /// An I/O region that is visible to the boot processor but has no system
+    /// components currently decoding this I/O region.
     #[default]
     NonExistent = 0,
-    /// An I/O region that is visible to the boot processor.
-    /// This I/O region is currently being decoded by a system component,
-    ///  but the I/O region cannot be used to access I/O devices.
+    /// Reserved I/O region
+    ///
+    /// An I/O region currently being decoded by a system component, but the I/O
+    /// region cannot be used to access I/O devices.
     Reserved,
-    /// An I/O region that is visible to the boot processor.
-    /// This I/O region is currently being decoded by a system component
-    /// that is producing I/O ports that can be used to access I/O devices.
+    /// Active I/O region
+    ///
+    /// An I/O region currently being decoded by a system component that produces
+    /// I/O ports that can be used to access I/O devices.
     Io,
+    /// Maximum value for GcdIoType enumeration
     Maximum,
 }
 
@@ -252,41 +352,60 @@ pub struct IoSpaceDescriptor {
 ///
 /// See <https://uefi.org/specs/PI/1.8A/V2_UEFI_System_Table.html#dxe-services-table>.
 pub struct DxeServicesTable {
+    /// Standard UEFI table header
     pub header: TableHeader,
 
     //
-    // Global Coherency
+    // Global Coherency Domain (GCD)
     //
+    /// Add memory space to GCD
     pub add_memory_space: AddMemorySpace,
+    /// Allocate memory space from GCD
     pub allocate_memory_space: AllocateMemorySpace,
+    /// Free memory space in GCD
     pub free_memory_space: FreeMemorySpace,
+    /// Remove memory space from GCD
     pub remove_memory_space: RemoveMemorySpace,
+    /// Get memory space descriptor
     pub get_memory_space_descriptor: GetMemorySpaceDescriptor,
+    /// Set memory space attributes
     pub set_memory_space_attributes: SetMemorySpaceAttributes,
+    /// Get memory space map
     pub get_memory_space_map: GetMemorySpaceMap,
+    /// Add I/O space to GCD
     pub add_io_space: AddIoSpace,
+    /// Allocate I/O space from GCD
     pub allocate_io_space: AllocateIoSpace,
+    /// Free I/O space in GCD
     pub free_io_space: FreeIoSpace,
+    /// Remove I/O space from GCD
     pub remove_io_space: RemoveIoSpace,
+    /// Get I/O space descriptor
     pub get_io_space_descriptor: GetIoSpaceDescriptor,
+    /// Get I/O space map
     pub get_io_space_map: GetIoSpaceMap,
 
     //
     // Dispatcher Services
     //
+    /// Dispatch drivers
     pub dispatch: Dispatch,
+    /// Schedule drivers for execution
     pub schedule: Schedule,
+    /// Establish trust for drivers
     pub trust: Trust,
 
     //
     // Service to process a single firmware volume found in
     // a capsule
     //
+    /// Process firmware volume from capsule
     pub process_firmware_volume: ProcessFirmwareVolume,
 
     //
-    // Extension to Global Coherency Domain Services
+    // Extension to Global Coherency Domain (GCD) Services
     //
+    /// Set memory space capabilities
     pub set_memory_space_capabilities: SetMemorySpaceCapabilities,
 }
 

--- a/sdk/patina/src/pi/fw_fs/ffs/attributes.rs
+++ b/sdk/patina/src/pi/fw_fs/ffs/attributes.rs
@@ -10,20 +10,32 @@
 //! SPDX-License-Identifier: Apache-2.0
 //!
 
+/// Raw FFS attribute constant definitions
 pub mod raw {
+    /// Large file attribute
     pub const LARGE_FILE: u8 = 0x01;
+    /// 2-byte data alignment
     pub const DATA_ALIGNMENT_2: u8 = 0x02;
+    /// File must be at a fixed address
     pub const FIXED: u8 = 0x04;
+    /// Data alignment mask
     pub const DATA_ALIGNMENT: u8 = 0x38;
+    /// File checksum attribute
     pub const CHECKSUM: u8 = 0x40;
 }
 
 #[repr(u8)]
 #[derive(Debug, Copy, Clone, PartialEq)]
+/// FFS file attribute enumeration
 pub enum Attribute {
+    /// Large file variant
     LargeFile = raw::LARGE_FILE,
+    /// 2-byte alignment variant
     DataAlignment2 = raw::DATA_ALIGNMENT_2,
+    /// Fixed address file
     Fixed = raw::FIXED,
+    /// Data alignment variant
     DataAlignment = raw::DATA_ALIGNMENT,
+    /// Checksum variant
     Checksum = raw::CHECKSUM,
 }

--- a/sdk/patina/src/pi/fw_fs/ffs/file.rs
+++ b/sdk/patina/src/pi/fw_fs/ffs/file.rs
@@ -12,94 +12,167 @@
 
 use r_efi::efi;
 
+/// Raw FFS file constant definitions
 pub mod raw {
     /// File State Bits
     pub mod state {
+        /// File header is under construction
         pub const HEADER_CONSTRUCTION: u8 = 0x01;
+        /// File header is valid
         pub const HEADER_VALID: u8 = 0x02;
+        /// File data is valid
         pub const DATA_VALID: u8 = 0x04;
+        /// File is marked for update
         pub const MARKED_FOR_UPDATE: u8 = 0x08;
+        /// File has been deleted
         pub const DELETED: u8 = 0x10;
+        /// File header is invalid
         pub const HEADER_INVALID: u8 = 0x20;
     }
 
     /// File Type Definitions
     pub mod r#type {
+        /// All file types
         pub const ALL: u8 = 0x00;
+        /// Raw data file
         pub const RAW: u8 = 0x01;
+        /// Freeform file
         pub const FREEFORM: u8 = 0x02;
+        /// Security (SEC) core file
         pub const SECURITY_CORE: u8 = 0x03;
+        /// PEI core file
         pub const PEI_CORE: u8 = 0x04;
+        /// DXE core file
         pub const DXE_CORE: u8 = 0x05;
+        /// Pre-EFI module (PEIM) file
         pub const PEIM: u8 = 0x06;
+        /// Driver Execution Environment (DXE) driver file
         pub const DRIVER: u8 = 0x07;
+        /// Combined PEIM and driver file
         pub const COMBINED_PEIM_DRIVER: u8 = 0x08;
+        /// Application file
         pub const APPLICATION: u8 = 0x09;
+        /// Management Mode (MM) file
         pub const MM: u8 = 0x0A;
+        /// Firmware volume image file
         pub const FIRMWARE_VOLUME_IMAGE: u8 = 0x0B;
+        /// Combined MM and DXE file
         pub const COMBINED_MM_DXE: u8 = 0x0C;
+        /// MM core file
         pub const MM_CORE: u8 = 0x0D;
+        /// MM standalone module file
         pub const MM_STANDALONE: u8 = 0x0E;
+        /// MM standalone core file
         pub const MM_CORE_STANDALONE: u8 = 0x0F;
+        /// OEM-defined file type minimum value
         pub const OEM_MIN: u8 = 0xc0;
+        /// OEM-defined file type maximum value
         pub const OEM_MAX: u8 = 0xdf;
+        /// Debug file type minimum value
         pub const DEBUG_MIN: u8 = 0xe0;
+        /// Debug file type maximum value
         pub const DEBUG_MAX: u8 = 0xef;
+        /// FFS-defined file type minimum value
         pub const FFS_MIN: u8 = 0xf1;
+        /// FFS-defined file type maximum value
         pub const FFS_MAX: u8 = 0xff;
+        /// FFS pad file type
         pub const FFS_PAD: u8 = 0xf0;
     }
 }
 
 #[repr(u8)]
 #[derive(Debug, Copy, Clone, PartialEq)]
+/// Firmware file type enumeration
 pub enum Type {
+    /// All file types
     All = raw::r#type::ALL,
+    /// Raw file type
     Raw = raw::r#type::RAW,
+    /// Free form file
     FreeForm = raw::r#type::FREEFORM,
+    /// Security core file
     SecurityCore = raw::r#type::SECURITY_CORE,
+    /// PEI core file
     PeiCore = raw::r#type::PEI_CORE,
+    /// DXE core file
     DxeCore = raw::r#type::DXE_CORE,
+    /// PEI module file
     Peim = raw::r#type::PEIM,
+    /// Driver file
     Driver = raw::r#type::DRIVER,
+    /// Combined PEIM driver file
     CombinedPeimDriver = raw::r#type::COMBINED_PEIM_DRIVER,
+    /// Application file
     Application = raw::r#type::APPLICATION,
+    /// Traditional Management Mode (MM) file
     Mm = raw::r#type::MM,
+    /// Firmware volume image file
     FirmwareVolumeImage = raw::r#type::FIRMWARE_VOLUME_IMAGE,
+    /// Combined MM/DXE file
     CombinedMmDxe = raw::r#type::COMBINED_MM_DXE,
+    /// Traditional Management Mode (MM) core file
     MmCore = raw::r#type::MM_CORE,
+    /// Standalone MM driver file
     MmStandalone = raw::r#type::MM_STANDALONE,
+    /// Standalone MM Core file
     MmCoreStandalone = raw::r#type::MM_CORE_STANDALONE,
+    /// Begininning of the OEM file type range
     OemMin = raw::r#type::OEM_MIN,
+    /// Max for the OEM file type range
     OemMax = raw::r#type::OEM_MAX,
+    /// Beginning of the debug file type range
     DebugMin = raw::r#type::DEBUG_MIN,
+    /// Max for the debug file type range
     DebugMax = raw::r#type::DEBUG_MAX,
+    /// A FFS padding file
     FfsPad = raw::r#type::FFS_PAD,
+    /// An unknown file
     FfsUnknown = raw::r#type::FFS_MIN,
+    /// Max file type value
     FfsMax = raw::r#type::FFS_MAX,
 }
 
+/// Firmware File State
+///
+/// Represents the current state of a firmware file in the Firmware File System.
+/// The state tracks the file's validity and lifecycle through various phases of
+/// construction, usage, and deletion. Based on PI Specification Volume 3, Section 3.2.3.1.
 #[repr(u8)]
 #[derive(Debug, Copy, Clone, PartialEq)]
 pub enum State {
+    /// File header is under construction and not yet valid
     HeaderConstruction = raw::state::HEADER_CONSTRUCTION,
+    /// File header has been constructed and is valid
     HeaderValid = raw::state::HEADER_VALID,
+    /// File data has been written and is valid
     DataValid = raw::state::DATA_VALID,
+    /// File is marked for update in a future firmware update operation
     MarkedForUpdate = raw::state::MARKED_FOR_UPDATE,
+    /// File has been deleted and should not be processed
     Deleted = raw::state::DELETED,
+    /// File header is invalid (checksum mismatch or corruption)
     HeaderInvalid = raw::state::HEADER_INVALID,
 }
 
 // EFI_FFS_FILE_HEADER
 #[repr(C)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+/// Firmware file header structure per PI Specification
 pub struct Header {
+    /// Unique file GUID identifier
     pub name: efi::Guid,
+    /// Header checksum value
     pub integrity_check_header: u8,
+    /// File checksum value
     pub integrity_check_file: u8,
+    /// Type of file (see file type constants)
     pub file_type: u8,
+    /// File attributes
     pub attributes: u8,
+    /// 24-bit file size in bytes
     pub size: [u8; 3],
+    /// File state (see state constants)
     pub state: u8,
 }
 
@@ -107,7 +180,10 @@ pub struct Header {
 #[repr(C)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[allow(dead_code)]
+/// Extended firmware file header structure (version 2) for files larger than 16MB
 pub struct Header2 {
+    /// Standard file header
     pub header: Header,
+    /// Extended 64-bit file size for large files
     pub extended_size: u64,
 }

--- a/sdk/patina/src/pi/fw_fs/ffs/guid.rs
+++ b/sdk/patina/src/pi/fw_fs/ffs/guid.rs
@@ -12,13 +12,16 @@
 use r_efi::efi;
 
 // {8C8CE578-8A3D-4F1C-9935-896185C32DD3}
+/// Firmware File System version 2 GUID identifier per PI Specification
 pub const EFI_FIRMWARE_FILE_SYSTEM2_GUID: efi::Guid =
     efi::Guid::from_fields(0x8c8ce578, 0x8a3d, 0x4f1c, 0x99, 0x35, &[0x89, 0x61, 0x85, 0xc3, 0x2d, 0xd3]);
 
 // {5473C07A-3DCB-4DCA-BD6F-1E9689E7349A}
+/// Firmware File System version 3 GUID identifier per PI Specification
 pub const EFI_FIRMWARE_FILE_SYSTEM3_GUID: efi::Guid =
     efi::Guid::from_fields(0x5473c07a, 0x3dcb, 0x4dca, 0xbd, 0x6f, &[0x1e, 0x96, 0x89, 0xe7, 0x34, 0x9a]);
 
 // {1BA0062E-C779-4582-8566-336AE8F78F09}
+/// GUID for the file at the top of a firmware volume
 pub const EFI_FFS_VOLUME_TOP_FILE_GUID: efi::Guid =
     efi::Guid::from_fields(0x1ba0062e, 0xc779, 0x4582, 0x85, 0x66, &[0x33, 0x6a, 0xe8, 0xf7, 0x8f, 0x9]);

--- a/sdk/patina/src/pi/fw_fs/ffs/section.rs
+++ b/sdk/patina/src/pi/fw_fs/ffs/section.rs
@@ -10,6 +10,7 @@
 //! SPDX-License-Identifier: Apache-2.0
 //!
 
+/// Type alias for section type identifiers
 pub type EfiSectionType = u8;
 
 /// Firmware File System Leaf Section Types
@@ -17,53 +18,91 @@ pub type EfiSectionType = u8;
 pub mod raw_type {
     /// Pseudo type. It is used as a wild card when retrieving sections to match all types.
     pub const ALL: u8 = 0x00;
-
+    /// Encapsulated section type constants
     pub mod encapsulated {
+        /// Compression encapsulated section
         pub const COMPRESSION: u8 = 0x01;
+        /// GUID-defined encapsulated section
         pub const GUID_DEFINED: u8 = 0x02;
+        /// Disposable encapsulated section
         pub const DISPOSABLE: u8 = 0x03;
     }
-
+    /// PE32 executable section
     pub const PE32: u8 = 0x10;
+    /// Position-independent code section
     pub const PIC: u8 = 0x11;
+    /// Terse executable section
     pub const TE: u8 = 0x12;
+    /// DXE dependency expression section
     pub const DXE_DEPEX: u8 = 0x13;
+    /// Version information section
     pub const VERSION: u8 = 0x14;
+    /// User interface string section
     pub const USER_INTERFACE: u8 = 0x15;
+    /// Compatibility16 section
     pub const COMPATIBILITY16: u8 = 0x16;
+    /// Firmware volume image section
     pub const FIRMWARE_VOLUME_IMAGE: u8 = 0x17;
+    /// Freeform GUID subtype section
     pub const FREEFORM_SUBTYPE_GUID: u8 = 0x18;
+    /// Raw data section
     pub const RAW: u8 = 0x19;
+    /// PEI dependency expression section
     pub const PEI_DEPEX: u8 = 0x1B;
+    /// MM dependency expression section
     pub const MM_DEPEX: u8 = 0x1C;
+    /// OEM-defined section type minimum
     pub const OEM_MIN: u8 = 0xC0;
+    /// OEM-defined section type maximum
     pub const OEM_MAX: u8 = 0xDF;
+    /// Debug section type minimum
     pub const DEBUG_MIN: u8 = 0xE0;
+    /// Debug section type maximum
     pub const DEBUG_MAX: u8 = 0xEF;
+    /// FFS-defined section type minimum
     pub const FFS_MIN: u8 = 0xF0;
+    /// FFS pad section type
     pub const FFS_PAD: u8 = 0xF0;
+    /// FFS-defined section type maximum
     pub const FFS_MAX: u8 = 0xFF;
 }
 
 #[repr(u8)]
 #[derive(Debug, Copy, Clone, PartialEq)]
 #[cfg_attr(test, derive(serde::Deserialize))]
+/// Section type enumeration for firmware file sections
 pub enum Type {
+    /// All section types
     All = raw_type::ALL,
+    /// Compression section
     Compression = raw_type::encapsulated::COMPRESSION,
+    /// GUID-defined section
     GuidDefined = raw_type::encapsulated::GUID_DEFINED,
+    /// Disposable section
     Disposable = raw_type::encapsulated::DISPOSABLE,
+    /// PE32 executable
     Pe32 = raw_type::PE32,
+    /// Position-independent code
     Pic = raw_type::PIC,
+    /// Terse executable
     Te = raw_type::TE,
+    /// DXE dependency expression
     DxeDepex = raw_type::DXE_DEPEX,
+    /// Version information
     Version = raw_type::VERSION,
+    /// User interface string
     UserInterface = raw_type::USER_INTERFACE,
+    /// Compatibility16 binary
     Compatibility16 = raw_type::COMPATIBILITY16,
+    /// Firmware volume image
     FirmwareVolumeImage = raw_type::FIRMWARE_VOLUME_IMAGE,
+    /// Freeform GUID subtype
     FreeformSubtypeGuid = raw_type::FREEFORM_SUBTYPE_GUID,
+    /// Raw data
     Raw = raw_type::RAW,
+    /// PEI dependency expression
     PeiDepex = raw_type::PEI_DEPEX,
+    /// MM dependency expression
     MmDepex = raw_type::MM_DEPEX,
 }
 
@@ -71,45 +110,64 @@ pub enum Type {
 #[repr(C)]
 #[derive(Debug)]
 pub struct Header {
+    /// Section size (24-bit)
     pub size: [u8; 3],
+    /// Section type identifier
     pub section_type: u8,
 }
 
+/// Section header structures and definitions
 pub mod header {
     use r_efi::efi;
 
     #[repr(C)]
     #[derive(Debug)]
+    /// Standard common section header for sections up to 16MB
     pub struct CommonSectionHeaderStandard {
+        /// Section size (24-bit)
         pub size: [u8; 3],
+        /// Section type identifier
         pub section_type: u8,
     }
 
     /// EFI_COMMON_SECTION_HEADER2 per PI spec 1.8A 3.2.4.1
     #[repr(C)]
     #[derive(Debug)]
+    /// Extended common section header for sections larger than 16MB
     pub struct CommonSectionHeaderExtended {
+        /// Section size (24-bit)
         pub size: [u8; 3],
+        /// Section type identifier
         pub section_type: u8,
+        /// Extended 32-bit section size
         pub extended_size: u32,
     }
 
     /// EFI_COMPRESSION_SECTION per PI spec 1.8A 3.2.5.2
     #[repr(C, packed)]
     #[derive(Debug, Clone, Copy)]
+    /// Compression section header
     pub struct Compression {
+        /// Uncompressed data length
         pub uncompressed_length: u32,
+        /// Compression algorithm type
         pub compression_type: u8,
     }
+    /// No compression applied
     pub const NOT_COMPRESSED: u8 = 0x00;
+    /// Standard compression (typically LZMA)
     pub const STANDARD_COMPRESSION: u8 = 0x01;
 
     /// EFI_GUID_DEFINED_SECTION per PI spec 1.8A 3.2.5.7
     #[repr(C)]
     #[derive(Debug, Clone, Copy)]
+    /// GUID-defined section header
     pub struct GuidDefined {
+        /// GUID identifying the section format
         pub section_definition_guid: efi::Guid,
+        /// Offset to section data from start of header
         pub data_offset: u16,
+        /// Section attributes
         pub attributes: u16,
         // Guid-specific header fields.
     }
@@ -117,14 +175,18 @@ pub mod header {
     /// EFI_VERSION_SECTION per PI spec 1.8A 3.2.5.15
     #[repr(C)]
     #[derive(Debug, Clone, Copy)]
+    /// Version section header
     pub struct Version {
+        /// Build number
         pub build_number: u16,
     }
 
     /// EFI_FREEFORM_SUBTYPE_GUID_SECTION per PI spec 1.8A 3.2.5.6
     #[repr(C)]
     #[derive(Debug, Clone, Copy)]
+    /// Freeform GUID subtype section header
     pub struct FreeformSubtypeGuid {
+        /// Subtype GUID identifier
         pub sub_type_guid: efi::Guid,
     }
 }

--- a/sdk/patina/src/pi/fw_fs/fv.rs
+++ b/sdk/patina/src/pi/fw_fs/fv.rs
@@ -13,9 +13,12 @@
 pub mod attributes;
 pub mod file;
 
+/// Type alias for firmware volume file types
 pub type EfiFvFileType = u8;
 
+/// Firmware File System revision number
 pub const FFS_REVISION: u8 = 2;
+/// Maximum file size for FFS version 2 (16MB)
 pub const FFS_V2_MAX_FILE_SIZE: usize = 0x1000000;
 
 /// Firmware Volume Write Policy bit definitions
@@ -29,39 +32,60 @@ mod raw {
 
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, PartialEq)]
+/// Firmware volume write policy enumeration
 pub enum WritePolicy {
+    /// Unreliable write - no guarantees on power loss
     UnreliableWrite = raw::write_policy::UNRELIABLE_WRITE,
+    /// Reliable write - atomic on power loss
     ReliableWrite = raw::write_policy::RELIABLE_WRITE,
 }
 
 /// EFI_FIRMWARE_VOLUME_HEADER
 #[repr(C)]
 #[derive(Debug, Clone, Copy)]
+/// Firmware volume header structure per PI Specification
 pub struct Header {
+    /// First 16 bytes are zeros for compatibility
     pub zero_vector: [u8; 16],
+    /// File system type GUID
     pub file_system_guid: r_efi::efi::Guid,
+    /// Total volume length in bytes
     pub fv_length: u64,
+    /// Firmware volume signature
     pub signature: u32,
+    /// Volume attributes
     pub attributes: u32,
+    /// Length of this header structure
     pub header_length: u16,
+    /// Header checksum
     pub checksum: u16,
+    /// Offset to extended header (0 if none)
     pub ext_header_offset: u16,
+    /// Reserved byte (must be 0)
     pub reserved: u8,
+    /// Header revision number
     pub revision: u8,
+    /// Variable-length block map array
     pub block_map: [BlockMapEntry; 0],
 }
 
 #[repr(C)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+/// Firmware volume block map entry describing physical layout
 pub struct BlockMapEntry {
+    /// Number of blocks of this size
     pub num_blocks: u32,
+    /// Length of each block
     pub length: u32,
 }
 
 /// EFI_FIRMWARE_VOLUME_EXT_HEADER
 #[repr(C)]
 #[derive(Debug, Clone, Copy)]
+/// Extended firmware volume header
 pub struct ExtHeader {
+    /// Firmware volume name GUID
     pub fv_name: r_efi::efi::Guid,
+    /// Size of this extended header
     pub ext_header_size: u32,
 }

--- a/sdk/patina/src/pi/fw_fs/fv/attributes.rs
+++ b/sdk/patina/src/pi/fw_fs/fv/attributes.rs
@@ -10,107 +10,200 @@
 //! SPDX-License-Identifier: Apache-2.0
 //!
 
+/// Type alias for firmware volume attributes (64-bit)
 pub type EfiFvAttributes = u64;
 
 /// EFI_FV_ATTRIBUTES bit definitions
 /// Note: `ALIGNMENT` traditionally has the same value as `ALIGNMENT_2G`. To reduce confusion, only
 ///       `ALIGNMENT_2G` is specified.
 pub mod raw {
+    /// Firmware volume attribute raw constants (version 2)
     pub mod fv2 {
+        /// Capability to disable read operations
         pub const READ_DISABLE_CAP: u64 = 0x0000000000000001;
+        /// Capability to enable read operations
         pub const READ_ENABLE_CAP: u64 = 0x0000000000000002;
+        /// Current read enable/disable status
         pub const READ_STATUS: u64 = 0x0000000000000004;
+        /// Capability to disable write operations
         pub const WRITE_DISABLE_CAP: u64 = 0x0000000000000008;
+        /// Capability to enable write operations
         pub const WRITE_ENABLE_CAP: u64 = 0x0000000000000010;
+        /// Current write enable/disable status
         pub const WRITE_STATUS: u64 = 0x0000000000000020;
+        /// Capability to lock the firmware volume
         pub const LOCK_CAP: u64 = 0x0000000000000040;
+        /// Current lock status
         pub const LOCK_STATUS: u64 = 0x0000000000000080;
+        /// Reliable write policy - ensures atomic writes
         pub const WRITE_POLICY_RELIABLE: u64 = 0x0000000000000100;
+        /// Capability to lock read operations
         pub const READ_LOCK_CAP: u64 = 0x0000000000001000;
+        /// Current read lock status
         pub const READ_LOCK_STATUS: u64 = 0x0000000000002000;
+        /// Capability to lock write operations
         pub const WRITE_LOCK_CAP: u64 = 0x0000000000004000;
+        /// Current write lock status
         pub const WRITE_LOCK_STATUS: u64 = 0x0000000000008000;
+        /// No alignment requirement (1-byte alignment)
         pub const ALIGNMENT_1: u64 = 0x0000000000000000;
+        /// 2-byte alignment requirement
         pub const ALIGNMENT_2: u64 = 0x0000000000010000;
+        /// 4-byte alignment requirement
         pub const ALIGNMENT_4: u64 = 0x0000000000020000;
+        /// 8-byte alignment requirement
         pub const ALIGNMENT_8: u64 = 0x0000000000030000;
+        /// 16-byte alignment requirement
         pub const ALIGNMENT_16: u64 = 0x0000000000040000;
+        /// 32-byte alignment requirement
         pub const ALIGNMENT_32: u64 = 0x0000000000050000;
+        /// 64-byte alignment requirement
         pub const ALIGNMENT_64: u64 = 0x0000000000060000;
+        /// 128-byte alignment requirement
         pub const ALIGNMENT_128: u64 = 0x0000000000070000;
+        /// 256-byte alignment requirement
         pub const ALIGNMENT_256: u64 = 0x0000000000080000;
+        /// 512-byte alignment requirement
         pub const ALIGNMENT_512: u64 = 0x0000000000090000;
+        /// 1 KB alignment requirement
         pub const ALIGNMENT_1K: u64 = 0x00000000000A0000;
+        /// 2 KB alignment requirement
         pub const ALIGNMENT_2K: u64 = 0x00000000000B0000;
+        /// 4 KB alignment requirement
         pub const ALIGNMENT_4K: u64 = 0x00000000000C0000;
+        /// 8 KB alignment requirement
         pub const ALIGNMENT_8K: u64 = 0x00000000000D0000;
+        /// 16 KB alignment requirement
         pub const ALIGNMENT_16K: u64 = 0x00000000000E0000;
+        /// 32 KB alignment requirement
         pub const ALIGNMENT_32K: u64 = 0x00000000000F0000;
+        /// 64 KB alignment requirement
         pub const ALIGNMENT_64K: u64 = 0x0000000000100000;
+        /// 128 KB alignment requirement
         pub const ALIGNMENT_128K: u64 = 0x0000000000110000;
+        /// 256 KB alignment requirement
         pub const ALIGNMENT_256K: u64 = 0x0000000000120000;
+        /// 512 KB alignment requirement
         pub const ALIGNMENT_512K: u64 = 0x0000000000130000;
+        /// 1 MB alignment requirement
         pub const ALIGNMENT_1M: u64 = 0x0000000000140000;
+        /// 2 MB alignment requirement
         pub const ALIGNMENT_2M: u64 = 0x0000000000150000;
+        /// 4 MB alignment requirement
         pub const ALIGNMENT_4M: u64 = 0x0000000000160000;
+        /// 8 MB alignment requirement
         pub const ALIGNMENT_8M: u64 = 0x0000000000170000;
+        /// 16 MB alignment requirement
         pub const ALIGNMENT_16M: u64 = 0x0000000000180000;
+        /// 32 MB alignment requirement
         pub const ALIGNMENT_32M: u64 = 0x0000000000190000;
+        /// 64 MB alignment requirement
         pub const ALIGNMENT_64M: u64 = 0x00000000001A0000;
+        /// 128 MB alignment requirement
         pub const ALIGNMENT_128M: u64 = 0x00000000001B0000;
+        /// 256 MB alignment requirement
         pub const ALIGNMENT_256M: u64 = 0x00000000001C0000;
+        /// 512 MB alignment requirement
         pub const ALIGNMENT_512M: u64 = 0x00000000001D0000;
+        /// 1 GB alignment requirement
         pub const ALIGNMENT_1G: u64 = 0x00000000001E0000;
+        /// 2 GB alignment requirement
         pub const ALIGNMENT_2G: u64 = 0x00000000001F0000;
     }
 }
 
 #[repr(u64)]
 #[derive(Debug, Copy, Clone, PartialEq)]
+/// Firmware volume attribute enumeration (version 2)
 pub enum Fv2 {
+    /// Read disable capability
     ReadDisableCap = raw::fv2::READ_DISABLE_CAP,
+    /// Read enable capability
     ReadEnableCap = raw::fv2::READ_ENABLE_CAP,
+    /// Read status
     ReadStatus = raw::fv2::READ_STATUS,
+    /// Write disable capability
     WriteDisableCap = raw::fv2::WRITE_DISABLE_CAP,
+    /// Write enable capability
     WriteEnableCap = raw::fv2::WRITE_ENABLE_CAP,
+    /// Write status
     WriteStatus = raw::fv2::WRITE_STATUS,
+    /// Lock capability
     LockCap = raw::fv2::LOCK_CAP,
+    /// Lock status
     LockStatus = raw::fv2::LOCK_STATUS,
+    /// Reliable write policy
     WritePolicyReliable = raw::fv2::WRITE_POLICY_RELIABLE,
+    /// Read lock capability
     ReadLockCap = raw::fv2::READ_LOCK_CAP,
+    /// Read lock status
     ReadLockStatus = raw::fv2::READ_LOCK_STATUS,
+    /// Write lock capability
     WriteLockCap = raw::fv2::WRITE_LOCK_CAP,
+    /// Write lock status
     WriteLockStatus = raw::fv2::WRITE_LOCK_STATUS,
+    /// 1-byte alignment
     Alignment1 = raw::fv2::ALIGNMENT_1,
+    /// 2-byte alignment
     Alignment2 = raw::fv2::ALIGNMENT_2,
+    /// 4-byte alignment
     Alignment4 = raw::fv2::ALIGNMENT_4,
+    /// 8-byte alignment
     Alignment8 = raw::fv2::ALIGNMENT_8,
+    /// 16-byte alignment
     Alignment16 = raw::fv2::ALIGNMENT_16,
+    /// 32-byte alignment
     Alignment32 = raw::fv2::ALIGNMENT_32,
+    /// 64-byte alignment
     Alignment64 = raw::fv2::ALIGNMENT_64,
+    /// 128-byte alignment
     Alignment128 = raw::fv2::ALIGNMENT_128,
+    /// 256-byte alignment
     Alignment256 = raw::fv2::ALIGNMENT_256,
+    /// 512-byte alignment
     Alignment512 = raw::fv2::ALIGNMENT_512,
+    /// 1 KB alignment
     Alignment1K = raw::fv2::ALIGNMENT_1K,
+    /// 2 KB alignment
     Alignment2K = raw::fv2::ALIGNMENT_2K,
+    /// 4 KB alignment
     Alignment4K = raw::fv2::ALIGNMENT_4K,
+    /// 8 KB alignment
     Alignment8K = raw::fv2::ALIGNMENT_8K,
+    /// 16 KB alignment
     Alignment16K = raw::fv2::ALIGNMENT_16K,
+    /// 32 KB alignment
     Alignment32K = raw::fv2::ALIGNMENT_32K,
+    /// 64 KB alignment
     Alignment64K = raw::fv2::ALIGNMENT_64K,
+    /// 128 KB alignment
     Alignment128K = raw::fv2::ALIGNMENT_128K,
+    /// 256 KB alignment
     Alignment256K = raw::fv2::ALIGNMENT_256K,
+    /// 512 KB alignment
     Alignment512K = raw::fv2::ALIGNMENT_512K,
+    /// 1 MB alignment
     Alignment1M = raw::fv2::ALIGNMENT_1M,
+    /// 2 MB alignment
     Alignment2M = raw::fv2::ALIGNMENT_2M,
+    /// 4 MB alignment
     Alignment4M = raw::fv2::ALIGNMENT_4M,
+    /// 8 MB alignment
     Alignment8M = raw::fv2::ALIGNMENT_8M,
+    /// 16 MB alignment
     Alignment16M = raw::fv2::ALIGNMENT_16M,
+    /// 32 MB alignment
     Alignment32M = raw::fv2::ALIGNMENT_32M,
+    /// 64 MB alignment
     Alignment64M = raw::fv2::ALIGNMENT_64M,
+    /// 128 MB alignment
     Alignment128M = raw::fv2::ALIGNMENT_128M,
+    /// 256 MB alignment
     Alignment256M = raw::fv2::ALIGNMENT_256M,
+    /// 512 MB alignment
     Alignment512M = raw::fv2::ALIGNMENT_512M,
+    /// 1 GB alignment
     Alignment1G = raw::fv2::ALIGNMENT_1G,
+    /// 2 GB alignment
     Alignment2G = raw::fv2::ALIGNMENT_2G,
 }

--- a/sdk/patina/src/pi/fw_fs/fv/file.rs
+++ b/sdk/patina/src/pi/fw_fs/fv/file.rs
@@ -10,22 +10,32 @@
 //! SPDX-License-Identifier: Apache-2.0
 //!
 
+/// Type alias for firmware volume file attributes as defined in the PI Specification
 pub type EfiFvFileAttributes = u32;
 
+/// Raw constant definitions for firmware volume file attributes
 pub mod raw {
     /// Firmware File Volume File Attributes
     /// Note: Typically named `EFI_FV_FILE_ATTRIB_*` in EDK II code.
+    /// Firmware volume file attribute constants
     pub mod attribute {
+        /// File alignment requirement mask
         pub const ALIGNMENT: u32 = 0x0000001F;
+        /// File must be loaded at a fixed address
         pub const FIXED: u32 = 0x00000100;
+        /// File can be memory-mapped
         pub const MEMORY_MAPPED: u32 = 0x00000200;
     }
 }
 
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, PartialEq)]
+/// Firmware volume file attribute enumeration
 pub enum Attribute {
+    /// Alignment requirement attribute
     Alignment = raw::attribute::ALIGNMENT,
+    /// Fixed address loading attribute
     Fixed = raw::attribute::FIXED,
+    /// Memory-mapped file attribute
     MemoryMapped = raw::attribute::MEMORY_MAPPED,
 }

--- a/sdk/patina/src/pi/fw_fs/fvb/attributes.rs
+++ b/sdk/patina/src/pi/fw_fs/fvb/attributes.rs
@@ -10,6 +10,7 @@
 //! SPDX-License-Identifier: Apache-2.0
 //!
 
+/// Type alias for firmware volume block attributes (version 2) as defined in the PI Specification
 pub type EfiFvbAttributes2 = u32;
 
 /// EFI_FV_FILE_ATTRIBUTES bit definitions
@@ -17,107 +18,205 @@ pub type EfiFvbAttributes2 = u32;
 /// `ALIGNMENT` traditionally has the same value as `ALIGNMENT_2G`. To reduce confusion, only
 /// `ALIGNMENT_2G` is specified.
 pub mod raw {
+    /// Raw FVB2 attribute constant definitions
     pub mod fvb2 {
+        /// Capability to disable read operations
         pub const READ_DISABLED_CAP: u32 = 0x00000001;
+        /// Capability to enable read operations
         pub const READ_ENABLED_CAP: u32 = 0x00000002;
+        /// Current read enable/disable status
         pub const READ_STATUS: u32 = 0x00000004;
+        /// Capability to disable write operations
         pub const WRITE_DISABLED_CAP: u32 = 0x00000008;
+        /// Capability to enable write operations
         pub const WRITE_ENABLED_CAP: u32 = 0x00000010;
+        /// Current write enable/disable status
         pub const WRITE_STATUS: u32 = 0x00000020;
+        /// Capability to lock the firmware volume block
         pub const LOCK_CAP: u32 = 0x00000040;
+        /// Current lock status
         pub const LOCK_STATUS: u32 = 0x00000080;
+        /// Sticky write attribute - data persists across resets
         pub const STICKY_WRITE: u32 = 0x00000200;
+        /// Block can be memory-mapped
         pub const MEMORY_MAPPED: u32 = 0x00000400;
+        /// Erase polarity bit - indicates value of erased bits
         pub const ERASE_POLARITY: u32 = 0x00000800;
+        /// Capability to lock read operations
         pub const READ_LOCK_CAP: u32 = 0x00001000;
+        /// Current read lock status
         pub const READ_LOCK_STATUS: u32 = 0x00002000;
+        /// Capability to lock write operations
         pub const WRITE_LOCK_CAP: u32 = 0x00004000;
+        /// Current write lock status
         pub const WRITE_LOCK_STATUS: u32 = 0x00008000;
+        /// No alignment requirement (1-byte alignment)
         pub const ALIGNMENT_1: u32 = 0x00000000;
+        /// 2-byte alignment requirement
         pub const ALIGNMENT_2: u32 = 0x00010000;
+        /// 4-byte alignment requirement
         pub const ALIGNMENT_4: u32 = 0x00020000;
+        /// 8-byte alignment requirement
         pub const ALIGNMENT_8: u32 = 0x00030000;
+        /// 16-byte alignment requirement
         pub const ALIGNMENT_16: u32 = 0x00040000;
+        /// 32-byte alignment requirement
         pub const ALIGNMENT_32: u32 = 0x00050000;
+        /// 64-byte alignment requirement
         pub const ALIGNMENT_64: u32 = 0x00060000;
+        /// 128-byte alignment requirement
         pub const ALIGNMENT_128: u32 = 0x00070000;
+        /// 256-byte alignment requirement
         pub const ALIGNMENT_256: u32 = 0x00080000;
+        /// 512-byte alignment requirement
         pub const ALIGNMENT_512: u32 = 0x00090000;
+        /// 1 KB alignment requirement
         pub const ALIGNMENT_1K: u32 = 0x000A0000;
+        /// 2 KB alignment requirement
         pub const ALIGNMENT_2K: u32 = 0x000B0000;
+        /// 4 KB alignment requirement
         pub const ALIGNMENT_4K: u32 = 0x000C0000;
+        /// 8 KB alignment requirement
         pub const ALIGNMENT_8K: u32 = 0x000D0000;
+        /// 16 KB alignment requirement
         pub const ALIGNMENT_16K: u32 = 0x000E0000;
+        /// 32 KB alignment requirement
         pub const ALIGNMENT_32K: u32 = 0x000F0000;
+        /// 64 KB alignment requirement
         pub const ALIGNMENT_64K: u32 = 0x00100000;
+        /// 128 KB alignment requirement
         pub const ALIGNMENT_128K: u32 = 0x00110000;
+        /// 256 KB alignment requirement
         pub const ALIGNMENT_256K: u32 = 0x00120000;
+        /// 512 KB alignment requirement
         pub const ALIGNMENT_512K: u32 = 0x00130000;
+        /// 1 MB alignment requirement
         pub const ALIGNMENT_1M: u32 = 0x00140000;
+        /// 2 MB alignment requirement
         pub const ALIGNMENT_2M: u32 = 0x00150000;
+        /// 4 MB alignment requirement
         pub const ALIGNMENT_4M: u32 = 0x00160000;
+        /// 8 MB alignment requirement
         pub const ALIGNMENT_8M: u32 = 0x00170000;
+        /// 16 MB alignment requirement
         pub const ALIGNMENT_16M: u32 = 0x00180000;
+        /// 32 MB alignment requirement
         pub const ALIGNMENT_32M: u32 = 0x00190000;
+        /// 64 MB alignment requirement
         pub const ALIGNMENT_64M: u32 = 0x001A0000;
+        /// 128 MB alignment requirement
         pub const ALIGNMENT_128M: u32 = 0x001B0000;
+        /// 256 MB alignment requirement
         pub const ALIGNMENT_256M: u32 = 0x001C0000;
+        /// 512 MB alignment requirement
         pub const ALIGNMENT_512M: u32 = 0x001D0000;
+        /// 1 GB alignment requirement
         pub const ALIGNMENT_1G: u32 = 0x001E0000;
+        /// 2 GB alignment requirement
         pub const ALIGNMENT_2G: u32 = 0x001F0000;
+        /// Weak alignment - less strict alignment requirements
         pub const WEAK_ALIGNMENT: u32 = 0x80000000;
     }
 }
 
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, PartialEq)]
+/// Firmware Volume Block attribute enumeration (version 2)
 pub enum Fvb2 {
+    /// Read disable capability
     ReadDisableCap = raw::fvb2::READ_DISABLED_CAP,
+    /// Read enable capability
     ReadEnableCap = raw::fvb2::READ_ENABLED_CAP,
+    /// Read status
     ReadStatus = raw::fvb2::READ_STATUS,
+    /// Write disable capability
     WriteDisableCap = raw::fvb2::WRITE_DISABLED_CAP,
+    /// Write enable capability
     WriteEnableCap = raw::fvb2::WRITE_ENABLED_CAP,
+    /// Write status
     WriteStatus = raw::fvb2::WRITE_STATUS,
+    /// Lock capability
     LockCap = raw::fvb2::LOCK_CAP,
+    /// Lock status
     LockStatus = raw::fvb2::LOCK_STATUS,
+    /// Sticky write - data persists across resets
     StickyWrite = raw::fvb2::STICKY_WRITE,
+    /// Memory-mapped block
     MemoryMapped = raw::fvb2::MEMORY_MAPPED,
+    /// Erase polarity
     ErasePolarity = raw::fvb2::ERASE_POLARITY,
+    /// Read lock capability
     ReadLockCap = raw::fvb2::READ_LOCK_CAP,
+    /// Read lock status
     ReadLockStatus = raw::fvb2::READ_LOCK_STATUS,
+    /// Write lock capability
     WriteLockCap = raw::fvb2::WRITE_LOCK_CAP,
+    /// Write lock status
     WriteLockStatus = raw::fvb2::WRITE_LOCK_STATUS,
+    /// 1-byte alignment
     Alignment1 = raw::fvb2::ALIGNMENT_1,
+    /// 2-byte alignment
     Alignment2 = raw::fvb2::ALIGNMENT_2,
+    /// 4-byte alignment
     Alignment4 = raw::fvb2::ALIGNMENT_4,
+    /// 8-byte alignment
     Alignment8 = raw::fvb2::ALIGNMENT_8,
+    /// 16-byte alignment
     Alignment16 = raw::fvb2::ALIGNMENT_16,
+    /// 32-byte alignment
     Alignment32 = raw::fvb2::ALIGNMENT_32,
+    /// 64-byte alignment
     Alignment64 = raw::fvb2::ALIGNMENT_64,
+    /// 128-byte alignment
     Alignment128 = raw::fvb2::ALIGNMENT_128,
+    /// 256-byte alignment
     Alignment256 = raw::fvb2::ALIGNMENT_256,
+    /// 512-byte alignment
     Alignment512 = raw::fvb2::ALIGNMENT_512,
+    /// 1 KB alignment
     Alignment1K = raw::fvb2::ALIGNMENT_1K,
+    /// 2 KB alignment
     Alignment2K = raw::fvb2::ALIGNMENT_2K,
+    /// 4 KB alignment
     Alignment4K = raw::fvb2::ALIGNMENT_4K,
+    /// 8 KB alignment
     Alignment8K = raw::fvb2::ALIGNMENT_8K,
+    /// 16 KB alignment
     Alignment16K = raw::fvb2::ALIGNMENT_16K,
+    /// 32 KB alignment
     Alignment32K = raw::fvb2::ALIGNMENT_32K,
+    /// 64 KB alignment
     Alignment64K = raw::fvb2::ALIGNMENT_64K,
+    /// 128 KB alignment
     Alignment128K = raw::fvb2::ALIGNMENT_128K,
+    /// 256 KB alignment
     Alignment256K = raw::fvb2::ALIGNMENT_256K,
+    /// 512 KB alignment
     Alignment512K = raw::fvb2::ALIGNMENT_512K,
+    /// 1 MB alignment
     Alignment1M = raw::fvb2::ALIGNMENT_1M,
+    /// 2 MB alignment
     Alignment2M = raw::fvb2::ALIGNMENT_2M,
+    /// 4 MB alignment
     Alignment4M = raw::fvb2::ALIGNMENT_4M,
+    /// 8 MB alignment
     Alignment8M = raw::fvb2::ALIGNMENT_8M,
+    /// 16 MB alignment
     Alignment16M = raw::fvb2::ALIGNMENT_16M,
+    /// 32 MB alignment
     Alignment32M = raw::fvb2::ALIGNMENT_32M,
+    /// 64 MB alignment
     Alignment64M = raw::fvb2::ALIGNMENT_64M,
+    /// 128 MB alignment
     Alignment128M = raw::fvb2::ALIGNMENT_128M,
+    /// 256 MB alignment
     Alignment256M = raw::fvb2::ALIGNMENT_256M,
+    /// 512 MB alignment
     Alignment512M = raw::fvb2::ALIGNMENT_512M,
+    /// 1 GB alignment
     Alignment1G = raw::fvb2::ALIGNMENT_1G,
+    /// 2 GB alignment
     Alignment2G = raw::fvb2::ALIGNMENT_2G,
+    /// Weak alignment - less strict requirements
     WeakAlignment = raw::fvb2::WEAK_ALIGNMENT,
 }

--- a/sdk/patina/src/pi/list_entry.rs
+++ b/sdk/patina/src/pi/list_entry.rs
@@ -16,7 +16,10 @@
 
 #[repr(C)]
 #[derive(Debug)]
+/// Doubly-linked list entry.
 pub struct Entry {
+    /// Forward link pointer to the next entry in the list.
     pub forward_link: *mut Entry,
+    /// Backward link pointer to the previous entry in the list.
     pub back_link: *mut Entry,
 }

--- a/sdk/patina/src/pi/protocols/bds.rs
+++ b/sdk/patina/src/pi/protocols/bds.rs
@@ -32,5 +32,6 @@ pub type BdsEntry = extern "efiapi" fn(*mut Protocol);
 /// UEFI Platform Initialization Specification, Release 1.8, Section II-12.2.1
 #[repr(C)]
 pub struct Protocol {
+    /// BDS architectural protocol entry point.
     pub entry: BdsEntry,
 }

--- a/sdk/patina/src/pi/protocols/communication.rs
+++ b/sdk/patina/src/pi/protocols/communication.rs
@@ -14,9 +14,11 @@
 use core::ffi::c_void;
 use r_efi::{efi, system};
 
+/// MM Communication Protocol GUID.
 pub const PROTOCOL_GUID: efi::Guid =
     efi::Guid::from_fields(0xc68ed8e2, 0x9dc6, 0x4cbd, 0x9d, 0x94, &[0xdb, 0x65, 0xac, 0xc5, 0xc3, 0x32]);
 
+/// MM Initialization GUID.
 pub const EFI_MM_INITIALIZATION_GUID: efi::Guid =
     efi::Guid::from_fields(0x99be0d8f, 0x3548, 0x48aa, 0xb5, 0x77, &[0xfc, 0xfb, 0xa5, 0x6a, 0x67, 0xf7]);
 
@@ -78,12 +80,16 @@ pub type Communicate =
     extern "efiapi" fn(this: *const Protocol, comm_buffer: *mut c_void, comm_size: usize) -> efi::Status;
 
 #[repr(C)]
+/// MM Communication Protocol structure.
 pub struct Protocol {
+    /// Communicate with the MM environment.
+    /// See [`Communicate`] for more details.
     pub communicate: Communicate,
 }
 
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
+/// MM communication header structure.
 pub struct EfiMmCommunicateHeader {
     /// To avoid confusion in interpreting frames, the communication buffer should always begin with the header.
     pub header_guid: r_efi::base::Guid,
@@ -94,6 +100,7 @@ pub struct EfiMmCommunicateHeader {
 
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
+/// MM initialization header structure.
 pub struct EfiMmInitializationHeader {
     /// To avoid confusion in interpreting frames, the communication buffer should always begin with the header.
     pub comm_header: EfiMmCommunicateHeader,

--- a/sdk/patina/src/pi/protocols/communication2.rs
+++ b/sdk/patina/src/pi/protocols/communication2.rs
@@ -15,6 +15,7 @@
 use core::ffi::c_void;
 use r_efi::efi;
 
+/// MM Communication Protocol GUID.
 pub const PROTOCOL_GUID: efi::Guid =
     efi::Guid::from_fields(0x378daedc, 0xf06b, 0x4446, 0x83, 0x14, &[0x40, 0xab, 0x93, 0x3c, 0x87, 0xa3]);
 
@@ -58,6 +59,9 @@ pub type Communicate2 = extern "efiapi" fn(
 ) -> efi::Status;
 
 #[repr(C)]
+/// MM Communication Protocol structure.
 pub struct Protocol {
+    /// Communicate with the MM environment (v2).
+    /// See [`Communicate2`] for more details.
     pub communicate2: Communicate2,
 }

--- a/sdk/patina/src/pi/protocols/communication3.rs
+++ b/sdk/patina/src/pi/protocols/communication3.rs
@@ -15,9 +15,11 @@
 use core::ffi::c_void;
 use r_efi::efi;
 
+/// MM Communication Protocol GUID.
 pub const PROTOCOL_GUID: efi::Guid =
     efi::Guid::from_fields(0xf7234a14, 0x0df2, 0x46c0, 0xad, 0x28, &[0x90, 0xe6, 0xb8, 0x83, 0xa7, 0x2f]);
 
+/// MM Communicate Header V3 GUID.
 pub const COMMUNICATE_HEADER_V3_GUID: efi::Guid =
     efi::Guid::from_fields(0x68e8c853, 0x2ba9, 0x4dd7, 0x9a, 0xc0, &[0x91, 0xe1, 0x61, 0x55, 0xc9, 0x35]);
 
@@ -63,11 +65,15 @@ pub type Communicate3 = extern "efiapi" fn(
 ) -> efi::Status;
 
 #[repr(C)]
+/// MM Communication Protocol structure.
 pub struct Protocol {
+    /// Communicate with the MM environment (v3).
+    /// See [`Communicate3`] for more details.
     pub communicate3: Communicate3,
 }
 
 #[repr(C)]
+/// MM communication header structure.
 pub struct EfiMmCommunicateHeader {
     /// Indicator GUID for MM core that the communication buffer is compliant with this v3 header.
     /// Must be COMMUNICATE_HEADER_V3_GUID.

--- a/sdk/patina/src/pi/protocols/firmware_volume.rs
+++ b/sdk/patina/src/pi/protocols/firmware_volume.rs
@@ -24,12 +24,22 @@ use fw_fs::{
 use core::ffi::c_void;
 use r_efi::efi::{Guid, Handle, Status};
 
+/// GUID for the Firmware Volume (FV) Protocol.
+///
+/// This protocol provides file-level access to firmware volumes. It abstracts
+/// the complexity of the firmware volume format to provide simple file-based
+/// read and write operations.
 pub const PROTOCOL_GUID: Guid =
     Guid::from_fields(0x220e73b6, 0x6bdb, 0x4413, 0x84, 0x5, &[0xb9, 0x74, 0xb1, 0x8, 0x61, 0x9a]);
 
+/// Enumeration of write policies for firmware volume operations.
 pub type EfiFvWritePolicy = u32;
 
 #[repr(C)]
+/// Data structure for writing files to firmware volumes.
+///
+/// Contains the metadata and content information needed to write a file
+/// to a firmware volume, including GUID, type, attributes, and data buffer.
 pub struct EfiFvWriteFileData {
     name_guid: *mut Guid,
     file_type: EfiFvFileType,
@@ -38,10 +48,22 @@ pub struct EfiFvWriteFileData {
     buffer_size: u32,
 }
 
+/// Retrieves the current attributes and current settings of the firmware volume.
+///
+/// Gets the current attributes and status of the firmware volume. These attributes
+/// control volume behavior and indicate current operational capabilities.
 pub type GetVolumeAttributes = extern "efiapi" fn(*const Protocol, *mut EfiFvAttributes) -> Status;
 
+/// Modifies the current settings of the firmware volume.
+///
+/// Sets the firmware volume attributes according to the input parameter, then
+/// returns the new settings. Some attributes may not be modifiable after creation.
 pub type SetVolumeAttributes = extern "efiapi" fn(*const Protocol, *mut EfiFvAttributes) -> Status;
 
+/// Reads an entire file from the firmware volume.
+///
+/// Locates a file within a firmware volume and reads the entire file into a buffer.
+/// The caller specifies the file to read by its GUID name.
 pub type ReadFile = extern "efiapi" fn(
     *const Protocol,
     *const Guid,
@@ -52,6 +74,10 @@ pub type ReadFile = extern "efiapi" fn(
     *mut u32,
 ) -> Status;
 
+/// Reads a specific section from a file within the firmware volume.
+///
+/// Locates a file by GUID and extracts a specific section by type and instance.
+/// This allows selective reading of particular components within a file.
 pub type ReadSection = extern "efiapi" fn(
     *const Protocol,
     *const Guid,
@@ -62,8 +88,16 @@ pub type ReadSection = extern "efiapi" fn(
     *mut u32,
 ) -> Status;
 
+/// Writes a file to the firmware volume.
+///
+/// Writes data to the firmware volume according to the specified write policy.
+/// The write policy determines how the operation handles existing files.
 pub type WriteFile = extern "efiapi" fn(*const Protocol, u32, EfiFvWritePolicy, *mut EfiFvWriteFileData) -> Status;
 
+/// Enumerates files in the firmware volume.
+///
+/// Retrieves the next file in the firmware volume. Repeated calls enumerate all
+/// files within the volume, providing file metadata for each entry.
 pub type GetNextFile = extern "efiapi" fn(
     *const Protocol,
     *mut c_void,
@@ -73,8 +107,16 @@ pub type GetNextFile = extern "efiapi" fn(
     *mut usize,
 ) -> Status;
 
+/// Retrieves volume-specific information.
+///
+/// Returns information about the firmware volume. The information type is specified
+/// by the InformationType GUID parameter.
 pub type GetInfo = extern "efiapi" fn(*const Protocol, *const Guid, *mut usize, *mut c_void) -> Status;
 
+/// Modifies volume-specific information.
+///
+/// Sets information about the firmware volume. The information type is specified
+/// by the InformationType GUID parameter.
 pub type SetInfo = extern "efiapi" fn(*const Protocol, *const Guid, usize, *const c_void) -> Status;
 
 /// The Firmware Volume Protocol provides file-level access to the firmware volume. Each firmware volume driver must
@@ -86,14 +128,24 @@ pub type SetInfo = extern "efiapi" fn(*const Protocol, *const Guid, usize, *cons
 /// UEFI Platform Initialization Specification, Release 1.8, Section III-3.4.1.1
 #[repr(C)]
 pub struct Protocol {
+    /// Gets the current attributes of the firmware volume.
     pub get_volume_attributes: GetVolumeAttributes,
+    /// Sets the attributes of the firmware volume.
     pub set_volume_attributes: SetVolumeAttributes,
+    /// Reads a file from the firmware volume.
     pub read_file: ReadFile,
+    /// Reads a section from a file in the firmware volume.
     pub read_section: ReadSection,
+    /// Writes a file to the firmware volume.
     pub write_file: WriteFile,
+    /// Finds the next file in the firmware volume.
     pub get_next_file: GetNextFile,
+    /// Size of the search key for get_next_file.
     pub key_size: u32,
+    /// Handle of the parent firmware volume.
     pub parent_handle: Handle,
+    /// Gets information about the firmware volume.
     pub get_info: GetInfo,
+    /// Sets information about the firmware volume.
     pub set_info: SetInfo,
 }

--- a/sdk/patina/src/pi/protocols/firmware_volume_block.rs
+++ b/sdk/patina/src/pi/protocols/firmware_volume_block.rs
@@ -18,40 +18,84 @@ use r_efi::efi::{Guid, Handle, Lba, Status};
 
 use crate::pi::{fw_fs::EfiFvbAttributes2, hob::EfiPhysicalAddress};
 
+/// GUID for the Firmware Volume Block (FVB) Protocol.
+///
+/// This protocol provides control over block-oriented firmware devices.
+/// It abstracts the block-oriented nature of firmware volumes to allow consumers
+/// to read, write, and erase firmware volume blocks uniformly.
 pub const PROTOCOL_GUID: Guid =
     Guid::from_fields(0x8f644fa9, 0xe850, 0x4db1, 0x9c, 0xe2, &[0xb, 0x44, 0x69, 0x8e, 0x8d, 0xa4]);
 
+/// Retrieves the current attributes and capabilities of a firmware volume.
+///
+/// On input, Attributes is a pointer to a caller-allocated EFI_FVB_ATTRIBUTES_2 in
+/// which the current attributes and capabilities are returned.
 pub type GetAttributes = extern "efiapi" fn(*mut Protocol, *mut EfiFvbAttributes2) -> Status;
 
+/// Sets firmware volume attributes and returns new attributes.
+///
+/// Modifies the current attributes of the firmware volume according to the input parameter,
+/// then returns the new attributes value in the same parameter.
 pub type SetAttributes = extern "efiapi" fn(*mut Protocol, *mut EfiFvbAttributes2) -> Status;
 
+/// Retrieves the physical address of the device.
+///
+/// Retrieves the physical address of a memory mapped FV. This function should
+/// only be called for memory mapped FVs.
 pub type GetPhysicalAddress = extern "efiapi" fn(*mut Protocol, *mut EfiPhysicalAddress) -> Status;
 
+/// Gets the size of a specific block within a firmware volume.
+///
+/// Retrieves the size, in bytes, of a specific block within a firmware volume and
+/// the number of similar-sized blocks in the firmware volume.
 pub type GetBlockSize = extern "efiapi" fn(*mut Protocol, Lba, *mut usize, *mut usize) -> Status;
 
+/// Reads data beginning at the specified offset.
+///
+/// Reads the specified number of bytes into the provided buffer from the specified block offset.
+/// The read operation may be performed on all the blocks in the firmware volume.
 pub type Read = extern "efiapi" fn(*mut Protocol, Lba, usize, *mut usize, *mut c_void) -> Status;
 
+/// Writes data beginning at the specified offset.
+///
+/// Writes the specified number of bytes from the input buffer to the block. The write
+/// operation may be performed on all the blocks in the firmware volume.
 pub type Write = extern "efiapi" fn(*mut Protocol, Lba, usize, *mut usize, *mut c_void) -> Status;
 
+/// Erases and initializes specified firmware volume blocks.
+///
+/// The variable argument list is a list of tuples that specify logical block addresses and
+/// the number of blocks to erase. The list is terminated with EFI_LBA_LIST_TERMINATOR.
 pub type EraseBlocks = extern "efiapi" fn(
     *mut Protocol,
     //... //TODO: variadic functions and eficall! do not mix presently.
 ) -> Status;
 
-/// The Firmware Volume Block Protocol is the low-level interface to a firmware volume. File-level access to a firmware
-/// volume should not be done using thE Firmware Volume Block Protocol. Normal access to a firmware volume must use
-/// the Firmware Volume Protocol.
+/// Provides low-level access to a firmware volume.
+///
+/// The Firmware Volume Block Protocol is the low-level interface used to access
+/// a firmware volume. File-level access to a firmware volume should not be done
+/// using the Firmware Volume Block Protocol. The Firmware Volume Protocol should
+/// be used for normal file-level access to a firmware volume.
 ///
 /// # Documentation
 /// UEFI Platform Initialization Specification, Release 1.8, Section III-3.4.2.1
 #[repr(C)]
 pub struct Protocol {
+    /// Returns the attributes and current settings of the firmware volume.
     pub get_attributes: GetAttributes,
+    /// Modifies the current settings of the firmware volume according to the input parameter.
     pub set_attributes: SetAttributes,
+    /// Retrieves the physical address of a memory-mapped firmware volume.
     pub get_physical_address: GetPhysicalAddress,
+    ///Retrieves the size in bytes of a specific block within a firmware volume.
     pub get_block_size: GetBlockSize,
+    /// Reads the specified number of bytes into a buffer from the specified block.
     pub read: Read,
+    /// Writes the specified number of bytes from the input buffer to the block.
     pub write: Write,
+    /// Erases and initializes a firmware volume block.
     pub erase_blocks: EraseBlocks,
+    /// Handle of the parent firmware volume.
     pub parent_handle: Handle,
 }

--- a/sdk/patina/src/pi/protocols/metronome.rs
+++ b/sdk/patina/src/pi/protocols/metronome.rs
@@ -37,6 +37,7 @@ pub type WaitForTick = extern "efiapi" fn(*const Protocol, tick_number: u32) -> 
 /// UEFI Platform Initialization Specification, Release 1.8, Section II-12.4.1
 #[repr(C)]
 pub struct Protocol {
+    /// Waits for a specified number of ticks.
     pub wait_for_tick: WaitForTick,
     /// The period of platform’s known time source in 100 ns units. This value on any platform must not exceed 200
     /// microseconds. The value in this field is a constant that must not be modified after the Metronome architectural

--- a/sdk/patina/src/pi/protocols/runtime.rs
+++ b/sdk/patina/src/pi/protocols/runtime.rs
@@ -16,6 +16,7 @@ use core::{ffi::c_void, sync::atomic::AtomicBool};
 use crate::pi::list_entry;
 use r_efi::efi;
 
+/// Runtime Arch Protocol GUID.
 pub const PROTOCOL_GUID: efi::Guid =
     efi::Guid::from_fields(0xb7dfb4e1, 0x052f, 0x449f, 0x87, 0xbe, &[0x98, 0x18, 0xfc, 0x91, 0xb7, 0x33]);
 
@@ -33,14 +34,23 @@ pub const PROTOCOL_GUID: efi::Guid =
 #[repr(C)]
 #[derive(Debug)]
 pub struct Protocol {
+    /// List head for registered runtime images.
     pub image_head: list_entry::Entry,
+    /// List head for registered runtime events.
     pub event_head: list_entry::Entry,
+    /// Size of each memory descriptor.
     pub memory_descriptor_size: usize,
+    /// Version of the memory descriptor.
     pub memory_descriptor_version: u32,
+    /// Total size of the memory map.
     pub memory_map_size: usize,
+    /// Physical address of the memory map.
     pub memory_map_physical: *mut efi::MemoryDescriptor,
+    /// Virtual address of the memory map.
     pub memory_map_virtual: *mut efi::MemoryDescriptor,
+    /// Whether virtual addressing mode is active.
     pub virtual_mode: AtomicBool,
+    /// Whether system is at runtime.
     pub at_runtime: AtomicBool,
 }
 
@@ -52,10 +62,15 @@ pub struct Protocol {
 #[repr(C)]
 #[derive(Debug)]
 pub struct ImageEntry {
+    /// Base address of the image.
     pub image_base: *mut c_void,
+    /// Size of the image.
     pub image_size: u64,
+    /// Relocation data for the image.
     pub relocation_data: *mut c_void,
+    /// Handle associated with the image.
     pub handle: efi::Handle,
+    /// Link entry in the image list.
     pub link: list_entry::Entry,
 }
 
@@ -67,10 +82,16 @@ pub struct ImageEntry {
 #[repr(C)]
 #[derive(Debug)]
 pub struct EventEntry {
+    /// Type of the runtime event.
     pub event_type: u32,
+    /// Task priority level for the event.
     pub notify_tpl: efi::Tpl,
+    /// Notification function for the event.
     pub notify_function: efi::EventNotify,
+    /// Context data for the event notification.
     pub context: *mut c_void,
+    /// Event handle.
     pub event: efi::Event,
+    /// Link entry in the image list.
     pub link: list_entry::Entry,
 }

--- a/sdk/patina/src/pi/protocols/security.rs
+++ b/sdk/patina/src/pi/protocols/security.rs
@@ -16,6 +16,7 @@
 
 use r_efi::efi;
 
+/// Security Arch Protocol GUID.
 pub const PROTOCOL_GUID: efi::Guid =
     efi::Guid::from_fields(0xA46423E3, 0x4617, 0x49f1, 0xB9, 0xFF, &[0xD1, 0xBF, 0xA9, 0x11, 0x58, 0x39]);
 
@@ -72,5 +73,6 @@ pub type EfiSecurityFileAuthenticationState = extern "efiapi" fn(
 /// attestation logging, and other exception operations.
 #[repr(C)]
 pub struct Protocol {
+    /// Function to check file authentication state. See [`EfiSecurityFileAuthenticationState`] for more details.
     pub file_authentication_state: EfiSecurityFileAuthenticationState,
 }

--- a/sdk/patina/src/pi/protocols/security2.rs
+++ b/sdk/patina/src/pi/protocols/security2.rs
@@ -27,6 +27,7 @@ use core::ffi::c_void;
 
 use r_efi::efi;
 
+/// Security2 Arch Protocol GUID.
 pub const PROTOCOL_GUID: efi::Guid =
     efi::Guid::from_fields(0x94ab2f58, 0x1438, 0x4ef1, 0x91, 0x52, &[0x18, 0x94, 0x1a, 0x3a, 0x0e, 0x68]);
 
@@ -87,5 +88,6 @@ pub type EfiSecurity2FileAuthentication = extern "efiapi" fn(
 /// or registered hashes).
 #[repr(C)]
 pub struct Protocol {
+    /// Function to check file authentication state. See [`EfiSecurity2FileAuthentication`] for more details.
     pub file_authentication: EfiSecurity2FileAuthentication,
 }

--- a/sdk/patina/src/pi/protocols/status_code.rs
+++ b/sdk/patina/src/pi/protocols/status_code.rs
@@ -13,6 +13,7 @@
 
 use r_efi::efi;
 
+/// Status Code Runtime Protocol GUID.
 pub const PROTOCOL_GUID: efi::Guid =
     efi::Guid::from_fields(0xD2B2B828, 0x0826, 0x48A7, 0xB3, 0xDF, &[0x98, 0x3C, 0x00, 0x60, 0x24, 0xF0]);
 
@@ -31,8 +32,11 @@ pub type EfiStatusCodeValue = u32;
 /// UEFI Platform Initialization Specification, Release 1.8, Section III-6.6.2.1
 #[repr(C)]
 pub struct EfiStatusCodeData {
+    /// Size of the status code data header.
     pub header_size: u16,
+    /// Size of the status code data.
     pub size: u16,
+    /// GUID identifying the type of status code data.
     pub r#type: efi::Guid,
 }
 
@@ -50,5 +54,6 @@ pub type ReportStatusCode =
 /// UEFI Platform Initialization Specification, Release 1.8, Section II-14.2.1
 #[repr(C)]
 pub struct Protocol {
+    /// Function to report status codes.
     pub report_status_code: ReportStatusCode,
 }

--- a/sdk/patina/src/pi/protocols/timer.rs
+++ b/sdk/patina/src/pi/protocols/timer.rs
@@ -14,6 +14,7 @@
 
 use r_efi::efi;
 
+/// Timer Arch Protocol GUID.
 pub const PROTOCOL_GUID: efi::Guid =
     efi::Guid::from_fields(0x26BACCB3, 0x6F42, 0x11D4, 0xBC, 0xE7, &[0x00, 0x80, 0xC7, 0x3C, 0x88, 0x81]);
 
@@ -109,8 +110,12 @@ pub type EfiTimerGenerateSoftInterrupt = extern "efiapi" fn(this: *mut Protocol)
 /// UEFI Platform Initialization Specification, Release 1.8, Section II-12.10.1
 #[repr(C)]
 pub struct Protocol {
+    /// Registers a handler function for timer interrupts.
     pub register_handler: EfiTimerRegisterHandler,
+    /// Sets the period of the timer interrupt.
     pub set_timer_period: EfiTimerSetTimerPeriod,
+    /// Gets the current period of the timer interrupt.
     pub get_timer_period: EfiTimerGetTimerPeriod,
+    /// Generates a software timer interrupt.
     pub generate_soft_interrupt: EfiTimerGenerateSoftInterrupt,
 }

--- a/sdk/patina/src/pi/protocols/watchdog.rs
+++ b/sdk/patina/src/pi/protocols/watchdog.rs
@@ -50,7 +50,10 @@ pub type GetTimerPeriod = extern "efiapi" fn(*const Protocol, *mut u64) -> efi::
 /// UEFI Platform Initialization Specification, Release 1.8, Section II-12.14.1
 #[repr(C)]
 pub struct Protocol {
+    /// Registers a handler function for watchdog timer expiry.
     pub register_handler: RegisterHandler,
+    /// Sets the period of the watchdog timer.
     pub set_timer_period: SetTimerPeriod,
+    /// Gets the current period of the watchdog timer.
     pub get_timer_period: GetTimerPeriod,
 }

--- a/sdk/patina/src/pi/status_code.rs
+++ b/sdk/patina/src/pi/status_code.rs
@@ -22,16 +22,22 @@ use r_efi::efi::protocols::debug_support;
 // All values masked by EFI_STATUS_CODE_RESERVED_MASK are
 // reserved for use by this specification.
 //
+/// Mask for extracting status code type.
 pub const EFI_STATUS_CODE_TYPE_MASK:      EfiStatusCodeType = 0x000000FF;
+/// Mask for extracting severity level.
 pub const EFI_STATUS_CODE_SEVERITY_MASK:  EfiStatusCodeType = 0xFF000000;
+/// Mask for reserved bits.
 pub const EFI_STATUS_CODE_RESERVED_MASK:  EfiStatusCodeType = 0x00FFFF00;
 
 // Definition of code types. All other values masked by
 // EFI_STATUS_CODE_TYPE_MASK are reserved for use by
 // this specification.
 //
+/// Progress code type.
 pub const EFI_PROGRESS_CODE:  EfiStatusCodeType = 0x00000001;
+/// Error code type.
 pub const EFI_ERROR_CODE:     EfiStatusCodeType = 0x00000002;
+/// Debug code type.
 pub const EFI_DEBUG_CODE:     EfiStatusCodeType = 0x00000003;
 
 // Definitions of severities, all other values masked by
@@ -42,16 +48,23 @@ pub const EFI_DEBUG_CODE:     EfiStatusCodeType = 0x00000003;
 // For example, if a memory error was not detected early enough,
 // the bad data could be consumed by other drivers.
 //
+/// Minor error severity.
 pub const EFI_ERROR_MINOR:        EfiStatusCodeType = 0x40000000;
+/// Major error severity.
 pub const EFI_ERROR_MAJOR:        EfiStatusCodeType = 0x80000000;
+/// Unrecovered error severity.
 pub const EFI_ERROR_UNRECOVERED:  EfiStatusCodeType = 0x90000000;
+/// Uncontained error severity.
 pub const EFI_ERROR_UNCONTAINED:  EfiStatusCodeType = 0xa0000000;
 
 // A Status Code Value is made up of the class, subclass, and
 // an operation.
 //
+/// Mask for extracting class code.
 pub const EFI_STATUS_CODE_CLASS_MASK:      EfiStatusCodeValue = 0xFF000000;
+/// Mask for extracting subclass code.
 pub const EFI_STATUS_CODE_SUBCLASS_MASK:   EfiStatusCodeValue = 0x00FF0000;
+/// Mask for extracting operation code.
 pub const EFI_STATUS_CODE_OPERATION_MASK:  EfiStatusCodeValue = 0x0000FFFF;
 
 // General partitioning scheme for Progress and Error Codes are:
@@ -59,40 +72,56 @@ pub const EFI_STATUS_CODE_OPERATION_MASK:  EfiStatusCodeValue = 0x0000FFFF;
 //   - 0x1000-0x7FFF    Subclass Specific.
 //   - 0x8000-0xFFFF    OEM specific.
 //
+/// Subclass-specific operation code.
 pub const EFI_SUBCLASS_SPECIFIC:  EfiStatusCodeValue = 0x1000;
+/// OEM-specific operation code.
 pub const EFI_OEM_SPECIFIC:       EfiStatusCodeValue = 0x8000;
 
 // Debug Code definitions for all classes and subclass.
 // Only one debug code is defined at this point and should
 // be used for anything that is sent to the debug stream.
 //
+/// Unspecified data class.
 pub const EFI_DC_UNSPECIFIED:  EfiStatusCodeValue = 0x0;
 
 // Class definitions.
 // Values of 4-127 are reserved for future use by this specification.
 // Values in the range 127-255 are reserved for OEM use.
 //
+/// Computing unit device class.
 pub const EFI_COMPUTING_UNIT:  EfiStatusCodeValue = 0x00000000;
+/// Peripheral device class.
 pub const EFI_PERIPHERAL:      EfiStatusCodeValue = 0x01000000;
+/// I/O bus device class.
 pub const EFI_IO_BUS:          EfiStatusCodeValue = 0x02000000;
+/// Software class.
 pub const EFI_SOFTWARE:        EfiStatusCodeValue = 0x03000000;
 
 // Computing Unit Subclass definitions.
 // Values of 8-127 are reserved for future use by this specification.
 // Values of 128-255 are reserved for OEM use.
 //
+/// Computing unit unspecified status code
 pub const EFI_COMPUTING_UNIT_UNSPECIFIED:         EfiStatusCodeValue = EFI_COMPUTING_UNIT;
+/// Host processor computing unit.
 pub const EFI_COMPUTING_UNIT_HOST_PROCESSOR:      EfiStatusCodeValue = EFI_COMPUTING_UNIT | 0x00010000;
+/// Firmware processor computing unit.
 pub const EFI_COMPUTING_UNIT_FIRMWARE_PROCESSOR:  EfiStatusCodeValue = EFI_COMPUTING_UNIT | 0x00020000;
+/// I/O processor computing unit.
 pub const EFI_COMPUTING_UNIT_IO_PROCESSOR:        EfiStatusCodeValue = EFI_COMPUTING_UNIT | 0x00030000;
+/// Cache computing unit.
 pub const EFI_COMPUTING_UNIT_CACHE:               EfiStatusCodeValue = EFI_COMPUTING_UNIT | 0x00040000;
+/// Memory computing unit.
 pub const EFI_COMPUTING_UNIT_MEMORY:              EfiStatusCodeValue = EFI_COMPUTING_UNIT | 0x00050000;
+/// Chipset computing unit.
 pub const EFI_COMPUTING_UNIT_CHIPSET:             EfiStatusCodeValue = EFI_COMPUTING_UNIT | 0x00060000;
 
 // Computing Unit Class Progress Code definitions.
 // These are shared by all subclasses.
 //
+/// Computing unit initialization begin.
 pub const EFI_CU_PC_INIT_BEGIN:  EfiStatusCodeValue = 0x00000000;
+/// Computing unit initialization end.
 pub const EFI_CU_PC_INIT_END:    EfiStatusCodeValue = 0x00000001;
 
 // Computing Unit Unspecified Subclass Progress Code definitions.
@@ -100,14 +129,23 @@ pub const EFI_CU_PC_INIT_END:    EfiStatusCodeValue = 0x00000001;
 
 // Computing Unit Host Processor Subclass Progress Code definitions.
 //
+/// Host processor power-on initialization progress code
 pub const EFI_CU_HP_PC_POWER_ON_INIT:           EfiStatusCodeValue = EFI_SUBCLASS_SPECIFIC;
+/// Host processor cache initialization.
 pub const EFI_CU_HP_PC_CACHE_INIT:              EfiStatusCodeValue = EFI_SUBCLASS_SPECIFIC | 0x00000001;
+/// Host processor RAM initialization.
 pub const EFI_CU_HP_PC_RAM_INIT:                EfiStatusCodeValue = EFI_SUBCLASS_SPECIFIC | 0x00000002;
+/// Host processor memory controller initialization.
 pub const EFI_CU_HP_PC_MEMORY_CONTROLLER_INIT:  EfiStatusCodeValue = EFI_SUBCLASS_SPECIFIC | 0x00000003;
+/// Host processor I/O initialization.
 pub const EFI_CU_HP_PC_IO_INIT:                 EfiStatusCodeValue = EFI_SUBCLASS_SPECIFIC | 0x00000004;
+/// Host processor BSP selection.
 pub const EFI_CU_HP_PC_BSP_SELECT:              EfiStatusCodeValue = EFI_SUBCLASS_SPECIFIC | 0x00000005;
+/// Host processor BSP reselection.
 pub const EFI_CU_HP_PC_BSP_RESELECT:            EfiStatusCodeValue = EFI_SUBCLASS_SPECIFIC | 0x00000006;
+/// Host processor AP initialization.
 pub const EFI_CU_HP_PC_AP_INIT:                 EfiStatusCodeValue = EFI_SUBCLASS_SPECIFIC | 0x00000007;
+/// Host processor SMM initialization.
 pub const EFI_CU_HP_PC_SMM_INIT:                EfiStatusCodeValue = EFI_SUBCLASS_SPECIFIC | 0x00000008;
 
 // Computing Unit Firmware Processor Subclass Progress Code definitions.
@@ -118,17 +156,26 @@ pub const EFI_CU_HP_PC_SMM_INIT:                EfiStatusCodeValue = EFI_SUBCLAS
 
 // Computing Unit Cache Subclass Progress Code definitions.
 //
+/// Cache presence detect progress code
 pub const EFI_CU_CACHE_PC_PRESENCE_DETECT:  EfiStatusCodeValue = EFI_SUBCLASS_SPECIFIC;
+/// Cache configuration.
 pub const EFI_CU_CACHE_PC_CONFIGURATION:    EfiStatusCodeValue = EFI_SUBCLASS_SPECIFIC | 0x00000001;
 
 // Computing Unit Memory Subclass Progress Code definitions.
 //
+/// Memory SPD read progress code
 pub const EFI_CU_MEMORY_PC_SPD_READ:         EfiStatusCodeValue = EFI_SUBCLASS_SPECIFIC;
+/// Memory presence detection.
 pub const EFI_CU_MEMORY_PC_PRESENCE_DETECT:  EfiStatusCodeValue = EFI_SUBCLASS_SPECIFIC | 0x00000001;
+/// Memory timing configuration.
 pub const EFI_CU_MEMORY_PC_TIMING:           EfiStatusCodeValue = EFI_SUBCLASS_SPECIFIC | 0x00000002;
+/// Memory configuration.
 pub const EFI_CU_MEMORY_PC_CONFIGURING:      EfiStatusCodeValue = EFI_SUBCLASS_SPECIFIC | 0x00000003;
+/// Memory optimization.
 pub const EFI_CU_MEMORY_PC_OPTIMIZING:       EfiStatusCodeValue = EFI_SUBCLASS_SPECIFIC | 0x00000004;
+/// Memory initialization.
 pub const EFI_CU_MEMORY_PC_INIT:             EfiStatusCodeValue = EFI_SUBCLASS_SPECIFIC | 0x00000005;
+/// Memory testing.
 pub const EFI_CU_MEMORY_PC_TEST:             EfiStatusCodeValue = EFI_SUBCLASS_SPECIFIC | 0x00000006;
 
 // Computing Unit Chipset Subclass Progress Code definitions.
@@ -136,55 +183,71 @@ pub const EFI_CU_MEMORY_PC_TEST:             EfiStatusCodeValue = EFI_SUBCLASS_S
 
 // South Bridge initialization prior to memory detection.
 //
+/// PEI CAR southbridge initialization progress code
 pub const EFI_CHIPSET_PC_PEI_CAR_SB_INIT:  EfiStatusCodeValue = EFI_SUBCLASS_SPECIFIC;
 
 // North Bridge initialization prior to memory detection.
 //
+/// PEI CAR northbridge initialization progress code
 pub const EFI_CHIPSET_PC_PEI_CAR_NB_INIT:  EfiStatusCodeValue = EFI_SUBCLASS_SPECIFIC|0x00000001;
 
 // South Bridge initialization after memory detection.
 //
+/// PEI memory southbridge initialization progress code
 pub const EFI_CHIPSET_PC_PEI_MEM_SB_INIT:  EfiStatusCodeValue = EFI_SUBCLASS_SPECIFIC|0x00000002;
 
 // North Bridge initialization after memory detection.
 //
+/// PEI memory northbridge initialization progress code
 pub const EFI_CHIPSET_PC_PEI_MEM_NB_INIT:  EfiStatusCodeValue = EFI_SUBCLASS_SPECIFIC|0x00000003;
 
 // PCI Host Bridge DXE initialization.
 //
+/// DXE hostbridge initialization progress code
 pub const EFI_CHIPSET_PC_DXE_HB_INIT:  EfiStatusCodeValue = EFI_SUBCLASS_SPECIFIC|0x00000004;
 
 // North Bridge DXE initialization.
 //
+/// DXE northbridge initialization progress code
 pub const EFI_CHIPSET_PC_DXE_NB_INIT:  EfiStatusCodeValue = EFI_SUBCLASS_SPECIFIC|0x00000005;
 
 // North Bridge specific SMM initialization in DXE.
 //
+/// DXE northbridge SMM initialization progress code
 pub const EFI_CHIPSET_PC_DXE_NB_SMM_INIT:  EfiStatusCodeValue = EFI_SUBCLASS_SPECIFIC|0x00000006;
 
 // Initialization of the South Bridge specific UEFI Runtime Services.
 //
+/// DXE southbridge runtime initialization progress code
 pub const EFI_CHIPSET_PC_DXE_SB_RT_INIT:  EfiStatusCodeValue = EFI_SUBCLASS_SPECIFIC|0x00000007;
 
 // South Bridge DXE initialization
 //
+/// DXE southbridge initialization progress code
 pub const EFI_CHIPSET_PC_DXE_SB_INIT:  EfiStatusCodeValue = EFI_SUBCLASS_SPECIFIC|0x00000008;
 
 // South Bridge specific SMM initialization in DXE.
 //
+/// DXE southbridge SMM initialization progress code
 pub const EFI_CHIPSET_PC_DXE_SB_SMM_INIT:  EfiStatusCodeValue = EFI_SUBCLASS_SPECIFIC|0x00000009;
 
 // Initialization of the South Bridge devices.
 //
+/// DXE southbridge devices initialization progress code
 pub const EFI_CHIPSET_PC_DXE_SB_DEVICES_INIT:  EfiStatusCodeValue = EFI_SUBCLASS_SPECIFIC|0x0000000a;
 
 // Computing Unit Class Error Code definitions.
 // These are shared by all subclasses.
 //
+/// Non-specific computing unit error.
 pub const EFI_CU_EC_NON_SPECIFIC:    EfiStatusCodeValue = 0x00000000;
+/// Computing unit disabled error.
 pub const EFI_CU_EC_DISABLED:        EfiStatusCodeValue = 0x00000001;
+/// Computing unit not supported error.
 pub const EFI_CU_EC_NOT_SUPPORTED:   EfiStatusCodeValue = 0x00000002;
+/// Computing unit not detected error.
 pub const EFI_CU_EC_NOT_DETECTED:    EfiStatusCodeValue = 0x00000003;
+/// Computing unit not configured error.
 pub const EFI_CU_EC_NOT_CONFIGURED:  EfiStatusCodeValue = 0x00000004;
 
 // Computing Unit Unspecified Subclass Error Code definitions.
@@ -192,25 +255,42 @@ pub const EFI_CU_EC_NOT_CONFIGURED:  EfiStatusCodeValue = 0x00000004;
 
 // Computing Unit Host Processor Subclass Error Code definitions.
 //
+/// Host processor invalid type error code
 pub const EFI_CU_HP_EC_INVALID_TYPE:         EfiStatusCodeValue = EFI_SUBCLASS_SPECIFIC;
+/// Host processor invalid speed error.
 pub const EFI_CU_HP_EC_INVALID_SPEED:        EfiStatusCodeValue = EFI_SUBCLASS_SPECIFIC | 0x00000001;
+/// Host processor mismatch error.
 pub const EFI_CU_HP_EC_MISMATCH:             EfiStatusCodeValue = EFI_SUBCLASS_SPECIFIC | 0x00000002;
+/// Host processor timer expired error.
 pub const EFI_CU_HP_EC_TIMER_EXPIRED:        EfiStatusCodeValue = EFI_SUBCLASS_SPECIFIC | 0x00000003;
+/// Host processor self-test error.
 pub const EFI_CU_HP_EC_SELF_TEST:            EfiStatusCodeValue = EFI_SUBCLASS_SPECIFIC | 0x00000004;
+/// Host processor internal error.
 pub const EFI_CU_HP_EC_INTERNAL:             EfiStatusCodeValue = EFI_SUBCLASS_SPECIFIC | 0x00000005;
+/// Host processor thermal error.
 pub const EFI_CU_HP_EC_THERMAL:              EfiStatusCodeValue = EFI_SUBCLASS_SPECIFIC | 0x00000006;
+/// Host processor low voltage error.
 pub const EFI_CU_HP_EC_LOW_VOLTAGE:          EfiStatusCodeValue = EFI_SUBCLASS_SPECIFIC | 0x00000007;
+/// Host processor high voltage error.
 pub const EFI_CU_HP_EC_HIGH_VOLTAGE:         EfiStatusCodeValue = EFI_SUBCLASS_SPECIFIC | 0x00000008;
+/// Host processor cache error.
 pub const EFI_CU_HP_EC_CACHE:                EfiStatusCodeValue = EFI_SUBCLASS_SPECIFIC | 0x00000009;
+/// Host processor microcode update error.
 pub const EFI_CU_HP_EC_MICROCODE_UPDATE:     EfiStatusCodeValue = EFI_SUBCLASS_SPECIFIC | 0x0000000A;
+/// Host processor correctable error.
 pub const EFI_CU_HP_EC_CORRECTABLE:          EfiStatusCodeValue = EFI_SUBCLASS_SPECIFIC | 0x0000000B;
+/// Host processor uncorrectable error.
 pub const EFI_CU_HP_EC_UNCORRECTABLE:        EfiStatusCodeValue = EFI_SUBCLASS_SPECIFIC | 0x0000000C;
+/// Host processor no microcode update error.
 pub const EFI_CU_HP_EC_NO_MICROCODE_UPDATE:  EfiStatusCodeValue = EFI_SUBCLASS_SPECIFIC | 0x0000000D;
 
 // Computing Unit Firmware Processor Subclass Error Code definitions.
 //
+/// Firmware processor hard failure error.
 pub const EFI_CU_FP_EC_HARD_FAIL:   EfiStatusCodeValue = EFI_SUBCLASS_SPECIFIC;
+/// Firmware processor soft failure error.
 pub const EFI_CU_FP_EC_SOFT_FAIL:   EfiStatusCodeValue = EFI_SUBCLASS_SPECIFIC | 0x00000001;
+/// Firmware processor communication error.
 pub const EFI_CU_FP_EC_COMM_ERROR:  EfiStatusCodeValue = EFI_SUBCLASS_SPECIFIC | 0x00000002;
 
 // Computing Unit IO Processor Subclass Error Code definitions.
@@ -218,62 +298,104 @@ pub const EFI_CU_FP_EC_COMM_ERROR:  EfiStatusCodeValue = EFI_SUBCLASS_SPECIFIC |
 
 // Computing Unit Cache Subclass Error Code definitions.
 //
+/// Cache invalid type error code
 pub const EFI_CU_CACHE_EC_INVALID_TYPE:   EfiStatusCodeValue = EFI_SUBCLASS_SPECIFIC;
+/// Cache invalid speed error.
 pub const EFI_CU_CACHE_EC_INVALID_SPEED:  EfiStatusCodeValue = EFI_SUBCLASS_SPECIFIC | 0x00000001;
+/// Cache invalid size error.
 pub const EFI_CU_CACHE_EC_INVALID_SIZE:   EfiStatusCodeValue = EFI_SUBCLASS_SPECIFIC | 0x00000002;
+/// Cache mismatch error.
 pub const EFI_CU_CACHE_EC_MISMATCH:       EfiStatusCodeValue = EFI_SUBCLASS_SPECIFIC | 0x00000003;
 
 // Computing Unit Memory Subclass Error Code definitions.
 //
+/// Memory invalid type error code
 pub const EFI_CU_MEMORY_EC_INVALID_TYPE:    EfiStatusCodeValue = EFI_SUBCLASS_SPECIFIC;
+/// Memory invalid speed error.
 pub const EFI_CU_MEMORY_EC_INVALID_SPEED:   EfiStatusCodeValue = EFI_SUBCLASS_SPECIFIC | 0x00000001;
+/// Memory correctable error.
 pub const EFI_CU_MEMORY_EC_CORRECTABLE:     EfiStatusCodeValue = EFI_SUBCLASS_SPECIFIC | 0x00000002;
+/// Memory uncorrectable error.
 pub const EFI_CU_MEMORY_EC_UNCORRECTABLE:   EfiStatusCodeValue = EFI_SUBCLASS_SPECIFIC | 0x00000003;
+/// Memory SPD failure error.
 pub const EFI_CU_MEMORY_EC_SPD_FAIL:        EfiStatusCodeValue = EFI_SUBCLASS_SPECIFIC | 0x00000004;
+/// Memory invalid size error.
 pub const EFI_CU_MEMORY_EC_INVALID_SIZE:    EfiStatusCodeValue = EFI_SUBCLASS_SPECIFIC | 0x00000005;
+/// Memory mismatch error.
 pub const EFI_CU_MEMORY_EC_MISMATCH:        EfiStatusCodeValue = EFI_SUBCLASS_SPECIFIC | 0x00000006;
+/// Memory S3 resume failure error.
 pub const EFI_CU_MEMORY_EC_S3_RESUME_FAIL:  EfiStatusCodeValue = EFI_SUBCLASS_SPECIFIC | 0x00000007;
+/// Memory update failure error.
 pub const EFI_CU_MEMORY_EC_UPDATE_FAIL:     EfiStatusCodeValue = EFI_SUBCLASS_SPECIFIC | 0x00000008;
+/// Memory none detected error.
 pub const EFI_CU_MEMORY_EC_NONE_DETECTED:   EfiStatusCodeValue = EFI_SUBCLASS_SPECIFIC | 0x00000009;
+/// Memory none useful error.
 pub const EFI_CU_MEMORY_EC_NONE_USEFUL:     EfiStatusCodeValue = EFI_SUBCLASS_SPECIFIC | 0x0000000A;
 
 // Computing Unit Chipset Subclass Error Code definitions.
 //
+/// Chipset bad battery error code
 pub const EFI_CHIPSET_EC_BAD_BATTERY:      EfiStatusCodeValue = EFI_SUBCLASS_SPECIFIC;
+/// Chipset DXE north bridge error.
 pub const EFI_CHIPSET_EC_DXE_NB_ERROR:     EfiStatusCodeValue = EFI_SUBCLASS_SPECIFIC | 0x00000001;
+/// Chipset DXE south bridge error.
 pub const EFI_CHIPSET_EC_DXE_SB_ERROR:     EfiStatusCodeValue = EFI_SUBCLASS_SPECIFIC | 0x00000002;
+/// Chipset intruder detected error.
 pub const EFI_CHIPSET_EC_INTRUDER_DETECT:  EfiStatusCodeValue = EFI_SUBCLASS_SPECIFIC | 0x00000003;
 
 // Peripheral Subclass definitions.
 // Values of 12-127 are reserved for future use by this specification.
 // Values of 128-255 are reserved for OEM use.
 //
+/// Unspecified peripheral device.
 pub const EFI_PERIPHERAL_UNSPECIFIED:      EfiStatusCodeValue = EFI_PERIPHERAL;
+/// Keyboard peripheral device.
 pub const EFI_PERIPHERAL_KEYBOARD:         EfiStatusCodeValue = EFI_PERIPHERAL | 0x00010000;
+/// Mouse peripheral device.
 pub const EFI_PERIPHERAL_MOUSE:            EfiStatusCodeValue = EFI_PERIPHERAL | 0x00020000;
+/// Local console peripheral device.
 pub const EFI_PERIPHERAL_LOCAL_CONSOLE:    EfiStatusCodeValue = EFI_PERIPHERAL | 0x00030000;
+/// Remote console peripheral device.
 pub const EFI_PERIPHERAL_REMOTE_CONSOLE:   EfiStatusCodeValue = EFI_PERIPHERAL | 0x00040000;
+/// Serial port peripheral device.
 pub const EFI_PERIPHERAL_SERIAL_PORT:      EfiStatusCodeValue = EFI_PERIPHERAL | 0x00050000;
+/// Parallel port peripheral device.
 pub const EFI_PERIPHERAL_PARALLEL_PORT:    EfiStatusCodeValue = EFI_PERIPHERAL | 0x00060000;
+/// Fixed media peripheral device.
 pub const EFI_PERIPHERAL_FIXED_MEDIA:      EfiStatusCodeValue = EFI_PERIPHERAL | 0x00070000;
+/// Removable media peripheral device.
 pub const EFI_PERIPHERAL_REMOVABLE_MEDIA:  EfiStatusCodeValue = EFI_PERIPHERAL | 0x00080000;
+/// Audio input peripheral device.
 pub const EFI_PERIPHERAL_AUDIO_INPUT:      EfiStatusCodeValue = EFI_PERIPHERAL | 0x00090000;
+/// Audio output peripheral device.
 pub const EFI_PERIPHERAL_AUDIO_OUTPUT:     EfiStatusCodeValue = EFI_PERIPHERAL | 0x000A0000;
+/// LCD display peripheral device.
 pub const EFI_PERIPHERAL_LCD_DEVICE:       EfiStatusCodeValue = EFI_PERIPHERAL | 0x000B0000;
+/// Network peripheral device.
 pub const EFI_PERIPHERAL_NETWORK:          EfiStatusCodeValue = EFI_PERIPHERAL | 0x000C0000;
+/// Docking station peripheral device.
 pub const EFI_PERIPHERAL_DOCKING:          EfiStatusCodeValue = EFI_PERIPHERAL | 0x000D0000;
+/// TPM peripheral device.
 pub const EFI_PERIPHERAL_TPM:              EfiStatusCodeValue = EFI_PERIPHERAL | 0x000E0000;
 
 // Peripheral Class Progress Code definitions.
 // These are shared by all subclasses.
 //
+/// Peripheral initialize progress code.
 pub const EFI_P_PC_INIT:             EfiStatusCodeValue = 0x00000000;
+/// Peripheral reset progress code.
 pub const EFI_P_PC_RESET:            EfiStatusCodeValue = 0x00000001;
+/// Peripheral disable progress code.
 pub const EFI_P_PC_DISABLE:          EfiStatusCodeValue = 0x00000002;
+/// Peripheral presence detect progress code.
 pub const EFI_P_PC_PRESENCE_DETECT:  EfiStatusCodeValue = 0x00000003;
+/// Peripheral enable progress code.
 pub const EFI_P_PC_ENABLE:           EfiStatusCodeValue = 0x00000004;
+/// Peripheral reconfigure progress code.
 pub const EFI_P_PC_RECONFIG:         EfiStatusCodeValue = 0x00000005;
+/// Peripheral detected progress code.
 pub const EFI_P_PC_DETECTED:         EfiStatusCodeValue = 0x00000006;
+/// Peripheral removed progress code.
 pub const EFI_P_PC_REMOVED:          EfiStatusCodeValue = 0x00000007;
 
 // Peripheral Class Unspecified Subclass Progress Code definitions.
@@ -281,11 +403,14 @@ pub const EFI_P_PC_REMOVED:          EfiStatusCodeValue = 0x00000007;
 
 // Peripheral Class Keyboard Subclass Progress Code definitions.
 //
+/// Keyboard clear buffer progress code.
 pub const EFI_P_KEYBOARD_PC_CLEAR_BUFFER:  EfiStatusCodeValue = EFI_SUBCLASS_SPECIFIC;
+/// Keyboard self-test progress code.
 pub const EFI_P_KEYBOARD_PC_SELF_TEST:     EfiStatusCodeValue = EFI_SUBCLASS_SPECIFIC | 0x00000001;
 
 // Peripheral Class Mouse Subclass Progress Code definitions.
 //
+/// Mouse self-test progress code.
 pub const EFI_P_MOUSE_PC_SELF_TEST:  EfiStatusCodeValue = EFI_SUBCLASS_SPECIFIC;
 
 // Peripheral Class Local Console Subclass Progress Code definitions.
@@ -296,6 +421,7 @@ pub const EFI_P_MOUSE_PC_SELF_TEST:  EfiStatusCodeValue = EFI_SUBCLASS_SPECIFIC;
 
 // Peripheral Class Serial Port Subclass Progress Code definitions.
 //
+/// Serial port clear buffer progress code.
 pub const EFI_P_SERIAL_PORT_PC_CLEAR_BUFFER:  EfiStatusCodeValue = EFI_SUBCLASS_SPECIFIC;
 
 // Peripheral Class Parallel Port Subclass Progress Code definitions.
@@ -322,15 +448,25 @@ pub const EFI_P_SERIAL_PORT_PC_CLEAR_BUFFER:  EfiStatusCodeValue = EFI_SUBCLASS_
 // Peripheral Class Error Code definitions.
 // These are shared by all subclasses.
 //
+/// Non-specific peripheral error.
 pub const EFI_P_EC_NON_SPECIFIC:       EfiStatusCodeValue = 0x00000000;
+/// Peripheral disabled error.
 pub const EFI_P_EC_DISABLED:           EfiStatusCodeValue = 0x00000001;
+/// Peripheral not supported error.
 pub const EFI_P_EC_NOT_SUPPORTED:      EfiStatusCodeValue = 0x00000002;
+/// Peripheral not detected error.
 pub const EFI_P_EC_NOT_DETECTED:       EfiStatusCodeValue = 0x00000003;
+/// Peripheral not configured error.
 pub const EFI_P_EC_NOT_CONFIGURED:     EfiStatusCodeValue = 0x00000004;
+/// Peripheral interface error.
 pub const EFI_P_EC_INTERFACE_ERROR:    EfiStatusCodeValue = 0x00000005;
+/// Peripheral controller error.
 pub const EFI_P_EC_CONTROLLER_ERROR:   EfiStatusCodeValue = 0x00000006;
+/// Peripheral input error.
 pub const EFI_P_EC_INPUT_ERROR:        EfiStatusCodeValue = 0x00000007;
+/// Peripheral output error.
 pub const EFI_P_EC_OUTPUT_ERROR:       EfiStatusCodeValue = 0x00000008;
+/// Peripheral resource conflict error.
 pub const EFI_P_EC_RESOURCE_CONFLICT:  EfiStatusCodeValue = 0x00000009;
 
 // Peripheral Class Unspecified Subclass Error Code definitions.
@@ -338,12 +474,16 @@ pub const EFI_P_EC_RESOURCE_CONFLICT:  EfiStatusCodeValue = 0x00000009;
 
 // Peripheral Class Keyboard Subclass Error Code definitions.
 //
+/// Keyboard locked error.
 pub const EFI_P_KEYBOARD_EC_LOCKED:       EfiStatusCodeValue = EFI_SUBCLASS_SPECIFIC;
+/// Keyboard stuck key error.
 pub const EFI_P_KEYBOARD_EC_STUCK_KEY:    EfiStatusCodeValue = EFI_SUBCLASS_SPECIFIC | 0x00000001;
+/// Keyboard buffer full error.
 pub const EFI_P_KEYBOARD_EC_BUFFER_FULL:  EfiStatusCodeValue = EFI_SUBCLASS_SPECIFIC | 0x00000002;
 
 // Peripheral Class Mouse Subclass Error Code definitions.
 //
+/// Mouse locked error.
 pub const EFI_P_MOUSE_EC_LOCKED:  EfiStatusCodeValue = EFI_SUBCLASS_SPECIFIC;
 
 // Peripheral Class Local Console Subclass Error Code definitions.
@@ -380,29 +520,49 @@ pub const EFI_P_MOUSE_EC_LOCKED:  EfiStatusCodeValue = EFI_SUBCLASS_SPECIFIC;
 // Values of 14-127 are reserved for future use by this specification.
 // Values of 128-255 are reserved for OEM use.
 //
+/// Unspecified I/O bus.
 pub const EFI_IO_BUS_UNSPECIFIED:  EfiStatusCodeValue = EFI_IO_BUS;
+/// PCI I/O bus.
 pub const EFI_IO_BUS_PCI:          EfiStatusCodeValue = EFI_IO_BUS | 0x00010000;
+/// USB I/O bus.
 pub const EFI_IO_BUS_USB:          EfiStatusCodeValue = EFI_IO_BUS | 0x00020000;
+/// IBA I/O bus.
 pub const EFI_IO_BUS_IBA:          EfiStatusCodeValue = EFI_IO_BUS | 0x00030000;
+/// AGP I/O bus.
 pub const EFI_IO_BUS_AGP:          EfiStatusCodeValue = EFI_IO_BUS | 0x00040000;
+/// PC Card I/O bus.
 pub const EFI_IO_BUS_PC_CARD:      EfiStatusCodeValue = EFI_IO_BUS | 0x00050000;
+/// LPC I/O bus.
 pub const EFI_IO_BUS_LPC:          EfiStatusCodeValue = EFI_IO_BUS | 0x00060000;
+/// SCSI I/O bus.
 pub const EFI_IO_BUS_SCSI:         EfiStatusCodeValue = EFI_IO_BUS | 0x00070000;
+/// ATA/ATAPI I/O bus.
 pub const EFI_IO_BUS_ATA_ATAPI:    EfiStatusCodeValue = EFI_IO_BUS | 0x00080000;
+/// Fibre Channel I/O bus.
 pub const EFI_IO_BUS_FC:           EfiStatusCodeValue = EFI_IO_BUS | 0x00090000;
+/// IP Network I/O bus.
 pub const EFI_IO_BUS_IP_NETWORK:   EfiStatusCodeValue = EFI_IO_BUS | 0x000A0000;
+/// SMBus I/O bus.
 pub const EFI_IO_BUS_SMBUS:        EfiStatusCodeValue = EFI_IO_BUS | 0x000B0000;
+/// I2C I/O bus.
 pub const EFI_IO_BUS_I2C:          EfiStatusCodeValue = EFI_IO_BUS | 0x000C0000;
 
 // IO Bus Class Progress Code definitions.
 // These are shared by all subclasses.
 //
+/// I/O bus initialize progress code.
 pub const EFI_IOB_PC_INIT:      EfiStatusCodeValue = 0x00000000;
+/// I/O bus reset progress code.
 pub const EFI_IOB_PC_RESET:     EfiStatusCodeValue = 0x00000001;
+/// I/O bus disable progress code.
 pub const EFI_IOB_PC_DISABLE:   EfiStatusCodeValue = 0x00000002;
+/// I/O bus detect progress code.
 pub const EFI_IOB_PC_DETECT:    EfiStatusCodeValue = 0x00000003;
+/// I/O bus enable progress code.
 pub const EFI_IOB_PC_ENABLE:    EfiStatusCodeValue = 0x00000004;
+/// I/O bus reconfigure progress code.
 pub const EFI_IOB_PC_RECONFIG:  EfiStatusCodeValue = 0x00000005;
+/// I/O bus hotplug progress code.
 pub const EFI_IOB_PC_HOTPLUG:   EfiStatusCodeValue = 0x00000006;
 
 // IO Bus Class Unspecified Subclass Progress Code definitions.
@@ -410,8 +570,11 @@ pub const EFI_IOB_PC_HOTPLUG:   EfiStatusCodeValue = 0x00000006;
 
 // IO Bus Class PCI Subclass Progress Code definitions.
 //
+/// PCI bus enumeration progress code.
 pub const EFI_IOB_PCI_BUS_ENUM:   EfiStatusCodeValue = EFI_SUBCLASS_SPECIFIC;
+/// PCI resource allocation progress code.
 pub const EFI_IOB_PCI_RES_ALLOC:  EfiStatusCodeValue = EFI_SUBCLASS_SPECIFIC | 0x00000001;
+/// PCI hot-plug controller initialization progress code.
 pub const EFI_IOB_PCI_HPC_INIT:   EfiStatusCodeValue = EFI_SUBCLASS_SPECIFIC | 0x00000002;
 
 // IO Bus Class USB Subclass Progress Code definitions.
@@ -434,9 +597,13 @@ pub const EFI_IOB_PCI_HPC_INIT:   EfiStatusCodeValue = EFI_SUBCLASS_SPECIFIC | 0
 
 // IO Bus Class ATA/ATAPI Subclass Progress Code definitions.
 //
+/// ATA bus SMART enable progress code.
 pub const EFI_IOB_ATA_BUS_SMART_ENABLE:          EfiStatusCodeValue = EFI_SUBCLASS_SPECIFIC;
+/// ATA bus SMART disable progress code.
 pub const EFI_IOB_ATA_BUS_SMART_DISABLE:         EfiStatusCodeValue = EFI_SUBCLASS_SPECIFIC | 0x00000001;
+/// ATA bus SMART over threshold progress code.
 pub const EFI_IOB_ATA_BUS_SMART_OVERTHRESHOLD:   EfiStatusCodeValue = EFI_SUBCLASS_SPECIFIC | 0x00000002;
+/// ATA bus SMART under threshold progress code.
 pub const EFI_IOB_ATA_BUS_SMART_UNDERTHRESHOLD:  EfiStatusCodeValue = EFI_SUBCLASS_SPECIFIC | 0x00000003;
 // IO Bus Class FC Subclass Progress Code definitions.
 //
@@ -453,15 +620,25 @@ pub const EFI_IOB_ATA_BUS_SMART_UNDERTHRESHOLD:  EfiStatusCodeValue = EFI_SUBCLA
 // IO Bus Class Error Code definitions.
 // These are shared by all subclasses.
 //
+/// Non-specific I/O bus error.
 pub const EFI_IOB_EC_NON_SPECIFIC:       EfiStatusCodeValue = 0x00000000;
+/// I/O bus disabled error.
 pub const EFI_IOB_EC_DISABLED:           EfiStatusCodeValue = 0x00000001;
+/// I/O bus not supported error.
 pub const EFI_IOB_EC_NOT_SUPPORTED:      EfiStatusCodeValue = 0x00000002;
+/// I/O bus not detected error.
 pub const EFI_IOB_EC_NOT_DETECTED:       EfiStatusCodeValue = 0x00000003;
+/// I/O bus not configured error.
 pub const EFI_IOB_EC_NOT_CONFIGURED:     EfiStatusCodeValue = 0x00000004;
+/// I/O bus interface error.
 pub const EFI_IOB_EC_INTERFACE_ERROR:    EfiStatusCodeValue = 0x00000005;
+/// I/O bus controller error.
 pub const EFI_IOB_EC_CONTROLLER_ERROR:   EfiStatusCodeValue = 0x00000006;
+/// I/O bus read error.
 pub const EFI_IOB_EC_READ_ERROR:         EfiStatusCodeValue = 0x00000007;
+/// I/O bus write error.
 pub const EFI_IOB_EC_WRITE_ERROR:        EfiStatusCodeValue = 0x00000008;
+/// I/O bus resource conflict error.
 pub const EFI_IOB_EC_RESOURCE_CONFLICT:  EfiStatusCodeValue = 0x00000009;
 
 // IO Bus Class Unspecified Subclass Error Code definitions.
@@ -469,7 +646,9 @@ pub const EFI_IOB_EC_RESOURCE_CONFLICT:  EfiStatusCodeValue = 0x00000009;
 
 // IO Bus Class PCI Subclass Error Code definitions.
 //
+/// PCI parity error.
 pub const EFI_IOB_PCI_EC_PERR:  EfiStatusCodeValue = EFI_SUBCLASS_SPECIFIC;
+/// PCI system error.
 pub const EFI_IOB_PCI_EC_SERR:  EfiStatusCodeValue = EFI_SUBCLASS_SPECIFIC | 0x00000001;
 
 // IO Bus Class USB Subclass Error Code definitions.
@@ -492,7 +671,9 @@ pub const EFI_IOB_PCI_EC_SERR:  EfiStatusCodeValue = EFI_SUBCLASS_SPECIFIC | 0x0
 
 // IO Bus Class ATA/ATAPI Subclass Error Code definitions.
 //
+/// ATA bus SMART not supported error.
 pub const EFI_IOB_ATA_BUS_SMART_NOTSUPPORTED:  EfiStatusCodeValue = EFI_SUBCLASS_SPECIFIC;
+/// ATA bus SMART disabled error.
 pub const EFI_IOB_ATA_BUS_SMART_DISABLED:      EfiStatusCodeValue = EFI_SUBCLASS_SPECIFIC | 0x00000001;
 
 // IO Bus Class FC Subclass Error Code definitions.
@@ -511,39 +692,68 @@ pub const EFI_IOB_ATA_BUS_SMART_DISABLED:      EfiStatusCodeValue = EFI_SUBCLASS
 // Values of 14-127 are reserved for future use by this specification.
 // Values of 128-255 are reserved for OEM use.
 //
+/// Unspecified software subclass.
 pub const EFI_SOFTWARE_UNSPECIFIED:          EfiStatusCodeValue = EFI_SOFTWARE;
+/// SEC software subclass.
 pub const EFI_SOFTWARE_SEC:                  EfiStatusCodeValue = EFI_SOFTWARE | 0x00010000;
+/// PEI Core software subclass.
 pub const EFI_SOFTWARE_PEI_CORE:             EfiStatusCodeValue = EFI_SOFTWARE | 0x00020000;
+/// PEI Module software subclass.
 pub const EFI_SOFTWARE_PEI_MODULE:           EfiStatusCodeValue = EFI_SOFTWARE | 0x00030000;
+/// DXE Core software subclass.
 pub const EFI_SOFTWARE_DXE_CORE:             EfiStatusCodeValue = EFI_SOFTWARE | 0x00040000;
+/// DXE BS Driver software subclass.
 pub const EFI_SOFTWARE_DXE_BS_DRIVER:        EfiStatusCodeValue = EFI_SOFTWARE | 0x00050000;
+/// DXE RT Driver software subclass.
 pub const EFI_SOFTWARE_DXE_RT_DRIVER:        EfiStatusCodeValue = EFI_SOFTWARE | 0x00060000;
+/// SMM Driver software subclass.
 pub const EFI_SOFTWARE_SMM_DRIVER:           EfiStatusCodeValue = EFI_SOFTWARE | 0x00070000;
+/// EFI Application software subclass.
 pub const EFI_SOFTWARE_EFI_APPLICATION:      EfiStatusCodeValue = EFI_SOFTWARE | 0x00080000;
+/// EFI OS Loader software subclass.
 pub const EFI_SOFTWARE_EFI_OS_LOADER:        EfiStatusCodeValue = EFI_SOFTWARE | 0x00090000;
+/// Runtime software subclass.
 pub const EFI_SOFTWARE_RT:                   EfiStatusCodeValue = EFI_SOFTWARE | 0x000A0000;
+/// Application level software subclass.
 pub const EFI_SOFTWARE_AL:                   EfiStatusCodeValue = EFI_SOFTWARE | 0x000B0000;
+/// EBC Exception software subclass.
 pub const EFI_SOFTWARE_EBC_EXCEPTION:        EfiStatusCodeValue = EFI_SOFTWARE | 0x000C0000;
+/// IA32 Exception software subclass.
 pub const EFI_SOFTWARE_IA32_EXCEPTION:       EfiStatusCodeValue = EFI_SOFTWARE | 0x000D0000;
+/// IPF Exception software subclass.
 pub const EFI_SOFTWARE_IPF_EXCEPTION:        EfiStatusCodeValue = EFI_SOFTWARE | 0x000E0000;
+/// PEI Service software subclass.
 pub const EFI_SOFTWARE_PEI_SERVICE:          EfiStatusCodeValue = EFI_SOFTWARE | 0x000F0000;
+/// EFI Boot Service software subclass.
 pub const EFI_SOFTWARE_EFI_BOOT_SERVICE:     EfiStatusCodeValue = EFI_SOFTWARE | 0x00100000;
+/// EFI Runtime Service software subclass.
 pub const EFI_SOFTWARE_EFI_RUNTIME_SERVICE:  EfiStatusCodeValue = EFI_SOFTWARE | 0x00110000;
+/// EFI DXE Service software subclass.
 pub const EFI_SOFTWARE_EFI_DXE_SERVICE:      EfiStatusCodeValue = EFI_SOFTWARE | 0x00120000;
+/// X64 Exception software subclass.
 pub const EFI_SOFTWARE_X64_EXCEPTION:        EfiStatusCodeValue = EFI_SOFTWARE | 0x00130000;
+/// ARM Exception software subclass.
 pub const EFI_SOFTWARE_ARM_EXCEPTION:        EfiStatusCodeValue = EFI_SOFTWARE | 0x00140000;
 
 
 // Software Class Progress Code definitions.
 // These are shared by all subclasses.
 //
+/// Software initialize progress code.
 pub const EFI_SW_PC_INIT:                EfiStatusCodeValue = 0x00000000;
+/// Software load progress code.
 pub const EFI_SW_PC_LOAD:                EfiStatusCodeValue = 0x00000001;
+/// Software initialize begin progress code.
 pub const EFI_SW_PC_INIT_BEGIN:          EfiStatusCodeValue = 0x00000002;
+/// Software initialize end progress code.
 pub const EFI_SW_PC_INIT_END:            EfiStatusCodeValue = 0x00000003;
+/// Software authenticate begin progress code.
 pub const EFI_SW_PC_AUTHENTICATE_BEGIN:  EfiStatusCodeValue = 0x00000004;
+/// Software authenticate end progress code.
 pub const EFI_SW_PC_AUTHENTICATE_END:    EfiStatusCodeValue = 0x00000005;
+/// Software input wait progress code.
 pub const EFI_SW_PC_INPUT_WAIT:          EfiStatusCodeValue = 0x00000006;
+/// Software user setup progress code.
 pub const EFI_SW_PC_USER_SETUP:          EfiStatusCodeValue = 0x00000007;
 
 // Software Class Unspecified Subclass Progress Code definitions.
@@ -551,46 +761,75 @@ pub const EFI_SW_PC_USER_SETUP:          EfiStatusCodeValue = 0x00000007;
 
 // Software Class SEC Subclass Progress Code definitions.
 //
+/// SEC entry point progress code.
 pub const EFI_SW_SEC_PC_ENTRY_POINT:      EfiStatusCodeValue = EFI_SUBCLASS_SPECIFIC;
+/// SEC handoff to next progress code.
 pub const EFI_SW_SEC_PC_HANDOFF_TO_NEXT:  EfiStatusCodeValue = EFI_SUBCLASS_SPECIFIC | 0x00000001;
 
 // Software Class PEI Core Subclass Progress Code definitions.
 //
+/// PEI Core entry point progress code.
 pub const EFI_SW_PEI_CORE_PC_ENTRY_POINT:      EfiStatusCodeValue = EFI_SUBCLASS_SPECIFIC;
+/// PEI Core handoff to next progress code.
 pub const EFI_SW_PEI_CORE_PC_HANDOFF_TO_NEXT:  EfiStatusCodeValue = EFI_SUBCLASS_SPECIFIC | 0x00000001;
+/// PEI Core return to last progress code.
 pub const EFI_SW_PEI_CORE_PC_RETURN_TO_LAST:   EfiStatusCodeValue = EFI_SUBCLASS_SPECIFIC | 0x00000002;
 
 // Software Class PEI Module Subclass Progress Code definitions.
 //
+/// PEI recovery begin progress code.
 pub const EFI_SW_PEI_PC_RECOVERY_BEGIN:  EfiStatusCodeValue = EFI_SUBCLASS_SPECIFIC;
+/// PEI capsule load progress code.
 pub const EFI_SW_PEI_PC_CAPSULE_LOAD:    EfiStatusCodeValue = EFI_SUBCLASS_SPECIFIC | 0x00000001;
+/// PEI capsule start progress code.
 pub const EFI_SW_PEI_PC_CAPSULE_START:   EfiStatusCodeValue = EFI_SUBCLASS_SPECIFIC | 0x00000002;
+/// PEI recovery user progress code.
 pub const EFI_SW_PEI_PC_RECOVERY_USER:   EfiStatusCodeValue = EFI_SUBCLASS_SPECIFIC | 0x00000003;
+/// PEI recovery auto progress code.
 pub const EFI_SW_PEI_PC_RECOVERY_AUTO:   EfiStatusCodeValue = EFI_SUBCLASS_SPECIFIC | 0x00000004;
+/// PEI S3 boot script progress code.
 pub const EFI_SW_PEI_PC_S3_BOOT_SCRIPT:  EfiStatusCodeValue = EFI_SUBCLASS_SPECIFIC | 0x00000005;
+/// PEI OS wake progress code.
 pub const EFI_SW_PEI_PC_OS_WAKE:         EfiStatusCodeValue = EFI_SUBCLASS_SPECIFIC | 0x00000006;
+/// PEI S3 started progress code.
 pub const EFI_SW_PEI_PC_S3_STARTED:      EfiStatusCodeValue = EFI_SUBCLASS_SPECIFIC | 0x00000007;
 
 // Software Class DXE Core Subclass Progress Code definitions.
 //
+/// DXE Core entry point progress code.
 pub const EFI_SW_DXE_CORE_PC_ENTRY_POINT:      EfiStatusCodeValue = EFI_SUBCLASS_SPECIFIC;
+/// DXE Core handoff to next progress code.
 pub const EFI_SW_DXE_CORE_PC_HANDOFF_TO_NEXT:  EfiStatusCodeValue = EFI_SUBCLASS_SPECIFIC | 0x00000001;
+/// DXE Core return to last progress code.
 pub const EFI_SW_DXE_CORE_PC_RETURN_TO_LAST:   EfiStatusCodeValue = EFI_SUBCLASS_SPECIFIC | 0x00000002;
+/// DXE Core start driver progress code.
 pub const EFI_SW_DXE_CORE_PC_START_DRIVER:     EfiStatusCodeValue = EFI_SUBCLASS_SPECIFIC | 0x00000003;
+/// DXE Core architecture ready progress code.
 pub const EFI_SW_DXE_CORE_PC_ARCH_READY:       EfiStatusCodeValue = EFI_SUBCLASS_SPECIFIC | 0x00000004;
 
 // Software Class DXE BS Driver Subclass Progress Code definitions.
 //
+/// DXE BS legacy option ROM init progress code.
 pub const EFI_SW_DXE_BS_PC_LEGACY_OPROM_INIT:             EfiStatusCodeValue = EFI_SUBCLASS_SPECIFIC;
+/// DXE BS ready to boot event progress code.
 pub const EFI_SW_DXE_BS_PC_READY_TO_BOOT_EVENT:           EfiStatusCodeValue = EFI_SUBCLASS_SPECIFIC | 0x00000001;
+/// DXE BS legacy boot event progress code.
 pub const EFI_SW_DXE_BS_PC_LEGACY_BOOT_EVENT:             EfiStatusCodeValue = EFI_SUBCLASS_SPECIFIC | 0x00000002;
+/// DXE BS exit boot services event progress code.
 pub const EFI_SW_DXE_BS_PC_EXIT_BOOT_SERVICES_EVENT:      EfiStatusCodeValue = EFI_SUBCLASS_SPECIFIC | 0x00000003;
+/// DXE BS virtual address change event progress code.
 pub const EFI_SW_DXE_BS_PC_VIRTUAL_ADDRESS_CHANGE_EVENT:  EfiStatusCodeValue = EFI_SUBCLASS_SPECIFIC | 0x00000004;
+/// DXE BS variable services init progress code.
 pub const EFI_SW_DXE_BS_PC_VARIABLE_SERVICES_INIT:        EfiStatusCodeValue = EFI_SUBCLASS_SPECIFIC | 0x00000005;
+/// DXE BS variable reclaim progress code.
 pub const EFI_SW_DXE_BS_PC_VARIABLE_RECLAIM:              EfiStatusCodeValue = EFI_SUBCLASS_SPECIFIC | 0x00000006;
+/// DXE BS attempt boot order event progress code.
 pub const EFI_SW_DXE_BS_PC_ATTEMPT_BOOT_ORDER_EVENT:      EfiStatusCodeValue = EFI_SUBCLASS_SPECIFIC | 0x00000007;
+/// DXE BS config reset progress code.
 pub const EFI_SW_DXE_BS_PC_CONFIG_RESET:                  EfiStatusCodeValue = EFI_SUBCLASS_SPECIFIC | 0x00000008;
+/// DXE BS CSM init progress code.
 pub const EFI_SW_DXE_BS_PC_CSM_INIT:                      EfiStatusCodeValue = EFI_SUBCLASS_SPECIFIC | 0x00000009;
+/// DXE BS boot option complete progress code.
 pub const EFI_SW_DXE_BS_PC_BOOT_OPTION_COMPLETE:          EfiStatusCodeValue = EFI_SUBCLASS_SPECIFIC | 0x0000000A;   // MU_CHANGE
 
 // Software Class SMM Driver Subclass Progress Code definitions.
@@ -604,8 +843,11 @@ pub const EFI_SW_DXE_BS_PC_BOOT_OPTION_COMPLETE:          EfiStatusCodeValue = E
 
 // Software Class EFI RT Subclass Progress Code definitions.
 //
+/// Runtime entry point progress code.
 pub const EFI_SW_RT_PC_ENTRY_POINT:      EfiStatusCodeValue = EFI_SUBCLASS_SPECIFIC;
+/// Runtime handoff to next progress code.
 pub const EFI_SW_RT_PC_HANDOFF_TO_NEXT:  EfiStatusCodeValue = EFI_SUBCLASS_SPECIFIC | 0x00000001;
+/// Runtime return to last progress code.
 pub const EFI_SW_RT_PC_RETURN_TO_LAST:   EfiStatusCodeValue = EFI_SUBCLASS_SPECIFIC | 0x00000002;
 
 // Software Class X64 Exception Subclass Progress Code definitions.
@@ -628,134 +870,250 @@ pub const EFI_SW_RT_PC_RETURN_TO_LAST:   EfiStatusCodeValue = EFI_SUBCLASS_SPECI
 
 // Software Class PEI Services Subclass Progress Code definitions.
 //
+/// PEI Services install PPI progress code.
 pub const EFI_SW_PS_PC_INSTALL_PPI:              EfiStatusCodeValue = EFI_SUBCLASS_SPECIFIC;
+/// PEI Services reinstall PPI progress code.
 pub const EFI_SW_PS_PC_REINSTALL_PPI:            EfiStatusCodeValue = EFI_SUBCLASS_SPECIFIC | 0x00000001;
+/// PEI Services locate PPI progress code.
 pub const EFI_SW_PS_PC_LOCATE_PPI:               EfiStatusCodeValue = EFI_SUBCLASS_SPECIFIC | 0x00000002;
+/// PEI Services notify PPI progress code.
 pub const EFI_SW_PS_PC_NOTIFY_PPI:               EfiStatusCodeValue = EFI_SUBCLASS_SPECIFIC | 0x00000003;
+/// PEI Services get boot mode progress code.
 pub const EFI_SW_PS_PC_GET_BOOT_MODE:            EfiStatusCodeValue = EFI_SUBCLASS_SPECIFIC | 0x00000004;
+/// PEI Services set boot mode progress code.
 pub const EFI_SW_PS_PC_SET_BOOT_MODE:            EfiStatusCodeValue = EFI_SUBCLASS_SPECIFIC | 0x00000005;
+/// PEI Services get HOB list progress code.
 pub const EFI_SW_PS_PC_GET_HOB_LIST:             EfiStatusCodeValue = EFI_SUBCLASS_SPECIFIC | 0x00000006;
+/// PEI Services create HOB progress code.
 pub const EFI_SW_PS_PC_CREATE_HOB:               EfiStatusCodeValue = EFI_SUBCLASS_SPECIFIC | 0x00000007;
+/// PEI Services FFS find next volume progress code.
 pub const EFI_SW_PS_PC_FFS_FIND_NEXT_VOLUME:     EfiStatusCodeValue = EFI_SUBCLASS_SPECIFIC | 0x00000008;
+/// PEI Services FFS find next file progress code.
 pub const EFI_SW_PS_PC_FFS_FIND_NEXT_FILE:       EfiStatusCodeValue = EFI_SUBCLASS_SPECIFIC | 0x00000009;
+/// PEI Services FFS find section data progress code.
 pub const EFI_SW_PS_PC_FFS_FIND_SECTION_DATA:    EfiStatusCodeValue = EFI_SUBCLASS_SPECIFIC | 0x0000000A;
+/// PEI Services install PEI memory progress code.
 pub const EFI_SW_PS_PC_INSTALL_PEI_MEMORY:       EfiStatusCodeValue = EFI_SUBCLASS_SPECIFIC | 0x0000000B;
+/// PEI Services allocate pages progress code.
 pub const EFI_SW_PS_PC_ALLOCATE_PAGES:           EfiStatusCodeValue = EFI_SUBCLASS_SPECIFIC | 0x0000000C;
+/// PEI Services allocate pool progress code.
 pub const EFI_SW_PS_PC_ALLOCATE_POOL:            EfiStatusCodeValue = EFI_SUBCLASS_SPECIFIC | 0x0000000D;
+/// PEI Services copy memory progress code.
 pub const EFI_SW_PS_PC_COPY_MEM:                 EfiStatusCodeValue = EFI_SUBCLASS_SPECIFIC | 0x0000000E;
+/// PEI Services set memory progress code.
 pub const EFI_SW_PS_PC_SET_MEM:                  EfiStatusCodeValue = EFI_SUBCLASS_SPECIFIC | 0x0000000F;
+/// PEI Services reset system progress code.
 pub const EFI_SW_PS_PC_RESET_SYSTEM:             EfiStatusCodeValue = EFI_SUBCLASS_SPECIFIC | 0x00000010;
+/// PEI Services FFS find file by name progress code.
 pub const EFI_SW_PS_PC_FFS_FIND_FILE_BY_NAME:    EfiStatusCodeValue = EFI_SUBCLASS_SPECIFIC | 0x00000013;
+/// PEI Services FFS get file info progress code.
 pub const EFI_SW_PS_PC_FFS_GET_FILE_INFO:        EfiStatusCodeValue = EFI_SUBCLASS_SPECIFIC | 0x00000014;
+/// PEI Services FFS get volume info progress code.
 pub const EFI_SW_PS_PC_FFS_GET_VOLUME_INFO:      EfiStatusCodeValue = EFI_SUBCLASS_SPECIFIC | 0x00000015;
+/// PEI Services FFS register for shadow progress code.
 pub const EFI_SW_PS_PC_FFS_REGISTER_FOR_SHADOW:  EfiStatusCodeValue = EFI_SUBCLASS_SPECIFIC | 0x00000016;
 
 // Software Class EFI Boot Services Subclass Progress Code definitions.
 //
+/// Boot Services RaiseTPL progress code.
 pub const EFI_SW_BS_PC_RAISE_TPL:                      EfiStatusCodeValue = EFI_SUBCLASS_SPECIFIC;
+/// Boot Services RestoreTPL progress code.
 pub const EFI_SW_BS_PC_RESTORE_TPL:                    EfiStatusCodeValue = EFI_SUBCLASS_SPECIFIC | 0x00000001;
+/// Boot Services AllocatePages progress code.
 pub const EFI_SW_BS_PC_ALLOCATE_PAGES:                 EfiStatusCodeValue = EFI_SUBCLASS_SPECIFIC | 0x00000002;
+/// Boot Services FreePages progress code.
 pub const EFI_SW_BS_PC_FREE_PAGES:                     EfiStatusCodeValue = EFI_SUBCLASS_SPECIFIC | 0x00000003;
+/// Boot Services GetMemoryMap progress code.
 pub const EFI_SW_BS_PC_GET_MEMORY_MAP:                 EfiStatusCodeValue = EFI_SUBCLASS_SPECIFIC | 0x00000004;
+/// Boot Services AllocatePool progress code.
 pub const EFI_SW_BS_PC_ALLOCATE_POOL:                  EfiStatusCodeValue = EFI_SUBCLASS_SPECIFIC | 0x00000005;
+/// Boot Services FreePool progress code.
 pub const EFI_SW_BS_PC_FREE_POOL:                      EfiStatusCodeValue = EFI_SUBCLASS_SPECIFIC | 0x00000006;
+/// Boot Services CreateEvent progress code.
 pub const EFI_SW_BS_PC_CREATE_EVENT:                   EfiStatusCodeValue = EFI_SUBCLASS_SPECIFIC | 0x00000007;
+/// Boot Services SetTimer progress code.
 pub const EFI_SW_BS_PC_SET_TIMER:                      EfiStatusCodeValue = EFI_SUBCLASS_SPECIFIC | 0x00000008;
+/// Boot Services WaitForEvent progress code.
 pub const EFI_SW_BS_PC_WAIT_FOR_EVENT:                 EfiStatusCodeValue = EFI_SUBCLASS_SPECIFIC | 0x00000009;
+/// Boot Services SignalEvent progress code.
 pub const EFI_SW_BS_PC_SIGNAL_EVENT:                   EfiStatusCodeValue = EFI_SUBCLASS_SPECIFIC | 0x0000000A;
+/// Boot Services CloseEvent progress code.
 pub const EFI_SW_BS_PC_CLOSE_EVENT:                    EfiStatusCodeValue = EFI_SUBCLASS_SPECIFIC | 0x0000000B;
+/// Boot Services CheckEvent progress code.
 pub const EFI_SW_BS_PC_CHECK_EVENT:                    EfiStatusCodeValue = EFI_SUBCLASS_SPECIFIC | 0x0000000C;
+/// Boot Services InstallProtocolInterface progress code.
 pub const EFI_SW_BS_PC_INSTALL_PROTOCOL_INTERFACE:     EfiStatusCodeValue = EFI_SUBCLASS_SPECIFIC | 0x0000000D;
+/// Boot Services ReinstallProtocolInterface progress code.
 pub const EFI_SW_BS_PC_REINSTALL_PROTOCOL_INTERFACE:   EfiStatusCodeValue = EFI_SUBCLASS_SPECIFIC | 0x0000000E;
+/// Boot Services UninstallProtocolInterface progress code.
 pub const EFI_SW_BS_PC_UNINSTALL_PROTOCOL_INTERFACE:   EfiStatusCodeValue = EFI_SUBCLASS_SPECIFIC | 0x0000000F;
+/// Boot Services HandleProtocol progress code.
 pub const EFI_SW_BS_PC_HANDLE_PROTOCOL:                EfiStatusCodeValue = EFI_SUBCLASS_SPECIFIC | 0x00000010;
+/// Boot Services PCHandleProtocol progress code.
 pub const EFI_SW_BS_PC_PC_HANDLE_PROTOCOL:             EfiStatusCodeValue = EFI_SUBCLASS_SPECIFIC | 0x00000011;
+/// Boot Services HandleProtocol progress code.
 pub const EFI_SW_BS_PC_REGISTER_PROTOCOL_NOTIFY:       EfiStatusCodeValue = EFI_SUBCLASS_SPECIFIC | 0x00000012;
+/// Boot Services LocateHandle progress code.
 pub const EFI_SW_BS_PC_LOCATE_HANDLE:                  EfiStatusCodeValue = EFI_SUBCLASS_SPECIFIC | 0x00000013;
+/// Boot Services InstallConfigurationTable progress code.
 pub const EFI_SW_BS_PC_INSTALL_CONFIGURATION_TABLE:    EfiStatusCodeValue = EFI_SUBCLASS_SPECIFIC | 0x00000014;
+/// Boot Services LoadImage progress code.
 pub const EFI_SW_BS_PC_LOAD_IMAGE:                     EfiStatusCodeValue = EFI_SUBCLASS_SPECIFIC | 0x00000015;
+/// Boot Services StartImage progress code.
 pub const EFI_SW_BS_PC_START_IMAGE:                    EfiStatusCodeValue = EFI_SUBCLASS_SPECIFIC | 0x00000016;
+/// Boot Services Exit progress code.
 pub const EFI_SW_BS_PC_EXIT:                           EfiStatusCodeValue = EFI_SUBCLASS_SPECIFIC | 0x00000017;
+/// Boot Services UnloadImage progress code.
 pub const EFI_SW_BS_PC_UNLOAD_IMAGE:                   EfiStatusCodeValue = EFI_SUBCLASS_SPECIFIC | 0x00000018;
+/// Boot Services ExitBootServices progress code.
 pub const EFI_SW_BS_PC_EXIT_BOOT_SERVICES:             EfiStatusCodeValue = EFI_SUBCLASS_SPECIFIC | 0x00000019;
+/// Boot Services GetNextMonotonicCount progress code.
 pub const EFI_SW_BS_PC_GET_NEXT_MONOTONIC_COUNT:       EfiStatusCodeValue = EFI_SUBCLASS_SPECIFIC | 0x0000001A;
+/// Boot Services Stall progress code.
 pub const EFI_SW_BS_PC_STALL:                          EfiStatusCodeValue = EFI_SUBCLASS_SPECIFIC | 0x0000001B;
+/// Boot Services SetWatchdogTimer progress code.
 pub const EFI_SW_BS_PC_SET_WATCHDOG_TIMER:             EfiStatusCodeValue = EFI_SUBCLASS_SPECIFIC | 0x0000001C;
+/// Boot Services ConnectController progress code.
 pub const EFI_SW_BS_PC_CONNECT_CONTROLLER:             EfiStatusCodeValue = EFI_SUBCLASS_SPECIFIC | 0x0000001D;
+/// Boot Services DisconnectController progress code.
 pub const EFI_SW_BS_PC_DISCONNECT_CONTROLLER:          EfiStatusCodeValue = EFI_SUBCLASS_SPECIFIC | 0x0000001E;
+/// Boot Services OpenProtocol progress code.
 pub const EFI_SW_BS_PC_OPEN_PROTOCOL:                  EfiStatusCodeValue = EFI_SUBCLASS_SPECIFIC | 0x0000001F;
+/// Boot Services CloseProtocol progress code.
 pub const EFI_SW_BS_PC_CLOSE_PROTOCOL:                 EfiStatusCodeValue = EFI_SUBCLASS_SPECIFIC | 0x00000020;
+/// Boot Services OpenProtocolInformation progress code.
 pub const EFI_SW_BS_PC_OPEN_PROTOCOL_INFORMATION:      EfiStatusCodeValue = EFI_SUBCLASS_SPECIFIC | 0x00000021;
+/// Boot Services ProtocolsPerHandle progress code.
 pub const EFI_SW_BS_PC_PROTOCOLS_PER_HANDLE:           EfiStatusCodeValue = EFI_SUBCLASS_SPECIFIC | 0x00000022;
+/// Boot Services LocateHandleBuffer progress code.
 pub const EFI_SW_BS_PC_LOCATE_HANDLE_BUFFER:           EfiStatusCodeValue = EFI_SUBCLASS_SPECIFIC | 0x00000023;
+/// Boot Services LocateProtocol progress code.
 pub const EFI_SW_BS_PC_LOCATE_PROTOCOL:                EfiStatusCodeValue = EFI_SUBCLASS_SPECIFIC | 0x00000024;
+/// Boot Services InstallMultipleProtocolInterfaces progress code.
 pub const EFI_SW_BS_PC_INSTALL_MULTIPLE_INTERFACES:    EfiStatusCodeValue = EFI_SUBCLASS_SPECIFIC | 0x00000025;
+/// Boot Services UninstallMultipleProtocolInterfaces progress code.
 pub const EFI_SW_BS_PC_UNINSTALL_MULTIPLE_INTERFACES:  EfiStatusCodeValue = EFI_SUBCLASS_SPECIFIC | 0x00000026;
+/// Boot Services CalculateCrc32 progress code.
 pub const EFI_SW_BS_PC_CALCULATE_CRC_32:               EfiStatusCodeValue = EFI_SUBCLASS_SPECIFIC | 0x00000027;
+/// Boot Services CopyMem progress code.
 pub const EFI_SW_BS_PC_COPY_MEM:                       EfiStatusCodeValue = EFI_SUBCLASS_SPECIFIC | 0x00000028;
+/// Boot Services SetMem progress code.
 pub const EFI_SW_BS_PC_SET_MEM:                        EfiStatusCodeValue = EFI_SUBCLASS_SPECIFIC | 0x00000029;
+/// Boot Services CreateEventEx progress code.
 pub const EFI_SW_BS_PC_CREATE_EVENT_EX:                EfiStatusCodeValue = EFI_SUBCLASS_SPECIFIC | 0x0000002A;
 
 // Software Class EFI Runtime Services Subclass Progress Code definitions.
 //
+/// Runtime Services GetTime progress code.
 pub const EFI_SW_RS_PC_GET_TIME:                       EfiStatusCodeValue = EFI_SUBCLASS_SPECIFIC;
+/// Runtime Services SetTime progress code.
 pub const EFI_SW_RS_PC_SET_TIME:                       EfiStatusCodeValue = EFI_SUBCLASS_SPECIFIC | 0x00000001;
+/// Runtime Services GetWakeupTime progress code.
 pub const EFI_SW_RS_PC_GET_WAKEUP_TIME:                EfiStatusCodeValue = EFI_SUBCLASS_SPECIFIC | 0x00000002;
+/// Runtime Services SetWakeupTime progress code.
 pub const EFI_SW_RS_PC_SET_WAKEUP_TIME:                EfiStatusCodeValue = EFI_SUBCLASS_SPECIFIC | 0x00000003;
+/// Runtime Services SetVirtualAddressMap progress code.
 pub const EFI_SW_RS_PC_SET_VIRTUAL_ADDRESS_MAP:        EfiStatusCodeValue = EFI_SUBCLASS_SPECIFIC | 0x00000004;
+/// Runtime Services ConvertPointer progress code.
 pub const EFI_SW_RS_PC_CONVERT_POINTER:                EfiStatusCodeValue = EFI_SUBCLASS_SPECIFIC | 0x00000005;
+/// Runtime Services GetVariable progress code.
 pub const EFI_SW_RS_PC_GET_VARIABLE:                   EfiStatusCodeValue = EFI_SUBCLASS_SPECIFIC | 0x00000006;
+/// Runtime Services GetNextVariableName progress code.
 pub const EFI_SW_RS_PC_GET_NEXT_VARIABLE_NAME:         EfiStatusCodeValue = EFI_SUBCLASS_SPECIFIC | 0x00000007;
+/// Runtime Services SetVariable progress code.
 pub const EFI_SW_RS_PC_SET_VARIABLE:                   EfiStatusCodeValue = EFI_SUBCLASS_SPECIFIC | 0x00000008;
+/// Runtime Services GetNextHighMonotonicCount progress code.
 pub const EFI_SW_RS_PC_GET_NEXT_HIGH_MONOTONIC_COUNT:  EfiStatusCodeValue = EFI_SUBCLASS_SPECIFIC | 0x00000009;
+/// Runtime Services ResetSystem progress code.
 pub const EFI_SW_RS_PC_RESET_SYSTEM:                   EfiStatusCodeValue = EFI_SUBCLASS_SPECIFIC | 0x0000000A;
+/// Runtime Services UpdateCapsule progress code.
 pub const EFI_SW_RS_PC_UPDATE_CAPSULE:                 EfiStatusCodeValue = EFI_SUBCLASS_SPECIFIC | 0x0000000B;
+/// Runtime Services QueryCapsuleCapabilities progress code.
 pub const EFI_SW_RS_PC_QUERY_CAPSULE_CAPABILITIES:     EfiStatusCodeValue = EFI_SUBCLASS_SPECIFIC | 0x0000000C;
+/// Runtime Services QueryVariableInfo progress code.
 pub const EFI_SW_RS_PC_QUERY_VARIABLE_INFO:            EfiStatusCodeValue = EFI_SUBCLASS_SPECIFIC | 0x0000000D;
 
 // Software Class EFI DXE Services Subclass Progress Code definitions
 //
+/// DXE Services AddMemorySpace progress code.
 pub const EFI_SW_DS_PC_ADD_MEMORY_SPACE:             EfiStatusCodeValue = EFI_SUBCLASS_SPECIFIC;
+/// DXE Services AllocateMemorySpace progress code.
 pub const EFI_SW_DS_PC_ALLOCATE_MEMORY_SPACE:        EfiStatusCodeValue = EFI_SUBCLASS_SPECIFIC | 0x00000001;
+/// DXE Services FreeMemorySpace progress code.
 pub const EFI_SW_DS_PC_FREE_MEMORY_SPACE:            EfiStatusCodeValue = EFI_SUBCLASS_SPECIFIC | 0x00000002;
+/// DXE Services RemoveMemorySpace progress code.
 pub const EFI_SW_DS_PC_REMOVE_MEMORY_SPACE:          EfiStatusCodeValue = EFI_SUBCLASS_SPECIFIC | 0x00000003;
+/// DXE Services GetMemorySpaceDescriptor progress code.
 pub const EFI_SW_DS_PC_GET_MEMORY_SPACE_DESCRIPTOR:  EfiStatusCodeValue = EFI_SUBCLASS_SPECIFIC | 0x00000004;
+/// DXE Services SetMemorySpaceAttributes progress code.
 pub const EFI_SW_DS_PC_SET_MEMORY_SPACE_ATTRIBUTES:  EfiStatusCodeValue = EFI_SUBCLASS_SPECIFIC | 0x00000005;
+/// DXE Services GetMemorySpaceMap progress code.
 pub const EFI_SW_DS_PC_GET_MEMORY_SPACE_MAP:         EfiStatusCodeValue = EFI_SUBCLASS_SPECIFIC | 0x00000006;
+/// DXE Services AddIoSpace progress code.
 pub const EFI_SW_DS_PC_ADD_IO_SPACE:                 EfiStatusCodeValue = EFI_SUBCLASS_SPECIFIC | 0x00000007;
+/// DXE Services AllocateIoSpace progress code.
 pub const EFI_SW_DS_PC_ALLOCATE_IO_SPACE:            EfiStatusCodeValue = EFI_SUBCLASS_SPECIFIC | 0x00000008;
+/// DXE Services FreeIoSpace progress code.
 pub const EFI_SW_DS_PC_FREE_IO_SPACE:                EfiStatusCodeValue = EFI_SUBCLASS_SPECIFIC | 0x00000009;
+/// DXE Services RemoveIoSpace progress code.
 pub const EFI_SW_DS_PC_REMOVE_IO_SPACE:              EfiStatusCodeValue = EFI_SUBCLASS_SPECIFIC | 0x0000000A;
+/// DXE Services GetIoSpaceDescriptor progress code.
 pub const EFI_SW_DS_PC_GET_IO_SPACE_DESCRIPTOR:      EfiStatusCodeValue = EFI_SUBCLASS_SPECIFIC | 0x0000000B;
+/// DXE Services GetIoSpaceMap progress code.
 pub const EFI_SW_DS_PC_GET_IO_SPACE_MAP:             EfiStatusCodeValue = EFI_SUBCLASS_SPECIFIC | 0x0000000C;
+/// DXE Services Dispatch progress code.
 pub const EFI_SW_DS_PC_DISPATCH:                     EfiStatusCodeValue = EFI_SUBCLASS_SPECIFIC | 0x0000000D;
+/// DXE Services Schedule progress code.
 pub const EFI_SW_DS_PC_SCHEDULE:                     EfiStatusCodeValue = EFI_SUBCLASS_SPECIFIC | 0x0000000E;
+/// DXE Services Trust progress code.
 pub const EFI_SW_DS_PC_TRUST:                        EfiStatusCodeValue = EFI_SUBCLASS_SPECIFIC | 0x0000000F;
+/// DXE Services ProcessFirmwareVolume progress code.
 pub const EFI_SW_DS_PC_PROCESS_FIRMWARE_VOLUME:      EfiStatusCodeValue = EFI_SUBCLASS_SPECIFIC | 0x00000010;
 
 // Software Class Error Code definitions.
 // These are shared by all subclasses.
 //
+/// Non-specific software error.
 pub const EFI_SW_EC_NON_SPECIFIC:                    EfiStatusCodeValue = 0x00000000;
+/// Load error.
 pub const EFI_SW_EC_LOAD_ERROR:                      EfiStatusCodeValue = 0x00000001;
+/// Invalid parameter error.
 pub const EFI_SW_EC_INVALID_PARAMETER:               EfiStatusCodeValue = 0x00000002;
+/// Unsupported operation error.
 pub const EFI_SW_EC_UNSUPPORTED:                     EfiStatusCodeValue = 0x00000003;
+/// Invalid buffer error.
 pub const EFI_SW_EC_INVALID_BUFFER:                  EfiStatusCodeValue = 0x00000004;
+/// Out of resources error.
 pub const EFI_SW_EC_OUT_OF_RESOURCES:                EfiStatusCodeValue = 0x00000005;
+/// Operation aborted error.
 pub const EFI_SW_EC_ABORTED:                         EfiStatusCodeValue = 0x00000006;
+/// Illegal software state error.
 pub const EFI_SW_EC_ILLEGAL_SOFTWARE_STATE:          EfiStatusCodeValue = 0x00000007;
+/// Illegal hardware state error.
 pub const EFI_SW_EC_ILLEGAL_HARDWARE_STATE:          EfiStatusCodeValue = 0x00000008;
+/// Start error.
 pub const EFI_SW_EC_START_ERROR:                     EfiStatusCodeValue = 0x00000009;
+/// Bad date/time error.
 pub const EFI_SW_EC_BAD_DATE_TIME:                   EfiStatusCodeValue = 0x0000000A;
+/// Invalid configuration error.
 pub const EFI_SW_EC_CFG_INVALID:                     EfiStatusCodeValue = 0x0000000B;
+/// Configuration clear request.
 pub const EFI_SW_EC_CFG_CLR_REQUEST:                 EfiStatusCodeValue = 0x0000000C;
+/// Default configuration.
 pub const EFI_SW_EC_CFG_DEFAULT:                     EfiStatusCodeValue = 0x0000000D;
+/// Invalid password error.
 pub const EFI_SW_EC_PWD_INVALID:                     EfiStatusCodeValue = 0x0000000E;
+/// Password clear request.
 pub const EFI_SW_EC_PWD_CLR_REQUEST:                 EfiStatusCodeValue = 0x0000000F;
+/// Password cleared.
 pub const EFI_SW_EC_PWD_CLEARED:                     EfiStatusCodeValue = 0x00000010;
+/// Event log full error.
 pub const EFI_SW_EC_EVENT_LOG_FULL:                  EfiStatusCodeValue = 0x00000011;
+/// Write protected error.
 pub const EFI_SW_EC_WRITE_PROTECTED:                 EfiStatusCodeValue = 0x00000012;
+/// Firmware volume corrupted error.
 pub const EFI_SW_EC_FV_CORRUPTED:                    EfiStatusCodeValue = 0x00000013;
+/// Inconsistent memory map error.
 pub const EFI_SW_EC_INCONSISTENT_MEMORY_MAP:         EfiStatusCodeValue = 0x00000014;
 
 // Software Class Unspecified Subclass Error Code definitions.
@@ -766,34 +1124,54 @@ pub const EFI_SW_EC_INCONSISTENT_MEMORY_MAP:         EfiStatusCodeValue = 0x0000
 
 // Software Class PEI Core Subclass Error Code definitions.
 //
+/// DXE image corrupted error.
 pub const EFI_SW_PEI_CORE_EC_DXE_CORRUPT:           EfiStatusCodeValue = EFI_SUBCLASS_SPECIFIC;
+/// DXE IPL not found error.
 pub const EFI_SW_PEI_CORE_EC_DXEIPL_NOT_FOUND:      EfiStatusCodeValue = EFI_SUBCLASS_SPECIFIC | 0x00000001;
+/// Memory not installed error.
 pub const EFI_SW_PEI_CORE_EC_MEMORY_NOT_INSTALLED:  EfiStatusCodeValue = EFI_SUBCLASS_SPECIFIC | 0x00000002;
 
 // Software Class PEI Module Subclass Error Code definitions.
 //
+/// No recovery capsule error.
 pub const EFI_SW_PEI_EC_NO_RECOVERY_CAPSULE:         EfiStatusCodeValue = EFI_SUBCLASS_SPECIFIC;
+/// Invalid capsule descriptor error.
 pub const EFI_SW_PEI_EC_INVALID_CAPSULE_DESCRIPTOR:  EfiStatusCodeValue = EFI_SUBCLASS_SPECIFIC | 0x00000001;
+/// S3 Resume PPI not found error.
 pub const EFI_SW_PEI_EC_S3_RESUME_PPI_NOT_FOUND:     EfiStatusCodeValue = EFI_SUBCLASS_SPECIFIC | 0x00000002;
+/// S3 boot script error.
 pub const EFI_SW_PEI_EC_S3_BOOT_SCRIPT_ERROR:        EfiStatusCodeValue = EFI_SUBCLASS_SPECIFIC | 0x00000003;
+/// S3 OS wake error.
 pub const EFI_SW_PEI_EC_S3_OS_WAKE_ERROR:            EfiStatusCodeValue = EFI_SUBCLASS_SPECIFIC | 0x00000004;
+/// S3 resume failed error.
 pub const EFI_SW_PEI_EC_S3_RESUME_FAILED:            EfiStatusCodeValue = EFI_SUBCLASS_SPECIFIC | 0x00000005;
+/// Recovery PPI not found error.
 pub const EFI_SW_PEI_EC_RECOVERY_PPI_NOT_FOUND:      EfiStatusCodeValue = EFI_SUBCLASS_SPECIFIC | 0x00000006;
+/// Recovery failed error.
 pub const EFI_SW_PEI_EC_RECOVERY_FAILED:             EfiStatusCodeValue = EFI_SUBCLASS_SPECIFIC | 0x00000007;
+/// S3 resume error.
 pub const EFI_SW_PEI_EC_S3_RESUME_ERROR:             EfiStatusCodeValue = EFI_SUBCLASS_SPECIFIC | 0x00000008;
+/// Invalid capsule error.
 pub const EFI_SW_PEI_EC_INVALID_CAPSULE:             EfiStatusCodeValue = EFI_SUBCLASS_SPECIFIC | 0x00000009;
 
 // Software Class DXE Foundation Subclass Error Code definitions.
 //
+/// No architecture protocol error.
 pub const EFI_SW_DXE_CORE_EC_NO_ARCH:             EfiStatusCodeValue = EFI_SUBCLASS_SPECIFIC;
+/// Image load failure error.
 pub const EFI_SW_DXE_CORE_EC_IMAGE_LOAD_FAILURE:  EfiStatusCodeValue = EFI_SUBCLASS_SPECIFIC | 0x00000001;    // MU_CHANGE
 
 // Software Class DXE Boot Service Driver Subclass Error Code definitions.
 //
+/// Legacy option ROM no space error.
 pub const EFI_SW_DXE_BS_EC_LEGACY_OPROM_NO_SPACE:   EfiStatusCodeValue = EFI_SUBCLASS_SPECIFIC;
+/// Invalid password error.
 pub const EFI_SW_DXE_BS_EC_INVALID_PASSWORD:        EfiStatusCodeValue = EFI_SUBCLASS_SPECIFIC | 0x00000001;
+/// Boot option load error.
 pub const EFI_SW_DXE_BS_EC_BOOT_OPTION_LOAD_ERROR:  EfiStatusCodeValue = EFI_SUBCLASS_SPECIFIC | 0x00000002;
+/// Boot option failed error.
 pub const EFI_SW_DXE_BS_EC_BOOT_OPTION_FAILED:      EfiStatusCodeValue = EFI_SUBCLASS_SPECIFIC | 0x00000003;
+/// Invalid IDE password error.
 pub const EFI_SW_DXE_BS_EC_INVALID_IDE_PASSWORD:    EfiStatusCodeValue = EFI_SUBCLASS_SPECIFIC | 0x00000004;
 
 // Software Class DXE Runtime Service Driver Subclass Error Code definitions.
@@ -818,60 +1196,102 @@ pub const EFI_SW_DXE_BS_EC_INVALID_IDE_PASSWORD:    EfiStatusCodeValue = EFI_SUB
 // These exceptions are derived from the debug protocol definitions in the EFI
 // specification.
 //
+/// EBC undefined exception.
 pub const EFI_SW_EC_EBC_UNDEFINED:             EfiStatusCodeValue = 0x00000000;
+/// EBC divide error exception.
 pub const EFI_SW_EC_EBC_DIVIDE_ERROR:          EfiStatusCodeValue = debug_support::EXCEPT_EBC_DIVIDE_ERROR as u32;
+/// EBC debug exception.
 pub const EFI_SW_EC_EBC_DEBUG:                 EfiStatusCodeValue = debug_support::EXCEPT_EBC_DEBUG as u32;
+/// EBC breakpoint exception.
 pub const EFI_SW_EC_EBC_BREAKPOINT:            EfiStatusCodeValue = debug_support::EXCEPT_EBC_BREAKPOINT as u32;
+/// EBC overflow exception.
 pub const EFI_SW_EC_EBC_OVERFLOW:              EfiStatusCodeValue = debug_support::EXCEPT_EBC_OVERFLOW as u32;
+/// EBC invalid opcode exception.
 pub const EFI_SW_EC_EBC_INVALID_OPCODE:        EfiStatusCodeValue = debug_support::EXCEPT_EBC_INVALID_OPCODE as u32;
+/// EBC stack fault exception.
 pub const EFI_SW_EC_EBC_STACK_FAULT:           EfiStatusCodeValue = debug_support::EXCEPT_EBC_STACK_FAULT as u32;
+/// EBC alignment check exception.
 pub const EFI_SW_EC_EBC_ALIGNMENT_CHECK:       EfiStatusCodeValue = debug_support::EXCEPT_EBC_ALIGNMENT_CHECK as u32;
+/// EBC instruction encoding exception.
 pub const EFI_SW_EC_EBC_INSTRUCTION_ENCODING:  EfiStatusCodeValue = debug_support::EXCEPT_EBC_INSTRUCTION_ENCODING as u32;
+/// EBC bad break exception.
 pub const EFI_SW_EC_EBC_BAD_BREAK:             EfiStatusCodeValue = debug_support::EXCEPT_EBC_BAD_BREAK as u32;
+/// EBC single step exception.
 pub const EFI_SW_EC_EBC_STEP:                  EfiStatusCodeValue = debug_support::EXCEPT_EBC_SINGLE_STEP as u32;
 
 // Software Class IA32 Exception Subclass Error Code definitions.
 // These exceptions are derived from the debug protocol definitions in the EFI
 // specification.
 //
+/// IA32 divide error exception.
 pub const EFI_SW_EC_IA32_DIVIDE_ERROR:     EfiStatusCodeValue = debug_support::EXCEPT_IA32_DIVIDE_ERROR as u32;
+/// IA32 debug exception.
 pub const EFI_SW_EC_IA32_DEBUG:            EfiStatusCodeValue = debug_support::EXCEPT_IA32_DEBUG as u32;
+/// IA32 NMI exception.
 pub const EFI_SW_EC_IA32_NMI:              EfiStatusCodeValue = debug_support::EXCEPT_IA32_NMI as u32;
+/// IA32 breakpoint exception.
 pub const EFI_SW_EC_IA32_BREAKPOINT:       EfiStatusCodeValue = debug_support::EXCEPT_IA32_BREAKPOINT as u32;
+/// IA32 overflow exception.
 pub const EFI_SW_EC_IA32_OVERFLOW:         EfiStatusCodeValue = debug_support::EXCEPT_IA32_OVERFLOW as u32;
+/// IA32 bound exception.
 pub const EFI_SW_EC_IA32_BOUND:            EfiStatusCodeValue = debug_support::EXCEPT_IA32_BOUND as u32;
+/// IA32 invalid opcode exception.
 pub const EFI_SW_EC_IA32_INVALID_OPCODE:   EfiStatusCodeValue = debug_support::EXCEPT_IA32_INVALID_OPCODE as u32;
+/// IA32 double fault exception.
 pub const EFI_SW_EC_IA32_DOUBLE_FAULT:     EfiStatusCodeValue = debug_support::EXCEPT_IA32_DOUBLE_FAULT as u32;
+/// IA32 invalid TSS exception.
 pub const EFI_SW_EC_IA32_INVALID_TSS:      EfiStatusCodeValue = debug_support::EXCEPT_IA32_INVALID_TSS as u32;
+/// IA32 segment not present exception.
 pub const EFI_SW_EC_IA32_SEG_NOT_PRESENT:  EfiStatusCodeValue = debug_support::EXCEPT_IA32_SEG_NOT_PRESENT as u32;
+/// IA32 stack fault exception.
 pub const EFI_SW_EC_IA32_STACK_FAULT:      EfiStatusCodeValue = debug_support::EXCEPT_IA32_STACK_FAULT as u32;
+/// IA32 general protection fault exception.
 pub const EFI_SW_EC_IA32_GP_FAULT:         EfiStatusCodeValue = debug_support::EXCEPT_IA32_GP_FAULT as u32;
+/// IA32 page fault exception.
 pub const EFI_SW_EC_IA32_PAGE_FAULT:       EfiStatusCodeValue = debug_support::EXCEPT_IA32_PAGE_FAULT as u32;
+/// IA32 floating-point error exception.
 pub const EFI_SW_EC_IA32_FP_ERROR:         EfiStatusCodeValue = debug_support::EXCEPT_IA32_FP_ERROR as u32;
+/// IA32 alignment check exception.
 pub const EFI_SW_EC_IA32_ALIGNMENT_CHECK:  EfiStatusCodeValue = debug_support::EXCEPT_IA32_ALIGNMENT_CHECK as u32;
+/// IA32 machine check exception.
 pub const EFI_SW_EC_IA32_MACHINE_CHECK:    EfiStatusCodeValue = debug_support::EXCEPT_IA32_MACHINE_CHECK as u32;
+/// IA32 SIMD exception.
 pub const EFI_SW_EC_IA32_SIMD:             EfiStatusCodeValue = debug_support::EXCEPT_IA32_SIMD as u32;
 
 // Software Class IPF Exception Subclass Error Code definitions.
 // These exceptions are derived from the debug protocol definitions in the EFI
 // specification.
 //
+/// IPF alternate data TLB exception.
 pub const EFI_SW_EC_IPF_ALT_DTLB:            EfiStatusCodeValue = debug_support::EXCEPT_IPF_ALT_DATA_TLB as u32;
+/// IPF data nested TLB exception.
 pub const EFI_SW_EC_IPF_DNESTED_TLB:         EfiStatusCodeValue = debug_support::EXCEPT_IPF_DATA_NESTED_TLB as u32;
+/// IPF breakpoint exception.
 pub const EFI_SW_EC_IPF_BREAKPOINT:          EfiStatusCodeValue = debug_support::EXCEPT_IPF_BREAKPOINT as u32;
+/// IPF external interrupt exception.
 pub const EFI_SW_EC_IPF_EXTERNAL_INTERRUPT:  EfiStatusCodeValue = debug_support::EXCEPT_IPF_EXTERNAL_INTERRUPT as u32;
+/// IPF general exception.
 pub const EFI_SW_EC_IPF_GEN_EXCEPT:          EfiStatusCodeValue = debug_support::EXCEPT_IPF_GENERAL_EXCEPTION as u32;
+/// IPF NAT consumption exception.
 pub const EFI_SW_EC_IPF_NAT_CONSUMPTION:     EfiStatusCodeValue = debug_support::EXCEPT_IPF_NAT_CONSUMPTION as u32;
+/// IPF debug exception.
 pub const EFI_SW_EC_IPF_DEBUG_EXCEPT:        EfiStatusCodeValue = debug_support::EXCEPT_IPF_DEBUG as u32;
+/// IPF unaligned access exception.
 pub const EFI_SW_EC_IPF_UNALIGNED_ACCESS:    EfiStatusCodeValue = debug_support::EXCEPT_IPF_UNALIGNED_REFERENCE as u32;
+/// IPF floating-point fault exception.
 pub const EFI_SW_EC_IPF_FP_FAULT:            EfiStatusCodeValue = debug_support::EXCEPT_IPF_FP_FAULT as u32;
+/// IPF floating-point trap exception.
 pub const EFI_SW_EC_IPF_FP_TRAP:             EfiStatusCodeValue = debug_support::EXCEPT_IPF_FP_TRAP as u32;
+/// IPF taken branch exception.
 pub const EFI_SW_EC_IPF_TAKEN_BRANCH:        EfiStatusCodeValue = debug_support::EXCEPT_IPF_TAKEN_BRANCH as u32;
+/// IPF single step exception.
 pub const EFI_SW_EC_IPF_SINGLE_STEP:         EfiStatusCodeValue = debug_support::EXCEPT_IPF_SINGLE_STEP as u32;
 
 // Software Class PEI Service Subclass Error Code definitions.
 //
+/// Reset not available error.
 pub const EFI_SW_PS_EC_RESET_NOT_AVAILABLE:     EfiStatusCodeValue = EFI_SUBCLASS_SPECIFIC;
+/// Memory installed twice error.
 pub const EFI_SW_PS_EC_MEMORY_INSTALLED_TWICE:  EfiStatusCodeValue = EFI_SUBCLASS_SPECIFIC | 0x00000001;
 
 // Software Class EFI Boot Service Subclass Error Code definitions.
@@ -882,51 +1302,84 @@ pub const EFI_SW_PS_EC_MEMORY_INSTALLED_TWICE:  EfiStatusCodeValue = EFI_SUBCLAS
 
 // Software Class EFI DXE Service Subclass Error Code definitions.
 //
+/// DXE BS begin connecting drivers progress code.
 pub const EFI_SW_DXE_BS_PC_BEGIN_CONNECTING_DRIVERS:  EfiStatusCodeValue = EFI_SUBCLASS_SPECIFIC | 0x00000005;
+/// DXE BS verifying password progress code.
 pub const EFI_SW_DXE_BS_PC_VERIFYING_PASSWORD:        EfiStatusCodeValue = EFI_SUBCLASS_SPECIFIC | 0x00000006;
 
 // Software Class DXE RT Driver Subclass Progress Code definitions.
 //
+/// ACPI S0 sleep state progress code.
 pub const EFI_SW_DXE_RT_PC_S0:  EfiStatusCodeValue = EFI_SUBCLASS_SPECIFIC;
+/// ACPI S1 sleep state progress code.
 pub const EFI_SW_DXE_RT_PC_S1:  EfiStatusCodeValue = EFI_SUBCLASS_SPECIFIC | 0x00000001;
+/// ACPI S2 sleep state progress code.
 pub const EFI_SW_DXE_RT_PC_S2:  EfiStatusCodeValue = EFI_SUBCLASS_SPECIFIC | 0x00000002;
+/// ACPI S3 sleep state progress code.
 pub const EFI_SW_DXE_RT_PC_S3:  EfiStatusCodeValue = EFI_SUBCLASS_SPECIFIC | 0x00000003;
+/// ACPI S4 sleep state progress code.
 pub const EFI_SW_DXE_RT_PC_S4:  EfiStatusCodeValue = EFI_SUBCLASS_SPECIFIC | 0x00000004;
+/// ACPI S5 sleep state progress code.
 pub const EFI_SW_DXE_RT_PC_S5:  EfiStatusCodeValue = EFI_SUBCLASS_SPECIFIC | 0x00000005;
 
 // Software Class X64 Exception Subclass Error Code definitions.
 // These exceptions are derived from the debug protocol
 // definitions in the EFI specification.
 //
+/// X64 divide error exception.
 pub const EFI_SW_EC_X64_DIVIDE_ERROR:     EfiStatusCodeValue = debug_support::EXCEPT_X64_DIVIDE_ERROR as u32;
+/// X64 debug exception.
 pub const EFI_SW_EC_X64_DEBUG:            EfiStatusCodeValue = debug_support::EXCEPT_X64_DEBUG as u32;
+/// X64 NMI exception.
 pub const EFI_SW_EC_X64_NMI:              EfiStatusCodeValue = debug_support::EXCEPT_X64_NMI as u32;
+/// X64 breakpoint exception.
 pub const EFI_SW_EC_X64_BREAKPOINT:       EfiStatusCodeValue = debug_support::EXCEPT_X64_BREAKPOINT as u32;
+/// X64 overflow exception.
 pub const EFI_SW_EC_X64_OVERFLOW:         EfiStatusCodeValue = debug_support::EXCEPT_X64_OVERFLOW as u32;
+/// X64 bound exception.
 pub const EFI_SW_EC_X64_BOUND:            EfiStatusCodeValue = debug_support::EXCEPT_X64_BOUND as u32;
+/// X64 invalid opcode exception.
 pub const EFI_SW_EC_X64_INVALID_OPCODE:   EfiStatusCodeValue = debug_support::EXCEPT_X64_INVALID_OPCODE as u32;
+/// X64 double fault exception.
 pub const EFI_SW_EC_X64_DOUBLE_FAULT:     EfiStatusCodeValue = debug_support::EXCEPT_X64_DOUBLE_FAULT as u32;
+/// X64 invalid TSS exception.
 pub const EFI_SW_EC_X64_INVALID_TSS:      EfiStatusCodeValue = debug_support::EXCEPT_X64_INVALID_TSS as u32;
+/// X64 segment not present exception.
 pub const EFI_SW_EC_X64_SEG_NOT_PRESENT:  EfiStatusCodeValue = debug_support::EXCEPT_X64_SEG_NOT_PRESENT as u32;
+/// X64 stack fault exception.
 pub const EFI_SW_EC_X64_STACK_FAULT:      EfiStatusCodeValue = debug_support::EXCEPT_X64_STACK_FAULT as u32;
+/// X64 general protection fault exception.
 pub const EFI_SW_EC_X64_GP_FAULT:         EfiStatusCodeValue = debug_support::EXCEPT_X64_GP_FAULT as u32;
+/// X64 page fault exception.
 pub const EFI_SW_EC_X64_PAGE_FAULT:       EfiStatusCodeValue = debug_support::EXCEPT_X64_PAGE_FAULT as u32;
+/// X64 floating-point error exception.
 pub const EFI_SW_EC_X64_FP_ERROR:         EfiStatusCodeValue = debug_support::EXCEPT_X64_FP_ERROR as u32;
+/// X64 alignment check exception.
 pub const EFI_SW_EC_X64_ALIGNMENT_CHECK:  EfiStatusCodeValue = debug_support::EXCEPT_X64_ALIGNMENT_CHECK as u32;
+/// X64 machine check exception.
 pub const EFI_SW_EC_X64_MACHINE_CHECK:    EfiStatusCodeValue = debug_support::EXCEPT_X64_MACHINE_CHECK as u32;
+/// X64 SIMD exception.
 pub const EFI_SW_EC_X64_SIMD:             EfiStatusCodeValue = debug_support::EXCEPT_X64_SIMD as u32;
 
 // Software Class ARM Exception Subclass Error Code definitions.
 // These exceptions are derived from the debug protocol
 // definitions in the EFI specification.
 //
+/// ARM reset exception.
 pub const EFI_SW_EC_ARM_RESET:                  EfiStatusCodeValue = debug_support::EXCEPT_ARM_RESET as u32;
+/// ARM undefined instruction exception.
 pub const EFI_SW_EC_ARM_UNDEFINED_INSTRUCTION:  EfiStatusCodeValue = debug_support::EXCEPT_ARM_UNDEFINED_INSTRUCTION as u32;
+/// ARM software interrupt exception.
 pub const EFI_SW_EC_ARM_SOFTWARE_INTERRUPT:     EfiStatusCodeValue = debug_support::EXCEPT_ARM_SOFTWARE_INTERRUPT as u32;
+/// ARM prefetch abort exception.
 pub const EFI_SW_EC_ARM_PREFETCH_ABORT:         EfiStatusCodeValue = debug_support::EXCEPT_ARM_PREFETCH_ABORT as u32;
+/// ARM data abort exception.
 pub const EFI_SW_EC_ARM_DATA_ABORT:             EfiStatusCodeValue = debug_support::EXCEPT_ARM_DATA_ABORT as u32;
+/// ARM reserved exception.
 pub const EFI_SW_EC_ARM_RESERVED:               EfiStatusCodeValue = debug_support::EXCEPT_ARM_RESERVED as u32;
+/// ARM IRQ exception.
 pub const EFI_SW_EC_ARM_IRQ:                    EfiStatusCodeValue = debug_support::EXCEPT_ARM_IRQ as u32;
+/// ARM FIQ exception.
 pub const EFI_SW_EC_ARM_FIQ:                    EfiStatusCodeValue = debug_support::EXCEPT_ARM_FIQ as u32;
 
 


### PR DESCRIPTION
## Description

Closes #904 

Add missing docs and improve some exisitng docs in the `pi` module such that `#![allow(missing_docs)]` can be removed. This improves existing documentation but also enforces that new additions have documentation going forward.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [x] Includes documentation?

## How This Was Tested

- `cargo make all`
- `cargo make doc-open` to review documentation

## Integration Instructions

- N/A