### PR TITLE
Split `serde` feature to support no_std UEFI builds

### DIFF
--- a/sdk/patina/Cargo.toml
+++ b/sdk/patina/Cargo.toml
@@ -68,7 +68,8 @@ default = []
 # with the `#[patina_test]` attribute. Otherwise, a linker crash or failure will
 # occur!
 enable_patina_tests = ["patina_macro/enable_patina_tests"]
-serde = ["dep:serde", "dep:serde_yaml", "dep:serde_json"]
+serde = ["dep:serde", "dep:serde_json"]
+serde-with-yaml = ["serde", "dep:serde_yaml"]
 
 unstable = ["unstable-device-path"]
 unstable-device-path = []


### PR DESCRIPTION
## Description

The `serde` feature previously included `serde_yaml`, which pulls in std in its dependencies. This prevented no_std UEFI builds from using patina's `serde` support.

Changes:

- `serde:` Now includes only `serde` and `serde_json` (which is no_std compatible)
- `serde-with-yaml`: New feature for builds that need YAML support

This allows firmware to use JSON serialization without pulling in std through `serde_yaml`'s dependency chain.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?
- [ ] Creates a new crate?

## How This Was Tested

- `cargo make all`
- Build with Patina FW Readiness tool which uses the `serde` feature in `patina`

## Integration Instructions

- Review the `patina` feature change