### PR TITLE
Debugger: Support Reading MTRR/MAIR via Monitor Command

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ patina_internal_depex = { version = "14.3.2", path = "core/patina_internal_depex
 patina_internal_device_path = { version = "14.3.2", path = "core/patina_internal_device_path" }
 patina_lzma_rs = { version = "0.3.1", default-features = false }
 patina_macro = { version = "14.3.2", path = "sdk/patina_macro" }
-patina_mtrr = { version = "1.0.0" }
+patina_mtrr = { version = "^1.1.4" }
 patina_paging = { version = "10" }
 patina_performance = { version = "14.3.2", path = "components/patina_performance" }
 patina_smbios = { version = "14.3.2", path = "components/patina_smbios" }

--- a/core/patina_debugger/Cargo.toml
+++ b/core/patina_debugger/Cargo.toml
@@ -21,6 +21,9 @@ bitfield-struct = { workspace = true  }
 [dev-dependencies]
 mockall = { workspace = true }
 
+[target.'cfg(all(target_arch="x86_64"))'.dependencies]
+patina_mtrr = { workspace = true }
+
 [features]
 default = ["alloc", "windbg_workarounds"]
 alloc = []

--- a/core/patina_debugger/src/arch.rs
+++ b/core/patina_debugger/src/arch.rs
@@ -21,9 +21,11 @@ use crate::ExceptionInfo;
 
 cfg_if::cfg_if! {
     if #[cfg(target_arch = "x86_64")] {
+        #[coverage(off)]
         mod x64;
         pub type SystemArch = x64::X64Arch;
     } else if #[cfg(target_arch = "aarch64")] {
+        #[coverage(off)]
         mod aarch64;
         pub type SystemArch = aarch64::Aarch64Arch;
     }

--- a/core/patina_debugger/src/arch/aarch64.rs
+++ b/core/patina_debugger/src/arch/aarch64.rs
@@ -237,6 +237,7 @@ impl DebuggerArch for Aarch64Arch {
         match tokens.next() {
             Some("regs") => {
                 print_sysreg!(ttbr0_el2, out);
+                print_sysreg!(mair_el2, out);
                 print_sysreg!(esr_el2, out);
                 print_sysreg!(far_el2, out);
                 print_sysreg!(tcr_el2, out);

--- a/core/patina_internal_cpu/src/interrupts/aarch64.rs
+++ b/core/patina_internal_cpu/src/interrupts/aarch64.rs
@@ -13,12 +13,14 @@ use patina_stacktrace::{StackFrame, StackTrace};
 
 cfg_if::cfg_if! {
     if #[cfg(all(target_os = "uefi", target_arch = "aarch64"))] {
+        #[coverage(off)]
         mod interrupt_manager;
         pub mod gic_manager;
         pub use interrupt_manager::InterruptsAarch64;
         use patina::{read_sysreg, write_sysreg};
     } else if #[cfg(feature = "doc")] {
         pub use interrupt_manager::InterruptsAarch64;
+        #[coverage(off)]
         mod interrupt_manager;
     }
 }

--- a/core/patina_internal_cpu/src/interrupts/x64.rs
+++ b/core/patina_internal_cpu/src/interrupts/x64.rs
@@ -14,10 +14,12 @@ use patina_stacktrace::{StackFrame, StackTrace};
 
 cfg_if::cfg_if! {
     if #[cfg(all(target_os = "uefi", target_arch = "x86_64"))] {
+        #[coverage(off)]
         mod interrupt_manager;
         pub use interrupt_manager::InterruptsX64;
     } else if #[cfg(feature = "doc")] {
         pub use interrupt_manager::InterruptsX64;
+        #[coverage(off)]
         mod interrupt_manager;
     }
 }

--- a/core/patina_internal_cpu/src/interrupts/x64/interrupt_manager.rs
+++ b/core/patina_internal_cpu/src/interrupts/x64/interrupt_manager.rs
@@ -15,6 +15,7 @@ use patina::{
     error::EfiError,
     pi::protocols::cpu_arch::EfiSystemContext,
 };
+use patina_mtrr::Mtrr;
 use patina_paging::{PageTable, PagingType};
 use patina_stacktrace::{StackFrame, StackTrace};
 use x86_64::{
@@ -273,4 +274,10 @@ unsafe fn dump_pte(cr2: u64, cr3: u64, paging_type: PagingType) {
     } {
         let _ = pt.dump_page_tables(cr2 & !(UEFI_PAGE_MASK as u64), UEFI_PAGE_SIZE as u64);
     }
+
+    // we don't carry the caching attributes in the page table, so get them from the MTRRs
+    let mtrr = patina_mtrr::create_mtrr_lib(0);
+    log::error!("");
+    log::error!("MTRR Cache Attribute: {}", mtrr.get_memory_attribute(cr2));
+    log::error!("");
 }


### PR DESCRIPTION
## Description

This commits an mtrr monitor cmd that accepts an address and returns the cache type for that address.

This also updates the page fault exception handler to print the caching type since that is not present in the page table dump.

In order to allow uefiext to parse the cache attributes in the page table walk, print MAIR_EL2 in the arch regs monitor command.

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Tested with the accompanying uefiext changes on Q35 and SBSA.

## Integration Instructions

N/A. Uefiext release notes will include usage.
