### PR TITLE
patina_dxe_core: Use `NonNull::expose_provenance`

### DIFF
--- a/patina_dxe_core/src/allocator.rs
+++ b/patina_dxe_core/src/allocator.rs
@@ -501,7 +501,7 @@ pub fn core_allocate_pages(
 
             if let Ok(ptr) = result {
                 // Safety: caller must ensure that "memory" is a valid pointer. It is null-checked above.
-                unsafe { memory.write_unaligned(ptr.cast::<u8>().as_ptr().expose_provenance() as u64) }
+                unsafe { memory.write_unaligned(ptr.expose_provenance().get() as u64) }
                 Ok(())
             } else {
                 result.map(|_| ())


### PR DESCRIPTION
## Description

In `patina_dxe_core::allocator::core_allocate_pages`, changes:

https://github.com/OpenDevicePartnership/patina/blob/85d86661a7e787309818c30cafd12f4690f128bd/patina_dxe_core/src/allocator.rs#L504

To:

https://github.com/OpenDevicePartnership/patina/blob/c2ceb10d89ddbc6250ec0143a676250dea941584/patina_dxe_core/src/allocator.rs#L504

As described in #634.

Fixes #634.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Ran existing tests in CI and locally.

Used CodeLLDB to step through test execution before and after to verify the written value was identical.

Ran `cargo miri test --no-fail-fast -q --color=never` twice on unmodified 5a58596309748bcf8e9c9b3a14e26e70e0bd7e3f and twice on c2ceb10d89ddbc6250ec0143a676250dea941584, piping each to their own text file. Diffing shows very small differences in test failures (which are different between two runs on the same commit too), but no change in the complaints from Miri (though Miri does have complaints, just nothing new).

## Integration Instructions

N/A