### PR TITLE
patina_smbios: add SMBIOS component

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,7 @@ patina_macro = { version = "14.1.1", path = "sdk/patina_macro" }
 patina_mtrr = { version = "1.0.0" }
 patina_paging = { version = "10" }
 patina_performance = { version = "14.1.1", path = "components/patina_performance" }
+patina_smbios = { version = "14.1.1", path = "components/patina_smbios" }
 patina_stacktrace = { version = "14.1.1", path = "core/patina_stacktrace" }
 proc-macro2 = { version = "1" }
 quote = { version = "1" }

--- a/components/patina_samples/Cargo.toml
+++ b/components/patina_samples/Cargo.toml
@@ -11,6 +11,8 @@ description = "Sample UEFI components for the DXE Core."
 [dependencies]
 log = { workspace = true }
 patina = { workspace = true }
+patina_macro = { workspace = true }
+patina_smbios = { workspace = true }
 
 [features]
 std = []

--- a/components/patina_samples/src/lib.rs
+++ b/components/patina_samples/src/lib.rs
@@ -7,6 +7,7 @@
 //!
 //! - [`component::hello_world::HelloStruct`]: Demonstrates a struct-based component with default entry point
 //! - [`component::hello_world::GreetingsEnum`]: Demonstrates an enum-based component with custom entry point
+//! - [`smbios_platform`]: Demonstrates SMBIOS platform configuration and record creation
 //!
 //! ## License
 //!
@@ -18,3 +19,4 @@
 #![feature(coverage_attribute)]
 #![coverage(off)] // Disable all coverage instrumentation for sample code
 pub mod component;
+pub mod smbios_platform;

--- a/components/patina_samples/src/smbios_platform.rs
+++ b/components/patina_samples/src/smbios_platform.rs
@@ -1,0 +1,334 @@
+//! SMBIOS Platform Example Component
+//!
+//! This component demonstrates the recommended SMBIOS integration pattern:
+//! 1. Uses the type-safe `add_record<T>()` API for adding SMBIOS records
+//! 2. Platform component publishes the table after all records are added
+//! 3. Uses structured record types
+//! 4. Shows how to create custom vendor-specific SMBIOS records (Type 0x80-0xFF)
+//!
+//! ## Usage
+//!
+//! In your platform's DXE core initialization:
+//!
+//! ```ignore
+//! use patina_smbios::component::SmbiosProvider;
+//! use patina_samples::SmbiosExampleComponent;
+//!
+//! Core::default()
+//!     // Add SMBIOS provider component with version
+//!     .with_component(SmbiosProvider::new(3, 9))
+//!     // Add your platform SMBIOS component
+//!     .with_component(SmbiosExampleComponent::new())
+//!     // ... rest of your components
+//! ```
+//!
+//! ## License
+//!
+//! Copyright (c) Microsoft Corporation.
+//!
+//! SPDX-License-Identifier: Apache-2.0
+
+extern crate alloc;
+
+use alloc::{string::String, vec};
+use patina::{
+    component::{IntoComponent, service::Service},
+    error::Result,
+};
+use patina_macro::SmbiosRecord;
+use patina_smbios::{
+    service::{SMBIOS_HANDLE_PI_RESERVED, Smbios, SmbiosExt, SmbiosTableHeader},
+    smbios_record::{
+        SmbiosRecordStructure, Type0PlatformFirmwareInformation, Type1SystemInformation, Type2BaseboardInformation,
+        Type3SystemEnclosure, Type127EndOfTable,
+    },
+};
+
+/// Example custom vendor-specific OEM record (Type 0x80)
+///
+/// This struct contains a `string_pool: Vec<String>` which is Rust metadata and NOT
+/// part of the SMBIOS binary format. It should NOT have `#[repr(C, packed)]` because
+/// it's never directly cast to bytes - always use `to_bytes()` for serialization.
+#[derive(SmbiosRecord)]
+#[smbios(record_type = 0x80)]
+pub struct VendorOemRecord {
+    /// SMBIOS table header
+    pub header: SmbiosTableHeader,
+    /// Example 32-bit vendor-specific OEM field
+    pub oem_field: u32,
+    /// String pool containing vendor and platform data strings
+    #[string_pool]
+    pub string_pool: alloc::vec::Vec<String>,
+}
+
+/// Example Platform SMBIOS Component
+///
+/// Demonstrates a real-world platform component that adds SMBIOS records
+/// using the type-safe `add_record<T>()` API.
+///
+/// This example shows:
+/// - Type 0: BIOS/Firmware information
+/// - Type 1: System information with UUID and serial numbers
+/// - Type 2: Baseboard/motherboard information
+/// - Type 3: System chassis/enclosure information
+/// - Type 0x80: Custom vendor-specific record (OEM range)
+/// - Type 127: End-of-table marker
+/// - Publishing the complete table to UEFI Configuration Table
+#[derive(IntoComponent, Default)]
+pub struct SmbiosExampleComponent;
+
+impl SmbiosExampleComponent {
+    /// Create a new SMBIOS platform component
+    pub fn new() -> Self {
+        Self
+    }
+
+    /// Platform SMBIOS initialization entry point
+    ///
+    /// Called by the component framework during DXE phase initialization.
+    /// The framework automatically provides the SMBIOS service as a dependency.
+    fn entry_point(self, smbios: Service<dyn Smbios>) -> Result<()> {
+        log::info!("=== Example Platform SMBIOS Component ===");
+
+        // Verify SMBIOS version
+        let (major, minor) = smbios.version();
+        log::info!("SMBIOS Version: {}.{}", major, minor);
+
+        // Add platform-specific SMBIOS records
+        log::info!("Creating platform SMBIOS records...");
+
+        // Type 0: Platform firmware/BIOS information
+        if let Err(e) = Self::add_bios_information(&smbios) {
+            log::error!("Failed to add BIOS information: {:?}", e);
+            return Err(e);
+        }
+
+        // Type 1: System information
+        if let Err(e) = Self::add_system_information(&smbios) {
+            log::error!("Failed to add system information: {:?}", e);
+            return Err(e);
+        }
+
+        // Type 2: Baseboard/motherboard information
+        if let Err(e) = Self::add_baseboard_information(&smbios) {
+            log::error!("Failed to add baseboard information: {:?}", e);
+            return Err(e);
+        }
+
+        // Type 3: System chassis/enclosure information
+        if let Err(e) = Self::add_system_enclosure(&smbios) {
+            log::error!("Failed to add system enclosure: {:?}", e);
+            return Err(e);
+        }
+
+        // Type 0x80: Platform-specific vendor record
+        if let Err(e) = Self::add_vendor_oem_record(&smbios) {
+            log::error!("Failed to add vendor OEM record: {:?}", e);
+            return Err(e);
+        }
+
+        // Type 127: End-of-table marker
+        if let Err(e) = Self::add_end_of_table(&smbios) {
+            log::error!("Failed to add end-of-table marker: {:?}", e);
+            return Err(e);
+        }
+
+        log::info!("Platform SMBIOS records created successfully");
+
+        // Publish the SMBIOS table to the UEFI Configuration Table
+        log::info!("Publishing SMBIOS table to Configuration Table...");
+        match smbios.publish_table() {
+            Ok((table_addr, entry_point_addr)) => {
+                log::info!("SMBIOS table published successfully");
+                log::info!("  Entry Point: 0x{:X}", entry_point_addr);
+                log::info!("  Table Data: 0x{:X}", table_addr);
+                log::info!("Use 'smbiosview' in UEFI Shell to view records");
+            }
+            Err(e) => {
+                log::error!("Failed to publish SMBIOS table: {:?}", e);
+                // Continue even if publication fails - not critical for boot
+            }
+        }
+
+        log::info!("SMBIOS platform component initialized successfully");
+        Ok(())
+    }
+
+    /// Add Type 0 (Platform Firmware/BIOS Information)
+    ///
+    /// Demonstrates adding firmware version, vendor, and ROM size information.
+    fn add_bios_information(smbios: &Service<dyn Smbios>) -> Result<()> {
+        let bios_info = Type0PlatformFirmwareInformation {
+            header: SmbiosTableHeader::new(0, 0, SMBIOS_HANDLE_PI_RESERVED),
+            vendor: 1,
+            firmware_version: 2,
+            bios_starting_address_segment: 0xE800,
+            firmware_release_date: 3,
+            firmware_rom_size: 0xFF, // 16MB
+            characteristics: 0x08,   // PCI supported
+            characteristics_ext1: 0x03,
+            characteristics_ext2: 0x03,
+            system_bios_major_release: 1,
+            system_bios_minor_release: 0,
+            embedded_controller_major_release: 0xFF,
+            embedded_controller_minor_release: 0xFF,
+            extended_bios_rom_size: 0,
+            string_pool: vec![
+                String::from("Example Firmware Vendor"),
+                String::from("1.0.0"),
+                String::from("10/24/2025"),
+            ],
+        };
+
+        let handle = smbios.add_record(None, &bios_info).map_err(|e| {
+            log::error!("Failed to add BIOS info: {:?}", e);
+            patina::error::EfiError::DeviceError
+        })?;
+
+        log::info!("  Type 0 (BIOS Info) - Handle 0x{:04X}", handle);
+        Ok(())
+    }
+
+    /// Add Type 1 (System Information)
+    ///
+    /// Demonstrates adding system UUID, manufacturer, product name, and serial number.
+    fn add_system_information(smbios: &Service<dyn Smbios>) -> Result<()> {
+        let system_info = Type1SystemInformation {
+            header: SmbiosTableHeader::new(1, 0, SMBIOS_HANDLE_PI_RESERVED),
+            manufacturer: 1,
+            product_name: 2,
+            version: 3,
+            serial_number: 4,
+            uuid: [0x12, 0x34, 0x56, 0x78, 0x9A, 0xBC, 0xDE, 0xF0, 0x12, 0x34, 0x56, 0x78, 0x9A, 0xBC, 0xDE, 0xF0],
+            wake_up_type: 0x06, // Power switch
+            sku_number: 5,
+            family: 6,
+            string_pool: vec![
+                String::from("Example Corporation"),
+                String::from("Example Platform"),
+                String::from("1.0"),
+                String::from("SYS-12345"),
+                String::from("SKU-EXAMPLE-001"),
+                String::from("Example Platform Family"),
+            ],
+        };
+
+        let handle = smbios.add_record(None, &system_info).map_err(|e| {
+            log::error!("Failed to add system info: {:?}", e);
+            patina::error::EfiError::DeviceError
+        })?;
+
+        log::info!("  Type 1 (System Info) - Handle 0x{:04X}", handle);
+        Ok(())
+    }
+
+    /// Add Type 2 (Baseboard/Motherboard Information)
+    ///
+    /// Demonstrates adding motherboard manufacturer, serial number, and asset tag.
+    fn add_baseboard_information(smbios: &Service<dyn Smbios>) -> Result<()> {
+        let baseboard_info = Type2BaseboardInformation {
+            header: SmbiosTableHeader::new(2, 0, SMBIOS_HANDLE_PI_RESERVED),
+            manufacturer: 1,
+            product: 2,
+            version: 3,
+            serial_number: 4,
+            asset_tag: 5,
+            feature_flags: 0x01, // Board is a hosting board
+            location_in_chassis: 6,
+            chassis_handle: 0x0003,
+            board_type: 0x0A, // Motherboard
+            contained_object_handles: 0,
+            string_pool: vec![
+                String::from("Example Corporation"),
+                String::from("Example Baseboard"),
+                String::from("1.0"),
+                String::from("MB-67890"),
+                String::from("ASSET-MB-001"),
+                String::from("Main Board Slot"),
+            ],
+        };
+
+        let handle = smbios.add_record(None, &baseboard_info).map_err(|e| {
+            log::error!("Failed to add baseboard info: {:?}", e);
+            patina::error::EfiError::DeviceError
+        })?;
+
+        log::info!("  Type 2 (Baseboard Info) - Handle 0x{:04X}", handle);
+        Ok(())
+    }
+
+    /// Add Type 3 (System Enclosure/Chassis)
+    ///
+    /// Demonstrates adding chassis type, manufacturer, and serial information.
+    fn add_system_enclosure(smbios: &Service<dyn Smbios>) -> Result<()> {
+        let enclosure_info = Type3SystemEnclosure {
+            header: SmbiosTableHeader::new(3, 0, SMBIOS_HANDLE_PI_RESERVED),
+            manufacturer: 1,
+            enclosure_type: 0x03, // Desktop
+            version: 2,
+            serial_number: 3,
+            asset_tag_number: 4,
+            bootup_state: 0x03,
+            power_supply_state: 0x03,
+            thermal_state: 0x03,
+            security_status: 0x02,
+            oem_defined: 0x00000000,
+            height: 0x00,
+            number_of_power_cords: 0x01,
+            contained_element_count: 0x00,
+            contained_element_record_length: 0x00,
+            string_pool: vec![
+                String::from("Example Corporation"),
+                String::from("Example Chassis v1.0"),
+                String::from("CHASSIS-99999"),
+                String::from("ASSET-CHASSIS-001"),
+            ],
+        };
+
+        let handle = smbios.add_record(None, &enclosure_info).map_err(|e| {
+            log::error!("Failed to add system enclosure: {:?}", e);
+            patina::error::EfiError::DeviceError
+        })?;
+
+        log::info!("  Type 3 (System Enclosure) - Handle 0x{:04X}", handle);
+        Ok(())
+    }
+
+    /// Add custom vendor-specific OEM record (Type 0x80)
+    ///
+    /// Demonstrates how platforms can add custom vendor-specific SMBIOS records.
+    /// Types 0x80-0xFF are reserved for OEM/vendor use.
+    fn add_vendor_oem_record(smbios: &Service<dyn Smbios>) -> Result<()> {
+        let vendor_record = VendorOemRecord {
+            header: SmbiosTableHeader::new(VendorOemRecord::RECORD_TYPE, 0, SMBIOS_HANDLE_PI_RESERVED),
+            oem_field: 0xDEADBEEF, // Example vendor-specific data
+            string_pool: vec![String::from("Example Vendor"), String::from("Platform Data v1.0")],
+        };
+
+        let handle = smbios.add_record(None, &vendor_record).map_err(|e| {
+            log::error!("Failed to add vendor OEM record: {:?}", e);
+            patina::error::EfiError::DeviceError
+        })?;
+
+        log::info!("  Type 0x80 (Vendor OEM) - Handle 0x{:04X}", handle);
+        Ok(())
+    }
+
+    /// Add Type 127 (End of Table) marker
+    ///
+    /// Required marker to indicate the end of the SMBIOS table.
+    fn add_end_of_table(smbios: &Service<dyn Smbios>) -> Result<()> {
+        let end_of_table = Type127EndOfTable {
+            header: SmbiosTableHeader::new(127, 0, SMBIOS_HANDLE_PI_RESERVED),
+            string_pool: vec![],
+        };
+
+        let handle = smbios.add_record(None, &end_of_table).map_err(|e| {
+            log::error!("Failed to add end-of-table: {:?}", e);
+            patina::error::EfiError::DeviceError
+        })?;
+
+        log::info!("  Type 127 (End of Table) - Handle 0x{:04X}", handle);
+        Ok(())
+    }
+}

--- a/components/patina_smbios/Cargo.toml
+++ b/components/patina_smbios/Cargo.toml
@@ -1,0 +1,30 @@
+[package]
+name = "patina_smbios"
+version.workspace = true
+license.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+repository.workspace = true
+description = "System Management BIOS (SMBIOS) support for Patina UEFI components."
+
+[dependencies]
+log = { workspace = true }
+mockall = { workspace = true, optional = true }
+patina = { workspace = true }
+patina_macro = { workspace = true }
+r-efi = { workspace = true }
+spin = { workspace = true }
+zerocopy = { workspace = true }
+zerocopy-derive = { workspace = true }
+
+[dev-dependencies]
+mockall = { workspace = true }
+patina = { workspace = true, features = ["mockall"] }
+
+[features]
+enable_patina_tests = []
+mockall = ["dep:mockall", "std"]
+std = []
+
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(coverage_nightly)'] }

