### PR TITLE
Cargo.toml: Enable the alloc feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,7 +68,7 @@ serial_test = { version = "3.0" }
 winapi = { version = "0.3" }
 serde = { version = "1.0", default-features = false, features = ["derive"] }
 serde_yaml = { version = "0.9" }
-serde_json = { version = "1.0", default-features = false }
+serde_json = { version = "1.0", default-features = false, features = ["alloc"] }
 lzma-rs = { version = "0.3" }
 
 [profile.release]


### PR DESCRIPTION
## Description

Follow official `serde_json` guidance to use the `alloc` feature since we have a memory allocator available and

https://docs.rs/serde_json/latest/serde_json/#no-std-support

If the code is truly needed when the allocator is not available, serde-json-core is an option:

https://github.com/rust-embedded-community/serde-json-core

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

- `cargo make all`
- In preparation for unsafe code analysis changes. This was one all each package in the workspace after the change:
  - `cargo geiger --output-format Json --all-features --target x86_64-unknown-uefi`
  - `cargo geiger --output-format Json --all-features --target aarch64-unknown-uefi`

## Integration Instructions

- N/A