### PR TITLE
GCD: Move Memory Block Init to Separate Function

### DIFF
--- a/patina_dxe_core/src/allocator/fixed_size_block_allocator.rs
+++ b/patina_dxe_core/src/allocator/fixed_size_block_allocator.rs
@@ -869,7 +869,7 @@ mod tests {
         let layout = Layout::from_size_align(size, UEFI_PAGE_SIZE).unwrap();
         let base = unsafe { System.alloc(layout) as u64 };
         unsafe {
-            gcd.add_memory_space(GcdMemoryType::SystemMemory, base as usize, size, efi::MEMORY_WB).unwrap();
+            gcd.init_memory_blocks(GcdMemoryType::SystemMemory, base as usize, size, efi::MEMORY_WB).unwrap();
         }
         base
     }

--- a/patina_dxe_core/src/allocator/uefi_allocator.rs
+++ b/patina_dxe_core/src/allocator/uefi_allocator.rs
@@ -300,7 +300,7 @@ mod tests {
         let layout = Layout::from_size_align(size, UEFI_PAGE_SIZE).unwrap();
         let base = unsafe { System.alloc(layout) as u64 };
         unsafe {
-            gcd.add_memory_space(dxe_services::GcdMemoryType::SystemMemory, base as usize, size, efi::MEMORY_WB)
+            gcd.init_memory_blocks(dxe_services::GcdMemoryType::SystemMemory, base as usize, size, efi::MEMORY_WB)
                 .unwrap();
         }
         base

--- a/patina_dxe_core/src/gcd.rs
+++ b/patina_dxe_core/src/gcd.rs
@@ -66,19 +66,14 @@ pub fn init_gcd(physical_hob_list: *const c_void) {
     assert!(memory_start < memory_end, "Not enough memory available for DXE core to start.");
 
     // initialize the GCD with an initial memory space. Note: this will fail if GCD.init() above didn't happen.
+    // SAFETY: We are directly using the free memory space from the PHIT HOB, which must be valid and reserved for use
+    // per spec.
     unsafe {
-        GCD.add_memory_space(
+        GCD.init_memory_blocks(
             GcdMemoryType::SystemMemory,
             free_memory_start as usize,
             free_memory_size as usize,
-            efi::MEMORY_UC
-                | efi::MEMORY_WC
-                | efi::MEMORY_WT
-                | efi::MEMORY_WB
-                | efi::MEMORY_WP
-                | efi::MEMORY_RP
-                | efi::MEMORY_XP
-                | efi::MEMORY_RO,
+            efi::MEMORY_ACCESS_MASK | efi::CACHE_ATTRIBUTE_MASK,
         )
         .expect("Failed to add initial region to GCD.");
     }

--- a/patina_dxe_core/src/test_support.rs
+++ b/patina_dxe_core/src/test_support.rs
@@ -62,7 +62,7 @@ pub(crate) unsafe fn init_test_gcd(size: Option<usize>) {
     unsafe { GCD.reset() };
     GCD.init(48, 16);
     unsafe {
-        GCD.add_memory_space(
+        GCD.init_memory_blocks(
             GcdMemoryType::SystemMemory,
             addr as usize,
             TEST_GCD_MEM_SIZE,


### PR DESCRIPTION
## Description

Currently, when the PHIT HOB is processed to update the GCD, it calls add_memory_space() which sees the GCD memory blocks capacity is 0, so it calls init_memory_blocks, which creates capacity in the memory blocks and then calls back into add_memory_space to add the region to the GCD, which this time sees the capacity is non-zero and so does not call init_memory_blocks again.

This commit breaks the call to init_memory_blocks out into a separately callable function that is called when the PHIT HOB is processed. This is done to simply this call stack, most importantly because it has been observed that speculative execution can mispredict the capacity == 0 branch for other add_memory_space calls and do speculative reads of MMIO (when it believes that this memory region will be the one that is added to initialize the memory blocks) that on some platforms can cause stuck transactions (e.g. if some of the MMIO isn't back by an actual device or memory).

It is the responsibility of the platform to correctly report its memory resources, but, we can be a bit more defensive here since an active issue was seen and this pattern was convoluted anyway.

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Tested on Q35, SBSA, and a physical ARM64 platform.

## Integration Instructions

N/A.