--- a/components/patina_smbios/README.md
+++ b/components/patina_smbios/README.md
@@ -1,0 +1,166 @@
+# Patina SMBIOS Component
+
+The Patina SMBIOS component provides type-safe SMBIOS table management for
+Patina-based firmware. It offers both a modern Rust service API and legacy
+C/EDKII protocol compatibility for managing SMBIOS records throughout the
+boot process.
+
+## Capabilities
+
+- Produces the `Smbios` service for adding, updating, and publishing SMBIOS
+  records with type-safe structured record types.
+- Installs the EDKII-compatible `EFI_SMBIOS_PROTOCOL` for C drivers that
+  need to interact with SMBIOS tables.
+- Manages SMBIOS record handles with automatic allocation, reuse, and PI
+  specification compliance.
+- Validates and serializes structured SMBIOS records with proper string
+  pool handling.
+- Publishes SMBIOS tables to the UEFI Configuration Table with proper
+  entry point structures and checksums.
+- Emits focused log output to aid in debugging record addition, string
+  updates, and table publication.
+
+## Components and Services
+
+- **SmbiosProvider component**: Creates the SMBIOS manager, registers the
+  `Service<dyn Smbios>`, and installs the C/EDKII protocol. Both interfaces
+  share the same underlying manager for consistency.
+- **Smbios trait**: Defines core operations (`version`, `publish_table`,
+  `update_string`, `remove`, `add_from_bytes`) accessible through trait
+  object dynamic dispatch.
+- **SmbiosExt trait**: Provides the type-safe `add_record<T>()` generic
+  method for adding structured records without manual serialization.
+
+## Configuration
+
+The SMBIOS component requires version configuration during instantiation:
+
+```rust
+commands.add_component(SmbiosProvider::new(3, 9));  // SMBIOS 3.9
+```
+
+> Only SMBIOS 3.x versions are supported. The component will panic at
+> initialization if `SmbiosProvider::new()` is called with an unsupported
+> major version (i.e., major version != 3). This is intentional to catch
+> configuration errors early during platform development. If the manager
+> creation fails during `entry_point()`, the component returns
+> `EfiError::Unsupported` instead of panicking.
+
+## Integration Guidance
+
+### Adding SMBIOS Records
+
+Platform components should use the type-safe `add_record<T>()` method from `SmbiosExt`:
+
+```rust
+use patina::component::service::Service;
+use patina_smbios::{
+    service::{Smbios, SmbiosExt, SmbiosTableHeader, SMBIOS_HANDLE_PI_RESERVED},
+    smbios_record::Type0PlatformFirmwareInformation,
+};
+
+fn platform_init(smbios: Service<dyn Smbios>) -> Result<()> {
+    // Create a Type 0 BIOS Information record
+    let bios_info = Type0PlatformFirmwareInformation {
+        header: SmbiosTableHeader::new(0, 0, SMBIOS_HANDLE_PI_RESERVED),
+        vendor: 1,
+        firmware_version: 2,
+        bios_starting_address_segment: 0xE800,
+        firmware_release_date: 3,
+        firmware_rom_size: 0xFF,
+        characteristics: 0x08,
+        characteristics_ext1: 0x03,
+        characteristics_ext2: 0x03,
+        system_bios_major_release: 1,
+        system_bios_minor_release: 0,
+        embedded_controller_major_release: 0xFF,
+        embedded_controller_minor_release: 0xFF,
+        extended_bios_rom_size: 0,
+        string_pool: vec![
+            String::from("Patina Firmware"),
+            String::from("1.0.0"),
+            String::from("10/31/2025")
+        ],
+    };
+
+    // Add the record and get the assigned handle
+    let handle = smbios.add_record(None, &bios_info)?;
+    log::info!("Added BIOS Info record with handle: 0x{:04X}", handle);
+
+    // Publish the table when all records are added
+    smbios.publish_table()?;
+    Ok(())
+}
+```
+
+### Available Record Types
+
+The crate provides structured types for common SMBIOS records:
+
+- **Type0PlatformFirmwareInformation**: BIOS/firmware information
+- **Type1SystemInformation**: System manufacturer, product name, UUID, SKU
+- **Type2BaseboardInformation**: Baseboard/motherboard information
+- **Type3SystemEnclosure**: Chassis/enclosure information
+- **Type127EndOfTable**: End-of-table marker (required)
+
+Each record type implements `SmbiosRecordStructure` and handles
+serialization automatically, including proper string pool conversion and
+length calculations.
+
+### String Pool Handling
+
+SMBIOS strings are stored in a `Vec<String>` field marked with
+`#[string_pool]`. String indices in record fields are 1-based. The
+serialization process automatically converts the string pool to
+null-terminated SMBIOS format:
+
+```rust
+string_pool: vec![
+    String::from("Vendor"),      // Index 1
+    String::from("Product"),     // Index 2
+    String::from("Version"),     // Index 3
+],
+```
+
+### Updating Existing Records
+
+Records can be updated after creation using `update_string`:
+
+```rust
+// Update string 1 in the record
+smbios.update_string(handle, 1, "New Vendor Name")?;
+```
+
+### C/EDKII Protocol Compatibility
+
+The component automatically installs the `EFI_SMBIOS_PROTOCOL` with functions:
+
+- `Add`: Add SMBIOS records from raw bytes
+- `UpdateString`: Update strings in existing records
+- `Remove`: Remove records by handle
+- `GetNext`: Iterate through SMBIOS records
+
+C drivers can locate and use this protocol as they would in traditional EDKII firmware.
+
+## Testing
+
+The crate includes comprehensive unit tests demonstrating:
+
+- Record creation and serialization
+- Handle allocation and reuse
+- String pool validation
+- Mock service patterns using `Service::mock()`
+- Integration with the service system
+
+Run tests with:
+
+```bash
+cargo test --lib
+```
+
+## Documentation
+
+For detailed implementation and architectural information, see the inline
+documentation and:
+
+- [SMBIOS Specification](https://www.dmtf.org/standards/smbios)

--- a/components/patina_smbios/src/component.rs
+++ b/components/patina_smbios/src/component.rs
@@ -1,0 +1,173 @@
+//! SMBIOS Service Implementation
+//!
+//! Defines the SMBIOS provider for use as a service
+//!
+//! ## License
+//!
+//! Copyright (c) Microsoft Corporation.
+//!
+//! SPDX-License-Identifier: Apache-2.0
+
+extern crate alloc;
+use crate::{
+    error::SmbiosError,
+    manager::{SmbiosManager, install_smbios_protocol},
+    service::SmbiosImpl,
+};
+use alloc::boxed::Box;
+use patina::{
+    boot_services::tpl::Tpl,
+    component::{IntoComponent, Storage},
+    error::Result,
+    tpl_mutex::TplMutex,
+};
+
+/// Internal configuration for SMBIOS service
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct SmbiosConfiguration {
+    /// SMBIOS major version (e.g., 3 for SMBIOS 3.x)
+    major_version: u8,
+    /// SMBIOS minor version (e.g., 0 for SMBIOS 3.0)
+    minor_version: u8,
+}
+
+impl SmbiosConfiguration {
+    /// Create a new SMBIOS configuration with the specified version
+    ///
+    /// # Errors
+    ///
+    /// Returns `SmbiosError::UnsupportedVersion` if major_version != 3
+    fn new(major_version: u8, minor_version: u8) -> core::result::Result<Self, SmbiosError> {
+        // Only SMBIOS 3.x is supported
+        if major_version != 3 {
+            return Err(SmbiosError::UnsupportedVersion);
+        }
+
+        // Accept any minor version for 3.x (forward compatible)
+        Ok(Self { major_version, minor_version })
+    }
+}
+
+/// Initializes and exposes SMBIOS provider service.
+///
+/// This component provides the `Service<Smbios>` which includes:
+/// - Type-safe record operations: `add_record<T>()`
+/// - Record management: `update_string()`, `remove()`
+/// - Table management: `version()`, `publish_table()`
+///
+/// The provider creates an SMBIOS manager instance protected by a TplMutex.
+/// A global reference is maintained for C/EDKII protocol compatibility.
+///
+/// # Example
+///
+/// ```ignore
+/// commands.add_component(SmbiosProvider::new(3, 9));
+/// ```
+#[derive(IntoComponent)]
+pub struct SmbiosProvider {
+    config: SmbiosConfiguration,
+}
+
+impl SmbiosProvider {
+    /// Create a new SMBIOS provider with the specified SMBIOS version.
+    ///
+    /// # Arguments
+    ///
+    /// * `major_version` - SMBIOS major version (must be 3)
+    /// * `minor_version` - SMBIOS minor version (any value for version 3.x)
+    ///
+    /// # Panics
+    ///
+    /// Panics if the version is invalid (major version != 3).
+    /// This is intentional to enforce correct version at compile/initialization time.
+    ///
+    /// # Example
+    ///
+    /// ```ignore
+    /// // For SMBIOS 3.9 specification
+    /// commands.add_component(SmbiosProvider::new(3, 9));
+    /// ```
+    pub fn new(major_version: u8, minor_version: u8) -> Self {
+        let config = SmbiosConfiguration::new(major_version, minor_version)
+            .expect("Invalid SMBIOS version: only SMBIOS 3.x is supported");
+        Self { config }
+    }
+
+    /// Initialize the SMBIOS provider and register it as a service
+    #[coverage(off)] // Component integration - tested via integration tests
+    fn entry_point(self, storage: &mut Storage) -> Result<()> {
+        let cfg = self.config;
+
+        // Create the manager with configured version
+        let manager = SmbiosManager::new(cfg.major_version, cfg.minor_version).map_err(|e| {
+            log::error!("Failed to create SMBIOS manager: {:?}", e);
+            patina::error::EfiError::Unsupported
+        })?;
+
+        // Get boot_services from storage - it already has 'static lifetime
+        // We use an unsafe cast because storage.boot_services() returns a reference with
+        // a shorter lifetime, but Storage guarantees boot_services lives for 'static
+        let boot_services_static: &'static patina::boot_services::StandardBootServices =
+            unsafe { &*(storage.boot_services() as *const _) };
+
+        // Create the SMBIOS service struct with owned TplMutex
+        let manager_mutex = TplMutex::new(boot_services_static, Tpl::NOTIFY, manager);
+        let smbios_service = SmbiosImpl {
+            manager: manager_mutex,
+            boot_services: boot_services_static,
+            major_version: cfg.major_version,
+            minor_version: cfg.minor_version,
+        };
+
+        // Leak the service to get a 'static reference
+        // This single leak gives us a reference that can be used for both protocol and service
+        let smbios_static: &'static SmbiosImpl = Box::leak(Box::new(smbios_service));
+
+        // Install the C/EDKII protocol using the leaked service's manager
+        if let Err(e) =
+            install_smbios_protocol(cfg.major_version, cfg.minor_version, smbios_static.manager(), boot_services_static)
+        {
+            log::error!("Failed to install SMBIOS protocol: {:?}", e);
+        }
+
+        // Register the leaked service (the IntoService impl for &'static T handles this)
+        storage.add_service(smbios_static);
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    extern crate std;
+
+    #[test]
+    fn test_smbios_provider_new() {
+        let provider = SmbiosProvider::new(3, 9);
+        assert_eq!(provider.config.major_version, 3);
+        assert_eq!(provider.config.minor_version, 9);
+    }
+
+    #[test]
+    fn test_smbios_configuration_custom() {
+        let provider = SmbiosProvider::new(3, 7);
+        assert_eq!(provider.config.major_version, 3);
+        assert_eq!(provider.config.minor_version, 7);
+    }
+
+    #[test]
+    #[should_panic(expected = "Invalid SMBIOS version")]
+    fn test_smbios_provider_invalid_version() {
+        // Should panic with invalid major version
+        let _provider = SmbiosProvider::new(2, 0);
+    }
+
+    // Test that we can create the component - this tests the primary constructor path
+    #[test]
+    fn test_component_creation() {
+        let provider = SmbiosProvider::new(3, 9);
+        assert_eq!(provider.config.major_version, 3);
+        assert_eq!(provider.config.minor_version, 9);
+    }
+}

--- a/components/patina_smbios/src/error.rs
+++ b/components/patina_smbios/src/error.rs
@@ -1,0 +1,118 @@
+//! Error types for SMBIOS operations
+//!
+//! This module defines the error types returned by SMBIOS service operations.
+//!
+//! ## License
+//!
+//! Copyright (c) Microsoft Corporation.
+//!
+//! SPDX-License-Identifier: Apache-2.0
+//!
+
+/// SMBIOS operation errors
+///
+/// This enum represents all possible errors that can occur during SMBIOS operations,
+/// including string validation, record management, handle allocation, and resource management.
+#[derive(Debug, Clone, PartialEq)]
+pub enum SmbiosError {
+    // String validation errors
+    /// String exceeds maximum allowed length (64 bytes)
+    StringTooLong,
+    /// String contains null terminator (not allowed - terminators are added during serialization)
+    StringContainsNull,
+    /// Empty string in string pool (consecutive null bytes)
+    EmptyStringInPool,
+
+    // Record format errors
+    /// Record buffer is too small to contain a valid SMBIOS header
+    RecordTooSmall,
+    /// Record header is malformed or cannot be parsed
+    MalformedRecordHeader,
+    /// String pool is missing required double-null termination
+    InvalidStringPoolTermination,
+    /// String pool area is too small (must be at least 2 bytes)
+    StringPoolTooSmall,
+
+    // Handle management errors
+    /// All available handles have been exhausted (reached 0xFFFE limit)
+    HandleExhausted,
+    /// The specified handle was not found in the record table
+    HandleNotFound,
+    /// String index is out of range for the specified record
+    StringIndexOutOfRange,
+
+    // Resource allocation errors
+    /// Failed to allocate memory for SMBIOS table or entry point
+    AllocationFailed,
+    /// No SMBIOS records available to install into configuration table
+    NoRecordsAvailable,
+
+    // State errors
+    /// SMBIOS manager has already been initialized
+    AlreadyInitialized,
+    /// SMBIOS manager has not been initialized yet
+    NotInitialized,
+
+    // Version errors
+    /// SMBIOS version is not supported (only 3.0 and above are supported)
+    UnsupportedVersion,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_smbios_error_all_variants() {
+        extern crate std;
+        use std::vec;
+
+        // Test all error variants for completeness
+        let errors = vec![
+            SmbiosError::StringTooLong,
+            SmbiosError::StringContainsNull,
+            SmbiosError::EmptyStringInPool,
+            SmbiosError::RecordTooSmall,
+            SmbiosError::MalformedRecordHeader,
+            SmbiosError::InvalidStringPoolTermination,
+            SmbiosError::StringPoolTooSmall,
+            SmbiosError::HandleExhausted,
+            SmbiosError::HandleNotFound,
+            SmbiosError::StringIndexOutOfRange,
+            SmbiosError::AllocationFailed,
+            SmbiosError::NoRecordsAvailable,
+            SmbiosError::AlreadyInitialized,
+            SmbiosError::NotInitialized,
+            SmbiosError::UnsupportedVersion,
+        ];
+
+        // Each should be cloneable and comparable
+        for err in errors {
+            let cloned = err.clone();
+            assert_eq!(err, cloned);
+        }
+    }
+
+    #[test]
+    fn test_smbios_error_clone_and_eq() {
+        let err1 = SmbiosError::StringTooLong;
+        let err2 = err1.clone();
+        assert_eq!(err1, err2);
+
+        let err3 = SmbiosError::AllocationFailed;
+        assert_ne!(err1, err3);
+    }
+
+    #[test]
+    fn test_smbios_error_types() {
+        // Verify we can construct each error type
+        let _e1 = SmbiosError::StringTooLong;
+        let _e2 = SmbiosError::HandleExhausted;
+        let _e3 = SmbiosError::AllocationFailed;
+        let _e4 = SmbiosError::NotInitialized;
+        let _e5 = SmbiosError::UnsupportedVersion;
+        let _e6 = SmbiosError::StringIndexOutOfRange;
+        let _e7 = SmbiosError::RecordTooSmall;
+        let _e8 = SmbiosError::InvalidStringPoolTermination;
+    }
+}

--- a/components/patina_smbios/src/lib.rs
+++ b/components/patina_smbios/src/lib.rs
@@ -1,0 +1,323 @@
+//! SMBIOS (System Management BIOS) component for Patina
+//!
+//! This crate provides a safe, type-safe Rust interface for working with SMBIOS tables in UEFI
+//! environments. It offers structured record types with automatic serialization, making SMBIOS
+//! table management simple and safe.
+//!
+//! # Architecture Overview
+//!
+//! The SMBIOS component provides a unified service interface for all SMBIOS operations:
+//!
+//! ## Service Architecture
+//!
+//! ```text
+//! ┌─────────────────────────────────────────────────────────────┐
+//! │                  Platform Components                        │
+//! │  (Rust code using component services)                       │
+//! └──────────────────────────┬──────────────────────────────────┘
+//!                            │
+//!                            ▼
+//!                ┌────────────────────────┐
+//!                │   Service<Smbios>      │
+//!                │                        │
+//!                │ Type-safe operations:  │
+//!                │ • add_record<T>()      │
+//!                │                        │
+//!                │ Record management:     │
+//!                │ • update_string()      │
+//!                │ • remove()             │
+//!                │                        │
+//!                │ Table management:      │
+//!                │ • version()            │
+//!                │ • publish_table()      │
+//!                └────────────┬───────────┘
+//!                             │
+//!                             ▼
+//!                  ┌──────────────────┐
+//!                  │  SMBIOS Manager  │
+//!                  │  (TPL_NOTIFY)    │
+//!                  └──────────────────┘
+//!                             ▼
+//!                  ┌─────────────────────┐
+//!                  │  SmbiosManager      │
+//!                  │  (Global Singleton) │
+//!                  │                     │
+//!                  │ • Record storage    │
+//!                  │ • Handle allocation │
+//!                  │ • Table generation  │
+//!                  └──────────┬──────────┘
+//!                             │
+//!                  ┌──────────┴──────────┐
+//!                  ▼                     ▼
+//!       ┌──────────────────┐  ┌──────────────────────┐
+//!       │ UEFI Config Table│  │ C Protocol Interface │
+//!       │ (SMBIOS 3.x)     │  │ (EDKII Compatible)   │
+//!       └──────────────────┘  └──────────────────────┘
+//! ```
+//!
+//! ### Key Components
+//!
+//! - **Smbios service**: Provides type-safe SMBIOS operations through structured records
+//! - **Global Manager**: Single source of truth for SMBIOS data, protected by TplMutex
+//! - **C Protocol**: EDKII-compatible protocol for legacy driver integration
+//!
+//! ## Thread Safety and TPL Protection
+//!
+//! The global SMBIOS manager is protected by a **TplMutex** at **TPL_NOTIFY** level:
+//!
+//! - Prevents timer interrupt reentrancy during SMBIOS operations
+//! - TPL automatically raised to NOTIFY when accessing the manager
+//! - TPL automatically restored when the lock guard drops
+//! - Safe for use in DXE phase with timer interrupts enabled
+//!
+//! # Usage Examples
+//!
+//! ## Basic Setup in Platform DXE
+//!
+//! ```ignore
+//! use patina::component::{Component, IntoComponent};
+//! use patina_smbios::component::SmbiosProvider;
+//!
+//! // Register SMBIOS provider component with SMBIOS version
+//! fn my_platform_init(mut commands: Commands) -> Result<()> {
+//!     // Register SMBIOS provider with SMBIOS 3.9 specification
+//!     commands.add_component(SmbiosProvider::new(3, 9));
+//!
+//!     Ok(())
+//! }
+//! ```
+//!
+//! ## Adding SMBIOS Records
+//!
+//! Use the type-safe `add_record<T>()` method to add SMBIOS records. This provides
+//! automatic serialization and compile-time type safety:
+//!
+//! ```ignore
+//! use patina::component::service::Service;
+//! use patina_smbios::service::Smbios;
+//! use patina_smbios::smbios_record::{Type0PlatformFirmwareInformation, SmbiosTableHeader};
+//! use patina_smbios::service::SMBIOS_HANDLE_PI_RESERVED;
+//!
+//! fn add_bios_info(
+//!     smbios: Service<Smbios>
+//! ) -> Result<()> {
+//!     // Create a Type 0 (BIOS Information) record
+//!     let bios_info = Type0PlatformFirmwareInformation {
+//!         header: SmbiosTableHeader::new(0, 0, SMBIOS_HANDLE_PI_RESERVED),
+//!         vendor: 1,                               // String index 1
+//!         firmware_version: 2,                     // String index 2
+//!         bios_starting_address_segment: 0xE000,   // Standard BIOS segment
+//!         firmware_release_date: 3,                // String index 3
+//!         firmware_rom_size: 0x0F,                 // 1MB
+//!         characteristics: 0x08,                   // PCI supported
+//!         characteristics_ext1: 0x03,              // ACPI supported
+//!         characteristics_ext2: 0x01,              // UEFI supported
+//!         system_bios_major_release: 2,
+//!         system_bios_minor_release: 4,
+//!         embedded_controller_major_release: 0xFF, // Not supported
+//!         embedded_controller_minor_release: 0xFF,
+//!         extended_bios_rom_size: 0x0000,
+//!         string_pool: vec![
+//!             String::from("ACME BIOS Corp"),
+//!             String::from("v2.4.1"),
+//!             String::from("09/26/2025"),
+//!         ],
+//!     };
+//!
+//!     // Add the record - serialization happens automatically!
+//!     let handle = smbios.add_record(None, &bios_info)?;
+//!
+//!     log::info!("Added BIOS info with handle: {}", handle);
+//!     Ok(())
+//! }
+//! ```
+//!
+//! ## Querying Records
+//!
+//! Record iteration is not currently exposed through the public API. In typical usage,
+//! platform components add their SMBIOS records during initialization, then the table
+//! is published for the operating system to read directly. The OS queries the SMBIOS
+//! table through the UEFI Configuration Table.
+//!
+//! If you need to query existing records before publishing, this functionality may be
+//! added to the `Service<Smbios>` interface in the future.
+//!
+//! ## Publishing the SMBIOS Table
+//!
+//! ```ignore
+//! use patina::component::service::Service;
+//! use patina_smbios::Smbios;
+//!
+//! fn publish_smbios(
+//!     smbios: Service<Smbios>
+//! ) -> Result<()> {
+//!     // Publish SMBIOS table to UEFI Configuration Table
+//!     let (table_addr, entry_point_addr) = smbios.publish_table()?;
+//!     
+//!     log::info!("SMBIOS table at: 0x{:X}", table_addr);
+//!     log::info!("Entry point at: 0x{:X}", entry_point_addr);
+//!     Ok(())
+//! }
+//! ```
+//!
+//! ## Updating Existing Records
+//!
+//! ```ignore
+//! use patina::component::service::Service;
+//! use patina_smbios::service::Smbios;
+//!
+//! fn update_firmware_version(
+//!     smbios: Service<Smbios>,
+//!     handle: u16,
+//!     new_version: &str
+//! ) -> Result<()> {
+//!     // Update string index 2 (firmware version) in the Type 0 record
+//!     smbios.update_string(handle, 2, new_version)?;
+//!     Ok(())
+//! }
+//! ```
+//!
+//! # Integration Guide
+//!
+//! ## Step 1: Add Dependency
+//!
+//! Add to your platform's `Cargo.toml`:
+//!
+//! ```toml
+//! [dependencies]
+//! patina_smbios = "14.0"
+//! ```
+//!
+//! ## Step 2: Register Provider Component
+//!
+//! In your platform initialization code, register the SMBIOS provider with your SMBIOS version:
+//!
+//! ```ignore
+//! use patina_smbios::component::SmbiosProvider;
+//!
+//! // Register with SMBIOS 3.9 specification
+//! commands.add_component(SmbiosProvider::new(3, 9));
+//! ```
+//!
+//! ## Step 3: Add Records in Your Components
+//!
+//! Request the SMBIOS service in your components and add records:
+//!
+//! ```ignore
+//! use patina::component::{IntoComponent, service::Service};
+//! use patina_smbios::service::Smbios;
+//! use patina_smbios::smbios_record::Type1SystemInformation;
+//!
+//! #[derive(IntoComponent)]
+//! struct MyPlatformComponent;
+//!
+//! impl MyPlatformComponent {
+//!     fn entry_point(
+//!         self,
+//!         smbios: Service<Smbios>,
+//!     ) -> Result<()> {
+//!         // Create and add your platform's SMBIOS records
+//!         let system_info = Type1SystemInformation { /* ... */ };
+//!         smbios.add_record(None, &system_info)?;
+//!         Ok(())
+//!     }
+//! }
+//! ```
+//!
+//! ## Step 4: Publish Table
+//!
+//! After all components have added their records, publish the table:
+//!
+//! ```ignore
+//! smbios.publish_table()?;
+//! ```
+//!
+//! # Safety and Architecture Guarantees
+//!
+//! ## Type Safety
+//!
+//! - Structured record types with automatic serialization
+//! - Compile-time verification of record structure
+//! - No manual byte manipulation required
+//! - Derive macro ensures correct SMBIOS format
+//!
+//! ## Memory Safety
+//!
+//! - All record data validated before storage
+//! - String pools checked for proper null termination
+//! - No unsafe pointer arithmetic exposed to users
+//! - All allocations tracked and managed by UEFI boot services
+//!
+//! ## Thread Safety
+//!
+//! - Global manager protected by TplMutex at TPL_NOTIFY
+//! - Prevents reentrancy from timer interrupts
+//! - Safe for concurrent access from different components
+//! - UEFI DXE model ensures single-threaded execution at same TPL
+//!
+//! ## Global State Justification
+//!
+//! The global SMBIOS manager is necessary because:
+//!
+//! 1. **C Protocol Requirement**: EDKII SMBIOS protocol callbacks don't receive `self` pointer,
+//!    requiring global state to access the manager
+//! 2. **Single Source of Truth**: All SMBIOS data (Rust + C consumers) must share one manager
+//! 3. **Table Publication**: Final SMBIOS table must contain all records from all producers
+//!
+//! The manager is installed once during initialization and remains valid for system lifetime.
+//!
+//! ## Privacy and Encapsulation
+//!
+//! - Manager module is **private** - not exposed to platform code
+//! - Platform code interacts only through the `Smbios` service
+//! - Component pattern ensures proper dependency injection
+//! - No direct hardcoded manager access possible
+//!
+//! # SMBIOS Specification Compliance
+//!
+//! This implementation follows **SMBIOS 3.0+** specification:
+//!
+//! - 64-bit table addresses (SMBIOS 3.x entry point structure)
+//! - No 4GB table size limitation
+//! - Standard string pool format (null-terminated, double-null terminated)
+//! - Proper checksum calculation for entry point
+//! - ACPI_RECLAIM_MEMORY type for table storage
+//!
+//! # Error Handling
+//!
+//! The [`error::SmbiosError`] enum provides detailed error information:
+//!
+//! - **String errors**: `StringTooLong`, `StringContainsNull`, `EmptyStringInPool`
+//! - **Format errors**: `RecordTooSmall`, `MalformedRecordHeader`, `InvalidStringPoolTermination`
+//! - **Handle errors**: `HandleExhausted`, `HandleNotFound`, `StringIndexOutOfRange`
+//! - **Resource errors**: `AllocationFailed`, `NoRecordsAvailable`
+//! - **State errors**: `AlreadyInitialized`, `NotInitialized`, `UnsupportedVersion`
+//!
+//! All errors are detailed and actionable for debugging.
+//!
+//! # Module Organization
+//!
+//! - [`component`]: Component registration and service providers
+//! - [`error`]: Error types for SMBIOS operations
+//! - [`service`]: Public service trait definitions and types
+//! - `manager`: Private SMBIOS manager implementation (not public)
+//! - `smbios_record`: Record structures and serialization (exported through `service`)
+//!
+//! # License
+//!
+//! Copyright (c) Microsoft Corporation.
+//!
+//! SPDX-License-Identifier: Apache-2.0
+
+#![cfg_attr(all(not(feature = "std"), not(test), not(feature = "mockall")), no_std)]
+#![feature(coverage_attribute)]
+
+// Allow the derive macro to reference this crate using `::patina_smbios::`
+extern crate self as patina_smbios;
+
+pub mod component;
+pub mod error;
+pub mod service;
+pub mod smbios_record;
+
+mod manager;

--- a/components/patina_smbios/src/manager.rs
+++ b/components/patina_smbios/src/manager.rs
@@ -1,0 +1,84 @@
+//! SMBIOS Manager Module
+//!
+//! This module provides the core SMBIOS manager implementation organized into focused submodules:
+//! - `core`: SmbiosManager struct and SmbiosRecords trait implementation
+//! - `record`: Internal record structures (SmbiosRecord)
+//! - `protocol`: C/EDKII protocol compatibility layer (SmbiosProtocol)
+//!
+//! ## License
+//!
+//! Copyright (c) Microsoft Corporation.
+//!
+//! SPDX-License-Identifier: Apache-2.0
+//!
+
+extern crate alloc;
+
+use patina::uefi_protocol::ProtocolInterface;
+
+mod core;
+mod protocol;
+mod record;
+
+// Re-export main types and functions
+pub use core::SmbiosManager;
+pub(crate) use record::SmbiosRecord;
+
+use alloc::boxed::Box;
+
+use patina::{
+    boot_services::{BootServices, StandardBootServices},
+    tpl_mutex::TplMutex,
+};
+use r_efi::efi;
+
+use crate::error::SmbiosError;
+
+use self::protocol::{SmbiosProtocol, SmbiosProtocolInternal};
+
+/// Installs the SMBIOS C/EDKII protocol for legacy driver compatibility.
+///
+/// This function registers the SMBIOS protocol with UEFI so that C/EDK drivers can access
+/// SMBIOS functionality. The protocol functions access the manager through the protocol struct.
+///
+/// The manager is protected by TplMutex at NOTIFY level. When protocol functions
+/// are called, the TplMutex.lock() automatically raises TPL to NOTIFY, preventing
+/// timer interrupt reentrancy. TPL is automatically restored when the lock guard drops.
+///
+/// Returns the protocol handle on success. The caller is responsible for managing the
+/// protocol lifetime (though in practice, UEFI protocols persist for the system lifetime).
+#[coverage(off)] // Protocol installation - tested via integration tests
+pub fn install_smbios_protocol(
+    major_version: u8,
+    minor_version: u8,
+    manager_mutex: &'static TplMutex<'static, SmbiosManager, StandardBootServices>,
+    boot_services: &'static StandardBootServices,
+) -> Result<efi::Handle, SmbiosError> {
+    // Create the protocol instance with internal struct
+    let internal = SmbiosProtocolInternal::new(major_version, minor_version, manager_mutex);
+    let interface = Box::into_raw(Box::new(internal));
+
+    // Install the protocol using the unchecked interface since we have a raw pointer
+    // We install the protocol field of the internal struct
+    // SAFETY: With #[repr(C)], the protocol field is at offset 0 of SmbiosProtocolInternal,
+    // so the address of the internal struct is the same as the address of the protocol field
+    let handle = unsafe {
+        boot_services.install_protocol_interface_unchecked(
+            None, // Let UEFI create a new handle
+            &SmbiosProtocol::PROTOCOL_GUID,
+            interface as *mut _,
+        )
+    };
+
+    match handle {
+        Ok(h) => Ok(h),
+        Err(status) => {
+            // Clean up on failure
+            unsafe {
+                drop(Box::from_raw(interface));
+            }
+            log::error!("Failed to install SMBIOS protocol: {:?}", status);
+            Err(SmbiosError::AllocationFailed)
+        }
+    }
+}

--- a/components/patina_smbios/src/manager/core.rs
+++ b/components/patina_smbios/src/manager/core.rs
@@ -1,0 +1,1197 @@
+//! Core SMBIOS manager implementation
+//!
+//! This module provides the core SMBIOS table manager that handles record storage,
+//! handle allocation, string pool management, and table publication.
+//!
+//! ## License
+//!
+//! Copyright (C) Microsoft Corporation.
+//!
+//! SPDX-License-Identifier: Apache-2.0
+//!
+
+extern crate alloc;
+
+use alloc::{boxed::Box, string::String, vec::Vec};
+use core::cell::RefCell;
+use patina::{
+    boot_services::{
+        BootServices,
+        allocation::{AllocType, MemoryType},
+    },
+    uefi_size_to_pages,
+};
+use r_efi::{
+    efi,
+    efi::{Handle, PhysicalAddress},
+};
+use zerocopy::{IntoBytes, Ref};
+use zerocopy_derive::{Immutable, IntoBytes as DeriveIntoBytes};
+
+use crate::{
+    error::SmbiosError,
+    service::{
+        SMBIOS_HANDLE_PI_RESERVED, SMBIOS_STRING_MAX_LENGTH, SmbiosHandle, SmbiosRecordsIter, SmbiosTableHeader,
+        SmbiosType,
+    },
+};
+
+use super::record::SmbiosRecord;
+
+/// SMBIOS 3.x Configuration Table GUID: F2FD1544-9794-4A2C-992E-E5BBCF20E394
+///
+/// This GUID identifies the SMBIOS 3.0+ entry point structure in the UEFI Configuration Table.
+/// Used for SMBIOS 3.0 and later versions which support 64-bit table addresses and remove
+/// the 4GB table size limitation of SMBIOS 2.x.
+pub const SMBIOS_3_X_TABLE_GUID: efi::Guid =
+    efi::Guid::from_fields(0xF2FD1544, 0x9794, 0x4A2C, 0x99, 0x2E, &[0xE5, 0xBB, 0xCF, 0x20, 0xE3, 0x94]);
+
+/// SMBIOS 3.0 entry point structure (64-bit)
+/// Per SMBIOS 3.0+ specification section 5.2.2
+#[repr(C, packed)]
+#[derive(Clone, Copy, DeriveIntoBytes, Immutable)]
+pub struct Smbios30EntryPoint {
+    /// Anchor string "_SM3_" (0x00)
+    pub anchor_string: [u8; 5],
+    /// Entry Point Structure Checksum (0x05)
+    pub checksum: u8,
+    /// Entry Point Length - 0x18 = 24 bytes (0x06)
+    pub length: u8,
+    /// SMBIOS Major Version (0x07)
+    pub major_version: u8,
+    /// SMBIOS Minor Version (0x08)
+    pub minor_version: u8,
+    /// SMBIOS Docrev - specification revision (0x09)
+    pub docrev: u8,
+    /// Entry Point Structure Revision - 0x01 (0x0A)
+    pub entry_point_revision: u8,
+    /// Reserved - must be 0x00 (0x0B)
+    pub reserved: u8,
+    /// Structure Table Maximum Size (0x0C)
+    pub table_max_size: u32,
+    /// Structure Table Address - 64-bit (0x10)
+    pub table_address: u64,
+}
+
+/// SMBIOS table manager
+///
+/// Manages SMBIOS records, handles, and table generation.
+pub struct SmbiosManager {
+    pub(super) records: RefCell<Vec<SmbiosRecord>>,
+    pub(super) next_handle: RefCell<SmbiosHandle>,
+    pub(super) freed_handles: RefCell<Vec<SmbiosHandle>>,
+    pub major_version: u8,
+    pub minor_version: u8,
+    entry_point_64: RefCell<Option<Box<Smbios30EntryPoint>>>,
+    table_64_address: RefCell<Option<PhysicalAddress>>,
+}
+
+impl SmbiosManager {
+    /// Creates a new SMBIOS manager with the specified version
+    ///
+    /// # Arguments
+    ///
+    /// * `major_version` - SMBIOS major version (must be 3)
+    /// * `minor_version` - SMBIOS minor version (any value for version 3.x)
+    ///
+    /// # Errors
+    ///
+    /// Returns `SmbiosError::UnsupportedVersion` if major version is not 3.
+    pub fn new(major_version: u8, minor_version: u8) -> Result<Self, SmbiosError> {
+        if major_version != 3 {
+            log::error!(
+                "SMBIOS version {}.{} is not supported. Only SMBIOS 3.x is supported.",
+                major_version,
+                minor_version
+            );
+            return Err(SmbiosError::UnsupportedVersion);
+        }
+
+        Ok(Self {
+            records: RefCell::new(Vec::new()),
+            next_handle: RefCell::new(1),
+            freed_handles: RefCell::new(Vec::new()),
+            major_version,
+            minor_version,
+            entry_point_64: RefCell::new(None),
+            table_64_address: RefCell::new(None),
+        })
+    }
+
+    /// Validate a string for use in SMBIOS records
+    ///
+    /// Ensures the string meets SMBIOS specification requirements:
+    /// - Does not exceed SMBIOS_STRING_MAX_LENGTH (64 bytes)
+    /// - Does not contain null terminators (they are added during serialization)
+    ///
+    /// # Arguments
+    ///
+    /// * `s` - The string to validate
+    ///
+    /// # Returns
+    ///
+    /// Returns `Ok(())` if valid, or an appropriate error if validation fails
+    pub(super) fn validate_string(s: &str) -> Result<(), SmbiosError> {
+        if s.len() > SMBIOS_STRING_MAX_LENGTH {
+            return Err(SmbiosError::StringTooLong);
+        }
+        // Strings must NOT contain null terminators - they are added during serialization
+        if s.bytes().any(|b| b == 0) {
+            return Err(SmbiosError::StringContainsNull);
+        }
+        Ok(())
+    }
+
+    /// Efficiently validate string pool format and count strings in a single pass
+    ///
+    /// This combines validation and counting for better performance
+    ///
+    /// # String Pool Format
+    /// SMBIOS string pools have a specific format:
+    /// - Each string is null-terminated ('\0')
+    /// - The entire pool ends with double null ("\0\0")
+    /// - Empty string pool is just double null ("\0\0")
+    /// - String indices in the record start at 1 (not 0)
+    ///
+    /// # Errors
+    /// Returns `SmbiosError::InvalidStringPoolTermination` if:
+    /// - The pool doesn't end with double null
+    /// - The pool is too small (< 2 bytes)
+    ///
+    /// Returns `SmbiosError::EmptyStringInPool` if consecutive nulls are found in the middle
+    ///
+    /// Returns `SmbiosError::StringTooLong` if any string exceeds SMBIOS_STRING_MAX_LENGTH
+    pub(super) fn validate_and_count_strings(string_pool_area: &[u8]) -> Result<usize, SmbiosError> {
+        let len = string_pool_area.len();
+
+        // Must end with double null
+        if len < 2 || string_pool_area[len - 1] != 0 || string_pool_area[len - 2] != 0 {
+            return Err(SmbiosError::InvalidStringPoolTermination);
+        }
+
+        // Handle empty string pool (just double null)
+        if len == 2 {
+            return Ok(0);
+        }
+
+        // Remove the final double-null terminator and split by null bytes
+        let data_without_terminator = &string_pool_area[..len - 2];
+
+        // Split by null bytes to get individual strings
+        let strings: Vec<&[u8]> = data_without_terminator.split(|&b| b == 0).collect();
+
+        // Validate each string
+        for string_bytes in &strings {
+            if string_bytes.is_empty() {
+                // Empty slice means consecutive nulls (invalid)
+                return Err(SmbiosError::EmptyStringInPool);
+            }
+            if string_bytes.len() > SMBIOS_STRING_MAX_LENGTH {
+                return Err(SmbiosError::StringTooLong);
+            }
+        }
+
+        Ok(strings.len())
+    }
+
+    /// Parse strings from an SMBIOS string pool into a Vec<&str>
+    ///
+    /// Extracts null-terminated strings from the string pool area as string slices.
+    /// This avoids heap allocation by returning references to the existing bytes.
+    ///
+    /// # Arguments
+    ///
+    /// * `string_pool_area` - Byte slice containing the string pool (must end with double null)
+    ///
+    /// # Returns
+    ///
+    /// Returns `Ok(Vec<&str>)` with all strings from the pool, or an error if the pool is malformed.
+    ///
+    /// # Errors
+    ///
+    /// Returns the same errors as `validate_and_count_strings` if the pool format is invalid.
+    pub(super) fn parse_strings_from_pool(string_pool_area: &[u8]) -> Result<Vec<&str>, SmbiosError> {
+        // First validate the pool
+        Self::validate_and_count_strings(string_pool_area)?;
+
+        let len = string_pool_area.len();
+
+        // Handle empty string pool (just double null)
+        if len == 2 {
+            return Ok(Vec::new());
+        }
+
+        // Remove the final double-null terminator and split by null bytes
+        let data_without_terminator = &string_pool_area[..len - 2];
+
+        // Split by null bytes and convert to &str slices
+        let strings: Result<Vec<&str>, _> = data_without_terminator
+            .split(|&b| b == 0)
+            .map(|bytes| core::str::from_utf8(bytes).map_err(|_| SmbiosError::MalformedRecordHeader))
+            .collect();
+
+        strings
+    }
+
+    /// Allocate a new handle using a free list for efficient O(1) allocation
+    ///
+    /// This implementation maintains a free list of previously freed handles to avoid
+    /// O(n) searches through all records. The allocation strategy is:
+    /// 1. If freed_handles is non-empty, pop and reuse a freed handle
+    /// 2. Otherwise, use next_handle and increment it
+    /// 3. If next_handle reaches the reserved range (0xFFFE), wrap to 1
+    /// 4. If all handles are exhausted, return OutOfResources
+    pub(super) fn allocate_handle(&self) -> Result<SmbiosHandle, SmbiosError> {
+        // First, try to reuse a freed handle (most efficient)
+        if let Some(handle) = self.freed_handles.borrow_mut().pop() {
+            return Ok(handle);
+        }
+
+        // No freed handles available, use next_handle
+        let candidate = *self.next_handle.borrow();
+
+        // Check if we've exhausted the handle space
+        // Valid handles are 1..=0xFEFF (0xFFFE and 0xFFFF are reserved)
+        if candidate >= SMBIOS_HANDLE_PI_RESERVED {
+            // All handles exhausted
+            return Err(SmbiosError::HandleExhausted);
+        }
+
+        *self.next_handle.borrow_mut() = candidate + 1;
+        Ok(candidate)
+    }
+
+    /// Builds the SMBIOS table and installs it in the UEFI Configuration Table
+    ///
+    /// This function performs the following steps:
+    /// 1. Consolidates all SMBIOS records into a contiguous memory buffer
+    /// 2. Creates an SMBIOS 3.x Entry Point Structure with proper checksum
+    /// 3. Allocates ACPI Reclaim memory for both the table and entry point
+    /// 4. Installs the entry point via the UEFI Configuration Table
+    ///
+    /// # Arguments
+    ///
+    /// * `boot_services` - UEFI Boot Services for memory allocation and table installation
+    ///
+    /// # Returns
+    ///
+    /// Returns a tuple of `(table_address, entry_point_address)` containing the physical
+    /// addresses where the SMBIOS table data and entry point structure were allocated.
+    ///
+    /// # Errors
+    ///
+    /// * `SmbiosError::NoRecordsAvailable` - No SMBIOS records have been added
+    /// * `SmbiosError::AllocationFailed` - Failed to allocate memory or install the configuration table
+    ///
+    /// # Safety
+    ///
+    /// This function uses unsafe code for:
+    /// - Creating mutable slices to allocated memory
+    /// - Writing the entry point structure to allocated memory
+    /// - Calling the UEFI `install_configuration_table` interface
+    ///
+    /// All memory allocations use UEFI Boot Services and are properly tracked by the firmware.
+    pub fn install_configuration_table(
+        &self,
+        boot_services: &patina::boot_services::StandardBootServices,
+    ) -> Result<(PhysicalAddress, PhysicalAddress), SmbiosError> {
+        let records = self.records.borrow();
+
+        // Step 1: Calculate total table size
+        let total_table_size: usize = records.iter().map(|r| r.data.len()).sum();
+
+        if total_table_size == 0 {
+            log::error!("Cannot install configuration table: no SMBIOS records have been added");
+            return Err(SmbiosError::NoRecordsAvailable);
+        }
+
+        // Step 2: Allocate memory for the table (using UEFI Boot Services memory allocation)
+        let table_pages = uefi_size_to_pages!(total_table_size);
+        let table_address = boot_services
+            .allocate_pages(
+                AllocType::AnyPage,
+                MemoryType::ACPI_RECLAIM_MEMORY, // SMBIOS tables go in ACPI Reclaim memory
+                table_pages,
+            )
+            .map_err(|_| SmbiosError::AllocationFailed)?;
+
+        // Step 3: Copy all records to the table
+        // SAFETY: `table_address` was just successfully allocated by UEFI Boot Services for
+        // `total_table_size` bytes. The memory is valid, properly aligned, and exclusively owned
+        // by this function. The size matches our calculation, making this slice creation safe.
+        let table_slice = unsafe { core::slice::from_raw_parts_mut(table_address as *mut u8, total_table_size) };
+        let mut offset = 0;
+
+        for record in records.iter() {
+            let record_bytes = record.data.as_slice();
+            table_slice[offset..offset + record_bytes.len()].copy_from_slice(record_bytes);
+            offset += record_bytes.len();
+        }
+
+        // Step 4: Create SMBIOS 3.0+ Entry Point Structure
+        let mut entry_point = Smbios30EntryPoint {
+            anchor_string: *b"_SM3_",
+            checksum: 0,
+            length: core::mem::size_of::<Smbios30EntryPoint>() as u8,
+            major_version: self.major_version,
+            minor_version: self.minor_version,
+            docrev: 0,
+            entry_point_revision: 1,
+            reserved: 0,
+            table_max_size: total_table_size as u32,
+            table_address: table_address as u64,
+        };
+
+        // Calculate checksum
+        entry_point.checksum = Self::calculate_checksum(&entry_point);
+
+        // Step 5: Allocate memory for entry point structure
+        let ep_pages = 1; // Entry point fits in one page
+        let ep_address = boot_services
+            .allocate_pages(AllocType::AnyPage, MemoryType::ACPI_RECLAIM_MEMORY, ep_pages)
+            .map_err(|_| SmbiosError::AllocationFailed)?;
+
+        // Step 6: Copy entry point to allocated memory
+        let ep_bytes = entry_point.as_bytes();
+        // SAFETY: `ep_address` was just successfully allocated by UEFI Boot Services for one page.
+        // The size `core::mem::size_of::<Smbios30EntryPoint>()` (24 bytes) fits well within one page (4KB).
+        // The memory is valid, properly aligned, and exclusively owned by this function.
+        let ep_slice = unsafe {
+            core::slice::from_raw_parts_mut(ep_address as *mut u8, core::mem::size_of::<Smbios30EntryPoint>())
+        };
+        ep_slice.copy_from_slice(ep_bytes);
+
+        // Step 7: Install in UEFI Configuration Table
+        // SAFETY: We're calling the UEFI `install_configuration_table` function with:
+        // - A valid GUID reference (&SMBIOS_3_X_TABLE_GUID)
+        // - A valid pointer to the entry point structure we just allocated and initialized
+        // The pointer remains valid for the system's lifetime as it's in ACPI_RECLAIM_MEMORY.
+        unsafe {
+            boot_services.install_configuration_table(&SMBIOS_3_X_TABLE_GUID, ep_address as *mut ()).map_err(|e| {
+                log::error!("Failed to install SMBIOS configuration table: {:?}", e);
+                SmbiosError::AllocationFailed
+            })?;
+        }
+
+        // Store addresses for future reference
+        drop(records); // Release borrow before mutating
+        self.entry_point_64.replace(Some(Box::new(entry_point)));
+        self.table_64_address.replace(Some(table_address as u64));
+
+        Ok((table_address as u64, ep_address as u64))
+    }
+
+    /// Calculate checksum for SMBIOS 3.x Entry Point Structure
+    ///
+    /// Computes the checksum byte value such that the sum of all bytes in the
+    /// entry point structure equals zero (modulo 256). This is required by the
+    /// SMBIOS specification for entry point validation.
+    ///
+    /// # Arguments
+    ///
+    /// * `entry_point` - Reference to the SMBIOS 3.0 Entry Point Structure
+    ///
+    /// # Returns
+    ///
+    /// The checksum byte value that makes the structure's byte sum equal to zero
+    ///
+    pub(super) fn calculate_checksum(entry_point: &Smbios30EntryPoint) -> u8 {
+        let bytes = entry_point.as_bytes();
+
+        let sum: u8 = bytes.iter().fold(0u8, |acc, &b| acc.wrapping_add(b));
+        0u8.wrapping_sub(sum)
+    }
+
+    /// Publish the SMBIOS table to UEFI configuration tables
+    pub fn publish_table(
+        &self,
+        boot_services: &patina::boot_services::StandardBootServices,
+    ) -> Result<(r_efi::efi::PhysicalAddress, r_efi::efi::PhysicalAddress), SmbiosError> {
+        self.install_configuration_table(boot_services)
+    }
+
+    /// Add a new SMBIOS record from raw bytes
+    pub fn add_from_bytes(
+        &self,
+        producer_handle: Option<Handle>,
+        record_data: &[u8],
+    ) -> Result<SmbiosHandle, SmbiosError> {
+        // Step 1: Validate minimum size for header (at least 4 bytes)
+        if record_data.len() < core::mem::size_of::<SmbiosTableHeader>() {
+            return Err(SmbiosError::RecordTooSmall);
+        }
+
+        // Step 2: Parse and validate header using zerocopy
+        let (header_ref, _rest) = Ref::<&[u8], SmbiosTableHeader>::from_prefix(record_data)
+            .map_err(|_| SmbiosError::MalformedRecordHeader)?;
+        let header: &SmbiosTableHeader = &header_ref;
+
+        // Step 3: Validate header->length is <= (record_data.length - 2) for string pool
+        // The string pool needs at least 2 bytes for the double-null terminator
+        if (header.length as usize + 2) > record_data.len() {
+            return Err(SmbiosError::RecordTooSmall);
+        }
+
+        // Step 4: Validate and count strings in a single efficient pass
+        let string_pool_start = header.length as usize;
+        let string_pool_area = &record_data[string_pool_start..];
+
+        if string_pool_area.len() < 2 {
+            return Err(SmbiosError::StringPoolTooSmall);
+        }
+
+        // Step 5: Validate string pool format and count strings
+        let string_count = Self::validate_and_count_strings(string_pool_area)?;
+
+        // If all validation passes, allocate handle and build record
+        let smbios_handle = self.allocate_handle()?;
+
+        let record_header =
+            SmbiosTableHeader { record_type: header.record_type, length: header.length, handle: smbios_handle };
+
+        // Update the handle in the actual data
+        let mut data = record_data.to_vec();
+        let handle_bytes = smbios_handle.to_le_bytes();
+        data[2] = handle_bytes[0]; // Handle is at offset 2 in header
+        data[3] = handle_bytes[1];
+
+        let smbios_record = SmbiosRecord::new(record_header, producer_handle, data, string_count);
+
+        self.records.borrow_mut().push(smbios_record);
+        Ok(smbios_handle)
+    }
+
+    /// Update a string in an existing SMBIOS record
+    pub fn update_string(
+        &self,
+        smbios_handle: SmbiosHandle,
+        string_number: usize,
+        string: &str,
+    ) -> Result<(), SmbiosError> {
+        Self::validate_string(string)?;
+
+        // Find the record index
+        let pos = self
+            .records
+            .borrow()
+            .iter()
+            .position(|r| r.header.handle == smbios_handle)
+            .ok_or(SmbiosError::HandleNotFound)?;
+
+        // Borrow the record
+        let mut records = self.records.borrow_mut();
+        let record = &mut records[pos];
+
+        if string_number == 0 || string_number > record.string_count {
+            return Err(SmbiosError::StringIndexOutOfRange);
+        }
+
+        // Parse the existing string pool
+        let header_length = record.header.length as usize;
+        if record.data.len() < header_length + 2 {
+            return Err(SmbiosError::RecordTooSmall);
+        }
+
+        // Extract existing strings from the string pool using the helper function
+        let string_pool_start = header_length;
+        let string_pool = &record.data[string_pool_start..];
+        let existing_strings_refs = Self::parse_strings_from_pool(string_pool)?;
+
+        // Convert to owned strings so we can modify them
+        let mut existing_strings: Vec<String> = existing_strings_refs.iter().map(|s| String::from(*s)).collect();
+
+        // Validate that we have enough strings
+        if string_number > existing_strings.len() {
+            return Err(SmbiosError::StringIndexOutOfRange);
+        }
+
+        // Update the target string (string_number is 1-indexed)
+        existing_strings[string_number - 1] = String::from(string);
+
+        // Rebuild the record data with updated string pool
+        let mut new_data =
+            Vec::with_capacity(header_length + existing_strings.iter().map(|s| s.len() + 1).sum::<usize>() + 1);
+
+        // Copy the structured data (header + fixed fields)
+        new_data.extend_from_slice(&record.data[..header_length]);
+
+        // Rebuild the string pool
+        for s in &existing_strings {
+            new_data.extend_from_slice(s.as_bytes());
+            new_data.push(0); // Null terminator
+        }
+
+        // Add final null terminator (double null at end)
+        new_data.push(0);
+
+        // Update the record with new data
+        record.data = new_data;
+
+        Ok(())
+    }
+
+    /// Remove an SMBIOS record
+    pub fn remove(&self, smbios_handle: SmbiosHandle) -> Result<(), SmbiosError> {
+        let pos = self
+            .records
+            .borrow()
+            .iter()
+            .position(|r| r.header.handle == smbios_handle)
+            .ok_or(SmbiosError::HandleNotFound)?;
+
+        self.records.borrow_mut().remove(pos);
+
+        // Add the freed handle to the free list for reuse
+        // Only add valid handles (1..0xFFFE) to the free list
+        if (1..SMBIOS_HANDLE_PI_RESERVED).contains(&smbios_handle) {
+            self.freed_handles.borrow_mut().push(smbios_handle);
+        }
+
+        Ok(())
+    }
+
+    /// Create an iterator over SMBIOS records
+    ///
+    /// This is a convenience method for Rust code that has direct access
+    /// to `SmbiosManager`. It provides idiomatic Rust iteration over records.
+    ///
+    /// **Note**: When using SMBIOS through the component service interface
+    /// (`Service<dyn SmbiosRecords>`), this iterator method is not available
+    /// due to trait object lifetime constraints. In production, SMBIOS records
+    /// are typically added during DXE phase then published for OS access.
+    ///
+    /// # Arguments
+    ///
+    /// * `record_type` - Optional filter for specific record type. `None` to
+    ///   iterate all records, `Some(type)` to filter by specific type.
+    ///
+    /// # Returns
+    ///
+    /// Returns an iterator yielding tuples of `(SmbiosTableHeader, Option<Handle>)`.
+    pub fn iter(&self, record_type: Option<SmbiosType>) -> SmbiosRecordsIter<'_> {
+        SmbiosRecordsIter::new(self.records.borrow(), record_type)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    extern crate std;
+    use std::{vec, vec::Vec};
+
+    use crate::{
+        error::SmbiosError,
+        service::{SMBIOS_HANDLE_PI_RESERVED, SMBIOS_STRING_MAX_LENGTH, SmbiosHandle, SmbiosTableHeader},
+    };
+    use r_efi::efi;
+    use zerocopy::IntoBytes;
+
+    /// Test helper: Build a simple SMBIOS record with the given header and strings
+    ///
+    /// This helper manually constructs a minimal SMBIOS record for testing purposes.
+    /// In production code, use structured record types (Type0, Type1, etc.) with to_bytes().
+    fn build_test_record_with_strings(header: &SmbiosTableHeader, strings: &[&str]) -> Vec<u8> {
+        let mut bytes = Vec::new();
+
+        // Serialize header
+        bytes.extend_from_slice(header.as_bytes());
+
+        // Add string pool
+        if strings.is_empty() {
+            // Empty string pool: just double null
+            bytes.push(0);
+            bytes.push(0);
+        } else {
+            for s in strings {
+                bytes.extend_from_slice(s.as_bytes());
+                bytes.push(0); // Null terminator
+            }
+            bytes.push(0); // Double null terminator
+        }
+
+        bytes
+    }
+
+    #[test]
+    fn test_smbios_record_builder_builds_bytes() {
+        // Ensure build_test_record_with_strings returns a proper record buffer
+        let header = SmbiosTableHeader::new(1, 4 + 2, SMBIOS_HANDLE_PI_RESERVED);
+        let strings = &["ACME Corp", "SuperServer 3000"];
+
+        let record = build_test_record_with_strings(&header, strings);
+
+        assert!(record.len() > core::mem::size_of::<SmbiosTableHeader>());
+        assert_eq!(record[0], 1u8);
+    }
+
+    #[test]
+    fn test_add_type0_platform_firmware_information_to_manager() {
+        let manager = SmbiosManager::new(3, 9).expect("failed to create manager");
+
+        // Manually build a Type 0 record with proper structure
+        let mut record_data = vec![
+            0,    // Type 0 (BIOS Information)
+            0x1A, // Length = 26 bytes (4-byte header + 22 bytes structured data)
+            0xFF, 0xFE, // Handle = SMBIOS_HANDLE_PI_RESERVED
+            // Structured data fields (22 bytes total):
+            1, // vendor (string index 1)
+            2, // bios_version (string index 2)
+            0x00, 0xE0, // bios_starting_address_segment (0xE000)
+            3,    // bios_release_date (string index 3)
+            0x0F, // bios_rom_size (1MB)
+            0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // characteristics (u64)
+            0x01, // characteristics_ext1
+            0x00, // characteristics_ext2
+            9,    // system_bios_major_release
+            9,    // system_bios_minor_release
+            0xFF, // embedded_controller_major_release
+            0xFF, // embedded_controller_minor_release
+            0x00, 0x00, // extended_bios_rom_size
+        ];
+
+        // Add string pool
+        record_data.extend_from_slice(b"TestVendor\0");
+        record_data.extend_from_slice(b"9.9.9\0");
+        record_data.extend_from_slice(b"09/24/2025\0");
+        record_data.push(0); // Double null terminator
+
+        let handle = manager.add_from_bytes(None, &record_data).expect("add_from_bytes failed");
+
+        let mut found = false;
+        for (found_header, _producer) in manager.iter(Some(0)) {
+            assert_eq!(found_header.record_type, 0);
+            let found_handle = found_header.handle;
+            assert_eq!(found_handle, handle);
+            found = true;
+        }
+        assert!(found);
+    }
+
+    #[test]
+    fn test_validate_string() {
+        // Success cases
+        assert!(SmbiosManager::validate_string("Valid String").is_ok());
+        assert!(SmbiosManager::validate_string("").is_ok());
+        assert!(SmbiosManager::validate_string("Hello World 123!").is_ok());
+        assert!(SmbiosManager::validate_string("Valid-String_With.Symbols").is_ok());
+        let max_string = "a".repeat(SMBIOS_STRING_MAX_LENGTH);
+        assert!(SmbiosManager::validate_string(&max_string).is_ok());
+
+        // Error cases
+        let long_string = "a".repeat(SMBIOS_STRING_MAX_LENGTH + 1);
+        assert_eq!(SmbiosManager::validate_string(&long_string), Err(SmbiosError::StringTooLong));
+        assert_eq!(SmbiosManager::validate_string("test\0string"), Err(SmbiosError::StringContainsNull));
+        assert_eq!(SmbiosManager::validate_string("before\0after"), Err(SmbiosError::StringContainsNull));
+    }
+
+    #[test]
+    fn test_validate_and_count_strings() {
+        // Success cases
+        assert_eq!(SmbiosManager::validate_and_count_strings(&[0u8, 0u8]), Ok(0)); // Empty pool
+        assert_eq!(SmbiosManager::validate_and_count_strings(b"test\0\0"), Ok(1)); // Single string
+        assert_eq!(SmbiosManager::validate_and_count_strings(b"first\0second\0third\0\0"), Ok(3)); // Multiple
+
+        // Error cases
+        assert_eq!(SmbiosManager::validate_and_count_strings(&[0u8]), Err(SmbiosError::InvalidStringPoolTermination)); // Too short
+        assert_eq!(
+            SmbiosManager::validate_and_count_strings(b"test\0"),
+            Err(SmbiosError::InvalidStringPoolTermination)
+        ); // No double null
+        assert_eq!(
+            SmbiosManager::validate_and_count_strings(b"test\0\0extra\0\0"),
+            Err(SmbiosError::EmptyStringInPool)
+        ); // Consecutive nulls
+
+        let mut pool = vec![b'a'; SMBIOS_STRING_MAX_LENGTH + 1];
+        pool.push(0);
+        pool.push(0);
+        assert_eq!(SmbiosManager::validate_and_count_strings(&pool), Err(SmbiosError::StringTooLong)); // String too long
+    }
+
+    #[test]
+    fn test_parse_strings_from_pool() {
+        // Success cases
+        let pool = b"first\0second\0third\0\0";
+        let strings = SmbiosManager::parse_strings_from_pool(pool).expect("parse failed");
+        assert_eq!(strings.len(), 3);
+        assert_eq!(strings[0], "first");
+        assert_eq!(strings[1], "second");
+        assert_eq!(strings[2], "third");
+
+        let pool_empty = b"\0\0";
+        assert_eq!(SmbiosManager::parse_strings_from_pool(pool_empty).expect("parse failed").len(), 0);
+
+        let pool_single = b"teststring\0\0";
+        let strings_single = SmbiosManager::parse_strings_from_pool(pool_single).expect("parse failed");
+        assert_eq!(strings_single.len(), 1);
+        assert_eq!(strings_single[0], "teststring");
+
+        let pool_chars = b"A\0B\0C\0\0";
+        let strings_chars = SmbiosManager::parse_strings_from_pool(pool_chars).expect("parse failed");
+        assert_eq!(strings_chars, vec!["A", "B", "C"]);
+
+        // Error cases
+        assert_eq!(SmbiosManager::parse_strings_from_pool(b"\0"), Err(SmbiosError::InvalidStringPoolTermination));
+        assert_eq!(
+            SmbiosManager::parse_strings_from_pool(b"test\0single"),
+            Err(SmbiosError::InvalidStringPoolTermination)
+        );
+        assert_eq!(SmbiosManager::parse_strings_from_pool(b"first\0\0extra\0\0"), Err(SmbiosError::EmptyStringInPool));
+    }
+
+    #[test]
+    fn test_build_record_with_strings() {
+        // Basic record with strings
+        let header = SmbiosTableHeader::new(1, 10, SMBIOS_HANDLE_PI_RESERVED);
+        let strings = &["Manufacturer", "Product"];
+        let record = build_test_record_with_strings(&header, strings);
+        assert!(record.len() >= core::mem::size_of::<SmbiosTableHeader>());
+        assert_eq!(record[0], 1);
+
+        // No strings
+        let strings_empty: &[&str] = &[];
+        let record_empty = build_test_record_with_strings(&header, strings_empty);
+        assert_eq!(record_empty[record_empty.len() - 1], 0);
+        assert_eq!(record_empty[record_empty.len() - 2], 0);
+
+        // Multiple strings with verification
+        let header2 = SmbiosTableHeader::new(2, 4, SMBIOS_HANDLE_PI_RESERVED);
+        let strings_multi = &["Manufacturer", "Product", "Version", "Serial"];
+        let record_multi = build_test_record_with_strings(&header2, strings_multi);
+        assert_eq!(record_multi[0], 2);
+        let pool = &record_multi[4..];
+        let parsed = SmbiosManager::parse_strings_from_pool(pool).expect("parse failed");
+        assert_eq!(parsed, vec!["Manufacturer", "Product", "Version", "Serial"]);
+
+        // Empty string edge case
+        let strings_empty_str = &[""];
+        let record_empty_str = build_test_record_with_strings(&header, strings_empty_str);
+        assert_eq!(record_empty_str[4], 0);
+        assert_eq!(record_empty_str[5], 0);
+    }
+
+    #[test]
+    fn test_version() {
+        let manager = SmbiosManager::new(3, 9).expect("failed to create manager");
+        assert_eq!((manager.major_version, manager.minor_version), (3, 9));
+    }
+
+    #[test]
+    fn test_version_custom_values() {
+        let manager = SmbiosManager::new(3, 7).expect("failed to create manager");
+        assert_eq!((manager.major_version, manager.minor_version), (3, 7));
+        let manager2 = SmbiosManager::new(3, 255).expect("failed to create manager");
+        assert_eq!((manager2.major_version, manager2.minor_version), (3, 255));
+    }
+
+    #[test]
+    fn test_allocate_handle_sequential() {
+        let manager = SmbiosManager::new(3, 9).expect("failed to create manager");
+        let handle1 = manager.allocate_handle().expect("allocation failed");
+        assert_eq!(handle1, 1);
+        let handle2 = manager.allocate_handle().expect("allocation failed");
+        assert_eq!(handle2, 2);
+    }
+
+    #[test]
+    fn test_allocate_handle_wraps_at_max() {
+        let manager = SmbiosManager::new(3, 9).expect("failed to create manager");
+        *manager.next_handle.borrow_mut() = 0xFFFD;
+        let handle1 = manager.allocate_handle().expect("allocation failed");
+        assert_eq!(handle1, 0xFFFD);
+        assert_eq!(manager.allocate_handle(), Err(SmbiosError::HandleExhausted));
+    }
+
+    #[test]
+    fn test_allocate_handle_uses_free_list() {
+        let manager = SmbiosManager::new(3, 9).expect("failed to create manager");
+        manager.freed_handles.borrow_mut().push(100);
+        manager.freed_handles.borrow_mut().push(50);
+        let handle1 = manager.allocate_handle().expect("allocation failed");
+        assert_eq!(handle1, 50);
+        let handle2 = manager.allocate_handle().expect("allocation failed");
+        assert_eq!(handle2, 100);
+        let handle3 = manager.allocate_handle().expect("allocation failed");
+        assert_eq!(handle3, 1);
+    }
+
+    #[test]
+    fn test_allocate_handle_with_gaps() {
+        let manager = SmbiosManager::new(3, 9).expect("failed to create manager");
+        let header1 = SmbiosTableHeader::new(1, 4, SMBIOS_HANDLE_PI_RESERVED);
+        let bytes1 = build_test_record_with_strings(&header1, &[]);
+        let _h1 = manager.add_from_bytes(None, &bytes1).expect("add failed");
+        let header2 = SmbiosTableHeader::new(1, 4, SMBIOS_HANDLE_PI_RESERVED);
+        let bytes2 = build_test_record_with_strings(&header2, &[]);
+        let h2 = manager.add_from_bytes(None, &bytes2).expect("add failed");
+        let header3 = SmbiosTableHeader::new(1, 4, SMBIOS_HANDLE_PI_RESERVED);
+        let bytes3 = build_test_record_with_strings(&header3, &[]);
+        let _h3 = manager.add_from_bytes(None, &bytes3).expect("add failed");
+        manager.remove(h2).expect("remove failed");
+        let header4 = SmbiosTableHeader::new(1, 4, SMBIOS_HANDLE_PI_RESERVED);
+        let bytes4 = build_test_record_with_strings(&header4, &[]);
+        let h4 = manager.add_from_bytes(None, &bytes4).expect("add failed");
+        assert_eq!(h4, h2);
+    }
+
+    #[test]
+    fn test_handle_reuse_after_remove() {
+        let manager = SmbiosManager::new(3, 9).expect("failed to create manager");
+        let mut record_data = vec![1u8, 4, 0, 0];
+        record_data.extend_from_slice(b"\0\0");
+        let handle1 = manager.add_from_bytes(None, &record_data).expect("add failed");
+        manager.remove(handle1).expect("remove failed");
+        let mut record_data2 = vec![2u8, 4, 0, 0];
+        record_data2.extend_from_slice(b"\0\0");
+        let handle2 = manager.add_from_bytes(None, &record_data2).expect("add failed");
+        assert_eq!(handle1, handle2);
+    }
+
+    #[test]
+    fn test_update_string_success() {
+        let manager = SmbiosManager::new(3, 9).expect("failed to create manager");
+        let mut record_data = vec![1u8, 4, 0, 0];
+        record_data.extend_from_slice(b"original\0\0");
+        let handle = manager.add_from_bytes(None, &record_data).expect("add failed");
+        manager.update_string(handle, 1, "updated").expect("update failed");
+        assert!(manager.update_string(handle, 1, "another").is_ok());
+    }
+
+    #[test]
+    fn test_update_string_handle_not_found() {
+        let manager = SmbiosManager::new(3, 9).expect("failed to create manager");
+        assert_eq!(manager.update_string(999, 1, "test"), Err(SmbiosError::HandleNotFound));
+    }
+
+    #[test]
+    fn test_update_string_invalid_string_number() {
+        let manager = SmbiosManager::new(3, 9).expect("failed to create manager");
+        let mut record_data = vec![1u8, 4, 0, 0];
+        record_data.extend_from_slice(b"test\0\0");
+        let handle = manager.add_from_bytes(None, &record_data).expect("add failed");
+        assert_eq!(manager.update_string(handle, 0, "new"), Err(SmbiosError::StringIndexOutOfRange));
+        assert_eq!(manager.update_string(handle, 2, "new"), Err(SmbiosError::StringIndexOutOfRange));
+    }
+
+    #[test]
+    fn test_update_string_too_long() {
+        let manager = SmbiosManager::new(3, 9).expect("failed to create manager");
+        let mut record_data = vec![1u8, 4, 0, 0];
+        record_data.extend_from_slice(b"test\0\0");
+        let handle = manager.add_from_bytes(None, &record_data).expect("add failed");
+        let long_string = "a".repeat(SMBIOS_STRING_MAX_LENGTH + 1);
+        assert_eq!(manager.update_string(handle, 1, &long_string), Err(SmbiosError::StringTooLong));
+    }
+
+    #[test]
+    fn test_update_string_rebuilds_pool() {
+        let manager = SmbiosManager::new(3, 9).expect("failed to create manager");
+        let mut record_data = vec![1u8, 4, 0, 0];
+        record_data.extend_from_slice(b"first\0second\0third\0\0");
+        let handle = manager.add_from_bytes(None, &record_data).expect("add failed");
+        manager.update_string(handle, 2, "new_second_string").expect("update failed");
+        assert!(manager.update_string(handle, 1, "new_first").is_ok());
+        assert!(manager.update_string(handle, 3, "new_third").is_ok());
+    }
+
+    #[test]
+    fn test_update_string_with_empty_string() {
+        let manager = SmbiosManager::new(3, 9).expect("failed to create manager");
+        let header = SmbiosTableHeader::new(1, 4, SMBIOS_HANDLE_PI_RESERVED);
+        let bytes = build_test_record_with_strings(&header, &["Original"]);
+        let handle = manager.add_from_bytes(None, &bytes).expect("add failed");
+        let result = manager.update_string(handle, 1, "");
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_update_string_buffer_too_small_error() {
+        use super::SmbiosRecord;
+        let manager = SmbiosManager::new(3, 9).expect("failed to create manager");
+        let header = SmbiosTableHeader::new(1, 10, 1);
+        let data = vec![1u8, 10, 1, 0];
+        let record = SmbiosRecord::new(header, None, data, 1);
+        manager.records.borrow_mut().push(record);
+        assert_eq!(manager.update_string(1, 1, "test"), Err(SmbiosError::RecordTooSmall));
+    }
+
+    #[test]
+    fn test_remove_success() {
+        let manager = SmbiosManager::new(3, 9).expect("failed to create manager");
+        let mut record_data = vec![1u8, 4, 0, 0];
+        record_data.extend_from_slice(b"\0\0");
+        let handle = manager.add_from_bytes(None, &record_data).expect("add failed");
+        assert!(manager.remove(handle).is_ok());
+        assert_eq!(manager.remove(handle), Err(SmbiosError::HandleNotFound));
+    }
+
+    #[test]
+    fn test_remove_last_record() {
+        let manager = SmbiosManager::new(3, 9).expect("failed to create manager");
+        let header = SmbiosTableHeader::new(1, 4, SMBIOS_HANDLE_PI_RESERVED);
+        let bytes = build_test_record_with_strings(&header, &[]);
+        let handle = manager.add_from_bytes(None, &bytes).expect("add failed");
+        manager.remove(handle).expect("remove failed");
+        assert_eq!(manager.records.borrow().len(), 0);
+    }
+
+    #[test]
+    fn test_remove_reserved_handle_not_added_to_free_list() {
+        let manager = SmbiosManager::new(3, 9).expect("failed to create manager");
+        let mut record_data = vec![1u8, 4, 0, 0];
+        record_data.extend_from_slice(b"\0\0");
+        let handle = manager.add_from_bytes(None, &record_data).expect("add failed");
+        manager.remove(handle).expect("remove failed");
+        let freed = manager.freed_handles.borrow();
+        assert_eq!(freed.len(), 1);
+        assert_eq!(freed[0], handle);
+    }
+
+    #[test]
+    fn test_iteration() {
+        let manager = SmbiosManager::new(3, 9).expect("failed to create manager");
+
+        // Empty manager
+        assert_eq!(manager.iter(None).count(), 0);
+
+        // Add test records: types [1, 2, 1, 3, 1]
+        for record_type in [1u8, 2, 1, 3, 1] {
+            let mut record_data = vec![record_type, 4, 0, 0];
+            record_data.extend_from_slice(b"\0\0");
+            manager.add_from_bytes(None, &record_data).expect("add failed");
+        }
+
+        // Iterate all - should have 5 records
+        assert_eq!(manager.iter(None).count(), 5);
+
+        // Filter by type 1 - should find 3 records
+        let mut count_type1 = 0;
+        for (header, _) in manager.iter(Some(1)) {
+            assert_eq!(header.record_type, 1);
+            count_type1 += 1;
+        }
+        assert_eq!(count_type1, 3);
+
+        // Filter by nonexistent type - should find 0
+        assert_eq!(manager.iter(Some(99)).count(), 0);
+    }
+
+    #[test]
+    fn test_iteration_navigation() {
+        let manager = SmbiosManager::new(3, 9).expect("failed to create manager");
+        let handles: Vec<SmbiosHandle> = (1..=3)
+            .map(|i| {
+                let mut record_data = vec![i, 4, 0, 0];
+                record_data.extend_from_slice(b"\0\0");
+                manager.add_from_bytes(None, &record_data).expect("add failed")
+            })
+            .collect();
+
+        // Navigate from middle handle
+        let result = manager.iter(None).skip_while(|(hdr, _)| hdr.handle != handles[1]).nth(1);
+        let (header, _) = result.expect("Should find next record");
+        // Copy to avoid unaligned reference
+        let found_handle = header.handle;
+        let found_type = header.record_type;
+        assert_eq!(found_handle, handles[2]);
+        assert_eq!(found_type, 3);
+
+        // Invalid start handle - should not find anything after skip
+        let result = manager.iter(None).skip_while(|(hdr, _)| hdr.handle != 9999).nth(1);
+        assert!(result.is_none(), "Should not find any record after non-existent handle");
+    }
+
+    #[test]
+    fn test_add_from_bytes_buffer_too_small() {
+        let manager = SmbiosManager::new(3, 9).expect("failed to create manager");
+        let small_buffer = vec![1u8, 2];
+        assert_eq!(manager.add_from_bytes(None, &small_buffer), Err(SmbiosError::RecordTooSmall));
+    }
+
+    #[test]
+    fn test_add_from_bytes_invalid_length() {
+        let manager = SmbiosManager::new(3, 9).expect("failed to create manager");
+        let invalid_data = vec![1u8, 255, 0, 0, 0, 0];
+        assert_eq!(manager.add_from_bytes(None, &invalid_data), Err(SmbiosError::RecordTooSmall));
+    }
+
+    #[test]
+    fn test_add_from_bytes_no_string_pool() {
+        let manager = SmbiosManager::new(3, 9).expect("failed to create manager");
+        let mut data = vec![1u8, 10, 0, 0];
+        data.extend_from_slice(&[0u8; 6]);
+        assert_eq!(manager.add_from_bytes(None, &data), Err(SmbiosError::RecordTooSmall));
+    }
+
+    #[test]
+    fn test_add_from_bytes_with_producer_handle() {
+        let manager = SmbiosManager::new(3, 9).expect("failed to create manager");
+        let producer = 0x1234 as efi::Handle;
+        let mut record_data = vec![1u8, 4, 0, 0];
+        record_data.extend_from_slice(b"\0\0");
+        let handle = manager.add_from_bytes(Some(producer), &record_data).expect("add failed");
+        let mut found = false;
+        for (header, found_producer) in manager.iter(None) {
+            assert_eq!(found_producer, Some(producer));
+            let found_handle = header.handle;
+            assert_eq!(found_handle, handle);
+            found = true;
+        }
+        assert!(found);
+    }
+
+    #[test]
+    fn test_add_from_bytes_with_strings() {
+        let manager = SmbiosManager::new(3, 9).expect("failed to create manager");
+        let mut record_data = vec![1u8, 6, 0, 0];
+        record_data.extend_from_slice(&[0x01, 0x02]);
+        record_data.extend_from_slice(b"String1\0String2\0\0");
+        let assigned_handle = manager.add_from_bytes(None, &record_data).expect("add failed");
+        let records = manager.records.borrow();
+        assert_eq!(records.len(), 1);
+        let handle = records[0].header.handle;
+        assert_eq!(handle, assigned_handle);
+        assert_eq!(records[0].string_count, 2);
+    }
+
+    #[test]
+    fn test_add_from_bytes_with_max_handle() {
+        let manager = SmbiosManager::new(3, 9).expect("failed to create manager");
+        let header = SmbiosTableHeader::new(1, 4, 0xFEFF);
+        let record_bytes = build_test_record_with_strings(&header, &[]);
+        let result = manager.add_from_bytes(None, &record_bytes);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_add_from_bytes_updates_handle_in_data() {
+        let manager = SmbiosManager::new(3, 9).expect("failed to create manager");
+        let mut record_data = vec![1u8, 4, 0xFF, 0xFF];
+        record_data.extend_from_slice(b"\0\0");
+        let assigned_handle = manager.add_from_bytes(None, &record_data).expect("add failed");
+        let records = manager.records.borrow();
+        let stored_data = &records[0].data;
+        let stored_handle = u16::from_le_bytes([stored_data[2], stored_data[3]]);
+        assert_eq!(stored_handle, assigned_handle);
+    }
+
+    #[test]
+    fn test_calculate_checksum() {
+        let entry_point = Smbios30EntryPoint {
+            anchor_string: *b"_SM3_",
+            checksum: 0,
+            length: 24,
+            major_version: 3,
+            minor_version: 9,
+            docrev: 0,
+            entry_point_revision: 1,
+            reserved: 0,
+            table_max_size: 0x1000,
+            table_address: 0x80000000,
+        };
+        let checksum = SmbiosManager::calculate_checksum(&entry_point);
+        let mut test_entry = entry_point;
+        test_entry.checksum = checksum;
+        let bytes = test_entry.as_bytes();
+        let sum: u8 = bytes.iter().fold(0u8, |acc, &b| acc.wrapping_add(b));
+        assert_eq!(sum, 0);
+    }
+
+    #[test]
+    fn test_calculate_checksum_zero() {
+        let entry_point = Smbios30EntryPoint {
+            anchor_string: [0, 0, 0, 0, 0],
+            checksum: 0,
+            length: 0,
+            major_version: 0,
+            minor_version: 0,
+            docrev: 0,
+            entry_point_revision: 0,
+            reserved: 0,
+            table_max_size: 0,
+            table_address: 0,
+        };
+        let checksum = SmbiosManager::calculate_checksum(&entry_point);
+        assert_eq!(checksum, 0);
+    }
+
+    #[test]
+    fn test_smbios_record_builder_with_fields() {
+        let header = SmbiosTableHeader::new(3, 4 + 3, SMBIOS_HANDLE_PI_RESERVED);
+        let strings = &["Chassis Manufacturer", "Tower", "v1.0"];
+        let record = build_test_record_with_strings(&header, strings);
+        assert_eq!(record[0], 3);
+        assert!(record.len() > 10);
+    }
+
+    #[test]
+    fn test_smbios_record_builder_empty_build() {
+        let header = SmbiosTableHeader::new(127, 4, SMBIOS_HANDLE_PI_RESERVED);
+        let record = build_test_record_with_strings(&header, &[]);
+        assert_eq!(record[0], 127);
+        assert_eq!(record[1], 4);
+        assert_eq!(record[record.len() - 1], 0);
+        assert_eq!(record[record.len() - 2], 0);
+    }
+
+    #[test]
+    fn test_smbios_record_builder_multiple_fields() {
+        let header = SmbiosTableHeader::new(3, 4 + 15, SMBIOS_HANDLE_PI_RESERVED);
+        let mut record_data = Vec::new();
+        record_data.extend_from_slice(header.as_bytes());
+        record_data.push(1);
+        record_data.push(0x12);
+        record_data.push(2);
+        record_data.push(3);
+        record_data.push(4);
+        record_data.push(0x03);
+        record_data.push(0x03);
+        record_data.push(0x03);
+        record_data.push(0x02);
+        record_data.extend_from_slice(&0x789ABCDE_u32.to_le_bytes());
+        record_data.push(0x04);
+        record_data.push(0x01);
+        record_data.push(0);
+        record_data.push(0);
+        assert_eq!(record_data[0], 3);
+        assert!(record_data.len() > core::mem::size_of::<SmbiosTableHeader>());
+    }
+
+    #[test]
+    fn test_smbios_record_builder_with_multiple_strings() {
+        let header = SmbiosTableHeader::new(1, 4, SMBIOS_HANDLE_PI_RESERVED);
+        let strings = &["String1", "String2", "String3"];
+        let record = build_test_record_with_strings(&header, strings);
+        assert_eq!(record[0], 1);
+        let record_str = core::str::from_utf8(&record[4..]).unwrap_or("");
+        assert!(record_str.contains("String1"));
+        assert!(record_str.contains("String2"));
+        assert!(record_str.contains("String3"));
+    }
+
+    #[test]
+    fn test_smbios_table_header() {
+        // Test creation and field access
+        let header = SmbiosTableHeader::new(42, 100, 0x1234);
+        let record_type = header.record_type;
+        let length = header.length;
+        let handle = header.handle;
+        assert_eq!(record_type, 42);
+        assert_eq!(length, 100);
+        assert_eq!(handle, 0x1234);
+
+        // Test with different values
+        let header2 = SmbiosTableHeader::new(5, 20, 42);
+        let record_type2 = header2.record_type;
+        let length2 = header2.length;
+        let handle2 = header2.handle;
+        assert_eq!(record_type2, 5);
+        assert_eq!(length2, 20);
+        assert_eq!(handle2, 42);
+    }
+
+    #[test]
+    fn test_smbios_handle_constants() {
+        assert_eq!(SMBIOS_HANDLE_PI_RESERVED, 0xFFFE);
+    }
+}

--- a/components/patina_smbios/src/manager/protocol.rs
+++ b/components/patina_smbios/src/manager/protocol.rs
@@ -1,0 +1,433 @@
+//! C/EDKII protocol compatibility layer
+//!
+//! This module provides the EDKII-compatible C protocol interface for SMBIOS operations.
+//! It implements the standard EDK2 SMBIOS protocol with functions for adding, updating,
+//! removing, and iterating SMBIOS records.
+//!
+//! This module is excluded from coverage as it's FFI code tested via integration.
+//!
+//! ## License
+//!
+//! Copyright (C) Microsoft Corporation.
+//!
+//! SPDX-License-Identifier: Apache-2.0
+//!
+
+use core::ffi::c_char;
+
+use patina::{boot_services::StandardBootServices, tpl_mutex::TplMutex, uefi_protocol::ProtocolInterface};
+use r_efi::efi;
+
+use crate::{
+    error::SmbiosError,
+    service::{SMBIOS_HANDLE_PI_RESERVED, SmbiosHandle, SmbiosTableHeader, SmbiosType},
+};
+
+use super::core::SmbiosManager;
+
+#[repr(C)]
+pub(super) struct SmbiosProtocol {
+    add: SmbiosAdd,
+    update_string: SmbiosUpdateString,
+    remove: SmbiosRemove,
+    get_next: SmbiosGetNext,
+    major_version: u8,
+    minor_version: u8,
+}
+
+/// Internal protocol struct that packs the manager behind the protocol
+#[repr(C)]
+pub(super) struct SmbiosProtocolInternal {
+    // The public protocol that external callers will depend on
+    pub(super) protocol: SmbiosProtocol,
+
+    // Internal component access only! Does not exist in C definition
+    pub(super) manager: &'static TplMutex<'static, SmbiosManager, StandardBootServices>,
+
+    // Storage for header returned by C protocol's get_next
+    // Avoids heap allocation - reused across calls
+    pub(super) header_buffer: core::cell::UnsafeCell<SmbiosTableHeader>,
+}
+
+unsafe impl ProtocolInterface for SmbiosProtocol {
+    const PROTOCOL_GUID: efi::Guid =
+        efi::Guid::from_fields(0x03583ff6, 0xcb36, 0x4940, 0x94, 0x7e, &[0xb9, 0xb3, 0x9f, 0x4a, 0xfa, 0xf7]);
+}
+
+#[allow(dead_code)]
+type SmbiosAdd =
+    extern "efiapi" fn(*const SmbiosProtocol, efi::Handle, *mut SmbiosHandle, *const SmbiosTableHeader) -> efi::Status;
+
+#[allow(dead_code)]
+type SmbiosUpdateString =
+    extern "efiapi" fn(*const SmbiosProtocol, *mut SmbiosHandle, *mut usize, *const c_char) -> efi::Status;
+
+#[allow(dead_code)]
+type SmbiosRemove = extern "efiapi" fn(*const SmbiosProtocol, SmbiosHandle) -> efi::Status;
+
+#[allow(dead_code)]
+type SmbiosGetNext = extern "efiapi" fn(
+    *const SmbiosProtocol,
+    *mut SmbiosHandle,
+    *mut SmbiosType,
+    *mut *mut SmbiosTableHeader,
+    *mut efi::Handle,
+) -> efi::Status;
+
+impl SmbiosProtocol {
+    pub(super) fn new(major_version: u8, minor_version: u8) -> Self {
+        Self {
+            add: Self::add_ext,
+            update_string: Self::update_string_ext,
+            remove: Self::remove_ext,
+            get_next: Self::get_next_ext,
+            major_version,
+            minor_version,
+        }
+    }
+}
+
+impl SmbiosProtocolInternal {
+    /// Creates a new SMBIOS protocol internal structure
+    ///
+    /// This constructor is tested via integration (Q35 platform component)
+    /// as it requires 'static boot services which cannot be mocked in unit tests.
+    #[cfg_attr(coverage_nightly, coverage(off))]
+    pub(super) fn new(
+        major_version: u8,
+        minor_version: u8,
+        manager: &'static TplMutex<'static, SmbiosManager, StandardBootServices>,
+    ) -> Self {
+        Self {
+            protocol: SmbiosProtocol::new(major_version, minor_version),
+            manager,
+            header_buffer: core::cell::UnsafeCell::new(SmbiosTableHeader::new(0, 0, 0)),
+        }
+    }
+}
+
+impl SmbiosProtocol {
+    /// C protocol implementation for adding SMBIOS records
+    ///
+    /// # Safety
+    ///
+    /// This function is only safe to call from the C UEFI protocol layer where the
+    /// caller guarantees that `record` points to a complete, valid SMBIOS record.
+    #[coverage(off)] // FFI function - tested via integration tests
+    extern "efiapi" fn add_ext(
+        protocol: *const SmbiosProtocol,
+        producer_handle: efi::Handle,
+        smbios_handle: *mut SmbiosHandle,
+        record: *const SmbiosTableHeader,
+    ) -> efi::Status {
+        // Safety checks
+        if smbios_handle.is_null() || record.is_null() {
+            return efi::Status::INVALID_PARAMETER;
+        }
+
+        // SAFETY: We must trust the C code was a responsible steward of this pointer
+        // Cast from protocol pointer to internal struct pointer
+        let internal = unsafe { &*(protocol as *const SmbiosProtocolInternal) };
+        let manager = internal.manager.lock();
+
+        // SAFETY: The C UEFI protocol caller guarantees that `record` points to a valid,
+        // complete SMBIOS record. We read the length field to determine the full record size.
+        unsafe {
+            let header = &*record;
+            let record_length = header.length as usize;
+
+            // Validate that we can safely read the record
+            if record_length < core::mem::size_of::<SmbiosTableHeader>() {
+                return efi::Status::INVALID_PARAMETER;
+            }
+
+            // Scan for the string pool terminator (double null)
+            let base_ptr = record as *const u8;
+
+            // Scan for double null terminator
+            let mut consecutive_nulls = 0;
+            let mut offset = record_length;
+            const MAX_STRING_POOL_SIZE: usize = 4096; // Safety limit
+
+            while consecutive_nulls < 2 && offset < record_length + MAX_STRING_POOL_SIZE {
+                let byte = *base_ptr.add(offset);
+                if byte == 0 {
+                    consecutive_nulls += 1;
+                } else {
+                    consecutive_nulls = 0;
+                }
+                offset += 1;
+            }
+
+            if consecutive_nulls < 2 {
+                // Malformed record - no double null terminator found
+                return efi::Status::INVALID_PARAMETER;
+            }
+
+            let total_size = offset;
+
+            // Create a slice of the complete record
+            let full_record_bytes = core::slice::from_raw_parts(base_ptr, total_size);
+
+            // Convert handle
+            let producer_opt = if producer_handle.is_null() { None } else { Some(producer_handle) };
+
+            // Add the record
+            match manager.add_from_bytes(producer_opt, full_record_bytes) {
+                Ok(handle) => {
+                    *smbios_handle = handle;
+                    efi::Status::SUCCESS
+                }
+                Err(SmbiosError::StringContainsNull) => efi::Status::INVALID_PARAMETER,
+                Err(SmbiosError::EmptyStringInPool) => efi::Status::INVALID_PARAMETER,
+                Err(SmbiosError::RecordTooSmall) => efi::Status::BUFFER_TOO_SMALL,
+                Err(SmbiosError::MalformedRecordHeader) => efi::Status::INVALID_PARAMETER,
+                Err(SmbiosError::InvalidStringPoolTermination) => efi::Status::INVALID_PARAMETER,
+                Err(SmbiosError::StringPoolTooSmall) => efi::Status::BUFFER_TOO_SMALL,
+                Err(SmbiosError::HandleExhausted) => efi::Status::OUT_OF_RESOURCES,
+                Err(SmbiosError::AllocationFailed) => efi::Status::OUT_OF_RESOURCES,
+                Err(SmbiosError::StringTooLong) => efi::Status::INVALID_PARAMETER,
+                Err(_) => efi::Status::DEVICE_ERROR,
+            }
+        }
+    }
+
+    #[coverage(off)] // FFI function - tested via integration tests
+    extern "efiapi" fn update_string_ext(
+        protocol: *const SmbiosProtocol,
+        smbios_handle: *mut SmbiosHandle,
+        string_number: *mut usize,
+        string: *const c_char,
+    ) -> efi::Status {
+        if smbios_handle.is_null() || string_number.is_null() || string.is_null() {
+            return efi::Status::INVALID_PARAMETER;
+        }
+
+        // SAFETY: Cast from protocol pointer to internal struct pointer
+        let internal = unsafe { &*(protocol as *const SmbiosProtocolInternal) };
+        let manager = internal.manager.lock();
+
+        unsafe {
+            let handle = *smbios_handle;
+            let str_num = *string_number;
+
+            // Convert C string to Rust str
+            let c_str = core::ffi::CStr::from_ptr(string);
+            let rust_str = match c_str.to_str() {
+                Ok(s) => s,
+                Err(_) => return efi::Status::INVALID_PARAMETER,
+            };
+
+            match manager.update_string(handle, str_num, rust_str) {
+                Ok(()) => efi::Status::SUCCESS,
+                Err(SmbiosError::StringContainsNull) => efi::Status::INVALID_PARAMETER,
+                Err(SmbiosError::HandleNotFound) => efi::Status::NOT_FOUND,
+                Err(SmbiosError::StringIndexOutOfRange) => efi::Status::INVALID_PARAMETER,
+                Err(SmbiosError::StringTooLong) => efi::Status::INVALID_PARAMETER,
+                Err(_) => efi::Status::DEVICE_ERROR,
+            }
+        }
+    }
+
+    #[coverage(off)] // FFI function - tested via integration tests
+    extern "efiapi" fn remove_ext(protocol: *const SmbiosProtocol, smbios_handle: SmbiosHandle) -> efi::Status {
+        // SAFETY: Cast from protocol pointer to internal struct pointer
+        let internal = unsafe { &*(protocol as *const SmbiosProtocolInternal) };
+        let manager = internal.manager.lock();
+
+        match manager.remove(smbios_handle) {
+            Ok(()) => efi::Status::SUCCESS,
+            Err(SmbiosError::HandleNotFound) => efi::Status::NOT_FOUND,
+            Err(_) => efi::Status::DEVICE_ERROR,
+        }
+    }
+
+    #[coverage(off)] // FFI function - tested via integration tests
+    extern "efiapi" fn get_next_ext(
+        protocol: *const SmbiosProtocol,
+        smbios_handle: *mut SmbiosHandle,
+        record_type: *mut SmbiosType,
+        record: *mut *mut SmbiosTableHeader,
+        producer_handle: *mut efi::Handle,
+    ) -> efi::Status {
+        if smbios_handle.is_null() || record.is_null() {
+            return efi::Status::INVALID_PARAMETER;
+        }
+
+        // SAFETY: Cast from protocol pointer to internal struct pointer
+        let internal = unsafe { &*(protocol as *const SmbiosProtocolInternal) };
+        let manager = internal.manager.lock();
+
+        unsafe {
+            let handle = *smbios_handle;
+            let type_filter = if record_type.is_null() { None } else { Some(*record_type) };
+
+            // Use the iterator to find the next record
+            let mut iter = manager.iter(type_filter);
+
+            // Skip records until we find the one after the current handle
+            let next_record = if handle == SMBIOS_HANDLE_PI_RESERVED {
+                // Starting iteration - get first record
+                iter.next()
+            } else {
+                // Find the record after the current handle
+                iter.skip_while(|(hdr, _)| hdr.handle != handle).nth(1)
+            };
+
+            match next_record {
+                Some((header_value, prod_handle)) => {
+                    *smbios_handle = header_value.handle;
+
+                    // Store header in internal buffer and return pointer to it
+                    let buffer_ptr = internal.header_buffer.get();
+                    *buffer_ptr = header_value;
+                    *record = buffer_ptr;
+
+                    if !producer_handle.is_null() {
+                        *producer_handle = prod_handle.unwrap_or(core::ptr::null_mut());
+                    }
+                    efi::Status::SUCCESS
+                }
+                None => {
+                    *smbios_handle = SMBIOS_HANDLE_PI_RESERVED;
+                    efi::Status::NOT_FOUND
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+#[coverage(off)]
+mod tests {
+    use super::*;
+    use crate::manager::SmbiosManager;
+    extern crate std;
+    use std::vec::Vec;
+
+    fn create_test_bios_info_record() -> Vec<u8> {
+        // Create a simple BIOS Information record (Type 0)
+        let mut record = Vec::new();
+
+        // Header
+        record.push(0); // Type: BIOS Information
+        record.push(24); // Length
+        record.extend_from_slice(&0x0001u16.to_le_bytes()); // Handle
+
+        // BIOS Information specific fields (simplified)
+        record.push(1); // Vendor string number
+        record.push(2); // BIOS Version string number
+        record.extend_from_slice(&0x0000u16.to_le_bytes()); // BIOS Starting Address Segment
+        record.push(3); // BIOS Release Date string number
+        record.push(0); // BIOS ROM Size
+        record.extend_from_slice(&[0; 8]); // BIOS Characteristics
+        record.extend_from_slice(&[0; 2]); // BIOS Characteristics Extension Bytes
+        record.push(0); // System BIOS Major Release
+        record.push(0); // System BIOS Minor Release
+        record.push(0); // Embedded Controller Firmware Major Release
+        record.push(0); // Embedded Controller Firmware Minor Release
+
+        // Strings section
+        record.extend_from_slice(b"Test Vendor\0"); // String 1
+        record.extend_from_slice(b"Test Version\0"); // String 2
+        record.extend_from_slice(b"01/01/2023\0"); // String 3
+        record.push(0); // End of strings marker
+
+        record
+    }
+
+    // Core manager functionality tests - these test the underlying logic
+    #[test]
+    fn test_manager_add_record() {
+        let manager = SmbiosManager::new(3, 6).unwrap();
+        let record_data = create_test_bios_info_record();
+
+        let result = manager.add_from_bytes(None, &record_data);
+        assert!(result.is_ok());
+
+        let handle = result.unwrap();
+        assert_ne!(handle, 0);
+    }
+
+    #[test]
+    fn test_manager_add_invalid_record() {
+        let manager = SmbiosManager::new(3, 6).unwrap();
+        let invalid_record = std::vec![1, 2, 3]; // Too small
+
+        let result = manager.add_from_bytes(None, &invalid_record);
+        assert!(result.is_err());
+        assert!(matches!(result.unwrap_err(), SmbiosError::RecordTooSmall));
+    }
+
+    #[test]
+    fn test_manager_operations() {
+        let manager = SmbiosManager::new(3, 6).unwrap();
+        let record_data = create_test_bios_info_record();
+
+        // Add record
+        let handle = manager.add_from_bytes(None, &record_data).unwrap();
+
+        // Update string
+        let result = manager.update_string(handle, 1, "Updated Vendor");
+        assert!(result.is_ok());
+
+        // Remove record
+        let result = manager.remove(handle);
+        assert!(result.is_ok());
+
+        // Try to remove again (should fail)
+        let result2 = manager.remove(handle);
+        assert!(result2.is_err());
+    }
+
+    // Protocol-specific tests
+    #[test]
+    fn test_protocol_new() {
+        let protocol = SmbiosProtocol::new(3, 9);
+        assert_eq!(protocol.major_version, 3);
+        assert_eq!(protocol.minor_version, 9);
+    }
+
+    #[test]
+    fn test_protocol_custom_version() {
+        // Test with SMBIOS 3.7 (a valid historical version)
+        let protocol = SmbiosProtocol::new(3, 7);
+        assert_eq!(protocol.major_version, 3);
+        assert_eq!(protocol.minor_version, 7);
+    }
+
+    #[test]
+    fn test_protocol_version_storage() {
+        // Test that version is stored in the protocol struct without needing manager access
+        let protocol1 = SmbiosProtocol::new(3, 0);
+        let protocol2 = SmbiosProtocol::new(3, 9);
+
+        assert_eq!(protocol1.major_version, 3);
+        assert_eq!(protocol1.minor_version, 0);
+        assert_eq!(protocol2.major_version, 3);
+        assert_eq!(protocol2.minor_version, 9);
+    }
+
+    #[test]
+    fn test_protocol_guid() {
+        use patina::uefi_protocol::ProtocolInterface;
+
+        // Verify the GUID matches the EDK2 SMBIOS protocol GUID
+        let expected_guid =
+            efi::Guid::from_fields(0x03583ff6, 0xcb36, 0x4940, 0x94, 0x7e, &[0xb9, 0xb3, 0x9f, 0x4a, 0xfa, 0xf7]);
+
+        assert_eq!(SmbiosProtocol::PROTOCOL_GUID, expected_guid);
+    }
+
+    #[test]
+    fn test_protocol_is_repr_c() {
+        // Verify SmbiosProtocol can be used as a C struct
+        // The size should be consistent (function pointers + version bytes)
+        let size = core::mem::size_of::<SmbiosProtocol>();
+
+        // Should have 4 function pointers and 2 u8 fields
+        // Size will vary by architecture but should be deterministic
+        assert!(size > 0);
+        assert_eq!(size, core::mem::size_of::<SmbiosProtocol>());
+    }
+}

--- a/components/patina_smbios/src/manager/record.rs
+++ b/components/patina_smbios/src/manager/record.rs
@@ -1,0 +1,79 @@
+//! Internal SMBIOS record structures and builder
+//!
+//! This module provides internal record representation and serialization utilities
+//! for SMBIOS table construction.
+//!
+//! ## License
+//!
+//! Copyright (C) Microsoft Corporation.
+//!
+//! SPDX-License-Identifier: Apache-2.0
+//!
+
+extern crate alloc;
+
+use alloc::vec::Vec;
+
+use crate::service::SmbiosTableHeader;
+use r_efi::efi::Handle;
+
+/// Internal SMBIOS record representation
+///
+/// This implementation is for SMBIOS 3.0+ specification which uses 64-bit addressing.
+pub struct SmbiosRecord {
+    /// SMBIOS table header
+    pub header: SmbiosTableHeader,
+    /// Optional handle of the producer that created this record
+    pub producer_handle: Option<Handle>,
+    /// Complete record data including header and strings
+    pub data: Vec<u8>,
+    pub(super) string_count: usize,
+}
+
+impl SmbiosRecord {
+    /// Creates a new SMBIOS record
+    pub fn new(header: SmbiosTableHeader, producer_handle: Option<Handle>, data: Vec<u8>, string_count: usize) -> Self {
+        Self { header, producer_handle, data, string_count }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    extern crate std;
+    use std::vec;
+
+    use r_efi::efi;
+
+    #[test]
+    fn test_smbios_record_new() {
+        let header = SmbiosTableHeader::new(1, 10, 5);
+        let data = vec![1u8, 10, 5, 0, 0, 0, 0, 0, 0, 0, 0, 0];
+        let record = SmbiosRecord::new(header, None, data.clone(), 0);
+        let record_type = record.header.record_type;
+        let handle = record.header.handle;
+        assert_eq!(record_type, 1);
+        assert_eq!(handle, 5);
+        assert_eq!(record.producer_handle, None);
+        assert_eq!(record.data, data);
+        assert_eq!(record.string_count, 0);
+    }
+
+    #[test]
+    fn test_smbios_record_with_producer_handle() {
+        let header = SmbiosTableHeader::new(2, 8, 10);
+        let producer = core::ptr::null_mut::<()>() as efi::Handle;
+        let data = vec![2u8, 8, 10, 0, 0, 0, 0, 0];
+        let record = SmbiosRecord::new(header, Some(producer), data, 2);
+        assert_eq!(record.string_count, 2);
+        assert_eq!(record.producer_handle, Some(producer));
+    }
+
+    #[test]
+    fn test_smbios_record_with_string_count() {
+        let header = SmbiosTableHeader::new(1, 4, 10);
+        let data = vec![1, 4, 10, 0, 0, 0];
+        let record = SmbiosRecord::new(header, None, data, 5);
+        assert_eq!(record.string_count, 5);
+    }
+}

--- a/components/patina_smbios/src/service.rs
+++ b/components/patina_smbios/src/service.rs
@@ -1,0 +1,727 @@
+//! SMBIOS service interfaces
+//!
+//! This module defines the public service types for SMBIOS operations.
+//! These are the primary interfaces that platform code uses to interact with SMBIOS.
+//!
+//! ## License
+//!
+//! Copyright (c) Microsoft Corporation.
+//!
+//! SPDX-License-Identifier: Apache-2.0
+//!
+
+extern crate alloc;
+use alloc::vec::Vec;
+use core::cell::Ref;
+use r_efi::efi::Handle;
+use zerocopy_derive::{FromBytes, Immutable, IntoBytes as DeriveIntoBytes, KnownLayout};
+
+#[cfg(any(test, feature = "mockall"))]
+use mockall::automock;
+
+/// SMBIOS record handle type (16-bit identifier)
+pub type SmbiosHandle = u16;
+
+/// SMBIOS record type
+pub type SmbiosType = u8;
+
+/// Special handle value for automatic assignment
+pub const SMBIOS_HANDLE_PI_RESERVED: SmbiosHandle = 0xFFFE;
+
+/// SMBIOS string maximum length per specification
+pub const SMBIOS_STRING_MAX_LENGTH: usize = 64;
+
+/// SMBIOS table header structure
+///
+/// This is the standard 4-byte header that appears at the start of every SMBIOS record.
+/// It contains the record type, length of structured data, and a unique handle.
+#[repr(C, packed)]
+#[derive(Debug, Clone, PartialEq, FromBytes, DeriveIntoBytes, Immutable, KnownLayout)]
+pub struct SmbiosTableHeader {
+    /// SMBIOS record type
+    pub record_type: SmbiosType,
+    /// Length of the structured data (including header)
+    pub length: u8,
+    /// Unique handle for this record
+    pub handle: SmbiosHandle,
+}
+
+impl SmbiosTableHeader {
+    /// Creates a new SMBIOS table header
+    pub fn new(record_type: SmbiosType, length: u8, handle: SmbiosHandle) -> Self {
+        Self { record_type, length, handle }
+    }
+}
+
+/// Iterator over SMBIOS records
+///
+/// This iterator is used internally by the SMBIOS manager for:
+/// - C protocol `GetNext` implementation (EDKII compatibility)
+/// - Internal iteration during table publication
+/// - Test validation
+///
+/// **Note:** This iterator is not exposed through the public `Service<Smbios>` API.
+/// Platform code typically adds records using `add_record<T>()` and then publishes
+/// the table for the OS to query directly.
+///
+/// # Type Filtering
+///
+/// The iterator can optionally filter by record type. If `None` is provided,
+/// all records are returned. If `Some(type)` is provided, only records of
+/// that type are returned.
+pub struct SmbiosRecordsIter<'a> {
+    records: Ref<'a, Vec<crate::manager::SmbiosRecord>>,
+    position: usize,
+    filter_type: Option<SmbiosType>,
+}
+
+impl<'a> SmbiosRecordsIter<'a> {
+    /// Create a new iterator over SMBIOS records
+    pub(crate) fn new(records: Ref<'a, Vec<crate::manager::SmbiosRecord>>, filter_type: Option<SmbiosType>) -> Self {
+        Self { records, position: 0, filter_type }
+    }
+}
+
+impl<'a> Iterator for SmbiosRecordsIter<'a> {
+    type Item = (SmbiosTableHeader, Option<Handle>);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        while self.position < self.records.len() {
+            let record = &self.records[self.position];
+            self.position += 1;
+
+            // Apply type filter if specified
+            if let Some(filter) = self.filter_type
+                && record.header.record_type != filter
+            {
+                continue;
+            }
+
+            return Some((record.header.clone(), record.producer_handle));
+        }
+
+        None
+    }
+}
+
+/// Object-safe trait for SMBIOS service operations
+///
+/// This trait defines the core SMBIOS operations that can be used through
+/// a trait object (`Service<dyn Smbios>`), enabling mocking and testing.
+///
+/// Generic operations like `add_record<T>()` are provided via an extension
+/// implementation on `Service<dyn Smbios>`.
+#[cfg_attr(any(test, feature = "mockall"), automock)]
+pub trait Smbios {
+    /// Gets the SMBIOS version information.
+    ///
+    /// # Returns
+    ///
+    /// A tuple of (major_version, minor_version).
+    fn version(&self) -> (u8, u8);
+
+    /// Publishes the SMBIOS table to the UEFI Configuration Table
+    ///
+    /// # Returns
+    ///
+    /// Returns a tuple of (table_address, entry_point_address) on success.
+    ///
+    /// # Errors
+    ///
+    /// Returns `SmbiosError` if no records, allocation fails, or installation fails.
+    fn publish_table(
+        &self,
+    ) -> core::result::Result<(r_efi::efi::PhysicalAddress, r_efi::efi::PhysicalAddress), crate::error::SmbiosError>;
+
+    /// Updates a string in an existing SMBIOS record.
+    ///
+    /// # Arguments
+    ///
+    /// * `smbios_handle` - Handle of the record to update
+    /// * `string_number` - 1-based index of the string to update
+    /// * `string` - New string value
+    fn update_string(
+        &self,
+        smbios_handle: SmbiosHandle,
+        string_number: usize,
+        string: &str,
+    ) -> core::result::Result<(), crate::error::SmbiosError>;
+
+    /// Removes an SMBIOS record from the SMBIOS table.
+    ///
+    /// # Arguments
+    ///
+    /// * `smbios_handle` - Handle of the record to remove
+    fn remove(&self, smbios_handle: SmbiosHandle) -> core::result::Result<(), crate::error::SmbiosError>;
+
+    /// Add an SMBIOS record from raw bytes.
+    ///
+    /// This is the non-generic version used internally by `add_record<T>()`.
+    ///
+    /// # Arguments
+    ///
+    /// * `producer_handle` - Optional handle of the producer creating this record
+    /// * `bytes` - Serialized SMBIOS record bytes
+    fn add_from_bytes(
+        &self,
+        producer_handle: Option<r_efi::efi::Handle>,
+        bytes: &[u8],
+    ) -> core::result::Result<SmbiosHandle, crate::error::SmbiosError>;
+}
+
+/// SMBIOS service implementation
+///
+/// This struct implements `Smbios` and is registered as `Service<dyn Smbios>`.
+/// Generic operations are available via extension methods on the service.
+///
+/// # Example
+///
+/// ```ignore
+/// fn entry_point(
+///     smbios: Service<dyn Smbios>,
+/// ) -> Result<()> {
+///     // Add structured records using generic extension method
+///     smbios.add_record(None, &bios_info)?;
+///     
+///     // Publish to configuration table
+///     smbios.publish_table()?;
+///     Ok(())
+/// }
+/// ```
+#[derive(patina::component::service::IntoService)]
+#[service(dyn Smbios)]
+pub struct SmbiosImpl {
+    pub(crate) manager: patina::tpl_mutex::TplMutex<
+        'static,
+        crate::manager::SmbiosManager,
+        patina::boot_services::StandardBootServices,
+    >,
+    pub(crate) boot_services: &'static patina::boot_services::StandardBootServices,
+    pub(crate) major_version: u8,
+    pub(crate) minor_version: u8,
+}
+
+impl SmbiosImpl {
+    /// Get a reference to the manager for protocol installation
+    ///
+    /// This is only used during component initialization to install the C/EDKII protocol
+    pub(crate) fn manager(
+        &self,
+    ) -> &patina::tpl_mutex::TplMutex<'static, crate::manager::SmbiosManager, patina::boot_services::StandardBootServices>
+    {
+        &self.manager
+    }
+}
+
+// Methods below are tested via integration (Q35 platform component)
+// They require StandardBootServices and TplMutex which aren't mockable in unit tests
+#[cfg_attr(coverage_nightly, coverage(off))]
+impl Smbios for SmbiosImpl {
+    fn version(&self) -> (u8, u8) {
+        (self.major_version, self.minor_version)
+    }
+
+    fn publish_table(
+        &self,
+    ) -> core::result::Result<(r_efi::efi::PhysicalAddress, r_efi::efi::PhysicalAddress), crate::error::SmbiosError>
+    {
+        let manager = self.manager.lock();
+        manager.publish_table(self.boot_services)
+    }
+
+    fn update_string(
+        &self,
+        smbios_handle: SmbiosHandle,
+        string_number: usize,
+        string: &str,
+    ) -> core::result::Result<(), crate::error::SmbiosError> {
+        let manager = self.manager.lock();
+        manager.update_string(smbios_handle, string_number, string)
+    }
+
+    fn remove(&self, smbios_handle: SmbiosHandle) -> core::result::Result<(), crate::error::SmbiosError> {
+        let manager = self.manager.lock();
+        manager.remove(smbios_handle)
+    }
+
+    fn add_from_bytes(
+        &self,
+        producer_handle: Option<r_efi::efi::Handle>,
+        bytes: &[u8],
+    ) -> core::result::Result<SmbiosHandle, crate::error::SmbiosError> {
+        let manager = self.manager.lock();
+        manager.add_from_bytes(producer_handle, bytes)
+    }
+}
+
+/// Extension trait providing generic methods for SMBIOS service
+///
+/// This trait provides the type-safe `add_record<T>()` method as an extension
+/// on `Service<dyn Smbios>`. The generic method can't be part of the
+/// trait object itself (trait objects can't have generic methods), so we
+/// implement it as an extension trait.
+///
+/// # Usage
+///
+/// ```ignore
+/// use patina_smbios::service::SmbiosExt;
+///
+/// fn my_component(smbios: Service<dyn Smbios>) {
+///     let bios_info = Type0PlatformFirmwareInformation { ... };
+///     let handle = smbios.add_record(None, &bios_info)?;
+/// }
+/// ```
+pub trait SmbiosExt {
+    /// Add an SMBIOS record from a structured type.
+    ///
+    /// This is a type-safe convenience method that automatically serializes
+    /// a structured record and adds it to the SMBIOS table.
+    ///
+    /// # Arguments
+    ///
+    /// * `producer_handle` - Optional handle of the producer creating this record
+    /// * `record` - A reference to any type implementing `SmbiosRecordStructure`
+    ///
+    /// # Returns
+    ///
+    /// Returns the assigned SMBIOS handle for the newly added record.
+    fn add_record<T>(
+        &self,
+        producer_handle: Option<r_efi::efi::Handle>,
+        record: &T,
+    ) -> core::result::Result<SmbiosHandle, crate::error::SmbiosError>
+    where
+        T: crate::smbios_record::SmbiosRecordStructure;
+}
+
+/// Implementation of extension trait for `Service<dyn Smbios>`
+#[cfg_attr(coverage_nightly, coverage(off))]
+impl SmbiosExt for patina::component::service::Service<dyn Smbios> {
+    fn add_record<T>(
+        &self,
+        producer_handle: Option<r_efi::efi::Handle>,
+        record: &T,
+    ) -> core::result::Result<SmbiosHandle, crate::error::SmbiosError>
+    where
+        T: crate::smbios_record::SmbiosRecordStructure,
+    {
+        let bytes = record.to_bytes();
+        self.add_from_bytes(producer_handle, &bytes)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    extern crate std;
+    use std::format;
+
+    #[test]
+    fn test_smbios_table_header_new() {
+        let header = SmbiosTableHeader::new(0, 24, 0x0001);
+        assert_eq!(header.record_type, 0);
+        assert_eq!(header.length, 24);
+        // Use local variable to avoid packed field alignment issues
+        let handle = header.handle;
+        assert_eq!(handle, 0x0001);
+    }
+
+    #[test]
+    fn test_smbios_table_header_clone() {
+        let header1 = SmbiosTableHeader::new(1, 32, 0x0002);
+        let header2 = header1.clone();
+        assert_eq!(header1, header2);
+    }
+
+    #[test]
+    fn test_smbios_table_header_debug() {
+        let header = SmbiosTableHeader::new(127, 4, 0xFFFF);
+        let debug_str = format!("{:?}", header);
+        assert!(debug_str.contains("127"));
+        assert!(debug_str.contains("4"));
+    }
+
+    #[test]
+    fn test_smbios_handle_pi_reserved() {
+        assert_eq!(SMBIOS_HANDLE_PI_RESERVED, 0xFFFE);
+    }
+
+    #[test]
+    fn test_smbios_string_max_length() {
+        assert_eq!(SMBIOS_STRING_MAX_LENGTH, 64);
+    }
+
+    #[test]
+    fn test_smbios_table_header_equality() {
+        let header1 = SmbiosTableHeader::new(0, 24, 0x0001);
+        let header2 = SmbiosTableHeader::new(0, 24, 0x0001);
+        let header3 = SmbiosTableHeader::new(1, 24, 0x0001);
+
+        assert_eq!(header1, header2);
+        assert_ne!(header1, header3);
+    }
+
+    #[test]
+    fn test_smbios_table_header_from_bytes() {
+        use zerocopy::IntoBytes;
+        let header = SmbiosTableHeader::new(127, 4, 0xFFFE);
+        let bytes = header.as_bytes();
+        assert_eq!(bytes.len(), 4);
+        assert_eq!(bytes[0], 127); // type
+        assert_eq!(bytes[1], 4); // length
+    }
+
+    #[test]
+    fn test_smbios_records_iter_basic() {
+        use crate::manager::SmbiosRecord;
+        use alloc::vec;
+        use core::cell::RefCell;
+
+        let records = RefCell::new(vec![
+            SmbiosRecord::new(SmbiosTableHeader::new(0, 24, 0x0001), None, vec![], 0),
+            SmbiosRecord::new(SmbiosTableHeader::new(1, 32, 0x0002), None, vec![], 0),
+        ]);
+
+        let borrowed = records.borrow();
+        let mut iter = SmbiosRecordsIter::new(borrowed, None);
+
+        let first = iter.next().unwrap();
+        assert_eq!(first.0.record_type, 0);
+        let handle = first.0.handle;
+        assert_eq!(handle, 0x0001);
+
+        let second = iter.next().unwrap();
+        assert_eq!(second.0.record_type, 1);
+        let handle = second.0.handle;
+        assert_eq!(handle, 0x0002);
+
+        assert!(iter.next().is_none());
+    }
+
+    #[test]
+    fn test_smbios_records_iter_with_filter() {
+        use crate::manager::SmbiosRecord;
+        use alloc::vec;
+        use core::cell::RefCell;
+
+        let records = RefCell::new(vec![
+            SmbiosRecord::new(SmbiosTableHeader::new(0, 24, 0x0001), None, vec![], 0),
+            SmbiosRecord::new(SmbiosTableHeader::new(1, 32, 0x0002), None, vec![], 0),
+            SmbiosRecord::new(SmbiosTableHeader::new(0, 24, 0x0003), None, vec![], 0),
+        ]);
+
+        let borrowed = records.borrow();
+        let mut iter = SmbiosRecordsIter::new(borrowed, Some(0));
+
+        let first = iter.next().unwrap();
+        assert_eq!(first.0.record_type, 0);
+        let handle = first.0.handle;
+        assert_eq!(handle, 0x0001);
+
+        let second = iter.next().unwrap();
+        assert_eq!(second.0.record_type, 0);
+        let handle = second.0.handle;
+        assert_eq!(handle, 0x0003);
+
+        assert!(iter.next().is_none());
+    }
+
+    #[test]
+    fn test_smbios_records_iter_empty() {
+        use crate::manager::SmbiosRecord;
+        use alloc::vec;
+        use core::cell::RefCell;
+
+        let records: RefCell<Vec<SmbiosRecord>> = RefCell::new(vec![]);
+        let borrowed = records.borrow();
+        let mut iter = SmbiosRecordsIter::new(borrowed, None);
+
+        assert!(iter.next().is_none());
+    }
+
+    #[test]
+    fn test_smbios_records_iter_no_match_filter() {
+        use crate::manager::SmbiosRecord;
+        use alloc::vec;
+        use core::cell::RefCell;
+
+        let records = RefCell::new(vec![
+            SmbiosRecord::new(SmbiosTableHeader::new(0, 24, 0x0001), None, vec![], 0),
+            SmbiosRecord::new(SmbiosTableHeader::new(1, 32, 0x0002), None, vec![], 0),
+        ]);
+
+        let borrowed = records.borrow();
+        let mut iter = SmbiosRecordsIter::new(borrowed, Some(127)); // Filter for type 127
+
+        assert!(iter.next().is_none());
+    }
+
+    // Mock-based tests demonstrating mockability of Smbios trait object
+
+    /// Mock implementation of Smbios for testing
+    struct MockSmbios {
+        version: (u8, u8),
+        add_from_bytes_result: core::result::Result<SmbiosHandle, crate::error::SmbiosError>,
+        expected_bytes: Option<Vec<u8>>,
+    }
+
+    impl Smbios for MockSmbios {
+        fn version(&self) -> (u8, u8) {
+            self.version
+        }
+
+        fn publish_table(
+            &self,
+        ) -> core::result::Result<(r_efi::efi::PhysicalAddress, r_efi::efi::PhysicalAddress), crate::error::SmbiosError>
+        {
+            Ok((0x1000, 0x2000))
+        }
+
+        fn update_string(
+            &self,
+            _smbios_handle: SmbiosHandle,
+            _string_number: usize,
+            _string: &str,
+        ) -> core::result::Result<(), crate::error::SmbiosError> {
+            Ok(())
+        }
+
+        fn remove(&self, _smbios_handle: SmbiosHandle) -> core::result::Result<(), crate::error::SmbiosError> {
+            Ok(())
+        }
+
+        fn add_from_bytes(
+            &self,
+            _producer_handle: Option<r_efi::efi::Handle>,
+            bytes: &[u8],
+        ) -> core::result::Result<SmbiosHandle, crate::error::SmbiosError> {
+            // Verify expected bytes if provided
+            if let Some(ref expected) = self.expected_bytes {
+                assert_eq!(bytes, expected.as_slice(), "add_from_bytes received unexpected bytes");
+            }
+            self.add_from_bytes_result.clone()
+        }
+    }
+
+    #[test]
+    fn test_mock_smbios_service_version() {
+        use patina::component::service::Service;
+
+        let mock = MockSmbios { version: (99, 88), add_from_bytes_result: Ok(0x1234), expected_bytes: None };
+        let service: Service<dyn Smbios> = Service::mock(Box::new(mock));
+
+        assert_eq!(service.version(), (99, 88));
+    }
+
+    #[test]
+    fn test_mock_smbios_service_add_from_bytes() {
+        use patina::component::service::Service;
+
+        let test_bytes = vec![127, 4, 0xFE, 0xFF, 0, 0]; // Type 127, length 4, handle 0xFFFE
+
+        let mock =
+            MockSmbios { version: (3, 0), add_from_bytes_result: Ok(0x5678), expected_bytes: Some(test_bytes.clone()) };
+        let service: Service<dyn Smbios> = Service::mock(Box::new(mock));
+
+        let result = service.add_from_bytes(None, &test_bytes);
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap(), 0x5678);
+    }
+
+    #[test]
+    fn test_mock_smbios_service_add_from_bytes_error() {
+        use patina::component::service::Service;
+
+        let mock = MockSmbios {
+            version: (3, 0),
+            add_from_bytes_result: Err(crate::error::SmbiosError::RecordTooSmall),
+            expected_bytes: None,
+        };
+        let service: Service<dyn Smbios> = Service::mock(Box::new(mock));
+
+        let result = service.add_from_bytes(None, &[1, 2, 3]);
+        assert!(result.is_err());
+        assert!(matches!(result.unwrap_err(), crate::error::SmbiosError::RecordTooSmall));
+    }
+
+    #[test]
+    fn test_mock_smbios_service_add_record_integration() {
+        use crate::smbios_record::{SmbiosRecordStructure, Type127EndOfTable};
+        use alloc::vec;
+        use patina::component::service::Service;
+
+        // Create a test record
+        let record = Type127EndOfTable { header: SmbiosTableHeader::new(127, 4, 0xFFFE), string_pool: vec![] };
+
+        // Serialize it to get expected bytes
+        let expected_bytes = record.to_bytes();
+
+        // Create mock that expects these exact bytes
+        let mock =
+            MockSmbios { version: (3, 0), add_from_bytes_result: Ok(0xABCD), expected_bytes: Some(expected_bytes) };
+        let service: Service<dyn Smbios> = Service::mock(Box::new(mock));
+
+        // Verify the mock works through Service
+        let result = service.add_from_bytes(None, &record.to_bytes());
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap(), 0xABCD);
+    }
+
+    #[test]
+    fn test_mock_smbios_service_all_trait_methods() {
+        use patina::component::service::Service;
+
+        let mock = MockSmbios { version: (3, 7), add_from_bytes_result: Ok(0x1111), expected_bytes: None };
+        let service: Service<dyn Smbios> = Service::mock(Box::new(mock));
+
+        // Test all trait methods
+        assert_eq!(service.version(), (3, 7));
+        assert!(service.publish_table().is_ok());
+        assert!(service.update_string(0x1234, 1, "test").is_ok());
+        assert!(service.remove(0x1234).is_ok());
+        assert!(service.add_from_bytes(None, &[127, 4, 0, 0, 0, 0]).is_ok());
+    }
+
+    #[test]
+    fn test_mock_add_record_extension_trait_pattern() {
+        use crate::smbios_record::{SmbiosRecordStructure, Type127EndOfTable};
+        use alloc::vec;
+        use patina::component::service::Service;
+
+        // Create a test record
+        let record = Type127EndOfTable { header: SmbiosTableHeader::new(127, 4, 0xFFFE), string_pool: vec![] };
+
+        // Serialize to get expected bytes
+        let expected_bytes = record.to_bytes();
+
+        // Create mock that verifies the bytes and returns a handle
+        let mock = MockSmbios {
+            version: (3, 0),
+            add_from_bytes_result: Ok(0x9999),
+            expected_bytes: Some(expected_bytes.clone()),
+        };
+        let service: Service<dyn Smbios> = Service::mock(Box::new(mock));
+
+        // Demonstrate how add_record<T>() delegates to add_from_bytes()
+        // The extension trait does:
+        //   1. let bytes = record.to_bytes();
+        //   2. self.add_from_bytes(producer_handle, &bytes)
+        let result = service.add_from_bytes(None, &expected_bytes);
+
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap(), 0x9999);
+        // Mock verified the bytes matched expected_bytes in add_from_bytes()
+    }
+
+    #[test]
+    fn test_mock_add_record_with_error() {
+        use crate::smbios_record::{SmbiosRecordStructure, Type127EndOfTable};
+        use alloc::vec;
+        use patina::component::service::Service;
+
+        // Mock that returns an error
+        let mock = MockSmbios {
+            version: (3, 0),
+            add_from_bytes_result: Err(crate::error::SmbiosError::HandleExhausted),
+            expected_bytes: None,
+        };
+        let service: Service<dyn Smbios> = Service::mock(Box::new(mock));
+
+        // Simulate add_record<T>() behavior
+        let record = Type127EndOfTable { header: SmbiosTableHeader::new(127, 4, 0xFFFE), string_pool: vec![] };
+        let bytes = record.to_bytes();
+
+        let result = service.add_from_bytes(None, &bytes);
+        assert!(result.is_err());
+        assert!(matches!(result.unwrap_err(), crate::error::SmbiosError::HandleExhausted));
+    }
+
+    #[test]
+    fn test_mock_multiple_record_types() {
+        use crate::smbios_record::{SmbiosRecordStructure, Type0PlatformFirmwareInformation, Type127EndOfTable};
+        use alloc::{string::String, vec};
+        use patina::component::service::Service;
+
+        // Test that mock can handle different record types
+        let type0 = Type0PlatformFirmwareInformation {
+            header: SmbiosTableHeader::new(0, 24, 0xFFFE),
+            vendor: 1,
+            firmware_version: 2,
+            bios_starting_address_segment: 0xE800,
+            firmware_release_date: 3,
+            firmware_rom_size: 0xFF,
+            characteristics: 0x08,
+            characteristics_ext1: 0x03,
+            characteristics_ext2: 0x03,
+            system_bios_major_release: 1,
+            system_bios_minor_release: 0,
+            embedded_controller_major_release: 0xFF,
+            embedded_controller_minor_release: 0xFF,
+            extended_bios_rom_size: 0,
+            string_pool: vec![String::from("Vendor"), String::from("1.0"), String::from("2025")],
+        };
+
+        let type127 = Type127EndOfTable { header: SmbiosTableHeader::new(127, 4, 0xFFFE), string_pool: vec![] };
+
+        // Mock returns different handles for different records
+        let mock_type0 =
+            MockSmbios { version: (3, 0), add_from_bytes_result: Ok(0x0001), expected_bytes: Some(type0.to_bytes()) };
+        let service_type0: Service<dyn Smbios> = Service::mock(Box::new(mock_type0));
+
+        let mock_type127 =
+            MockSmbios { version: (3, 0), add_from_bytes_result: Ok(0x0002), expected_bytes: Some(type127.to_bytes()) };
+        let service_type127: Service<dyn Smbios> = Service::mock(Box::new(mock_type127));
+
+        // Verify different records work with mock
+        let result0 = service_type0.add_from_bytes(None, &type0.to_bytes());
+        assert_eq!(result0.unwrap(), 0x0001);
+
+        let result127 = service_type127.add_from_bytes(None, &type127.to_bytes());
+        assert_eq!(result127.unwrap(), 0x0002);
+    }
+
+    #[test]
+    fn test_service_mock_pattern() {
+        use crate::smbios_record::{SmbiosRecordStructure, Type127EndOfTable};
+        use alloc::vec;
+        use patina::component::service::Service;
+
+        // Create a mock service using the standard Service::mock pattern
+        let mock = MockSmbios { version: (3, 6), add_from_bytes_result: Ok(0xBEEF), expected_bytes: None };
+
+        // This is the pattern used throughout the Patina codebase for testing
+        let service: Service<dyn Smbios> = Service::mock(Box::new(mock));
+
+        // Verify trait methods work through Service
+        assert_eq!(service.version(), (3, 6));
+        assert!(service.publish_table().is_ok());
+
+        // Verify extension trait methods work through Service
+        let record = Type127EndOfTable { header: SmbiosTableHeader::new(127, 4, 0xFFFE), string_pool: vec![] };
+        let result = service.add_from_bytes(None, &record.to_bytes());
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap(), 0xBEEF);
+    }
+
+    #[test]
+    fn test_service_mock_with_extension_trait() {
+        use crate::smbios_record::{SmbiosRecordStructure, Type127EndOfTable};
+        use alloc::vec;
+        use patina::component::service::Service;
+
+        // Create test record
+        let record = Type127EndOfTable { header: SmbiosTableHeader::new(127, 4, 0xFFFE), string_pool: vec![] };
+        let expected_bytes = record.to_bytes();
+
+        // Mock that validates bytes and returns handle
+        let mock =
+            MockSmbios { version: (3, 0), add_from_bytes_result: Ok(0x1337), expected_bytes: Some(expected_bytes) };
+
+        let service: Service<dyn Smbios> = Service::mock(Box::new(mock));
+
+        // The extension trait method add_record<T>() works through Service
+        // It serializes the record and calls add_from_bytes (which the mock implements)
+        let handle = service.add_record(None, &record).unwrap();
+        assert_eq!(handle, 0x1337);
+    }
+}

--- a/components/patina_smbios/src/smbios_record.rs
+++ b/components/patina_smbios/src/smbios_record.rs
@@ -1,0 +1,788 @@
+//! SMBIOS Record Types and Serialization
+//!
+//! This module provides type-safe structures for creating SMBIOS (System Management BIOS)
+//! records with automatic serialization to the standard binary format. It includes built-in
+//! types for common SMBIOS tables and a powerful derive macro for creating custom records.
+//!
+//! # SMBIOS Record Structure
+//!
+//! Every SMBIOS record consists of three parts in the binary format:
+//!
+//! ```text
+//! ┌─────────────┬──────────────────────┬────────────────────────────┐
+//! │   Header    │   Structured Data    │       String Pool          │
+//! │   (4 bytes) │   (varies by type)   │  (null-terminated strings) │
+//! └─────────────┴──────────────────────┴────────────────────────────┘
+//! ```
+//!
+//! 1. **Header** (4 bytes): Record type, length, and handle
+//! 2. **Structured Data**: Fixed-size fields specific to the record type
+//! 3. **String Pool**: Variable-length null-terminated strings referenced by indices
+//!
+//! # Quick Start
+//!
+//! Create and serialize a BIOS Information record (Type 0):
+//!
+//! ```ignore
+//! use patina_smbios::smbios_record::{Type0PlatformFirmwareInformation, SmbiosTableHeader};
+//! use patina_smbios::service::SMBIOS_HANDLE_PI_RESERVED;
+//! use alloc::vec;
+//!
+//! // Create the record
+//! let bios_info = Type0PlatformFirmwareInformation {
+//!     header: SmbiosTableHeader::new(0, 0, SMBIOS_HANDLE_PI_RESERVED),
+//!     
+//!     // String indices (reference the string pool below)
+//!     vendor: 1,
+//!     firmware_version: 2,
+//!     firmware_release_date: 3,
+//!     
+//!     // Binary fields
+//!     bios_starting_address_segment: 0xE000,
+//!     firmware_rom_size: 0x0F,
+//!     characteristics: 0x08,
+//!     characteristics_ext1: 0x03,
+//!     characteristics_ext2: 0x01,
+//!     system_bios_major_release: 2,
+//!     system_bios_minor_release: 4,
+//!     embedded_controller_major_release: 0xFF,
+//!     embedded_controller_minor_release: 0xFF,
+//!     extended_bios_rom_size: 0x0000,
+//!     
+//!     // String pool (1-indexed)
+//!     string_pool: vec![
+//!         String::from("Patina BIOS"),    // Index 1
+//!         String::from("v2.4.0"),         // Index 2
+//!         String::from("10/28/2025"),     // Index 3
+//!     ],
+//! };
+//! ```
+//!
+//! # Understanding String Pools
+//!
+//! SMBIOS uses an efficient string storage format where text strings are stored in a
+//! "string pool" at the end of each record, referenced by 1-based indices.
+//!
+//! ## String Pool Format
+//!
+//! ```text
+//! [Header + Structured Data][String 1\0][String 2\0][String 3\0]\0
+//!                            └────────── String Pool ──────────┘
+//! ```
+//!
+//! ## Key Rules
+//!
+//! - **1-based indexing**: Strings are numbered 1, 2, 3, ... (not 0, 1, 2)
+//! - **Index 0 means "no string"**: Use when a string field is not applicable
+//! - **Null termination**: Each string ends with `\0` (added automatically)
+//! - **Double null terminator**: Pool ends with `\0\0`
+//! - **Empty pool**: Represented as just `\0\0` (2 bytes)
+//! - **Max length**: 64 bytes per string (SMBIOS specification)
+//!
+//! ## Example
+//!
+//! ```ignore
+//! // Define strings
+//! string_pool: vec![
+//!     String::from("ACME Corp"),     // Index 1
+//!     String::from("Model X100"),    // Index 2
+//!     String::from("v1.0"),          // Index 3
+//! ]
+//!
+//! // Reference strings in fields
+//! manufacturer: 1,     // "ACME Corp"
+//! product_name: 2,     // "Model X100"
+//! version: 3,          // "v1.0"
+//! unused_field: 0,     // No string
+//! ```
+//!
+//! Binary output:
+//! ```text
+//! [... structured data ...][ACME Corp\0][Model X100\0][v1.0\0]\0
+//! ```
+//!
+//! # Validation
+//!
+//! All record types implement the `validate()` method through the [`SmbiosRecordStructure`] trait:
+//!
+//! ```ignore
+//! let record = Type1SystemInformation { /* ... */ };
+//!
+//! match record.validate() {
+//!     Ok(()) => {
+//!         // Record is valid
+//!     }
+//!     Err(SmbiosError::StringTooLong) => {
+//!         log::error!("String exceeds 64-byte limit");
+//!     }
+//!     Err(e) => {
+//!         log::error!("Validation error: {:?}", e);
+//!     }
+//! }
+//! ```
+//!
+//! Validation checks:
+//! - All strings ≤ 64 bytes
+//! - No embedded null bytes in strings
+//! - String pool is well-formed
+//!
+//! # Creating Custom Record Types
+//!
+//! Define vendor-specific SMBIOS records (types 128-255) using the derive macro:
+//!
+//! ```ignore
+//! use patina_macro::SmbiosRecord;
+//! use patina_smbios::service::SmbiosTableHeader;
+//!
+//! #[derive(SmbiosRecord)]
+//! #[smbios(record_type = 0x80)]  // Vendor-specific (128-255)
+//! pub struct CustomRecord {
+//!     pub header: SmbiosTableHeader,     // Required
+//!     pub vendor_id: u32,                // Custom field
+//!     pub revision: u16,                 // Custom field
+//!     pub flags: u8,                     // Custom field
+//!     pub name: u8,                      // String index
+//!     #[string_pool]
+//!     pub string_pool: Vec<String>,      // Required for strings
+//! }
+//! ```
+//!
+//! ## Derive Macro Requirements
+//!
+//! 1. **`#[smbios(record_type = N)]`**: Specify the SMBIOS type number (0-255)
+//! 2. **`header` field**: Must be of type `SmbiosTableHeader`
+//! 3. **`#[string_pool]`**: Mark the `Vec<String>` field (if using strings)
+//!
+//! ## Supported Field Types
+//!
+//! - **Primitives**: `u8`, `u16`, `u32`, `u64` (little-endian serialization)
+//! - **Arrays**: `[u8; N]` (direct memory copy, e.g., UUIDs, MACs)
+//! - **String pool**: `Vec<String>` (converted to SMBIOS format)
+//!
+//! ## Advanced Example
+//!
+//! ```ignore
+//! #[derive(SmbiosRecord)]
+//! #[smbios(record_type = 0x81)]
+//! pub struct ExtendedDeviceInfo {
+//!     pub header: SmbiosTableHeader,
+//!     pub device_id: u64,
+//!     pub capabilities: u32,
+//!     pub mac_address: [u8; 6],          // 6-byte MAC
+//!     pub serial: u8,                    // String index
+//!     pub model: u8,                     // String index
+//!     #[string_pool]
+//!     pub string_pool: Vec<String>,
+//! }
+//!
+//! // Usage
+//! let device = ExtendedDeviceInfo {
+//!     header: SmbiosTableHeader::new(0x81, 0, SMBIOS_HANDLE_PI_RESERVED),
+//!     device_id: 0x1234567890ABCDEF,
+//!     capabilities: 0x000000FF,
+//!     mac_address: [0x00, 0x11, 0x22, 0x33, 0x44, 0x55],
+//!     serial: 1,
+//!     model: 2,
+//!     string_pool: vec![
+//!         String::from("SN987654321"),
+//!         String::from("Device Model X"),
+//!     ],
+//! };
+//! ```
+//!
+//! # Serialization Details
+//!
+//! The `#[derive(SmbiosRecord)]` macro generates a `to_bytes()` implementation that:
+//!
+//! 1. Calculates total structure size (header + fields)
+//! 2. Creates the SMBIOS header with correct type and length
+//! 3. Serializes primitive fields in little-endian byte order
+//! 4. Copies array fields directly (e.g., UUIDs)
+//! 5. Appends string pool with proper null termination
+//! 6. Returns complete SMBIOS record as `Vec<u8>`
+//!
+//! **Critical**: The `string_pool` field is **Rust metadata only** and is NOT part of
+//! the binary structure. Never use `#[repr(C)]` or cast these structs to bytes directly.
+//! Always use `to_bytes()`.
+//!
+//! # Best Practices
+//!
+//! ## String Management
+//! - Use 1-based indices (1, 2, 3, ...)
+//! - Use index 0 for "no string"
+//! - Keep strings under 64 bytes
+//! - Order string pool to match field indices
+//! - Don't add null terminators (automatic)
+//!
+//! ## Field Values
+//! - Use 0xFF for "not present" (SMBIOS convention)
+//! - Use 0x00 for "unknown" or disabled
+//!
+//! ## Error Handling
+//! - Handle `SmbiosError::StringTooLong` gracefully
+//! - Test with various string lengths
+//!
+//! # See Also
+//!
+//! - [`SmbiosRecordStructure`] - Base trait for all SMBIOS records
+//! - [`SmbiosTableHeader`] - SMBIOS record header structure
+//! - [SMBIOS Specification](https://www.dmtf.org/standards/smbios) - Official DMTF spec
+//!
+//! # License
+//!
+//! Copyright (c) Microsoft Corporation.
+//!
+//! SPDX-License-Identifier: Apache-2.0
+
+extern crate alloc;
+use crate::{
+    error::SmbiosError,
+    service::{SMBIOS_HANDLE_PI_RESERVED, SmbiosTableHeader},
+};
+use alloc::{string::String, vec::Vec};
+
+/// Base trait for SMBIOS record structures
+///
+/// This trait defines the interface for all SMBIOS record types. Each record type
+/// must implement serialization to convert from the high-level Rust struct to the
+/// binary SMBIOS format.
+pub trait SmbiosRecordStructure {
+    /// The SMBIOS record type number (e.g., 0 for BIOS Information, 1 for System Information)
+    const RECORD_TYPE: u8;
+
+    /// Convert the structure to a complete SMBIOS record byte array
+    ///
+    /// This serializes the struct into the SMBIOS binary format:
+    /// [Header][Structured Fields][String Pool]
+    fn to_bytes(&self) -> Vec<u8>;
+
+    /// Validate the structure before serialization
+    ///
+    /// Checks that all fields meet SMBIOS specification requirements, such as:
+    /// - Strings are not too long (≤ 64 bytes)
+    /// - Required fields are populated
+    fn validate(&self) -> Result<(), SmbiosError>;
+
+    /// Get the string pool for this record
+    fn string_pool(&self) -> &[String];
+
+    /// Get mutable access to the string pool
+    fn string_pool_mut(&mut self) -> &mut Vec<String>;
+}
+
+/// Type 0: Platform Firmware Information (BIOS Information)
+///
+/// # Important: Not C-Compatible
+///
+/// This struct is **NOT** `#[repr(C)]` and should **NEVER** be directly cast to bytes
+/// or used in FFI contexts. The `string_pool` field contains Rust-native `String` types
+/// (which are fat pointers) and is **NOT** part of the SMBIOS table binary format.
+///
+/// ## Proper Usage
+///
+/// Always use the `to_bytes()` method to convert this struct to bytes for the
+/// SMBIOS table. The generated serialization code:
+/// - Extracts only the primitive fields (u8, u16, u64) for the structured portion
+/// - Converts the `string_pool` to null-terminated byte sequences in the SMBIOS format
+/// - Properly handles all alignment and padding requirements
+///
+/// ## String Pool
+///
+/// The `string_pool` field is metadata that holds the actual string content. The primitive
+/// string fields (e.g., `vendor`, `firmware_version`) contain 1-based indices into this pool.
+/// During serialization, the string pool is converted to the SMBIOS null-terminated string
+/// format and appended after the structured data.
+#[derive(patina_macro::SmbiosRecord)]
+#[smbios(record_type = 0)]
+pub struct Type0PlatformFirmwareInformation {
+    /// SMBIOS table header
+    pub header: SmbiosTableHeader,
+    /// Vendor string index
+    pub vendor: u8,
+    /// Firmware version string index
+    pub firmware_version: u8,
+    /// BIOS starting address segment
+    pub bios_starting_address_segment: u16,
+    /// Firmware release date string index
+    pub firmware_release_date: u8,
+    /// Firmware ROM size
+    pub firmware_rom_size: u8,
+    /// BIOS characteristics
+    pub characteristics: u64,
+    /// BIOS characteristics extension byte 1
+    pub characteristics_ext1: u8,
+    /// BIOS characteristics extension byte 2
+    pub characteristics_ext2: u8,
+    /// System BIOS major release
+    pub system_bios_major_release: u8,
+    /// System BIOS minor release
+    pub system_bios_minor_release: u8,
+    /// Embedded controller firmware major release
+    pub embedded_controller_major_release: u8,
+    /// Embedded controller firmware minor release
+    pub embedded_controller_minor_release: u8,
+    /// Extended BIOS ROM size
+    pub extended_bios_rom_size: u16,
+
+    /// String pool containing the actual string content.
+    ///
+    /// **IMPORTANT**: This field is NOT part of the SMBIOS table binary layout.
+    /// It is Rust metadata that gets converted to null-terminated bytes during serialization.
+    /// Never attempt to directly cast this struct to bytes or use it in FFI - always use
+    /// `SmbiosSerializer::serialize()`.
+    #[string_pool]
+    pub string_pool: Vec<String>,
+}
+
+/// Type 1: System Information
+///
+/// # Important: Not C-Compatible
+///
+/// This struct contains a `string_pool: Vec<String>` field which is Rust metadata and
+/// **NOT** part of the SMBIOS table binary format. Never cast this struct to bytes directly.
+/// Always use `to_bytes()` to convert to proper SMBIOS format.
+///
+/// See [`Type0PlatformFirmwareInformation`] for detailed documentation on proper usage.
+#[derive(patina_macro::SmbiosRecord)]
+#[smbios(record_type = 1)]
+pub struct Type1SystemInformation {
+    /// SMBIOS table header
+    pub header: SmbiosTableHeader,
+    /// Manufacturer string index
+    pub manufacturer: u8,
+    /// Product name string index
+    pub product_name: u8,
+    /// Version string index
+    pub version: u8,
+    /// Serial number string index
+    pub serial_number: u8,
+    /// UUID bytes
+    pub uuid: [u8; 16],
+    /// Wake-up type
+    pub wake_up_type: u8,
+    /// SKU number string index
+    pub sku_number: u8,
+    /// Family string index
+    pub family: u8,
+
+    /// String pool (NOT part of binary SMBIOS format - see struct documentation)
+    #[string_pool]
+    pub string_pool: Vec<String>,
+}
+
+/// Type 2: Baseboard Information
+///
+/// # Important: Not C-Compatible
+///
+/// This struct contains a `string_pool: Vec<String>` field which is Rust metadata and
+/// **NOT** part of the SMBIOS table binary format. Never cast this struct to bytes directly.
+/// Always use `to_bytes()` to convert to proper SMBIOS format.
+///
+/// See [`Type0PlatformFirmwareInformation`] for detailed documentation on proper usage.
+#[derive(patina_macro::SmbiosRecord)]
+#[smbios(record_type = 2)]
+pub struct Type2BaseboardInformation {
+    /// SMBIOS table header
+    pub header: SmbiosTableHeader,
+    /// Manufacturer string index
+    pub manufacturer: u8,
+    /// Product string index
+    pub product: u8,
+    /// Version string index
+    pub version: u8,
+    /// Serial number string index
+    pub serial_number: u8,
+    /// Asset tag string index
+    pub asset_tag: u8,
+    /// Feature flags
+    pub feature_flags: u8,
+    /// Location in chassis string index
+    pub location_in_chassis: u8,
+    /// Chassis handle
+    pub chassis_handle: u16,
+    /// Board type
+    pub board_type: u8,
+    /// Number of contained object handles
+    pub contained_object_handles: u8,
+
+    /// String pool (NOT part of binary SMBIOS format - see struct documentation)
+    #[string_pool]
+    pub string_pool: Vec<String>,
+}
+
+/// Type 3: System Enclosure
+///
+/// # Important: Not C-Compatible
+///
+/// This struct contains a `string_pool: Vec<String>` field which is Rust metadata and
+/// **NOT** part of the SMBIOS table binary format. Never cast this struct to bytes directly.
+/// Always use `to_bytes()` to convert to proper SMBIOS format.
+///
+/// See [`Type0PlatformFirmwareInformation`] for detailed documentation on proper usage.
+#[derive(patina_macro::SmbiosRecord)]
+#[smbios(record_type = 3)]
+pub struct Type3SystemEnclosure {
+    /// SMBIOS table header
+    pub header: SmbiosTableHeader,
+    /// Manufacturer string index
+    pub manufacturer: u8,
+    /// Enclosure type
+    pub enclosure_type: u8,
+    /// Version string index
+    pub version: u8,
+    /// Serial number string index
+    pub serial_number: u8,
+    /// Asset tag number string index
+    pub asset_tag_number: u8,
+    /// Boot-up state
+    pub bootup_state: u8,
+    /// Power supply state
+    pub power_supply_state: u8,
+    /// Thermal state
+    pub thermal_state: u8,
+    /// Security status
+    pub security_status: u8,
+    /// OEM-defined
+    pub oem_defined: u32,
+    /// Height
+    pub height: u8,
+    /// Number of power cords
+    pub number_of_power_cords: u8,
+    /// Contained element count
+    pub contained_element_count: u8,
+    /// Contained element record length
+    pub contained_element_record_length: u8,
+
+    /// String pool (NOT part of binary SMBIOS format - see struct documentation)
+    #[string_pool]
+    pub string_pool: Vec<String>,
+}
+
+/// SMBIOS Type 127: End-of-Table
+///
+/// The End-of-Table marker indicates the end of the SMBIOS structure table.
+/// This is a simple marker structure with no additional fields beyond the standard header.
+///
+/// Per SMBIOS specification 3.0+:
+/// - Type: 127
+/// - Length: 4 (header only)
+/// - No strings
+#[derive(patina_macro::SmbiosRecord)]
+#[smbios(record_type = 127)]
+pub struct Type127EndOfTable {
+    /// SMBIOS header
+    pub header: SmbiosTableHeader,
+
+    /// String pool (always empty for Type 127)
+    #[string_pool]
+    pub string_pool: Vec<String>,
+}
+
+impl Type127EndOfTable {
+    /// Create a new End-of-Table marker
+    pub fn new() -> Self {
+        Self { header: SmbiosTableHeader::new(127, 4, SMBIOS_HANDLE_PI_RESERVED), string_pool: Vec::new() }
+    }
+}
+
+impl Default for Type127EndOfTable {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::service::SMBIOS_STRING_MAX_LENGTH;
+    use alloc::vec;
+
+    #[test]
+    fn test_type0_new() {
+        let type0 = Type0PlatformFirmwareInformation {
+            header: SmbiosTableHeader { record_type: 0, length: 0, handle: 0 },
+            vendor: 1,
+            firmware_version: 2,
+            bios_starting_address_segment: 0xE800,
+            firmware_release_date: 3,
+            firmware_rom_size: 0xFF,
+            characteristics: 0x08,
+            characteristics_ext1: 0x03,
+            characteristics_ext2: 0x03,
+            system_bios_major_release: 1,
+            system_bios_minor_release: 0,
+            embedded_controller_major_release: 0xFF,
+            embedded_controller_minor_release: 0xFF,
+            extended_bios_rom_size: 0,
+            string_pool: vec![String::from("Vendor"), String::from("Version"), String::from("Date")],
+        };
+
+        assert!(type0.validate().is_ok());
+        assert_eq!(type0.string_pool().len(), 3);
+        assert_eq!(Type0PlatformFirmwareInformation::RECORD_TYPE, 0);
+    }
+
+    #[test]
+    fn test_type0_validate_string_too_long() {
+        let type0 = Type0PlatformFirmwareInformation {
+            header: SmbiosTableHeader { record_type: 0, length: 0, handle: 0 },
+            vendor: 1,
+            firmware_version: 2,
+            bios_starting_address_segment: 0xE800,
+            firmware_release_date: 3,
+            firmware_rom_size: 0xFF,
+            characteristics: 0x08,
+            characteristics_ext1: 0x03,
+            characteristics_ext2: 0x03,
+            system_bios_major_release: 1,
+            system_bios_minor_release: 0,
+            embedded_controller_major_release: 0xFF,
+            embedded_controller_minor_release: 0xFF,
+            extended_bios_rom_size: 0,
+            string_pool: vec![String::from("x").repeat(SMBIOS_STRING_MAX_LENGTH + 1)],
+        };
+
+        assert_eq!(type0.validate(), Err(SmbiosError::StringTooLong));
+    }
+
+    #[test]
+    fn test_type1_new() {
+        let type1 = Type1SystemInformation {
+            header: SmbiosTableHeader { record_type: 1, length: 0, handle: 0 },
+            manufacturer: 1,
+            product_name: 2,
+            version: 3,
+            serial_number: 4,
+            uuid: [0; 16],
+            wake_up_type: 0x06,
+            sku_number: 5,
+            family: 6,
+            string_pool: vec![
+                String::from("Manufacturer"),
+                String::from("Product"),
+                String::from("Version"),
+                String::from("Serial"),
+                String::from("SKU"),
+                String::from("Family"),
+            ],
+        };
+
+        assert!(type1.validate().is_ok());
+        assert_eq!(type1.string_pool().len(), 6);
+        assert_eq!(Type1SystemInformation::RECORD_TYPE, 1);
+    }
+
+    #[test]
+    fn test_type1_string_pool_mut() {
+        let mut type1 = Type1SystemInformation {
+            header: SmbiosTableHeader { record_type: 1, length: 0, handle: 0 },
+            manufacturer: 1,
+            product_name: 2,
+            version: 3,
+            serial_number: 4,
+            uuid: [0; 16],
+            wake_up_type: 0x06,
+            sku_number: 5,
+            family: 6,
+            string_pool: vec![String::from("Initial")],
+        };
+
+        let pool = type1.string_pool_mut();
+        pool.push(String::from("Added"));
+
+        assert_eq!(type1.string_pool().len(), 2);
+        assert_eq!(type1.string_pool()[1], "Added");
+    }
+
+    #[test]
+    fn test_type2_new() {
+        let type2 = Type2BaseboardInformation {
+            header: SmbiosTableHeader { record_type: 2, length: 0, handle: 0 },
+            manufacturer: 1,
+            product: 2,
+            version: 3,
+            serial_number: 4,
+            asset_tag: 5,
+            feature_flags: 0x01,
+            location_in_chassis: 6,
+            chassis_handle: 0x0003,
+            board_type: 0x0A,
+            contained_object_handles: 0,
+            string_pool: vec![
+                String::from("Manufacturer"),
+                String::from("Product"),
+                String::from("Version"),
+                String::from("Serial"),
+                String::from("Asset Tag"),
+                String::from("Location"),
+            ],
+        };
+
+        assert!(type2.validate().is_ok());
+        assert_eq!(type2.string_pool().len(), 6);
+        assert_eq!(Type2BaseboardInformation::RECORD_TYPE, 2);
+    }
+
+    #[test]
+    fn test_type127_end_of_table() {
+        let type127 = Type127EndOfTable::new();
+
+        assert_eq!(type127.header.record_type, 127);
+        assert_eq!(type127.header.length, 4);
+        // Copy to avoid unaligned reference
+        let handle = type127.header.handle;
+        assert_eq!(handle, SMBIOS_HANDLE_PI_RESERVED);
+        assert_eq!(type127.string_pool.len(), 0);
+        assert!(type127.validate().is_ok());
+        assert_eq!(Type127EndOfTable::RECORD_TYPE, 127);
+    }
+
+    #[test]
+    fn test_type127_default() {
+        let type127 = Type127EndOfTable::default();
+
+        assert_eq!(type127.header.record_type, 127);
+        assert_eq!(type127.string_pool.len(), 0);
+    }
+
+    #[test]
+    fn test_smbios_record_structure_validation() {
+        // Test that validation catches string length issues
+        let mut type1 = Type1SystemInformation {
+            header: SmbiosTableHeader { record_type: 1, length: 0, handle: 0 },
+            manufacturer: 1,
+            product_name: 2,
+            version: 3,
+            serial_number: 4,
+            uuid: [0; 16],
+            wake_up_type: 0x06,
+            sku_number: 5,
+            family: 6,
+            string_pool: vec![String::from("Valid")],
+        };
+
+        assert!(type1.validate().is_ok());
+
+        // Add an invalid string
+        type1.string_pool.push("x".repeat(SMBIOS_STRING_MAX_LENGTH + 1));
+        assert_eq!(type1.validate(), Err(SmbiosError::StringTooLong));
+    }
+
+    #[test]
+    fn test_type3_new() {
+        let type3 = Type3SystemEnclosure {
+            header: SmbiosTableHeader { record_type: 3, length: 21, handle: 0x0300 },
+            manufacturer: 1,
+            enclosure_type: 0x01, // Other
+            version: 2,
+            serial_number: 3,
+            asset_tag_number: 4,
+            bootup_state: 0x03,       // Safe
+            power_supply_state: 0x03, // Safe
+            thermal_state: 0x03,      // Safe
+            security_status: 0x03,    // None
+            oem_defined: 0,
+            height: 0, // Unspecified
+            number_of_power_cords: 1,
+            contained_element_count: 0,
+            contained_element_record_length: 0,
+            string_pool: vec![
+                String::from("Test Manufacturer"),
+                String::from("1.0"),
+                String::from("SN123456"),
+                String::from("Asset-001"),
+            ],
+        };
+
+        assert_eq!(type3.header.record_type, 3);
+        assert_eq!(Type3SystemEnclosure::RECORD_TYPE, 3);
+        assert_eq!(type3.manufacturer, 1);
+        assert_eq!(type3.string_pool.len(), 4);
+        assert!(type3.validate().is_ok());
+    }
+
+    #[test]
+    fn test_type3_to_bytes() {
+        let type3 = Type3SystemEnclosure {
+            header: SmbiosTableHeader { record_type: 3, length: 21, handle: 0x0300 },
+            manufacturer: 1,
+            enclosure_type: 0x01,
+            version: 2,
+            serial_number: 3,
+            asset_tag_number: 4,
+            bootup_state: 0x03,
+            power_supply_state: 0x03,
+            thermal_state: 0x03,
+            security_status: 0x03,
+            oem_defined: 0,
+            height: 0,
+            number_of_power_cords: 1,
+            contained_element_count: 0,
+            contained_element_record_length: 0,
+            string_pool: vec![
+                String::from("Manufacturer"),
+                String::from("Version"),
+                String::from("Serial"),
+                String::from("Asset"),
+            ],
+        };
+
+        let bytes = type3.to_bytes();
+        // Verify header
+        assert_eq!(bytes[0], 3); // Type
+        assert_eq!(bytes[1], 21); // Length
+        // Verify some fields
+        assert_eq!(bytes[4], 1); // manufacturer
+        assert_eq!(bytes[5], 0x01); // enclosure_type
+        // Verify strings are present
+        assert!(bytes.len() > 21);
+    }
+
+    #[test]
+    fn test_type2_validation() {
+        let type2 = Type2BaseboardInformation {
+            header: SmbiosTableHeader { record_type: 2, length: 0, handle: 0x0200 },
+            manufacturer: 1,
+            product: 2,
+            version: 3,
+            serial_number: 4,
+            asset_tag: 5,
+            feature_flags: 0,
+            location_in_chassis: 6,
+            chassis_handle: 0,
+            board_type: 0,
+            contained_object_handles: 0,
+            string_pool: vec![
+                String::from("Board Manufacturer"),
+                String::from("Board Product"),
+                String::from("1.0"),
+                String::from("SN123"),
+                String::from("Asset-123"),
+                String::from("Location"),
+            ],
+        };
+
+        assert_eq!(Type2BaseboardInformation::RECORD_TYPE, 2);
+        assert!(type2.validate().is_ok());
+    }
+
+    #[test]
+    fn test_string_pool_empty() {
+        let type1 = Type1SystemInformation {
+            header: SmbiosTableHeader { record_type: 1, length: 0, handle: 0 },
+            manufacturer: 0,
+            product_name: 0,
+            version: 0,
+            serial_number: 0,
+            uuid: [0; 16],
+            wake_up_type: 0x06,
+            sku_number: 0,
+            family: 0,
+            string_pool: vec![],
+        };
+
+        let bytes = type1.to_bytes();
+        // Should have double null terminator even with no strings
+        assert!(bytes.ends_with(&[0, 0]));
+    }
+}

--- a/sdk/patina_macro/src/smbios_record_macro.rs
+++ b/sdk/patina_macro/src/smbios_record_macro.rs
@@ -1,0 +1,489 @@
+//! Derive macro for SMBIOS record structures.
+//!
+//! This macro generates a complete `SmbiosRecordStructure` trait implementation,
+//! eliminating the need for manual boilerplate code.
+//!
+//! ## Usage
+//!
+//! ```rust,ignore
+//! use patina_macro::SmbiosRecord;
+//!
+//! #[derive(SmbiosRecord)]
+//! #[smbios(record_type = 0x80)]  // Vendor-specific type
+//! pub struct VendorOemRecord {
+//!     pub header: SmbiosTableHeader,
+//!     pub oem_field: u32,
+//!     #[string_pool]
+//!     pub string_pool: Vec<String>,
+//! }
+//! ```
+//!
+//! ## License
+//!
+//! Copyright (c) Microsoft Corporation.
+//!
+//! SPDX-License-Identifier: Apache-2.0
+
+use proc_macro2::TokenStream;
+use quote::quote;
+use syn::{Fields, ItemStruct, Lit, Meta, parse::Parse, spanned::Spanned};
+
+struct SmbiosRecord {
+    item: ItemStruct,
+    string_pool_field: Option<syn::Ident>,
+    record_type: Option<u8>,
+}
+
+impl Parse for SmbiosRecord {
+    fn parse(stream: syn::parse::ParseStream) -> syn::Result<Self> {
+        let item: ItemStruct = stream.parse()?;
+
+        // Find the #[smbios(record_type = ...)] attribute
+        let mut record_type = None;
+        for attr in &item.attrs {
+            if attr.path().is_ident("smbios")
+                && let Meta::List(meta_list) = &attr.meta
+            {
+                // Parse record_type = value
+                let nested: syn::punctuated::Punctuated<Meta, syn::Token![,]> =
+                    meta_list.parse_args_with(syn::punctuated::Punctuated::parse_terminated)?;
+
+                for meta in nested {
+                    if let Meta::NameValue(nv) = meta
+                        && nv.path.is_ident("record_type")
+                        && let syn::Expr::Lit(expr_lit) = &nv.value
+                        && let Lit::Int(lit_int) = &expr_lit.lit
+                    {
+                        record_type = Some(lit_int.base10_parse()?);
+                    }
+                }
+            }
+        }
+
+        // Find the field marked with #[string_pool]
+        let mut string_pool_field = None;
+        let mut string_pool_count = 0;
+
+        if let Fields::Named(fields) = &item.fields {
+            for field in fields.named.iter() {
+                let has_string_pool = field.attrs.iter().any(|attr| attr.path().is_ident("string_pool"));
+
+                if has_string_pool {
+                    string_pool_count += 1;
+                    string_pool_field = field.ident.clone();
+                }
+            }
+        }
+
+        if string_pool_count > 1 {
+            return Err(syn::Error::new(
+                item.span(),
+                "Only one field can be marked with #[string_pool] - SMBIOS records have a single string pool",
+            ));
+        }
+
+        Ok(SmbiosRecord { item, string_pool_field, record_type })
+    }
+}
+
+/// Generate the SmbiosRecordStructure trait implementation
+///
+/// This macro generates a complete SmbiosRecordStructure implementation including:
+/// - RECORD_TYPE constant
+/// - to_bytes() serialization
+/// - validate() string length checking
+/// - string_pool() and string_pool_mut() accessors
+pub(crate) fn smbios_record_derive(item: TokenStream) -> TokenStream {
+    let record = match syn::parse2::<SmbiosRecord>(item) {
+        Ok(r) => r,
+        Err(e) => return e.to_compile_error(),
+    };
+
+    let name = &record.item.ident;
+    let (impl_generics, ty_generics, where_clause) = record.item.generics.split_for_impl();
+
+    // Detect if we're inside patina_smbios crate or using it externally
+    // Use crate:: for internal, ::patina_smbios:: for external
+    let crate_path = quote! { ::patina_smbios };
+
+    // Get the record type - required for trait implementation
+    let record_type = match record.record_type {
+        Some(rt) => rt,
+        None => {
+            return syn::Error::new(
+                record.item.span(),
+                "Missing #[smbios(record_type = ...)] attribute. Example: #[smbios(record_type = 0x80)]",
+            )
+            .to_compile_error();
+        }
+    };
+
+    // Collect all non-string-pool fields for serialization
+    let mut field_serializations = Vec::new();
+    let mut structured_size_calc = quote! { core::mem::size_of::<SmbiosTableHeader>() };
+
+    if let Fields::Named(fields) = &record.item.fields {
+        for field in fields.named.iter() {
+            let field_name = field.ident.as_ref().unwrap();
+            let field_ty = &field.ty;
+
+            // Skip the string_pool field and header field
+            let is_string_pool = field.attrs.iter().any(|attr| attr.path().is_ident("string_pool"));
+            if is_string_pool || field_name == "header" {
+                continue;
+            }
+
+            // Validate field type - must be a primitive integer type or byte array
+            let is_valid_type = match field_ty {
+                syn::Type::Path(type_path) => {
+                    let path = &type_path.path;
+                    path.segments.len() == 1 && {
+                        let segment = &path.segments[0];
+                        matches!(
+                            segment.ident.to_string().as_str(),
+                            "u8" | "u16" | "u32" | "u64" | "i8" | "i16" | "i32" | "i64"
+                        )
+                    }
+                }
+                syn::Type::Array(type_array) => {
+                    matches!(&*type_array.elem,
+                        syn::Type::Path(elem_path)
+                            if elem_path.path.segments.len() == 1 &&
+                               elem_path.path.segments[0].ident == "u8")
+                }
+                _ => false,
+            };
+
+            if !is_valid_type {
+                return syn::Error::new(
+                    field.span(),
+                    format!(
+                        "Field '{}' has unsupported type. SMBIOS record fields must be primitive integer types (u8, u16, u32, u64, i8, i16, i32, i64) or byte arrays ([u8; N]). Found: {}",
+                        field_name,
+                        quote!(#field_ty)
+                    ),
+                )
+                .to_compile_error();
+            }
+
+            // Add field size to structured size calculation
+            structured_size_calc = quote! {
+                #structured_size_calc + core::mem::size_of::<#field_ty>()
+            };
+
+            // Generate serialization for this field based on type
+            // Special case for byte arrays (like UUID) - copy directly without to_le_bytes()
+            let serialization = match field_ty {
+                syn::Type::Array(_) => {
+                    quote! {
+                        bytes.extend_from_slice(&self.#field_name);
+                    }
+                }
+                _ => {
+                    quote! {
+                        bytes.extend_from_slice(&self.#field_name.to_le_bytes());
+                    }
+                }
+            };
+
+            field_serializations.push(serialization);
+        }
+    }
+
+    // String pool methods
+    let (string_pool_impl, validate_impl) = if let Some(pool_field) = &record.string_pool_field {
+        (
+            quote! {
+                fn string_pool(&self) -> &[alloc::string::String] {
+                    &self.#pool_field
+                }
+
+                fn string_pool_mut(&mut self) -> &mut alloc::vec::Vec<alloc::string::String> {
+                    &mut self.#pool_field
+                }
+            },
+            quote! {
+                fn validate(&self) -> core::result::Result<(), #crate_path::error::SmbiosError> {
+                    for string in &self.#pool_field {
+                        if string.len() > #crate_path::service::SMBIOS_STRING_MAX_LENGTH {
+                            return Err(#crate_path::error::SmbiosError::StringTooLong);
+                        }
+                    }
+                    Ok(())
+                }
+            },
+        )
+    } else {
+        (
+            quote! {
+                fn string_pool(&self) -> &[alloc::string::String] {
+                    &[]
+                }
+
+                fn string_pool_mut(&mut self) -> &mut alloc::vec::Vec<alloc::string::String> {
+                    // Return a dummy mutable reference - this should never be used
+                    static mut EMPTY: alloc::vec::Vec<alloc::string::String> = alloc::vec::Vec::new();
+                    unsafe { &mut EMPTY }
+                }
+            },
+            quote! {
+                fn validate(&self) -> core::result::Result<(), #crate_path::error::SmbiosError> {
+                    Ok(())
+                }
+            },
+        )
+    };
+
+    // Generate serialize_strings helper
+    let serialize_strings = if record.string_pool_field.is_some() {
+        let pool_field = record.string_pool_field.as_ref().unwrap();
+        quote! {
+            let mut string_bytes = alloc::vec::Vec::new();
+            if self.#pool_field.is_empty() {
+                string_bytes.extend_from_slice(&[0, 0]);
+            } else {
+                for string in &self.#pool_field {
+                    if !string.is_empty() {
+                        string_bytes.extend_from_slice(string.as_bytes());
+                    }
+                    string_bytes.push(0);
+                }
+                string_bytes.push(0);
+            }
+            bytes.extend_from_slice(&string_bytes);
+        }
+    } else {
+        quote! {
+            bytes.extend_from_slice(&[0, 0]);
+        }
+    };
+
+    quote! {
+        impl #impl_generics #crate_path::smbios_record::SmbiosRecordStructure for #name #ty_generics #where_clause {
+            const RECORD_TYPE: u8 = #record_type;
+
+            fn to_bytes(&self) -> alloc::vec::Vec<u8> {
+                let mut bytes = alloc::vec::Vec::new();
+
+                // Calculate structured data size (header + all fields except string_pool)
+                let structured_size = #structured_size_calc;
+
+                // Serialize header (type, length, handle)
+                bytes.push(Self::RECORD_TYPE);
+                bytes.push(structured_size as u8);
+                bytes.extend_from_slice(&self.header.handle.to_le_bytes());
+
+                // Serialize all other fields
+                #(#field_serializations)*
+
+                // Serialize string pool
+                #serialize_strings
+
+                bytes
+            }
+
+            #validate_impl
+
+            #string_pool_impl
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use quote::quote;
+
+    #[test]
+    fn test_single_string_pool_only() {
+        let input = quote! {
+            #[derive(SmbiosRecord)]
+            #[repr(C, packed)]
+            pub struct TestRecord {
+                pub header: SmbiosTableHeader,
+                #[string_pool]
+                pub strings1: Vec<String>,
+                #[string_pool]
+                pub strings2: Vec<String>,
+            }
+        };
+
+        let output = smbios_record_derive(input);
+        let output_str = output.to_string();
+        // Should error about multiple string pools
+        assert!(output_str.contains("compile_error") || output_str.contains("Only one"));
+    }
+
+    #[test]
+    fn test_unsupported_field_type_string() {
+        let input = quote! {
+            #[derive(SmbiosRecord)]
+            #[smbios(record_type = 0x80)]
+            pub struct TestRecord {
+                pub header: SmbiosTableHeader,
+                pub invalid_field: String,
+                #[string_pool]
+                pub strings: Vec<String>,
+            }
+        };
+
+        let output = smbios_record_derive(input);
+        let output_str = output.to_string();
+        // Should error about unsupported type for invalid_field
+        assert!(output_str.contains("compile_error"));
+        assert!(output_str.contains("invalid_field"));
+        assert!(output_str.contains("unsupported type"));
+    }
+
+    #[test]
+    fn test_unsupported_field_type_vec() {
+        let input = quote! {
+            #[derive(SmbiosRecord)]
+            #[smbios(record_type = 0x80)]
+            pub struct TestRecord {
+                pub header: SmbiosTableHeader,
+                pub data: Vec<u8>,
+                #[string_pool]
+                pub strings: Vec<String>,
+            }
+        };
+
+        let output = smbios_record_derive(input);
+        let output_str = output.to_string();
+        // Should error about unsupported Vec type
+        assert!(output_str.contains("compile_error"));
+        assert!(output_str.contains("data"));
+        assert!(output_str.contains("unsupported type"));
+    }
+
+    #[test]
+    fn test_unsupported_field_type_custom_struct() {
+        let input = quote! {
+            #[derive(SmbiosRecord)]
+            #[smbios(record_type = 0x80)]
+            pub struct TestRecord {
+                pub header: SmbiosTableHeader,
+                pub custom: CustomStruct,
+                #[string_pool]
+                pub strings: Vec<String>,
+            }
+        };
+
+        let output = smbios_record_derive(input);
+        let output_str = output.to_string();
+        // Should error about unsupported custom struct type
+        assert!(output_str.contains("compile_error"));
+        assert!(output_str.contains("custom"));
+        assert!(output_str.contains("unsupported type"));
+    }
+
+    #[test]
+    fn test_unsupported_field_type_option() {
+        let input = quote! {
+            #[derive(SmbiosRecord)]
+            #[smbios(record_type = 0x80)]
+            pub struct TestRecord {
+                pub header: SmbiosTableHeader,
+                pub optional: Option<u32>,
+                #[string_pool]
+                pub strings: Vec<String>,
+            }
+        };
+
+        let output = smbios_record_derive(input);
+        let output_str = output.to_string();
+        // Should error about unsupported Option type
+        assert!(output_str.contains("compile_error"));
+        assert!(output_str.contains("optional"));
+        assert!(output_str.contains("unsupported type"));
+    }
+
+    #[test]
+    fn test_valid_primitive_types() {
+        let input = quote! {
+            #[derive(SmbiosRecord)]
+            #[smbios(record_type = 0x80)]
+            pub struct TestRecord {
+                pub header: SmbiosTableHeader,
+                pub byte: u8,
+                pub word: u16,
+                pub dword: u32,
+                pub qword: u64,
+                pub signed_byte: i8,
+                pub signed_word: i16,
+                pub signed_dword: i32,
+                pub signed_qword: i64,
+                #[string_pool]
+                pub strings: Vec<String>,
+            }
+        };
+
+        let output = smbios_record_derive(input);
+        let output_str = output.to_string();
+        // Should NOT contain compile_error - all types are valid
+        assert!(!output_str.contains("compile_error"));
+        assert!(output_str.contains("impl"));
+        assert!(output_str.contains("SmbiosRecordStructure"));
+    }
+
+    #[test]
+    fn test_valid_byte_array() {
+        let input = quote! {
+            #[derive(SmbiosRecord)]
+            #[smbios(record_type = 0x80)]
+            pub struct TestRecord {
+                pub header: SmbiosTableHeader,
+                pub uuid: [u8; 16],
+                #[string_pool]
+                pub strings: Vec<String>,
+            }
+        };
+
+        let output = smbios_record_derive(input);
+        let output_str = output.to_string();
+        // Should NOT contain compile_error - byte array is valid
+        assert!(!output_str.contains("compile_error"));
+        assert!(output_str.contains("impl"));
+        assert!(output_str.contains("SmbiosRecordStructure"));
+    }
+
+    #[test]
+    fn test_invalid_array_type() {
+        let input = quote! {
+            #[derive(SmbiosRecord)]
+            #[smbios(record_type = 0x80)]
+            pub struct TestRecord {
+                pub header: SmbiosTableHeader,
+                pub invalid_array: [u32; 4],
+                #[string_pool]
+                pub strings: Vec<String>,
+            }
+        };
+
+        let output = smbios_record_derive(input);
+        let output_str = output.to_string();
+        // Should error - only [u8; N] arrays are allowed
+        assert!(output_str.contains("compile_error"));
+        assert!(output_str.contains("invalid_array"));
+        assert!(output_str.contains("unsupported type"));
+    }
+
+    #[test]
+    fn test_missing_record_type_attribute() {
+        let input = quote! {
+            #[derive(SmbiosRecord)]
+            pub struct TestRecord {
+                pub header: SmbiosTableHeader,
+                pub field: u8,
+                #[string_pool]
+                pub strings: Vec<String>,
+            }
+        };
+
+        let output = smbios_record_derive(input);
+        let output_str = output.to_string();
+        // Should error about missing record_type
+        assert!(output_str.contains("compile_error"));
+        assert!(output_str.contains("Missing") || output_str.contains("record_type"));
+    }
+}


### PR DESCRIPTION
## Description

Adds a new SMBIOS component for managing SMBIOS tables and records in UEFI environments with type-safe Rust APIs and EDKII compatibility.

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [x] Includes tests?
- [x] Includes documentation?

### Features
#### Core Functionality
- **SMBIOS 3.9 Support** - Implements SMBIOS 3.9 specification (configurable for 3.x versions)
- **Type-Safe Record API** - `add_record<T>()` with compile-time validation using Rust type system
- **Configuration Table Publication** - Publishes SMBIOS 3.x entry point and tables to UEFI Configuration Table
- **EDKII-Compatible Protocol** - C FFI layer implementing EDK2 SMBIOS protocol interface (Add, UpdateString, Remove, GetNext)
- **Thread-Safe Operations** - TPL_NOTIFY synchronization via `TplMutex` for timer-interrupt safety

(skip cargo release dry run)

## How This Was Tested

Unit test: `cargo test`

Integration tests: `cargo make q35`
- Boots QEMU with Q35 platform
- SMBIOS component initializes and publishes table
- C Protocol FFI tests execute and log results
- Use 'smbiosview' in UEFI Shell to verify published records

C Protocol FFI Layer tests:
  - `Add` - Raw byte-level record addition via C protocol
  - `UpdateString` - String modification via C protocol  
  - `Remove` - Record deletion via C protocol
  - `GetNext` - Record enumeration via C protocol
  - Error handling - Operations on invalid/removed handles
 
Sample:
```
        let protocol = unsafe { &*(protocol_ptr as *const SmbiosProtocol) };

        // Test 1: Add a record using the C protocol Add function
        log::info!("  Test 1: Protocol Add function...");
        let test_record = Self::create_test_type2_record();
        let mut handle: SmbiosHandle = 0;
        
        let status = (protocol.add)(
            protocol,
            core::ptr::null_mut(), // producer_handle
            &mut handle,
            test_record.as_ptr() as *const SmbiosTableHeader,
        );

```

## Integration Instructions

patina-dxe-core-qemu:
https://github.com/OpenDevicePartnership/patina-dxe-core-qemu/pull/59
Add the following to _start function in DXE core binary:
```
use patina_smbios::component::SmbiosProvider;

pub extern "efiapi" fn _start(physical_hob_list: *const c_void) -> ! {
    Core::default()
        .with_component(SmbiosProvider::new(3, 9))
        .with_component(q35_services::smbios_platform::Q35SmbiosPlatform::new())
        <other components>
}
```

patina-qemu:
https://github.com/OpenDevicePartnership/patina-qemu/pull/78

Co-authored-by: Kat Perez <katperez@microsoft.com>
Co-authored-by: Ansley Thompson <ansley.thompson@dell.com>