### PR TITLE
Ignore patina automation bot PRs in release notes

### DIFF
--- a/.github/release-draft-config.yml
+++ b/.github/release-draft-config.yml
@@ -92,3 +92,4 @@ exclude-labels:
 
 exclude-contributors:
   - 'github-actions[bot]'
+  - 'patina-automation[bot]'


### PR DESCRIPTION
## Description

Do not show changes from `patina-automation[bot]`.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

- N/A

## Integration Instructions

- N/A