### PR TITLE
Add workflow to display unsafe code data in the readme

### DIFF
--- a/.github/workflows/calculate-unsafe-code.yml
+++ b/.github/workflows/calculate-unsafe-code.yml
@@ -1,0 +1,25 @@
+# @file calculate-unsafe-code.yml
+#
+# A workflow that counts the amount of unsafe code in the repository with data broken
+# down into various categories.
+#
+##
+# Copyright (c) Microsoft Corporation.
+# SPDX-License-Identifier: Apache-2.0
+##
+name: Calcuate Unsafe Code
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+  schedule:
+    # Run daily at 6 AM UTC
+    - cron: '0 6 * * *'
+
+jobs:
+  calculate_unsafe_code:
+    name: Run
+    uses: OpenDevicePartnership/patina-devops/.github/workflows/CalculateUnsafeCode.yml@v0.0.3
+    secrets: inherit

--- a/.markdownlint.yml
+++ b/.markdownlint.yml
@@ -9,5 +9,5 @@
 {
     "default": true,
     "MD013": {"line_length": 120, "code_blocks": false, "tables": false},
-    "MD033": {"allowed_elements": ["br"]}
+    "MD033": {"allowed_elements": ["br", "center", "div"]}
 }

--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-
 # Patina
 
 [![release]][_release]
@@ -10,6 +9,20 @@ This repository hosts the Patina project - a Rust implementation of UEFI firmwar
 
 The goal of this project is to serve as a replacement for core UEFI firmware components so they are written in Pure
 Rust as opposed to Rust wrappers around core implementation still written in C.
+
+---
+
+<center>
+<div align="center">
+
+Unsafe Code<br />
+
+[![overall_unsafe_code]][_overall_unsafe_code] [![fn_unsafe_code]][_fn_unsafe_code] [![expr_unsafe_code]][_expr_unsafe_code]
+
+[![impl_unsafe_code]][_impl_unsafe_code] [![traits_unsafe_code]][_traits_unsafe_code] [![methods_unsafe_code]][_methods_unsafe_code]
+
+</div>
+</center>
 
 ## Background
 
@@ -240,3 +253,16 @@ directory.
 [_ci]: https://github.com/OpenDevicePartnership/patina/actions/workflows/ci-workflow.yml
 [cov]: https://codecov.io/gh/OpenDevicePartnership/patina/graph/badge.svg?token=CWHWOUUGY6
 [_cov]: https://codecov.io/gh/OpenDevicePartnership/patina
+
+[overall_unsafe_code]: https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/OpenDevicePartnership/patina/refs/heads/unsafe-code-badges/x86_64-unknown-uefi/badge_overall.json
+[_overall_unsafe_code]: https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/OpenDevicePartnership/patina/refs/heads/unsafe-code-badges/x86_64-unknown-uefi/badge_overall.json
+[fn_unsafe_code]: https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/OpenDevicePartnership/patina/refs/heads/unsafe-code-badges/x86_64-unknown-uefi/badge_functions.json
+[_fn_unsafe_code]: https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/OpenDevicePartnership/patina/refs/heads/unsafe-code-badges/x86_64-unknown-uefi/badge_functions.json
+[expr_unsafe_code]: https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/OpenDevicePartnership/patina/refs/heads/unsafe-code-badges/x86_64-unknown-uefi/badge_exprs.json
+[_expr_unsafe_code]: https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/OpenDevicePartnership/patina/refs/heads/unsafe-code-badges/x86_64-unknown-uefi/badge_exprs.json
+[impl_unsafe_code]: https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/OpenDevicePartnership/patina/refs/heads/unsafe-code-badges/x86_64-unknown-uefi/badge_item_impls.json
+[_impl_unsafe_code]: https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/OpenDevicePartnership/patina/refs/heads/unsafe-code-badges/x86_64-unknown-uefi/badge_item_impls.json
+[traits_unsafe_code]: https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/OpenDevicePartnership/patina/refs/heads/unsafe-code-badges/x86_64-unknown-uefi/badge_item_traits.json
+[_traits_unsafe_code]: https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/OpenDevicePartnership/patina/refs/heads/unsafe-code-badges/x86_64-unknown-uefi/badge_item_traits.json
+[methods_unsafe_code]: https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/OpenDevicePartnership/patina/refs/heads/unsafe-code-badges/x86_64-unknown-uefi/badge_methods.json
+[_methods_unsafe_code]: https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/OpenDevicePartnership/patina/refs/heads/unsafe-code-badges/x86_64-unknown-uefi/badge_methods.json

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -6,6 +6,7 @@ components = ["rust-src", "clippy", "rustfmt", "rust-docs"]
 # A custom section for CI pipelines to install tools
 [tools]
 cargo-deny = "^0.17"
+cargo-geiger = "0.13.0"
 cargo-llvm-cov = "0.6.18"
 cargo-make = "0.37.21"
 cargo-release = "0.25.12"


### PR DESCRIPTION
## Description

Closes #948 

Uses the `CalculateUnsafeCode` workflow in patina-devops to calculate the amount of unsafe code in the repo in various categories and show that data in badges in the readme.

---

Results are broken down into these categories.

- Overall: Combined percentage across all categories
- Functions: Percentage of functions marked as `unsafe`
- Expressions: Percentage of `unsafe` expressions and blocks
- Implementations: Percentage of `unsafe` trait implementations
- Traits: Percentage of `unsafe` trait definitions
- Methods: Percentage of methods marked as `unsafe`.

---

Example of badges for the current patina repo (on [fork](https://github.com/makubacki/patina)):

<img width="846" height="398" alt="image" src="https://github.com/user-attachments/assets/c64e649e-2968-4dce-99ab-ddc4c3609b8c" />

---

Currently:

- \<10% = Green
- \>10% and \<15% = Yellow
- 15%+ = Red

---

Example of workflow analysis table: https://github.com/OpenDevicePartnership/patina/blob/unsafe-code-badges/unsafe_analysis.md

---

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [x] Includes documentation?

## How This Was Tested

- Run workflow on fork and verify analysis output and JSON output are correct
- Check badges on fork to verify they resolve against the JSON file and are aesthetically positioned as expected

## Integration Instructions

- N/A - Only impacts badges in the local repo readme