### PR TITLE
patina_internal_cpu: Update Paging API to Always Return Cache Attrs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ patina_internal_device_path = { version = "14.1.0", path = "core/patina_internal
 patina_lzma_rs = { version = "0.3.1", default-features = false }
 patina_macro = { version = "14.1.0", path = "sdk/patina_macro" }
 patina_mtrr = { version = "1.0.0" }
-patina_paging = { version = "^9.0.3" }
+patina_paging = { version = "10" }
 patina_performance = { version = "14.1.0", path = "components/patina_performance" }
 patina_stacktrace = { version = "14.1.0", path = "core/patina_stacktrace" }
 proc-macro2 = { version = "1" }

--- a/core/patina_debugger/src/memory.rs
+++ b/core/patina_debugger/src/memory.rs
@@ -161,17 +161,17 @@ mod tests {
     use crate::*;
     use gdbstub::target::ext::breakpoints;
     use mockall::{predicate::*, *};
-    use patina_paging::{MemoryAttributes, PtResult};
+    use patina_paging::{MemoryAttributes, PtError};
 
     mock! {
         pub MemPageTable {}
 
         impl PageTable for MemPageTable {
-            fn map_memory_region(&mut self, address: u64, size: u64, attributes: MemoryAttributes) -> PtResult<()>;
-            fn unmap_memory_region(&mut self, address: u64, size: u64) -> PtResult<()>;
-            fn install_page_table(&mut self) -> PtResult<()>;
-            fn query_memory_region(&self, address: u64, size: u64) -> PtResult<MemoryAttributes>;
-            fn dump_page_tables(&self, address: u64, size: u64) -> PtResult<()>;
+            fn map_memory_region(&mut self, address: u64, size: u64, attributes: MemoryAttributes) -> Result<(), PtError>;
+            fn unmap_memory_region(&mut self, address: u64, size: u64) -> Result<(), PtError>;
+            fn install_page_table(&mut self) -> Result<(), PtError>;
+            fn query_memory_region(&self, address: u64, size: u64) -> Result<MemoryAttributes, PtError>;
+            fn dump_page_tables(&self, address: u64, size: u64) -> Result<(), PtError>;
         }
     }
 

--- a/core/patina_internal_cpu/src/paging.rs
+++ b/core/patina_internal_cpu/src/paging.rs
@@ -9,15 +9,95 @@
 //! SPDX-License-Identifier: Apache-2.0
 //!
 
+use patina_paging::{MemoryAttributes, PtError};
+
 cfg_if::cfg_if! {
-    if #[cfg(all(target_os = "uefi", target_arch = "x86_64"))] {
+    if #[cfg(all(target_arch = "x86_64"))] {
         mod x64;
         pub use x64::create_cpu_x64_paging as create_cpu_paging;
-    } else if #[cfg(all(target_os = "uefi", target_arch = "aarch64"))] {
+    } else if #[cfg(all(target_arch = "aarch64"))] {
         mod aarch64;
         pub use aarch64::create_cpu_aarch64_paging as create_cpu_paging;
     } else {
         mod null;
         pub use null::create_cpu_null_paging as create_cpu_paging;
     }
