### PR TITLE
ignore patina_samples for coverage calculations

### DIFF
--- a/components/patina_samples/src/lib.rs
+++ b/components/patina_samples/src/lib.rs
@@ -16,5 +16,5 @@
 //!
 #![cfg_attr(not(feature = "std"), no_std)]
 #![feature(coverage_attribute)]
-
+#![coverage(off)] // Disable all coverage instrumentation for sample code
 pub mod component;


### PR DESCRIPTION
## Description

While `patina_samples` are compile-able and usable for a platform, they are intended to be viewable examples, not components that actually perform any real function. Due to this, there is no need to calculate code coverage for them.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

N/A

## Integration Instructions

N/A
