### PR TITLE
patina_dxe_core/gcd: Skip setting mem attrs for V1 MMIO and Reserved HOBs

### DIFF
--- a/patina_dxe_core/src/gcd.rs
+++ b/patina_dxe_core/src/gcd.rs
@@ -218,6 +218,17 @@ pub fn add_hob_resource_descriptors_to_gcd(hob_list: &HobList) {
                     )
                     .expect("Failed to add memory space to GCD");
                 }
+
+                // V1 HOBs don't provide cache attributes for MMIO/Reserved memory. Skip setting attributes.
+                #[cfg(feature = "v1_resource_descriptor_support")]
+                if memory_attributes == 0 {
+                    log::debug!(
+                        "Skipping setting memory attributes for {gcd_mem_type:?} range {:#x?} with 0 attributes (V1 HOB)",
+                        split_range
+                    );
+                    continue;
+                }
+
                 match GCD.set_memory_space_attributes(
                     split_range.start as usize,
                     split_range.end.saturating_sub(split_range.start) as usize,


### PR DESCRIPTION
## Description

Closes #1012 

Currently, the memory attributes for MMIO resource descriptor V1 HOBs
is being calculated as `0` (since no cache attributes are set).

This causes an assert:

```
GCD failed to set memory attributes 0x0 for base: 0xFEDA3000,
length: 0x1000
```

This change skips calling `set_memory_space_attributes()` for V1
resource descriptor HOBs with `0` memory attributes which matches
previous behavior for V1 HOBs.

---

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?
- [ ] Creates a new crate?

## How This Was Tested

- `cargo make all`
- Verified a physical platform with V1 HOBs no longer asserts on MMIO or reserved HOBs that have attributes set to `0` during HOB list processing.

## Integration Instructions

- N/A