### PR TITLE
Do not run vet in the main CI worfklow

### DIFF
--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -29,6 +29,6 @@ jobs:
     with:
       build-tasks: "build,build-x64,build-aarch64"
       mdbook-path: "docs"
-      run-cargo-vet: true
+      run-cargo-vet: false
       run-release-dry-run: ${{ !contains(github.event.pull_request.body, '(skip cargo release dry run)') }}
     secrets: inherit


### PR DESCRIPTION
## Description

Commit fbd8252 removed `vet` from the `all` task so it is not run during the main developer workflow locally. This also removes it from the main CI workflow. It will be run in a separate workflow that reports the audit state of the codebase's dependencies.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

- CI workflow

## Integration Instructions

- N/A