### PR TITLE
patina_internal_depex: Set prints to debug instead of trace

### DIFF
--- a/components/patina_adv_logger/src/logger.rs
+++ b/components/patina_adv_logger/src/logger.rs
@@ -137,7 +137,7 @@ const fn log_level_to_debug_level(level: Level) -> u32 {
         Level::Warn => memory_log::DEBUG_LEVEL_WARNING,
         Level::Info => memory_log::DEBUG_LEVEL_INFO,
         Level::Trace => memory_log::DEBUG_LEVEL_VERBOSE,
-        Level::Debug => memory_log::DEBUG_LEVEL_VERBOSE,
+        Level::Debug => memory_log::DEBUG_LEVEL_INFO,
     }
 }
 

--- a/core/patina_internal_depex/src/lib.rs
+++ b/core/patina_internal_depex/src/lib.rs
@@ -152,11 +152,11 @@ impl Depex {
     /// Evaluates a DEPEX expression.
     pub fn eval(&mut self, protocols: &[efi::Guid]) -> bool {
         let mut stack = Vec::with_capacity(DEPEX_STACK_SIZE_INCREMENT);
-        log::trace!("Depex:");
+        log::debug!("Depex:");
         for (index, opcode) in self.expression.iter_mut().enumerate() {
             match opcode {
                 Opcode::Before(_) | Opcode::After(_) => {
-                    log::trace!("  {opcode:#x?}");
+                    log::debug!("  {opcode:#x?}");
                     if index != 0 {
                         debug_assert!(false, "Invalid BEFORE or AFTER not at start of depex {:#x?}", self.expression);
                         return false;
@@ -182,7 +182,7 @@ impl Depex {
                     return false;
                 }
                 Opcode::Sor => {
-                    log::trace!("  {opcode:#x?}");
+                    log::debug!("  {opcode:#x?}");
                     if index != 0 {
                         debug_assert!(false, "Invalid SOR not at start of depex.");
                         return false;
@@ -202,7 +202,7 @@ impl Depex {
                         }
                         stack.push(false);
                     }
-                    log::trace!(
+                    log::debug!(
                         "  {opcode:x?} => {:?}, stack ->{:?}",
                         stack.last(),
                         stack.iter().rev().collect::<Vec<_>>()
@@ -212,7 +212,7 @@ impl Depex {
                     let operator1 = stack.pop().unwrap_or(false);
                     let operator2 = stack.pop().unwrap_or(false);
                     stack.push(operator1 && operator2);
-                    log::trace!(
+                    log::debug!(
                         "  {opcode:x?}({operator1:?},{operator2:?}) => {:?}, stack ->{:?}",
                         stack.last(),
                         stack.iter().rev().collect::<Vec<_>>()
@@ -222,7 +222,7 @@ impl Depex {
                     let operator1 = stack.pop().unwrap_or(false);
                     let operator2 = stack.pop().unwrap_or(false);
                     stack.push(operator1 || operator2);
-                    log::trace!(
+                    log::debug!(
                         "  {opcode:x?}({operator1:?},{operator2:?}) => {:?}, stack ->{:?}",
                         stack.last(),
                         stack.iter().rev().collect::<Vec<_>>()
@@ -231,7 +231,7 @@ impl Depex {
                 Opcode::Not => {
                     let operator = stack.pop().unwrap_or(false);
                     stack.push(!operator);
-                    log::trace!(
+                    log::debug!(
                         "  {opcode:x?}({operator:?}) => {:?}, stack ->{:?}",
                         stack.last(),
                         stack.iter().rev().collect::<Vec<_>>()
@@ -239,7 +239,7 @@ impl Depex {
                 }
                 Opcode::True => {
                     stack.push(true);
-                    log::trace!(
+                    log::debug!(
                         "  {opcode:x?} => {:?}, stack ->{:?}",
                         stack.last(),
                         stack.iter().rev().collect::<Vec<_>>()
@@ -247,7 +247,7 @@ impl Depex {
                 }
                 Opcode::False => {
                     stack.push(false);
-                    log::trace!(
+                    log::debug!(
                         "  {opcode:x?} => {:?}, stack ->{:?}",
                         stack.last(),
                         stack.iter().rev().collect::<Vec<_>>()
@@ -255,7 +255,7 @@ impl Depex {
                 }
                 Opcode::End => {
                     let operator = stack.pop().unwrap_or(false);
-                    log::trace!(
+                    log::debug!(
                         "  {opcode:x?} => final result: {:?}, final stack ->{:?}",
                         operator,
                         stack.iter().rev().collect::<Vec<_>>()

--- a/patina_dxe_core/src/dispatcher.rs
+++ b/patina_dxe_core/src/dispatcher.rs
@@ -177,7 +177,7 @@ pub fn dispatch() -> Result<bool, EfiError> {
         let driver_candidates: Vec<_> = dispatcher.pending_drivers.drain(..).collect();
         let mut scheduled_driver_candidates = Vec::new();
         for mut candidate in driver_candidates {
-            log::trace!("Evaluating depex for candidate: {:?}", guid_fmt!(candidate.file_name));
+            log::debug!(target: "patina_internal_depex", "Evaluating depex for candidate: {:?}", guid_fmt!(candidate.file_name));
             let depex_satisfied = match candidate.depex {
                 Some(ref mut depex) => depex.eval(&PROTOCOL_DB.registered_protocols()),
                 None => dispatcher.arch_protocols_available,


### PR DESCRIPTION
## Description

Change depex prints to `debug!` instead of `trace!` to remove file path and line numbers from depex prints.
Map `Level::Debug` to `DEBUG_LEVEL_INFO` to allow log filtering based on AdvancedLogger init arguments instead of PCD Debug Print levels. By default, the existing Q35 and SBSA instantiations of logger use `max_level: log::LevelFilter::Info`, so they will not see any added prints due to the new Debug level mapping.

Size change of a local build with `max_level_debug` feature flag set: from 1973248 to 1981440 bytes.

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Verified target_filters and max_level arguments work correctly to enable and disable Depex prints.

## Integration Instructions

Patina consumers can use the target_filters and max_level arguments of Advanced Logger to enable Depex logs:

`("patina_internal_depex", log::LevelFilter::Debug)`
