### PR TITLE
mdbook: Update background examples for `mdbook test`

### DIFF
--- a/docs/src/patina.md
+++ b/docs/src/patina.md
@@ -220,26 +220,8 @@ implemented the ability for the Patina DXE Core dispatch process to dispatch pla
 and services with each other but through Rust interfaces that are safe and statically checked versus the dynamic and
 disjoint nature of the protocol database in the C DXE Core.
 
-This snippet shows a simple example of how the Patina DXE Core is instantiated and customized in a simple platform
-binary crate:
-
-```rust
-#[cfg_attr(target_os = "uefi", export_name = "efi_main")]
-pub extern "efiapi" fn _start(physical_hob_list: *const c_void) -> ! {
-    log::set_logger(&LOGGER).map(|()| log::set_max_level(log::LevelFilter::Trace)).unwrap();
-    let adv_logger_component = AdvancedLoggerComponent::<Uart16550>::new(&LOGGER);
-    adv_logger_component.init_advanced_logger(physical_hob_list).unwrap();
-
-    patina_debugger::set_debugger(&DEBUGGER);
-
-    Core::default()
-        .init_memory(physical_hob_list)                                                 // DXE Core initializes GCD with the HOB list
-        .with_service(patina_ffs_extractors::CompositeSectionExtractor::default()) // A trait implementation that can be consumed by any component
-        .with_component(adv_logger_component)                                            // The "advanced logger" Rust component is added for dispatch
-        .start()
-        .unwrap();
-}
-```
+For an example of how the Patina DXE Core is instantiated and customized in a platform binary, see the
+[Patina DXE Core Integration Guide](integrate/dxe_core.md).
 
 ``` admonish note
 Rust is an exciting new next step and there is more to share about the Patina DXE Core in future documentation.


### PR DESCRIPTION
## Description

Closes #974 

The examples are updated to pass:
`rustup run nightly-2025-09-19 mdbook test docs -L target\debug\deps`

Most code snippets are marked `no_run` as exercising the full Patina code does not make sense in the context of the example. A few are marked `ignore` if compilation would have a lot of overhead with little return.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [x] Includes tests?
- [x] Includes documentation?

## How This Was Tested

- `cargo make clean`
- `cargo make build-lib`
- `rustup run nightly-2025-09-19 mdbook test docs -L target\debug\deps`

## Integration Instructions

- N/A