+}
+
+/// Enum representing the cache attribute value of a memory region if it is not maintained
+/// by the page table. On x64 platforms, this allows for unmapped pages to still reflect
+/// the cache attributes as managed by MTRRs. On ARM64 this will always be NotSupported as
+/// cache attributes are always managed by the page table.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CacheAttributeValue {
+    /// Valid cache attributes for the memory region
+    Valid(MemoryAttributes),
+    /// The memory region is unmapped
+    Unmapped,
+    /// Cache attributes are only supported via the page table for this architecture
+    NotSupported,
+}
+
+/// The PatinaPageTable trait is Patina's abstraction layer over the PageTable trait
+/// provided by patina-paging. This trait manages architectural abstractions over the page tables.
+pub trait PatinaPageTable {
+    /// Function to map the designated memory region to with provided
+    /// attributes. The requested memory region will be mapped with the specified
+    /// attributes, regardless of the current mapping state of the region.
+    ///
+    /// ## Arguments
+    /// * `address` - The memory address to map.
+    /// * `size` - The memory size to map.
+    /// * `attributes` - The memory attributes to map. The acceptable
+    ///   input will be ExecuteProtect, ReadOnly, as well as Uncacheable,
+    ///   WriteCombining, WriteThrough, Writeback, UncacheableExport
+    ///   Compatible attributes can be "Ored"
+    ///
+    /// ## Errors
+    /// * Returns `Ok(())` if successful else `Err(PtError)` if failed
+    fn map_memory_region(&mut self, address: u64, size: u64, attributes: MemoryAttributes) -> Result<(), PtError>;
+
+    /// Function to unmap the memory region provided by the caller. The
+    /// requested memory region must be fully mapped prior to this call. The
+    /// entire region does not need to have the same mapping state in order
+    /// to unmap it.
+    ///
+    /// ## Arguments
+    /// * `address` - The memory address to map.
+    /// * `size` - The memory size to map.
+    ///
+    /// ## Errors
+    /// * Returns `Ok(())` if successful else `Err(PtError)` if failed
+    fn unmap_memory_region(&mut self, address: u64, size: u64) -> Result<(), PtError>;
+
+    /// Function to install the page table from this page table instance.
+    ///
+    /// ## Errors
+    /// * Returns `Ok(())` if successful else `Err(PtError)` if failed
+    fn install_page_table(&mut self) -> Result<(), PtError>;
+
+    /// Function to query the mapping status and return attribute of supplied
+    /// memory region if it is properly and consistently mapped. This function
+    /// returns the caching attributes for platforms where caching attributes
+    /// are managed outside of the page table (e.g., x86_64 MTRRs), even when
+    /// the page range itself is unmapped.
+    ///
+    /// ## Arguments
+    /// * `address` - The memory address to map.
+    /// * `size` - The memory size to map.
+    ///
+    /// ## Returns
+    ///   `Ok(MemoryAttributes)` if the page range is mapped else
+    ///   `Err(PtError, None)` if the page is unmapped and the cache attributes are not available
+    ///   `Err(PtError, Some(MemoryAttributes))` if the page is unmapped but caching attributes are available
+    fn query_memory_region(&self, address: u64, size: u64) -> Result<MemoryAttributes, (PtError, CacheAttributeValue)>;
+
+    /// Function to dump memory ranges with their attributes. It uses current
+    /// cr3 as the base. This function can be used from
+    /// `test_dump_page_tables()` test case
+    ///
+    /// ## Arguments
+    /// * `address` - The memory address to map.
+    /// * `size` - The memory size to map.
+    fn dump_page_tables(&self, address: u64, size: u64) -> Result<(), PtError>;
 }

--- a/core/patina_internal_cpu/src/paging/null.rs
+++ b/core/patina_internal_cpu/src/paging/null.rs
@@ -9,8 +9,9 @@
 //! SPDX-License-Identifier: Apache-2.0
 //!
 use alloc::boxed::Box;
-use patina_paging::{MemoryAttributes, PageTable, PtError, PtResult};
+use patina_paging::{CacheAttributeValue, MemoryAttributes, PtError};
 
+use crate::paging::PatinaPageTable;
 use patina_paging::page_allocator::PageAllocator;
 use r_efi::efi;
 
@@ -23,7 +24,7 @@ where
     _allocator: core::marker::PhantomData<A>,
 }
 
-impl<A> PageTable for EfiCpuPagingNull<A>
+impl<A> PatinaPageTable for EfiCpuPagingNull<A>
 where
     A: PageAllocator,
 {
@@ -39,11 +40,15 @@ where
         Ok(())
     }
 
-    fn query_memory_region(&self, _address: u64, _size: u64) -> Result<MemoryAttributes, PtError> {
+    fn query_memory_region(
+        &self,
+        _address: u64,
+        _size: u64,
+    ) -> Result<MemoryAttributes, (PtError, CacheAttributeValue)> {
         Ok(MemoryAttributes::empty())
     }
 
-    fn dump_page_tables(&self, _address: u64, _size: u64) -> PtResult<()> {
+    fn dump_page_tables(&self, _address: u64, _size: u64) -> Result<(), PtError> {
         Ok(())
     }
 }
@@ -51,6 +56,6 @@ where
 /// Used to specify that this architecture paging implementation is not supported.
 pub fn create_cpu_null_paging<A: PageAllocator + 'static>(
     _page_allocator: A,
-) -> Result<Box<dyn PageTable>, efi::Status> {
+) -> Result<Box<dyn PatinaPageTable>, efi::Status> {
     Err(efi::Status::UNSUPPORTED)
 }


### PR DESCRIPTION
## Description

Currently patina_internal_cpu will not return MTRR cache attributes if a page is unmapped; it will simply return an error. However, the GCD code needs to send the cache attribute changed event to MpDxe to wake up the APs and sync MTRRs whenever the cache attributes change. The GCD took the approach of always sending the event when a page was unmapped and is getting mapped; that resulted in large numbers of the event getting fired, each having to wake up the APs.

This changes the patina_internal_cpu API to return the cache attributes if covered by MTRRs even when the page is unmapped. For ARM64, where the cache attributes are entirely contained within the page table and the MP code starts cores fresh every time with the BSP page table, so syncing is not required, cache attributes will never be returned if the page is unmapped.

This greatly reduces the number of times the event is fired to only the times it needs to.

This PR also updates to paging v10, which just included a breaking change to update the API to not use a custom Result type.

Closes #899 .

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Tested booting Q35, SBSA, and a physical Intel platform to Windows and observing the number of cache attribute change events decreasing (on Q35 from 403 -> 2).

## Integration Instructions

N/A.
