### PR TITLE
dxe_core: Always Apply NX to UC Memory

### DIFF
--- a/docs/src/integrate/patina_dxe_core_requirements.md
+++ b/docs/src/integrate/patina_dxe_core_requirements.md
@@ -231,6 +231,16 @@ created or modified when an image is started, then `EFI_BOOT_SERVICES.ConnectCon
 Patina does not implement this behavior. Images and platforms dependent on this behavior will need to be modified to
 explicitly call `ConnectController()` on any handles that they create or modify.
 
+#### 3.4 EFI_MEMORY_UC Memory Must Be Non-Executable
+
+Patina will automatically apply EFI_MEMORY_XP to all SetMemorySpaceAttributes(), CpuArchProtocol->SetMemoryAttributes(),
+and MemoryAttributesProtocol->SetMemoryAttributes() calls that pass in EFI_MEMORY_UC. In the DXE time frame, no uncached
+memory (typically representing device memory) should be marked as executable. For AArch64, the ARM ARM v8 B2.7.2 states
+that having executable device memory (what EFI_MEMORY_UC maps to) is a programming error and has been observed to cause
+crashes due to speculative execution trying instruction fetches from memory that is not ready to be touched or should
+never be touched. For x86 platforms, we still should protect these ranges to prevent devices having access to executable
+memory.
+
 ### 4. Known Limitations
 
 This section details requirements Patina currently has due to limitations in implementation, but that support will be


### PR DESCRIPTION
## Description

This commit adds a new memory rules function that is easy to audit the rules that Patina applies to memory. For now, this function consists of a single rule, which is if EFI_MEMORY_UC is set on a range, EFI_MEMORY_XP must also be set.

In DXE, we should never be executing from UC memory and on AArch64 it is architecturally defined as a programming error to have device memory (what UC maps to) that is not marked XP. EDK II's ArmCpuDxe always sets XP when UC is requested.

It has been observed that speculative execution on AArch64 platforms can attempt to do an instruction fetch from device memory (which is allowed if XP is not set) and crash the system if the region touched is MMIO that does not have backing memory (say space between device registers).

For all architectures, Patina enforces that UC memory should not be executed from.

This commit also makes the XP requirement for all added memory more explicit in adding resource descriptor HOBs, though this is not a functional change.

- [x] Impacts functionality?
- [x] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Tested by booting to Windows on Q35, SBSA, and physical ARM64 and Intel platforms

## Integration Instructions

N/A.
