### PR TITLE
Restore global state after executing MAT tests.

### DIFF
--- a/patina_dxe_core/src/config_tables/memory_attributes_table.rs
+++ b/patina_dxe_core/src/config_tables/memory_attributes_table.rs
@@ -272,6 +272,9 @@ mod tests {
                 init_system_table();
             }
             f();
+
+            POST_RTB.store(false, Ordering::Relaxed);
+            MEMORY_ATTRIBUTES_TABLE.store(core::ptr::null_mut(), Ordering::Relaxed);
         })
         .unwrap();
     }


### PR DESCRIPTION
## Description

The memory attribute table unit tests set POST_RTB global state. This has side effects (e.g. casuing the installation of the MAT table on the next runtime allocation) that can interfere with other unit tests. 

This change restores global state to defaults after executing MAT unit tests. 

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [x] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Executed unit tests, no longer observe intermittent failures of other tests due to POST_RTB state.

## Integration Instructions

N/A
