### PR TITLE
gcd: Fix Mapping Memory Range Print

### DIFF
--- a/patina_dxe_core/src/gcd.rs
+++ b/patina_dxe_core/src/gcd.rs
@@ -202,9 +202,6 @@ pub fn add_hob_resource_descriptors_to_gcd(hob_list: &HobList) {
                     .take_while(|r| r.is_some())
                     .flatten()
             {
-                log::info!(
-                    "Mapping memory range {split_range:#x?} as {gcd_mem_type:?} with attributes {resource_attributes:#x?}",
-                );
                 unsafe {
                     GCD.add_memory_space(
                         gcd_mem_type,
@@ -214,6 +211,10 @@ pub fn add_hob_resource_descriptors_to_gcd(hob_list: &HobList) {
                     )
                     .expect("Failed to add memory space to GCD");
                 }
+
+                log::info!(
+                    "Mapping memory range {split_range:#x?} as {gcd_mem_type:?} with attributes {memory_attributes:#x?}",
+                );
 
                 match GCD.set_memory_space_attributes(
                     split_range.start as usize,


### PR DESCRIPTION
## Description

This fixes a print to print out the EFI attributes that are getting set, not the resource attributes (which are capabilities) from the resource descriptor HOB.

In addition, move this print down to only print when we are actually setting attributes for v2 HOBs, since v1 HOBs will confusingly say we are mapping them with 0 attributes.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?
- [ ] Creates a new crate?

## How This Was Tested

N/A.

## Integration Instructions

N/A.
