### PR TITLE
Update to patina-devops v0.1.1

### DIFF
--- a/.github/workflows/calculate-unsafe-code.yml
+++ b/.github/workflows/calculate-unsafe-code.yml
@@ -21,5 +21,5 @@ on:
 jobs:
   calculate_unsafe_code:
     name: Run
-    uses: OpenDevicePartnership/patina-devops/.github/workflows/CalculateUnsafeCode.yml@v0.1.0
+    uses: OpenDevicePartnership/patina-devops/.github/workflows/CalculateUnsafeCode.yml@v0.1.1
     secrets: inherit

--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -25,7 +25,7 @@ on:
 jobs:
   ci_workflow:
     name: Run
-    uses: OpenDevicePartnership/patina-devops/.github/workflows/CiWorkflow.yml@v0.1.0
+    uses: OpenDevicePartnership/patina-devops/.github/workflows/CiWorkflow.yml@v0.1.1
     with:
       build-tasks: "build,build-x64,build-aarch64"
       run-cargo-vet: false
@@ -33,7 +33,7 @@ jobs:
     secrets: inherit
   mdbook_docs_test:
     name: Run
-    uses: OpenDevicePartnership/patina-devops/.github/workflows/MdbookWorkflow.yml@v0.1.0
+    uses: OpenDevicePartnership/patina-devops/.github/workflows/MdbookWorkflow.yml@v0.1.1
     with:
       mdbook-path: "docs"
       build-cmd: cargo make build-lib

--- a/.github/workflows/label-issues.yml
+++ b/.github/workflows/label-issues.yml
@@ -31,5 +31,5 @@ jobs:
       contents: read
       pull-requests: write
 
-    uses: OpenDevicePartnership/patina-devops/.github/workflows/Labeler.yml@v0.1.0
+    uses: OpenDevicePartnership/patina-devops/.github/workflows/Labeler.yml@v0.1.1
     secrets: inherit

--- a/.github/workflows/label-sync.yml
+++ b/.github/workflows/label-sync.yml
@@ -22,5 +22,5 @@ jobs:
     permissions:
       issues: write
 
-    uses: OpenDevicePartnership/patina-devops/.github/workflows/LabelSyncer.yml@v0.1.0
+    uses: OpenDevicePartnership/patina-devops/.github/workflows/LabelSyncer.yml@v0.1.1
     secrets: inherit

--- a/.github/workflows/publish-mdbook.yml
+++ b/.github/workflows/publish-mdbook.yml
@@ -32,7 +32,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: 🛠️ Download Rust Tools 🛠️
-        uses: OpenDevicePartnership/patina-devops/.github/actions/rust-tool-cache@v0.1.0
+        uses: OpenDevicePartnership/patina-devops/.github/actions/rust-tool-cache@v0.1.1
 
       - name: 📄 Build Documentation 📄
         run: mdbook build docs

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -16,7 +16,7 @@ on:
 jobs:
   release:
     name: Release
-    uses: OpenDevicePartnership/patina-devops/.github/workflows/ReleaseWorkflow.yml@v0.1.0
+    uses: OpenDevicePartnership/patina-devops/.github/workflows/ReleaseWorkflow.yml@v0.1.1
     with:
       ignore-prefix: 'patina-v'
     secrets: inherit

--- a/.github/workflows/rust-version-check.yml
+++ b/.github/workflows/rust-version-check.yml
@@ -22,5 +22,5 @@ jobs:
         pull-requests: write
         contents: read
 
-      uses: OpenDevicePartnership/patina-devops/.github/workflows/RustVersionCheck.yml@v0.1.0
+      uses: OpenDevicePartnership/patina-devops/.github/workflows/RustVersionCheck.yml@v0.1.1
       secrets: inherit

--- a/.github/workflows/triage-issues.yml
+++ b/.github/workflows/triage-issues.yml
@@ -17,5 +17,5 @@ jobs:
       contents: read
       issues: write
 
-    uses: OpenDevicePartnership/patina-devops/.github/workflows/IssueTriager.yml@v0.1.0
+    uses: OpenDevicePartnership/patina-devops/.github/workflows/IssueTriager.yml@v0.1.1
     secrets: inherit

--- a/.github/workflows/update-release-draft.yml
+++ b/.github/workflows/update-release-draft.yml
@@ -25,5 +25,5 @@ jobs:
       contents: write
       pull-requests: write
 
-    uses: OpenDevicePartnership/patina-devops/.github/workflows/UpdateReleaseDraft.yml@v0.1.0
+    uses: OpenDevicePartnership/patina-devops/.github/workflows/UpdateReleaseDraft.yml@v0.1.1
     secrets: inherit


### PR DESCRIPTION
## Description

Updates to patina-devops v0.1.1 which splits the mdbook building into a new job and also adds mdbook example testing.

Tangentially this update also re-orders some CI tests to improve the overall time it takes to complete CI.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

CI

## Integration Instructions

N/A
