### PR TITLE
uefi_allocators: performance improvements

### DIFF
--- a/patina_dxe_core/src/allocator/uefi_allocator.rs
+++ b/patina_dxe_core/src/allocator/uefi_allocator.rs
@@ -177,12 +177,10 @@ impl UefiAllocator {
             debug_assert!(false, "Pool signature is incorrect.");
             return Err(EfiError::InvalidParameter);
         }
-
         // check if allocation is from this pool.
         if allocation_info.memory_type != self.memory_type() {
             return Err(EfiError::NotFound);
         }
-
         //zero after check so it doesn't get reused.
         allocation_info.signature = 0;
 


### PR DESCRIPTION
## Description

improve performance of `free_pool`, `allocate_pool` and `get_memory_map`
by moving the memory type of the allocator out from behind the TplLock.

Additionally, for `free_pool`, we now calculate the offset value once at compile
time, rather than per run.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

There was a cascade of performance gains across the board, validated via @berlin-with0ut-return's uefi performance. Attached are the perf gains documented. Please note that these are not rigorous mathemtically validated performance gains / losses. It is a simple run of each call X number of times. Performance will vary:

| Name                           | Cycles/op (Before) | Cycles/op (After) | Performance Gain (%) |
|--------------------------------|--------------------|-------------------|----------------------|
| connect_controller             |            3296969 |           2150385 | +53.3%              |
| check_event                    |               6761 |              6424 | +5.2%               |
| create_event                   |               7639 |              8972 | −17.5%              |
| close_event                    |               4679 |              4740 | −1.3%               |
| signal_event                   |               4977 |              5947 | −19.5%              |
| start_image, exit              |           78216392 |          71964320 | +8.7%               |
| load_image                     |           38275459 |          34029241 | +12.5%              |
| allocate_pages                 |             308635 |            133620 | +131.1%             |
| allocate_pool                  |              14559 |              8865 | +64.2%              |
| free_pages                     |             357250 |            353232 | +1.1%               |
| free_pool                      |              10399 |              4843 | +114.6%             |
| copy_mem                       |             278854 |            287338 | −3.0%               |
| set_mem                        |             225318 |            223958 | +0.6%               |
| get_memory_map                 |           11442007 |           4162507 | +174.8%             |
| calculate_crc32                |              11593 |             13545 | −14.4%              |
| install_configuration_table    |             105705 |            140420 | −24.8%              |
| install_protocol_interface     |              24460 |             20228 | +20.9%              |
| open_protocol                  |              17480 |             11616 | +50.5%              |
| handle_protocol                |              11071 |             10415 | +6.3%               |
| close_protocol                 |              18232 |             12327 | +47.9%              |
| locate_device_path             |             650826 |            451704 | +44.1%              |
| open_protocol_information      |              43387 |             34476 | +25.9%              |
| protocols_per_handle           |              40039 |             34012 | +17.7%              |
| register_protocol_notify       |             109958 |             82108 | +33.9%              |
| reinstall_protocol_interface   |            3418932 |           2054019 | +66.5%              |
| uninstall_protocol_interface   |             148641 |             48670 | +205.2%             |
| raise_tpl                      |               1590 |              1572 | +1.1%               |
| restore_tpl                    |               2623 |              2519 | +4.1%               |
| **Average (higher is better)** |                    |                   | **+36.8%**          |



## Integration Instructions

N/A
