### PR TITLE
Update trigger for skipping release dry-run

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -7,6 +7,7 @@
 - [ ] Breaking change?
 - [ ] Includes tests?
 - [ ] Includes documentation?
+- [ ] Creates a new crate?
 
 ## How This Was Tested
 

--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -30,5 +30,5 @@ jobs:
       build-tasks: "build,build-x64,build-aarch64"
       mdbook-path: "docs"
       run-cargo-vet: false
-      run-release-dry-run: ${{ !contains(github.event.pull_request.body, '(skip cargo release dry run)') }}
+      run-release-dry-run: ${{ !contains(github.event.pull_request.body, '- [x] Creates a new crate?') }}
     secrets: inherit


### PR DESCRIPTION

## Description

Updates the trigger to skip the release dry run step to allow the user to simply click the button in the draft

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?
- [x] Creates a new crate?

## How This Was Tested

This exact workflow checks the box and the test is skipped.

## Integration Instructions

N/A
