### PR TITLE
.vscode/settings.json: Remove vscode-nmake-tools setting

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,9 +5,6 @@
     "check",
     "--message-format=json"
   ],
-  "vscode-nmake-tools.workspaceBuildDirectories": [
-    "."
-  ],
   "rust-analyzer.cargo.targetDir": true,
   "rust-analyzer.runnables.extraEnv": {
     "RUSTC_BOOTSTRAP": "1"


### PR DESCRIPTION
## Description

This setting is no longer needed.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

- N/A - Dead code

## Integration Instructions

- N/A