### PR TITLE
smbios: replace TplMutex with RefCell to fix deadlocks and auto-add Type 127 marker

### DIFF
--- a/components/patina_samples/src/smbios_platform.rs
+++ b/components/patina_samples/src/smbios_platform.rs
@@ -40,7 +40,7 @@ use patina_smbios::{
     service::{SMBIOS_HANDLE_PI_RESERVED, Smbios, SmbiosExt, SmbiosTableHeader},
     smbios_record::{
         SmbiosRecordStructure, Type0PlatformFirmwareInformation, Type1SystemInformation, Type2BaseboardInformation,
-        Type3SystemEnclosure, Type127EndOfTable,
+        Type3SystemEnclosure,
     },
 };
 
@@ -127,11 +127,8 @@ impl SmbiosExampleComponent {
             return Err(e);
         }
 
-        // Type 127: End-of-table marker
-        if let Err(e) = Self::add_end_of_table(&smbios) {
-            log::error!("Failed to add end-of-table marker: {:?}", e);
-            return Err(e);
-        }
+        // Note: Type 127 End-of-Table marker is automatically added by the SMBIOS manager
+        // during initialization, so there's no need to add it manually.
 
         log::info!("Platform SMBIOS records created successfully");
 
@@ -311,24 +308,6 @@ impl SmbiosExampleComponent {
         })?;
 
         log::info!("  Type 0x80 (Vendor OEM) - Handle 0x{:04X}", handle);
-        Ok(())
-    }
-
-    /// Add Type 127 (End of Table) marker
-    ///
-    /// Required marker to indicate the end of the SMBIOS table.
-    fn add_end_of_table(smbios: &Service<dyn Smbios>) -> Result<()> {
-        let end_of_table = Type127EndOfTable {
-            header: SmbiosTableHeader::new(127, 0, SMBIOS_HANDLE_PI_RESERVED),
-            string_pool: vec![],
-        };
-
-        let handle = smbios.add_record(None, &end_of_table).map_err(|e| {
-            log::error!("Failed to add end-of-table: {:?}", e);
-            patina::error::EfiError::DeviceError
-        })?;
-
-        log::info!("  Type 127 (End of Table) - Handle 0x{:04X}", handle);
         Ok(())
     }
 }

--- a/components/patina_smbios/src/component.rs
+++ b/components/patina_smbios/src/component.rs
@@ -12,14 +12,13 @@ extern crate alloc;
 use crate::{
     error::SmbiosError,
     manager::{SmbiosManager, install_smbios_protocol},
-    service::SmbiosImpl,
+    service::{Smbios, SmbiosImpl},
 };
 use alloc::boxed::Box;
+use core::cell::RefCell;
 use patina::{
-    boot_services::tpl::Tpl,
     component::{IntoComponent, Storage},
     error::Result,
-    tpl_mutex::TplMutex,
 };
 
 /// Internal configuration for SMBIOS service
@@ -55,7 +54,7 @@ impl SmbiosConfiguration {
 /// - Record management: `update_string()`, `remove()`
 /// - Table management: `version()`, `publish_table()`
 ///
-/// The provider creates an SMBIOS manager instance protected by a TplMutex.
+/// The provider creates an SMBIOS manager instance protected by a RefCell.
 /// A global reference is maintained for C/EDKII protocol compatibility.
 ///
 /// # Example
@@ -98,22 +97,29 @@ impl SmbiosProvider {
     fn entry_point(self, storage: &mut Storage) -> Result<()> {
         let cfg = self.config;
 
-        // Create the manager with configured version
-        let manager = SmbiosManager::new(cfg.major_version, cfg.minor_version).map_err(|e| {
-            log::error!("Failed to create SMBIOS manager: {:?}", e);
-            patina::error::EfiError::Unsupported
-        })?;
-
         // Get boot_services from storage - it already has 'static lifetime
         // We use an unsafe cast because storage.boot_services() returns a reference with
         // a shorter lifetime, but Storage guarantees boot_services lives for 'static
         let boot_services_static: &'static patina::boot_services::StandardBootServices =
             unsafe { &*(storage.boot_services() as *const _) };
 
-        // Create the SMBIOS service struct with owned TplMutex
-        let manager_mutex = TplMutex::new(boot_services_static, Tpl::NOTIFY, manager);
+        // Create the manager with configured version
+        let manager = SmbiosManager::new(cfg.major_version, cfg.minor_version).map_err(|e| {
+            log::error!("Failed to create SmbiosManager: {:?}", e);
+            patina::error::EfiError::Unsupported
+        })?;
+
+        // Allocate pre-allocated buffers for table publication
+        // This automatically adds the Type 127 End-of-Table marker internally
+        // to ensure SMBIOS compliance
+        manager.allocate_buffers(boot_services_static).map_err(|e| {
+            log::error!("Failed to allocate SMBIOS buffers: {:?}", e);
+            patina::error::EfiError::Unsupported
+        })?;
+
+        let manager_cell = RefCell::new(manager);
         let smbios_service = SmbiosImpl {
-            manager: manager_mutex,
+            manager: manager_cell,
             boot_services: boot_services_static,
             major_version: cfg.major_version,
             minor_version: cfg.minor_version,
@@ -133,14 +139,24 @@ impl SmbiosProvider {
         // Register the leaked service (the IntoService impl for &'static T handles this)
         storage.add_service(smbios_static);
 
+        // Publish the SMBIOS table immediately with the Type 127 End-of-Table marker
+        // This installs the table into the UEFI Configuration Table so it's visible to
+        // tools like smbiosview. Other drivers can still add records via the protocol's
+        // Add() function, which will dynamically rebuild and update the table.
+        smbios_static.publish_table().map_err(|e| {
+            log::error!("Failed to publish SMBIOS table: {:?}", e);
+            patina::error::EfiError::Unsupported
+        })?;
+
         Ok(())
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     extern crate std;
+
+    use super::*;
 
     #[test]
     fn test_smbios_provider_new() {

--- a/components/patina_smbios/src/error.rs
+++ b/components/patina_smbios/src/error.rs
@@ -52,21 +52,27 @@ pub enum SmbiosError {
     AlreadyInitialized,
     /// SMBIOS manager has not been initialized yet
     NotInitialized,
+    /// Manager is already borrowed (resource temporarily unavailable)
+    AlreadyBorrowed,
 
     // Version errors
     /// SMBIOS version is not supported (only 3.0 and above are supported)
     UnsupportedVersion,
+
+    // Record type errors
+    /// Type 127 End-of-Table marker is automatically managed and cannot be added manually
+    Type127Managed,
 }
 
 #[cfg(test)]
 mod tests {
+    extern crate std;
+
     use super::*;
+    use std::vec;
 
     #[test]
     fn test_smbios_error_all_variants() {
-        extern crate std;
-        use std::vec;
-
         // Test all error variants for completeness
         let errors = vec![
             SmbiosError::StringTooLong,
@@ -83,7 +89,9 @@ mod tests {
             SmbiosError::NoRecordsAvailable,
             SmbiosError::AlreadyInitialized,
             SmbiosError::NotInitialized,
+            SmbiosError::AlreadyBorrowed,
             SmbiosError::UnsupportedVersion,
+            SmbiosError::Type127Managed,
         ];
 
         // Each should be cloneable and comparable

--- a/components/patina_smbios/src/manager.rs
+++ b/components/patina_smbios/src/manager.rs
@@ -21,15 +21,12 @@ mod protocol;
 mod record;
 
 // Re-export main types and functions
-pub use core::SmbiosManager;
+pub use core::{SMBIOS_3_X_TABLE_GUID, SmbiosManager};
 pub(crate) use record::SmbiosRecord;
 
 use alloc::boxed::Box;
 
-use patina::{
-    boot_services::{BootServices, StandardBootServices},
-    tpl_mutex::TplMutex,
-};
+use patina::boot_services::{BootServices, StandardBootServices};
 use r_efi::efi;
 
 use crate::error::SmbiosError;
@@ -41,21 +38,17 @@ use self::protocol::{SmbiosProtocol, SmbiosProtocolInternal};
 /// This function registers the SMBIOS protocol with UEFI so that C/EDK drivers can access
 /// SMBIOS functionality. The protocol functions access the manager through the protocol struct.
 ///
-/// The manager is protected by TplMutex at NOTIFY level. When protocol functions
-/// are called, the TplMutex.lock() automatically raises TPL to NOTIFY, preventing
-/// timer interrupt reentrancy. TPL is automatically restored when the lock guard drops.
-///
 /// Returns the protocol handle on success. The caller is responsible for managing the
 /// protocol lifetime (though in practice, UEFI protocols persist for the system lifetime).
 #[coverage(off)] // Protocol installation - tested via integration tests
 pub fn install_smbios_protocol(
     major_version: u8,
     minor_version: u8,
-    manager_mutex: &'static TplMutex<'static, SmbiosManager, StandardBootServices>,
+    manager_cell: &'static ::core::cell::RefCell<SmbiosManager>,
     boot_services: &'static StandardBootServices,
 ) -> Result<efi::Handle, SmbiosError> {
     // Create the protocol instance with internal struct
-    let internal = SmbiosProtocolInternal::new(major_version, minor_version, manager_mutex);
+    let internal = SmbiosProtocolInternal::new(major_version, minor_version, manager_cell, boot_services);
     let interface = Box::into_raw(Box::new(internal));
 
     // Install the protocol using the unchecked interface since we have a raw pointer
@@ -72,12 +65,11 @@ pub fn install_smbios_protocol(
 
     match handle {
         Ok(h) => Ok(h),
-        Err(status) => {
+        Err(_status) => {
             // Clean up on failure
             unsafe {
                 drop(Box::from_raw(interface));
             }
-            log::error!("Failed to install SMBIOS protocol: {:?}", status);
             Err(SmbiosError::AllocationFailed)
         }
     }

--- a/components/patina_smbios/src/manager/core.rs
+++ b/components/patina_smbios/src/manager/core.rs
@@ -25,7 +25,7 @@ use r_efi::{
     efi,
     efi::{Handle, PhysicalAddress},
 };
-use zerocopy::{IntoBytes, Ref};
+use zerocopy::{FromBytes, IntoBytes, Ref};
 use zerocopy_derive::{Immutable, IntoBytes as DeriveIntoBytes};
 
 use crate::{
@@ -34,6 +34,7 @@ use crate::{
         SMBIOS_HANDLE_PI_RESERVED, SMBIOS_STRING_MAX_LENGTH, SmbiosHandle, SmbiosRecordsIter, SmbiosTableHeader,
         SmbiosType,
     },
+    smbios_record::{SmbiosRecordStructure, Type127EndOfTable},
 };
 
 use super::record::SmbiosRecord;
@@ -76,6 +77,9 @@ pub struct Smbios30EntryPoint {
 /// SMBIOS table manager
 ///
 /// Manages SMBIOS records, handles, and table generation.
+///
+/// The manager uses pre-allocated buffers for table publication to avoid
+/// repeated memory allocations and maintain a stable table address throughout DXE.
 pub struct SmbiosManager {
     pub(super) records: RefCell<Vec<SmbiosRecord>>,
     pub(super) next_handle: RefCell<SmbiosHandle>,
@@ -84,6 +88,14 @@ pub struct SmbiosManager {
     pub minor_version: u8,
     entry_point_64: RefCell<Option<Box<Smbios30EntryPoint>>>,
     table_64_address: RefCell<Option<PhysicalAddress>>,
+
+    // Pre-allocated buffers for table publication
+    /// Pre-allocated buffer for SMBIOS table data (e.g., 64KB)
+    table_buffer_addr: RefCell<Option<PhysicalAddress>>,
+    /// Maximum size of the pre-allocated table buffer
+    table_buffer_max_size: usize,
+    /// Pre-allocated buffer for entry point structure
+    ep_buffer_addr: RefCell<Option<PhysicalAddress>>,
 }
 
 impl SmbiosManager {
@@ -115,7 +127,65 @@ impl SmbiosManager {
             minor_version,
             entry_point_64: RefCell::new(None),
             table_64_address: RefCell::new(None),
+            // Pre-allocated buffers start as None, set up during component init
+            table_buffer_addr: RefCell::new(None),
+            table_buffer_max_size: 64 * 1024, // 64KB default max size
+            ep_buffer_addr: RefCell::new(None),
         })
+    }
+
+    /// Allocate pre-allocated buffers for SMBIOS table publication
+    ///
+    /// This allocates a large buffer for the SMBIOS table and entry point upfront
+    /// to avoid repeated allocations on every Add(). The buffers are reused for
+    /// all table publications.
+    ///
+    /// Also automatically adds the Type 127 End-of-Table marker to ensure
+    /// SMBIOS compliance and maintain the invariant that it's always last.
+    ///
+    /// Must be called at TPL_APPLICATION or lower to allow memory allocation.
+    ///
+    /// # Arguments
+    ///
+    /// * `boot_services` - Boot services for memory allocation
+    ///
+    /// # Errors
+    ///
+    /// Returns `SmbiosError::AllocationFailed` if buffer allocation fails
+    /// Returns `SmbiosError::HandleExhausted` if unable to allocate handle for Type 127
+    pub fn allocate_buffers(
+        &self,
+        boot_services: &patina::boot_services::StandardBootServices,
+    ) -> Result<(), SmbiosError> {
+        // Check if already allocated
+        if self.table_buffer_addr.borrow().is_some() {
+            return Ok(());
+        }
+
+        // Allocate table buffer
+        let table_pages = uefi_size_to_pages!(self.table_buffer_max_size);
+        let table_addr = boot_services
+            .allocate_pages(AllocType::AnyPage, MemoryType::ACPI_RECLAIM_MEMORY, table_pages)
+            .map_err(|_| SmbiosError::AllocationFailed)?;
+
+        // Allocate entry point buffer (1 page is plenty)
+        let ep_addr = boot_services
+            .allocate_pages(AllocType::AnyPage, MemoryType::ACPI_RECLAIM_MEMORY, 1)
+            .map_err(|_| SmbiosError::AllocationFailed)?;
+
+        *self.table_buffer_addr.borrow_mut() = Some(table_addr as u64);
+        *self.ep_buffer_addr.borrow_mut() = Some(ep_addr as u64);
+
+        // Automatically add Type 127 End-of-Table marker to ensure SMBIOS compliance
+        // This is added directly to records to bypass the add_from_bytes validation
+        // which rejects Type 127 to prevent external callers from adding it
+        let type127 = Type127EndOfTable::new();
+        let bytes = type127.to_bytes();
+        let header = SmbiosTableHeader::new(127, 4, self.allocate_handle()?);
+        let record = SmbiosRecord::new(header, None, bytes, 0);
+        self.records.borrow_mut().push(record);
+
+        Ok(())
     }
 
     /// Validate a string for use in SMBIOS records
@@ -261,126 +331,6 @@ impl SmbiosManager {
         Ok(candidate)
     }
 
-    /// Builds the SMBIOS table and installs it in the UEFI Configuration Table
-    ///
-    /// This function performs the following steps:
-    /// 1. Consolidates all SMBIOS records into a contiguous memory buffer
-    /// 2. Creates an SMBIOS 3.x Entry Point Structure with proper checksum
-    /// 3. Allocates ACPI Reclaim memory for both the table and entry point
-    /// 4. Installs the entry point via the UEFI Configuration Table
-    ///
-    /// # Arguments
-    ///
-    /// * `boot_services` - UEFI Boot Services for memory allocation and table installation
-    ///
-    /// # Returns
-    ///
-    /// Returns a tuple of `(table_address, entry_point_address)` containing the physical
-    /// addresses where the SMBIOS table data and entry point structure were allocated.
-    ///
-    /// # Errors
-    ///
-    /// * `SmbiosError::NoRecordsAvailable` - No SMBIOS records have been added
-    /// * `SmbiosError::AllocationFailed` - Failed to allocate memory or install the configuration table
-    ///
-    /// # Safety
-    ///
-    /// This function uses unsafe code for:
-    /// - Creating mutable slices to allocated memory
-    /// - Writing the entry point structure to allocated memory
-    /// - Calling the UEFI `install_configuration_table` interface
-    ///
-    /// All memory allocations use UEFI Boot Services and are properly tracked by the firmware.
-    pub fn install_configuration_table(
-        &self,
-        boot_services: &patina::boot_services::StandardBootServices,
-    ) -> Result<(PhysicalAddress, PhysicalAddress), SmbiosError> {
-        let records = self.records.borrow();
-
-        // Step 1: Calculate total table size
-        let total_table_size: usize = records.iter().map(|r| r.data.len()).sum();
-
-        if total_table_size == 0 {
-            log::error!("Cannot install configuration table: no SMBIOS records have been added");
-            return Err(SmbiosError::NoRecordsAvailable);
-        }
-
-        // Step 2: Allocate memory for the table (using UEFI Boot Services memory allocation)
-        let table_pages = uefi_size_to_pages!(total_table_size);
-        let table_address = boot_services
-            .allocate_pages(
-                AllocType::AnyPage,
-                MemoryType::ACPI_RECLAIM_MEMORY, // SMBIOS tables go in ACPI Reclaim memory
-                table_pages,
-            )
-            .map_err(|_| SmbiosError::AllocationFailed)?;
-
-        // Step 3: Copy all records to the table
-        // SAFETY: `table_address` was just successfully allocated by UEFI Boot Services for
-        // `total_table_size` bytes. The memory is valid, properly aligned, and exclusively owned
-        // by this function. The size matches our calculation, making this slice creation safe.
-        let table_slice = unsafe { core::slice::from_raw_parts_mut(table_address as *mut u8, total_table_size) };
-        let mut offset = 0;
-
-        for record in records.iter() {
-            let record_bytes = record.data.as_slice();
-            table_slice[offset..offset + record_bytes.len()].copy_from_slice(record_bytes);
-            offset += record_bytes.len();
-        }
-
-        // Step 4: Create SMBIOS 3.0+ Entry Point Structure
-        let mut entry_point = Smbios30EntryPoint {
-            anchor_string: *b"_SM3_",
-            checksum: 0,
-            length: core::mem::size_of::<Smbios30EntryPoint>() as u8,
-            major_version: self.major_version,
-            minor_version: self.minor_version,
-            docrev: 0,
-            entry_point_revision: 1,
-            reserved: 0,
-            table_max_size: total_table_size as u32,
-            table_address: table_address as u64,
-        };
-
-        // Calculate checksum
-        entry_point.checksum = Self::calculate_checksum(&entry_point);
-
-        // Step 5: Allocate memory for entry point structure
-        let ep_pages = 1; // Entry point fits in one page
-        let ep_address = boot_services
-            .allocate_pages(AllocType::AnyPage, MemoryType::ACPI_RECLAIM_MEMORY, ep_pages)
-            .map_err(|_| SmbiosError::AllocationFailed)?;
-
-        // Step 6: Copy entry point to allocated memory
-        let ep_bytes = entry_point.as_bytes();
-        // SAFETY: `ep_address` was just successfully allocated by UEFI Boot Services for one page.
-        // The size `core::mem::size_of::<Smbios30EntryPoint>()` (24 bytes) fits well within one page (4KB).
-        // The memory is valid, properly aligned, and exclusively owned by this function.
-        let ep_slice = unsafe {
-            core::slice::from_raw_parts_mut(ep_address as *mut u8, core::mem::size_of::<Smbios30EntryPoint>())
-        };
-        ep_slice.copy_from_slice(ep_bytes);
-
-        // Step 7: Install in UEFI Configuration Table
-        // SAFETY: We're calling the UEFI `install_configuration_table` function with:
-        // - A valid GUID reference (&SMBIOS_3_X_TABLE_GUID)
-        // - A valid pointer to the entry point structure we just allocated and initialized
-        // The pointer remains valid for the system's lifetime as it's in ACPI_RECLAIM_MEMORY.
-        unsafe {
-            boot_services.install_configuration_table(&SMBIOS_3_X_TABLE_GUID, ep_address as *mut ()).map_err(|e| {
-                log::error!("Failed to install SMBIOS configuration table: {:?}", e);
-                SmbiosError::AllocationFailed
-            })?;
-        }
-
-        // Store addresses for future reference
-        drop(records); // Release borrow before mutating
-        self.entry_point_64.replace(Some(Box::new(entry_point)));
-        self.table_64_address.replace(Some(table_address as u64));
-
-        Ok((table_address as u64, ep_address as u64))
-    }
-
     /// Calculate checksum for SMBIOS 3.x Entry Point Structure
     ///
     /// Computes the checksum byte value such that the sum of all bytes in the
@@ -402,12 +352,94 @@ impl SmbiosManager {
         0u8.wrapping_sub(sum)
     }
 
-    /// Publish the SMBIOS table to UEFI configuration tables
-    pub fn publish_table(
+    /// Build SMBIOS table data into pre-allocated buffers
+    ///
+    /// Rebuilds the SMBIOS table from current records into the pre-allocated buffers.
+    /// This is much faster than allocating new memory each time and maintains a
+    /// stable table address.
+    ///
+    /// Returns (table_address, entry_point_address, entry_point_struct)
+    /// This does NOT call install_configuration_table - that must be done separately without holding locks
+    ///
+    /// # Errors
+    ///
+    /// Returns error if:
+    /// - Buffers not allocated (call allocate_buffers() first)
+    /// - No records in table
+    /// - Table size exceeds pre-allocated buffer
+    pub fn build_table_data(
         &self,
-        boot_services: &patina::boot_services::StandardBootServices,
-    ) -> Result<(r_efi::efi::PhysicalAddress, r_efi::efi::PhysicalAddress), SmbiosError> {
-        self.install_configuration_table(boot_services)
+        _boot_services: &patina::boot_services::StandardBootServices,
+    ) -> Result<(PhysicalAddress, PhysicalAddress, Smbios30EntryPoint), SmbiosError> {
+        // Get pre-allocated buffer addresses
+        let table_address = self.table_buffer_addr.borrow().ok_or(SmbiosError::AllocationFailed)?;
+
+        let ep_address = self.ep_buffer_addr.borrow().ok_or(SmbiosError::AllocationFailed)?;
+
+        // Borrow records
+        let records = self.records.borrow();
+
+        // Step 1: Calculate total table size
+        let total_table_size: usize = records.iter().map(|r| r.data.len()).sum();
+
+        if total_table_size == 0 {
+            log::error!("Cannot build table: no SMBIOS records have been added");
+            return Err(SmbiosError::NoRecordsAvailable);
+        }
+
+        // Step 2: Check size fits in pre-allocated buffer
+        if total_table_size > self.table_buffer_max_size {
+            return Err(SmbiosError::AllocationFailed);
+        }
+
+        // Step 3: Copy all records to the pre-allocated buffer
+        // Records Vec maintains invariant: Type 127 is always last
+        // So we can just copy in order
+        let table_slice = unsafe { core::slice::from_raw_parts_mut(table_address as *mut u8, total_table_size) };
+        let mut offset = 0;
+
+        for record in records.iter() {
+            let record_bytes = record.data.as_slice();
+            table_slice[offset..offset + record_bytes.len()].copy_from_slice(record_bytes);
+            offset += record_bytes.len();
+        }
+
+        // Step 4: Create entry point structure
+        let mut entry_point = Smbios30EntryPoint {
+            anchor_string: *b"_SM3_",
+            checksum: 0,
+            length: core::mem::size_of::<Smbios30EntryPoint>() as u8,
+            major_version: self.major_version,
+            minor_version: self.minor_version,
+            docrev: 0,
+            entry_point_revision: 1,
+            reserved: 0,
+            table_max_size: total_table_size as u32,
+            table_address,
+        };
+
+        entry_point.checksum = Self::calculate_checksum(&entry_point);
+
+        // Step 5: Copy entry point to pre-allocated buffer
+        let ep_bytes = entry_point.as_bytes();
+        let ep_slice = unsafe {
+            core::slice::from_raw_parts_mut(ep_address as *mut u8, core::mem::size_of::<Smbios30EntryPoint>())
+        };
+        ep_slice.copy_from_slice(ep_bytes);
+
+        Ok((table_address, ep_address, entry_point))
+    }
+
+    /// Store table addresses after installation
+    /// This is called after install_configuration_table completes
+    pub fn store_table_addresses(
+        &self,
+        table_address: PhysicalAddress,
+        _ep_address: PhysicalAddress,
+        entry_point: Smbios30EntryPoint,
+    ) {
+        self.entry_point_64.replace(Some(Box::new(entry_point)));
+        self.table_64_address.replace(Some(table_address));
     }
 
     /// Add a new SMBIOS record from raw bytes
@@ -426,13 +458,19 @@ impl SmbiosManager {
             .map_err(|_| SmbiosError::MalformedRecordHeader)?;
         let header: &SmbiosTableHeader = &header_ref;
 
-        // Step 3: Validate header->length is <= (record_data.length - 2) for string pool
+        // Step 3: Reject Type 127 End-of-Table marker - it's automatically managed
+        // The manager adds Type 127 during initialization, and it must remain unique and last
+        if header.record_type == 127 {
+            return Err(SmbiosError::Type127Managed);
+        }
+
+        // Step 4: Validate header->length is <= (record_data.length - 2) for string pool
         // The string pool needs at least 2 bytes for the double-null terminator
         if (header.length as usize + 2) > record_data.len() {
             return Err(SmbiosError::RecordTooSmall);
         }
 
-        // Step 4: Validate and count strings in a single efficient pass
+        // Step 5: Validate and count strings in a single efficient pass
         let string_pool_start = header.length as usize;
         let string_pool_area = &record_data[string_pool_start..];
 
@@ -440,7 +478,7 @@ impl SmbiosManager {
             return Err(SmbiosError::StringPoolTooSmall);
         }
 
-        // Step 5: Validate string pool format and count strings
+        // Step 6: Validate string pool format and count strings
         let string_count = Self::validate_and_count_strings(string_pool_area)?;
 
         // If all validation passes, allocate handle and build record
@@ -451,13 +489,22 @@ impl SmbiosManager {
 
         // Update the handle in the actual data
         let mut data = record_data.to_vec();
-        let handle_bytes = smbios_handle.to_le_bytes();
-        data[2] = handle_bytes[0]; // Handle is at offset 2 in header
-        data[3] = handle_bytes[1];
+        let (header_mut, _rest) =
+            SmbiosTableHeader::mut_from_prefix(&mut data[..]).expect("header was already validated");
+        header_mut.handle = smbios_handle;
 
         let smbios_record = SmbiosRecord::new(record_header, producer_handle, data, string_count);
 
-        self.records.borrow_mut().push(smbios_record);
+        // Maintain invariant: Type 127 End-of-Table marker must always be last
+        let mut records = self.records.borrow_mut();
+
+        // Insert before Type 127 if present, otherwise append
+        if let Some(pos) = records.iter().position(|r| r.header.record_type == 127) {
+            records.insert(pos, smbios_record);
+        } else {
+            records.push(smbios_record);
+        }
+
         Ok(smbios_handle)
     }
 
@@ -568,6 +615,7 @@ impl SmbiosManager {
     /// # Returns
     ///
     /// Returns an iterator yielding tuples of `(SmbiosTableHeader, Option<Handle>)`.
+    #[allow(dead_code)]
     pub fn iter(&self, record_type: Option<SmbiosType>) -> SmbiosRecordsIter<'_> {
         SmbiosRecordsIter::new(self.records.borrow(), record_type)
     }
@@ -575,14 +623,18 @@ impl SmbiosManager {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     extern crate std;
+
+    use super::*;
     use std::{vec, vec::Vec};
 
     use crate::{
         error::SmbiosError,
+        manager::SmbiosRecord,
         service::{SMBIOS_HANDLE_PI_RESERVED, SMBIOS_STRING_MAX_LENGTH, SmbiosHandle, SmbiosTableHeader},
+        smbios_record::{SmbiosRecordStructure, Type127EndOfTable},
     };
+    use patina::boot_services::{MockBootServices, StandardBootServices};
     use r_efi::efi;
     use zerocopy::IntoBytes;
 
@@ -906,7 +958,6 @@ mod tests {
 
     #[test]
     fn test_update_string_buffer_too_small_error() {
-        use super::SmbiosRecord;
         let manager = SmbiosManager::new(3, 9).expect("failed to create manager");
         let header = SmbiosTableHeader::new(1, 10, 1);
         let data = vec![1u8, 10, 1, 0];
@@ -1193,5 +1244,302 @@ mod tests {
     #[test]
     fn test_smbios_handle_constants() {
         assert_eq!(SMBIOS_HANDLE_PI_RESERVED, 0xFFFE);
+    }
+
+    #[test]
+    fn test_type127_insertion_logic_with_manual_add() {
+        // Test that the Type 127 insertion logic still works when Type 127 is manually added
+        // (e.g., during component initialization) by directly manipulating records
+        let manager = SmbiosManager::new(3, 9).expect("failed to create manager");
+
+        // Manually add a Type 127 record (bypassing add_from_bytes, simulating component init)
+        let type127 = Type127EndOfTable::new();
+        let bytes = type127.to_bytes();
+        let header = SmbiosTableHeader::new(127, 4, 1);
+        let record = SmbiosRecord::new(header, None, bytes, 0);
+        manager.records.borrow_mut().push(record);
+
+        // Verify Type 127 was added
+        let records = manager.records.borrow();
+        assert_eq!(records.len(), 1);
+        assert_eq!(records[0].header.record_type, 127);
+    }
+
+    #[test]
+    fn test_non_type127_added_without_type127_present() {
+        // Test adding a non-Type-127 record when no Type 127 exists
+        // This covers the None branch (line 473)
+        let manager = SmbiosManager::new(3, 9).expect("failed to create manager");
+
+        // Add a Type 1 record (no Type 127 present)
+        let header = SmbiosTableHeader::new(1, 4, SMBIOS_HANDLE_PI_RESERVED);
+        let record = build_test_record_with_strings(&header, &["Test Manufacturer"]);
+
+        manager.add_from_bytes(None, &record).expect("add_from_bytes failed");
+
+        let records = manager.records.borrow();
+        assert_eq!(records.len(), 1);
+        assert_eq!(records[0].header.record_type, 1);
+    }
+
+    #[test]
+    fn test_non_type127_inserted_before_type127() {
+        // Test adding a non-Type-127 record when Type 127 already exists
+        // This covers the Some branch in the insertion logic
+        let manager = SmbiosManager::new(3, 9).expect("failed to create manager");
+
+        // Manually add Type 127 (simulating component initialization)
+        let type127 = Type127EndOfTable::new();
+        let bytes127 = type127.to_bytes();
+        let header127 = SmbiosTableHeader::new(127, 4, 100);
+        let record127 = SmbiosRecord::new(header127, None, bytes127, 0);
+        manager.records.borrow_mut().push(record127);
+
+        // Now add a Type 1 record - should be inserted before Type 127
+        let header1 = SmbiosTableHeader::new(1, 4, SMBIOS_HANDLE_PI_RESERVED);
+        let record1 = build_test_record_with_strings(&header1, &["Test Manufacturer"]);
+        manager.add_from_bytes(None, &record1).expect("add Type 1 failed");
+
+        // Verify ordering: Type 1 should be at index 0, Type 127 at index 1
+        let records = manager.records.borrow();
+        assert_eq!(records.len(), 2);
+        assert_eq!(records[0].header.record_type, 1);
+        assert_eq!(records[1].header.record_type, 127);
+    }
+
+    #[test]
+    fn test_multiple_records_before_type127() {
+        // Test adding multiple non-Type-127 records, all inserted before Type 127
+        let manager = SmbiosManager::new(3, 9).expect("failed to create manager");
+
+        // Manually add Type 127 first (simulating component initialization)
+        let type127 = Type127EndOfTable::new();
+        let bytes127 = type127.to_bytes();
+        let header127 = SmbiosTableHeader::new(127, 4, 100);
+        let record127 = SmbiosRecord::new(header127, None, bytes127, 0);
+        manager.records.borrow_mut().push(record127);
+
+        // Add Type 1
+        let header1 = SmbiosTableHeader::new(1, 4, SMBIOS_HANDLE_PI_RESERVED);
+        let record1 = build_test_record_with_strings(&header1, &["System Manufacturer"]);
+        manager.add_from_bytes(None, &record1).expect("add Type 1 failed");
+
+        // Add Type 2
+        let header2 = SmbiosTableHeader::new(2, 4, SMBIOS_HANDLE_PI_RESERVED);
+        let record2 = build_test_record_with_strings(&header2, &["Board Manufacturer"]);
+        manager.add_from_bytes(None, &record2).expect("add Type 2 failed");
+
+        // Verify Type 127 is always last
+        let records = manager.records.borrow();
+        assert_eq!(records.len(), 3);
+        assert_eq!(records[0].header.record_type, 1);
+        assert_eq!(records[1].header.record_type, 2);
+        assert_eq!(records[2].header.record_type, 127);
+    }
+
+    #[test]
+    fn test_type127_always_remains_last() {
+        // Test that Type 127 remains last even when added in the middle of operations
+        let manager = SmbiosManager::new(3, 9).expect("failed to create manager");
+
+        // Add Type 1
+        let header1 = SmbiosTableHeader::new(1, 4, SMBIOS_HANDLE_PI_RESERVED);
+        let record1 = build_test_record_with_strings(&header1, &["System"]);
+        manager.add_from_bytes(None, &record1).expect("add Type 1 failed");
+
+        // Manually add Type 127 in the middle (simulating component initialization after some records added)
+        let type127 = Type127EndOfTable::new();
+        let bytes127 = type127.to_bytes();
+        let header127 = SmbiosTableHeader::new(127, 4, 100);
+        let record127 = SmbiosRecord::new(header127, None, bytes127, 0);
+        manager.records.borrow_mut().push(record127);
+
+        // Add Type 2 after Type 127 was added
+        let header2 = SmbiosTableHeader::new(2, 4, SMBIOS_HANDLE_PI_RESERVED);
+        let record2 = build_test_record_with_strings(&header2, &["Board"]);
+        manager.add_from_bytes(None, &record2).expect("add Type 2 failed");
+
+        // Verify Type 127 is still last
+        let records = manager.records.borrow();
+        assert_eq!(records.len(), 3);
+        assert_eq!(records[2].header.record_type, 127);
+        assert_eq!(records[0].header.record_type, 1);
+        assert_eq!(records[1].header.record_type, 2);
+    }
+
+    #[test]
+    fn test_new_with_unsupported_major_version() {
+        // Test version 2.x (unsupported)
+        let result = SmbiosManager::new(2, 0);
+        assert!(matches!(result, Err(SmbiosError::UnsupportedVersion)));
+
+        // Test version 1.x (unsupported)
+        let result = SmbiosManager::new(1, 0);
+        assert!(matches!(result, Err(SmbiosError::UnsupportedVersion)));
+
+        // Test version 4.x (unsupported)
+        let result = SmbiosManager::new(4, 0);
+        assert!(matches!(result, Err(SmbiosError::UnsupportedVersion)));
+    }
+
+    #[test]
+    fn test_add_type127_rejected() {
+        // Type 127 End-of-Table is automatically managed and should be rejected
+        let manager = SmbiosManager::new(3, 9).expect("failed to create manager");
+
+        // Build a Type 127 record
+        let type127 = Type127EndOfTable::new();
+        let bytes = type127.to_bytes();
+
+        // Attempt to add Type 127 should be rejected
+        let result = manager.add_from_bytes(None, &bytes);
+        assert_eq!(result, Err(SmbiosError::Type127Managed));
+
+        // Verify no records were added
+        assert_eq!(manager.records.borrow().len(), 0);
+    }
+
+    #[test]
+    fn test_add_type127_rejected_even_with_existing_type127() {
+        // Even if Type 127 already exists, attempting to add another should be rejected
+        let manager = SmbiosManager::new(3, 9).expect("failed to create manager");
+
+        // Manually add a Type 127 (simulating component initialization)
+        // We bypass add_from_bytes by directly manipulating the records for this test
+        let type127 = Type127EndOfTable::new();
+        let bytes = type127.to_bytes();
+        let header = SmbiosTableHeader::new(127, 4, 1);
+        let record = SmbiosRecord::new(header, None, bytes.clone(), 0);
+        manager.records.borrow_mut().push(record);
+
+        // Now attempt to add another Type 127 via add_from_bytes
+        let result = manager.add_from_bytes(None, &bytes);
+        assert_eq!(result, Err(SmbiosError::Type127Managed));
+
+        // Verify only one Type 127 exists (the original)
+        let records = manager.records.borrow();
+        assert_eq!(records.len(), 1);
+        assert_eq!(records[0].header.record_type, 127);
+    }
+
+    #[test]
+    fn test_allocate_buffers_already_allocated() {
+        // Create a mock boot services
+        let mock_bs = Box::leak(Box::new(MockBootServices::new()));
+        let boot_services: &'static StandardBootServices =
+            unsafe { &*(mock_bs as *const MockBootServices as *const StandardBootServices) };
+
+        let manager = SmbiosManager::new(3, 9).expect("failed to create manager");
+
+        // Set buffers as already allocated
+        *manager.table_buffer_addr.borrow_mut() = Some(0x1000);
+        *manager.ep_buffer_addr.borrow_mut() = Some(0x2000);
+
+        // Calling allocate_buffers should succeed immediately without allocation
+        let result = manager.allocate_buffers(boot_services);
+        assert!(result.is_ok());
+
+        // Buffers should still be the same
+        assert_eq!(*manager.table_buffer_addr.borrow(), Some(0x1000));
+        assert_eq!(*manager.ep_buffer_addr.borrow(), Some(0x2000));
+    }
+
+    #[test]
+    fn test_build_table_data_no_records() {
+        let mock_bs = Box::leak(Box::new(MockBootServices::new()));
+        let boot_services: &'static StandardBootServices =
+            unsafe { &*(mock_bs as *const MockBootServices as *const StandardBootServices) };
+
+        let manager = SmbiosManager::new(3, 9).expect("failed to create manager");
+
+        // Set up buffers (simulated allocation)
+        *manager.table_buffer_addr.borrow_mut() = Some(0x1000);
+        *manager.ep_buffer_addr.borrow_mut() = Some(0x2000);
+
+        // Try to build table with no records
+        let result = manager.build_table_data(boot_services);
+        assert!(matches!(result, Err(SmbiosError::NoRecordsAvailable)));
+    }
+
+    #[test]
+    fn test_build_table_data_table_too_large() {
+        let mock_bs = Box::leak(Box::new(MockBootServices::new()));
+        let boot_services: &'static StandardBootServices =
+            unsafe { &*(mock_bs as *const MockBootServices as *const StandardBootServices) };
+
+        let manager = SmbiosManager::new(3, 9).expect("failed to create manager");
+
+        // Set up buffers with small max size
+        *manager.table_buffer_addr.borrow_mut() = Some(0x1000);
+        *manager.ep_buffer_addr.borrow_mut() = Some(0x2000);
+
+        // Add a record
+        let header = SmbiosTableHeader::new(1, 4, SMBIOS_HANDLE_PI_RESERVED);
+        let record = build_test_record_with_strings(&header, &["Test"]);
+        manager.add_from_bytes(None, &record).expect("add failed");
+
+        // Create a manager with a very small buffer size (by accessing the field directly)
+        let manager2 = SmbiosManager {
+            records: manager.records,
+            next_handle: manager.next_handle,
+            freed_handles: manager.freed_handles,
+            major_version: 3,
+            minor_version: 9,
+            entry_point_64: RefCell::new(None),
+            table_64_address: RefCell::new(None),
+            table_buffer_addr: RefCell::new(Some(0x1000)),
+            table_buffer_max_size: 1, // Tiny buffer - will fail
+            ep_buffer_addr: RefCell::new(Some(0x2000)),
+        };
+
+        let result = manager2.build_table_data(boot_services);
+        assert!(matches!(result, Err(SmbiosError::AllocationFailed)));
+    }
+
+    #[test]
+    fn test_store_table_addresses() {
+        let manager = SmbiosManager::new(3, 9).expect("failed to create manager");
+
+        let entry_point = Smbios30EntryPoint {
+            anchor_string: *b"_SM3_",
+            checksum: 0,
+            length: 24,
+            major_version: 3,
+            minor_version: 9,
+            docrev: 0,
+            entry_point_revision: 1,
+            reserved: 0,
+            table_max_size: 1000,
+            table_address: 0x5000,
+        };
+
+        manager.store_table_addresses(0x5000, 0x6000, entry_point);
+
+        assert_eq!(*manager.table_64_address.borrow(), Some(0x5000));
+        assert!(manager.entry_point_64.borrow().is_some());
+    }
+
+    #[test]
+    fn test_update_string_multiple_strings() {
+        let manager = SmbiosManager::new(3, 9).expect("failed to create manager");
+        let header = SmbiosTableHeader::new(1, 4, SMBIOS_HANDLE_PI_RESERVED);
+        let record = build_test_record_with_strings(&header, &["first", "second", "third"]);
+        let handle = manager.add_from_bytes(None, &record).expect("add failed");
+
+        // Update the second string
+        manager.update_string(handle, 2, "updated_second").expect("update failed");
+
+        // Verify the update worked by checking the record data
+        let records = manager.records.borrow();
+        let updated_record = &records[0];
+        let string_pool_start = updated_record.header.length as usize;
+        let string_pool = &updated_record.data[string_pool_start..];
+
+        // Parse strings to verify
+        let strings = SmbiosManager::parse_strings_from_pool(string_pool).expect("parse failed");
+        assert_eq!(strings.len(), 3);
+        assert_eq!(strings[0], "first");
+        assert_eq!(strings[1], "updated_second");
+        assert_eq!(strings[2], "third");
     }
 }

--- a/components/patina_smbios/src/manager/protocol.rs
+++ b/components/patina_smbios/src/manager/protocol.rs
@@ -13,9 +13,9 @@
 //! SPDX-License-Identifier: Apache-2.0
 //!
 
-use core::ffi::c_char;
+use core::{cell::RefCell, ffi::c_char};
 
-use patina::{boot_services::StandardBootServices, tpl_mutex::TplMutex, uefi_protocol::ProtocolInterface};
+use patina::{boot_services::StandardBootServices, uefi_protocol::ProtocolInterface};
 use r_efi::efi;
 
 use crate::{
@@ -41,12 +41,16 @@ pub(super) struct SmbiosProtocolInternal {
     // The public protocol that external callers will depend on
     pub(super) protocol: SmbiosProtocol,
 
-    // Internal component access only! Does not exist in C definition
-    pub(super) manager: &'static TplMutex<'static, SmbiosManager, StandardBootServices>,
+    manager: &'static RefCell<SmbiosManager>,
 
-    // Storage for header returned by C protocol's get_next
+    boot_services: &'static StandardBootServices,
+
+    // Storage for complete record returned by C protocol's get_next
+    // SMBIOS records can be up to several hundred bytes (header + fixed fields + strings)
+    // Using 1KB buffer to accommodate all typical records
     // Avoids heap allocation - reused across calls
-    pub(super) header_buffer: core::cell::UnsafeCell<SmbiosTableHeader>,
+    record_buffer: core::cell::UnsafeCell<[u8; 1024]>,
+    record_buffer_used: core::cell::UnsafeCell<usize>,
 }
 
 unsafe impl ProtocolInterface for SmbiosProtocol {
@@ -96,12 +100,15 @@ impl SmbiosProtocolInternal {
     pub(super) fn new(
         major_version: u8,
         minor_version: u8,
-        manager: &'static TplMutex<'static, SmbiosManager, StandardBootServices>,
+        manager: &'static RefCell<SmbiosManager>,
+        boot_services: &'static StandardBootServices,
     ) -> Self {
         Self {
             protocol: SmbiosProtocol::new(major_version, minor_version),
             manager,
-            header_buffer: core::cell::UnsafeCell::new(SmbiosTableHeader::new(0, 0, 0)),
+            boot_services,
+            record_buffer: core::cell::UnsafeCell::new([0u8; 1024]),
+            record_buffer_used: core::cell::UnsafeCell::new(0),
         }
     }
 }
@@ -128,7 +135,10 @@ impl SmbiosProtocol {
         // SAFETY: We must trust the C code was a responsible steward of this pointer
         // Cast from protocol pointer to internal struct pointer
         let internal = unsafe { &*(protocol as *const SmbiosProtocolInternal) };
-        let manager = internal.manager.lock();
+        let manager = match internal.manager.try_borrow() {
+            Ok(m) => m,
+            Err(_) => return efi::Status::DEVICE_ERROR,
+        };
 
         // SAFETY: The C UEFI protocol caller guarantees that `record` points to a valid,
         // complete SMBIOS record. We read the length field to determine the full record size.
@@ -176,6 +186,39 @@ impl SmbiosProtocol {
             match manager.add_from_bytes(producer_opt, full_record_bytes) {
                 Ok(handle) => {
                     *smbios_handle = handle;
+
+                    // Republish the table with the new record using the two-step deadlock-free approach:
+                    // 1. Build table data into pre-allocated buffer (WITH manager lock)
+                    // 2. Install configuration table (WITHOUT manager lock to avoid deadlock)
+
+                    // Drop manager borrow before republishing
+                    drop(manager);
+
+                    // Rebuild table data into pre-allocated buffer
+                    // The configuration table was already installed during init and points to our
+                    // pre-allocated entry point buffer. We just need to update the data in place.
+                    let (table_addr, ep_addr, entry_point) = {
+                        let manager = match internal.manager.try_borrow() {
+                            Ok(m) => m,
+                            Err(_) => return efi::Status::DEVICE_ERROR,
+                        };
+                        match manager.build_table_data(internal.boot_services) {
+                            Ok((t_addr, e_addr, ep_struct)) => (t_addr, e_addr, ep_struct),
+                            Err(_) => {
+                                return efi::Status::DEVICE_ERROR;
+                            }
+                        }
+                    }; // manager borrow dropped here
+
+                    // Store addresses in manager
+                    {
+                        let manager = match internal.manager.try_borrow() {
+                            Ok(m) => m,
+                            Err(_) => return efi::Status::DEVICE_ERROR,
+                        };
+                        manager.store_table_addresses(table_addr, ep_addr, entry_point);
+                    }
+
                     efi::Status::SUCCESS
                 }
                 Err(SmbiosError::StringContainsNull) => efi::Status::INVALID_PARAMETER,
@@ -205,7 +248,10 @@ impl SmbiosProtocol {
 
         // SAFETY: Cast from protocol pointer to internal struct pointer
         let internal = unsafe { &*(protocol as *const SmbiosProtocolInternal) };
-        let manager = internal.manager.lock();
+        let manager = match internal.manager.try_borrow() {
+            Ok(m) => m,
+            Err(_) => return efi::Status::DEVICE_ERROR,
+        };
 
         unsafe {
             let handle = *smbios_handle;
@@ -233,7 +279,10 @@ impl SmbiosProtocol {
     extern "efiapi" fn remove_ext(protocol: *const SmbiosProtocol, smbios_handle: SmbiosHandle) -> efi::Status {
         // SAFETY: Cast from protocol pointer to internal struct pointer
         let internal = unsafe { &*(protocol as *const SmbiosProtocolInternal) };
-        let manager = internal.manager.lock();
+        let manager = match internal.manager.try_borrow() {
+            Ok(m) => m,
+            Err(_) => return efi::Status::DEVICE_ERROR,
+        };
 
         match manager.remove(smbios_handle) {
             Ok(()) => efi::Status::SUCCESS,
@@ -256,40 +305,73 @@ impl SmbiosProtocol {
 
         // SAFETY: Cast from protocol pointer to internal struct pointer
         let internal = unsafe { &*(protocol as *const SmbiosProtocolInternal) };
-        let manager = internal.manager.lock();
 
         unsafe {
-            let handle = *smbios_handle;
-            let type_filter = if record_type.is_null() { None } else { Some(*record_type) };
+            let handle = core::ptr::read_unaligned(smbios_handle);
+            let type_filter = if record_type.is_null() { None } else { Some(core::ptr::read_unaligned(record_type)) };
 
-            // Use the iterator to find the next record
-            let mut iter = manager.iter(type_filter);
-
-            // Skip records until we find the one after the current handle
-            let next_record = if handle == SMBIOS_HANDLE_PI_RESERVED {
-                // Starting iteration - get first record
-                iter.next()
-            } else {
-                // Find the record after the current handle
-                iter.skip_while(|(hdr, _)| hdr.handle != handle).nth(1)
+            // Borrow the manager to access records
+            // Keep the manager borrow alive for the entire search
+            let manager_ref = match internal.manager.try_borrow() {
+                Ok(m) => m,
+                Err(_) => return efi::Status::DEVICE_ERROR,
             };
+            let records = manager_ref.records.borrow();
 
-            match next_record {
-                Some((header_value, prod_handle)) => {
-                    *smbios_handle = header_value.handle;
+            // Find the next matching record
+            let mut found_record: Option<&crate::manager::SmbiosRecord> = None;
+            let mut start_searching = handle == SMBIOS_HANDLE_PI_RESERVED;
 
-                    // Store header in internal buffer and return pointer to it
-                    let buffer_ptr = internal.header_buffer.get();
-                    *buffer_ptr = header_value;
-                    *record = buffer_ptr;
+            for rec in records.iter() {
+                // Apply type filter if specified
+                if let Some(filter) = type_filter
+                    && rec.header.record_type != filter
+                {
+                    continue;
+                }
+
+                // If starting fresh, take the first matching record
+                if start_searching {
+                    found_record = Some(rec);
+                    break;
+                }
+
+                // Otherwise, skip until we find the current handle, then take the next one
+                if rec.header.handle == handle {
+                    start_searching = true;
+                }
+            }
+
+            match found_record {
+                Some(rec) => {
+                    // Copy packed struct fields to avoid unaligned reference errors
+                    let rec_handle = rec.header.handle;
+
+                    // Copy the complete record data into our buffer
+                    let buffer_ptr = internal.record_buffer.get();
+                    let buffer_slice = &mut *buffer_ptr;
+
+                    if rec.data.len() > buffer_slice.len() {
+                        return efi::Status::BUFFER_TOO_SMALL;
+                    }
+
+                    // Copy record data to buffer
+                    buffer_slice[..rec.data.len()].copy_from_slice(&rec.data);
+                    *internal.record_buffer_used.get() = rec.data.len();
+
+                    // Update output parameters
+                    core::ptr::write_unaligned(smbios_handle, rec_handle);
+                    core::ptr::write_unaligned(record, buffer_ptr as *mut SmbiosTableHeader);
 
                     if !producer_handle.is_null() {
-                        *producer_handle = prod_handle.unwrap_or(core::ptr::null_mut());
+                        let prod_h = rec.producer_handle.unwrap_or(core::ptr::null_mut());
+                        core::ptr::write_unaligned(producer_handle, prod_h);
                     }
+
                     efi::Status::SUCCESS
                 }
                 None => {
-                    *smbios_handle = SMBIOS_HANDLE_PI_RESERVED;
+                    core::ptr::write_unaligned(smbios_handle, SMBIOS_HANDLE_PI_RESERVED);
                     efi::Status::NOT_FOUND
                 }
             }
@@ -300,9 +382,10 @@ impl SmbiosProtocol {
 #[cfg(test)]
 #[coverage(off)]
 mod tests {
+    extern crate std;
+
     use super::*;
     use crate::manager::SmbiosManager;
-    extern crate std;
     use std::vec::Vec;
 
     fn create_test_bios_info_record() -> Vec<u8> {

--- a/components/patina_smbios/src/manager/record.rs
+++ b/components/patina_smbios/src/manager/record.rs
@@ -39,8 +39,9 @@ impl SmbiosRecord {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     extern crate std;
+
+    use super::*;
     use std::vec;
 
     use r_efi::efi;

--- a/components/patina_smbios/src/service.rs
+++ b/components/patina_smbios/src/service.rs
@@ -13,6 +13,7 @@
 extern crate alloc;
 use alloc::vec::Vec;
 use core::cell::Ref;
+use patina::boot_services::BootServices;
 use r_efi::efi::Handle;
 use zerocopy_derive::{FromBytes, Immutable, IntoBytes as DeriveIntoBytes, KnownLayout};
 
@@ -77,6 +78,7 @@ pub struct SmbiosRecordsIter<'a> {
 
 impl<'a> SmbiosRecordsIter<'a> {
     /// Create a new iterator over SMBIOS records
+    #[allow(dead_code)]
     pub(crate) fn new(records: Ref<'a, Vec<crate::manager::SmbiosRecord>>, filter_type: Option<SmbiosType>) -> Self {
         Self { records, position: 0, filter_type }
     }
@@ -191,31 +193,24 @@ pub trait Smbios {
 #[derive(patina::component::service::IntoService)]
 #[service(dyn Smbios)]
 pub struct SmbiosImpl {
-    pub(crate) manager: patina::tpl_mutex::TplMutex<
-        'static,
-        crate::manager::SmbiosManager,
-        patina::boot_services::StandardBootServices,
-    >,
+    pub(crate) manager: ::core::cell::RefCell<crate::manager::SmbiosManager>,
     pub(crate) boot_services: &'static patina::boot_services::StandardBootServices,
     pub(crate) major_version: u8,
     pub(crate) minor_version: u8,
 }
 
 impl SmbiosImpl {
-    /// Get a reference to the manager for protocol installation
+    /// Get a reference to the manager RefCell for protocol installation
     ///
     /// This is only used during component initialization to install the C/EDKII protocol
-    pub(crate) fn manager(
-        &self,
-    ) -> &patina::tpl_mutex::TplMutex<'static, crate::manager::SmbiosManager, patina::boot_services::StandardBootServices>
-    {
+    pub(crate) fn manager(&self) -> &::core::cell::RefCell<crate::manager::SmbiosManager> {
         &self.manager
     }
 }
 
-// Methods below are tested via integration (Q35 platform component)
-// They require StandardBootServices and TplMutex which aren't mockable in unit tests
-#[cfg_attr(coverage_nightly, coverage(off))]
+// These methods are tested via QEMU platform integration tests as they require
+// real UEFI boot services with memory allocation and configuration table installation.
+#[coverage(off)]
 impl Smbios for SmbiosImpl {
     fn version(&self) -> (u8, u8) {
         (self.major_version, self.minor_version)
@@ -225,8 +220,27 @@ impl Smbios for SmbiosImpl {
         &self,
     ) -> core::result::Result<(r_efi::efi::PhysicalAddress, r_efi::efi::PhysicalAddress), crate::error::SmbiosError>
     {
-        let manager = self.manager.lock();
-        manager.publish_table(self.boot_services)
+        // Step 1: Build table data with lock held
+        let (table_addr, ep_addr, entry_point) = {
+            let manager = self.manager.try_borrow().map_err(|_| crate::error::SmbiosError::AlreadyBorrowed)?;
+            manager.build_table_data(self.boot_services)?
+        }; // Lock is released here
+
+        // Step 2: Install configuration table WITHOUT holding the lock (critical for avoiding deadlock!)
+        // Call UEFI install WITHOUT the lock - this may trigger callbacks
+        unsafe {
+            self.boot_services
+                .install_configuration_table(&crate::manager::SMBIOS_3_X_TABLE_GUID, ep_addr as *mut ())
+                .map_err(|_| crate::error::SmbiosError::AllocationFailed)?;
+        }
+
+        // Step 3: Store addresses with lock held
+        {
+            let manager = self.manager.try_borrow().map_err(|_| crate::error::SmbiosError::AlreadyBorrowed)?;
+            manager.store_table_addresses(table_addr, ep_addr, entry_point);
+        }
+
+        Ok((table_addr, ep_addr))
     }
 
     fn update_string(
@@ -235,13 +249,27 @@ impl Smbios for SmbiosImpl {
         string_number: usize,
         string: &str,
     ) -> core::result::Result<(), crate::error::SmbiosError> {
-        let manager = self.manager.lock();
-        manager.update_string(smbios_handle, string_number, string)
+        // Update string in manager
+        {
+            let manager = self.manager.try_borrow().map_err(|_| crate::error::SmbiosError::AlreadyBorrowed)?;
+            manager.update_string(smbios_handle, string_number, string)?;
+        } // Release borrow
+
+        // Republish table with updated record
+        self.publish_table()?;
+        Ok(())
     }
 
     fn remove(&self, smbios_handle: SmbiosHandle) -> core::result::Result<(), crate::error::SmbiosError> {
-        let manager = self.manager.lock();
-        manager.remove(smbios_handle)
+        // Remove record from manager
+        {
+            let manager = self.manager.try_borrow().map_err(|_| crate::error::SmbiosError::AlreadyBorrowed)?;
+            manager.remove(smbios_handle)?;
+        } // Release borrow
+
+        // Republish table without removed record
+        self.publish_table()?;
+        Ok(())
     }
 
     fn add_from_bytes(
@@ -249,8 +277,17 @@ impl Smbios for SmbiosImpl {
         producer_handle: Option<r_efi::efi::Handle>,
         bytes: &[u8],
     ) -> core::result::Result<SmbiosHandle, crate::error::SmbiosError> {
-        let manager = self.manager.lock();
-        manager.add_from_bytes(producer_handle, bytes)
+        // Add record to manager
+        let handle = {
+            let manager = self.manager.try_borrow().map_err(|_| crate::error::SmbiosError::AlreadyBorrowed)?;
+            manager.add_from_bytes(producer_handle, bytes)?
+        }; // Release borrow
+
+        // Republish table with new record
+        // This rebuilds into pre-allocated buffer and updates configuration table
+        self.publish_table()?;
+
+        Ok(handle)
     }
 }
 
@@ -312,9 +349,22 @@ impl SmbiosExt for patina::component::service::Service<dyn Smbios> {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     extern crate std;
+
+    use super::*;
     use std::format;
+
+    use crate::{
+        manager::{SmbiosManager, SmbiosRecord},
+        smbios_record::{SmbiosRecordStructure, Type0PlatformFirmwareInformation, Type127EndOfTable},
+    };
+    use alloc::{string::String, vec, vec::Vec};
+    use core::cell::RefCell;
+    use patina::{
+        boot_services::{MockBootServices, StandardBootServices},
+        component::service::Service,
+    };
+    use zerocopy::IntoBytes;
 
     #[test]
     fn test_smbios_table_header_new() {
@@ -363,7 +413,6 @@ mod tests {
 
     #[test]
     fn test_smbios_table_header_from_bytes() {
-        use zerocopy::IntoBytes;
         let header = SmbiosTableHeader::new(127, 4, 0xFFFE);
         let bytes = header.as_bytes();
         assert_eq!(bytes.len(), 4);
@@ -373,10 +422,6 @@ mod tests {
 
     #[test]
     fn test_smbios_records_iter_basic() {
-        use crate::manager::SmbiosRecord;
-        use alloc::vec;
-        use core::cell::RefCell;
-
         let records = RefCell::new(vec![
             SmbiosRecord::new(SmbiosTableHeader::new(0, 24, 0x0001), None, vec![], 0),
             SmbiosRecord::new(SmbiosTableHeader::new(1, 32, 0x0002), None, vec![], 0),
@@ -400,10 +445,6 @@ mod tests {
 
     #[test]
     fn test_smbios_records_iter_with_filter() {
-        use crate::manager::SmbiosRecord;
-        use alloc::vec;
-        use core::cell::RefCell;
-
         let records = RefCell::new(vec![
             SmbiosRecord::new(SmbiosTableHeader::new(0, 24, 0x0001), None, vec![], 0),
             SmbiosRecord::new(SmbiosTableHeader::new(1, 32, 0x0002), None, vec![], 0),
@@ -428,10 +469,6 @@ mod tests {
 
     #[test]
     fn test_smbios_records_iter_empty() {
-        use crate::manager::SmbiosRecord;
-        use alloc::vec;
-        use core::cell::RefCell;
-
         let records: RefCell<Vec<SmbiosRecord>> = RefCell::new(vec![]);
         let borrowed = records.borrow();
         let mut iter = SmbiosRecordsIter::new(borrowed, None);
@@ -441,10 +478,6 @@ mod tests {
 
     #[test]
     fn test_smbios_records_iter_no_match_filter() {
-        use crate::manager::SmbiosRecord;
-        use alloc::vec;
-        use core::cell::RefCell;
-
         let records = RefCell::new(vec![
             SmbiosRecord::new(SmbiosTableHeader::new(0, 24, 0x0001), None, vec![], 0),
             SmbiosRecord::new(SmbiosTableHeader::new(1, 32, 0x0002), None, vec![], 0),
@@ -505,8 +538,6 @@ mod tests {
 
     #[test]
     fn test_mock_smbios_service_version() {
-        use patina::component::service::Service;
-
         let mock = MockSmbios { version: (99, 88), add_from_bytes_result: Ok(0x1234), expected_bytes: None };
         let service: Service<dyn Smbios> = Service::mock(Box::new(mock));
 
@@ -515,8 +546,6 @@ mod tests {
 
     #[test]
     fn test_mock_smbios_service_add_from_bytes() {
-        use patina::component::service::Service;
-
         let test_bytes = vec![127, 4, 0xFE, 0xFF, 0, 0]; // Type 127, length 4, handle 0xFFFE
 
         let mock =
@@ -530,8 +559,6 @@ mod tests {
 
     #[test]
     fn test_mock_smbios_service_add_from_bytes_error() {
-        use patina::component::service::Service;
-
         let mock = MockSmbios {
             version: (3, 0),
             add_from_bytes_result: Err(crate::error::SmbiosError::RecordTooSmall),
@@ -546,10 +573,6 @@ mod tests {
 
     #[test]
     fn test_mock_smbios_service_add_record_integration() {
-        use crate::smbios_record::{SmbiosRecordStructure, Type127EndOfTable};
-        use alloc::vec;
-        use patina::component::service::Service;
-
         // Create a test record
         let record = Type127EndOfTable { header: SmbiosTableHeader::new(127, 4, 0xFFFE), string_pool: vec![] };
 
@@ -569,8 +592,6 @@ mod tests {
 
     #[test]
     fn test_mock_smbios_service_all_trait_methods() {
-        use patina::component::service::Service;
-
         let mock = MockSmbios { version: (3, 7), add_from_bytes_result: Ok(0x1111), expected_bytes: None };
         let service: Service<dyn Smbios> = Service::mock(Box::new(mock));
 
@@ -584,10 +605,6 @@ mod tests {
 
     #[test]
     fn test_mock_add_record_extension_trait_pattern() {
-        use crate::smbios_record::{SmbiosRecordStructure, Type127EndOfTable};
-        use alloc::vec;
-        use patina::component::service::Service;
-
         // Create a test record
         let record = Type127EndOfTable { header: SmbiosTableHeader::new(127, 4, 0xFFFE), string_pool: vec![] };
 
@@ -615,10 +632,6 @@ mod tests {
 
     #[test]
     fn test_mock_add_record_with_error() {
-        use crate::smbios_record::{SmbiosRecordStructure, Type127EndOfTable};
-        use alloc::vec;
-        use patina::component::service::Service;
-
         // Mock that returns an error
         let mock = MockSmbios {
             version: (3, 0),
@@ -638,10 +651,6 @@ mod tests {
 
     #[test]
     fn test_mock_multiple_record_types() {
-        use crate::smbios_record::{SmbiosRecordStructure, Type0PlatformFirmwareInformation, Type127EndOfTable};
-        use alloc::{string::String, vec};
-        use patina::component::service::Service;
-
         // Test that mock can handle different record types
         let type0 = Type0PlatformFirmwareInformation {
             header: SmbiosTableHeader::new(0, 24, 0xFFFE),
@@ -682,10 +691,6 @@ mod tests {
 
     #[test]
     fn test_service_mock_pattern() {
-        use crate::smbios_record::{SmbiosRecordStructure, Type127EndOfTable};
-        use alloc::vec;
-        use patina::component::service::Service;
-
         // Create a mock service using the standard Service::mock pattern
         let mock = MockSmbios { version: (3, 6), add_from_bytes_result: Ok(0xBEEF), expected_bytes: None };
 
@@ -705,10 +710,6 @@ mod tests {
 
     #[test]
     fn test_service_mock_with_extension_trait() {
-        use crate::smbios_record::{SmbiosRecordStructure, Type127EndOfTable};
-        use alloc::vec;
-        use patina::component::service::Service;
-
         // Create test record
         let record = Type127EndOfTable { header: SmbiosTableHeader::new(127, 4, 0xFFFE), string_pool: vec![] };
         let expected_bytes = record.to_bytes();
@@ -723,5 +724,114 @@ mod tests {
         // It serializes the record and calls add_from_bytes (which the mock implements)
         let handle = service.add_record(None, &record).unwrap();
         assert_eq!(handle, 0x1337);
+    }
+
+    #[test]
+    fn test_smbios_impl_already_borrowed_error() {
+        // Create a mock boot services
+        let mock_bs = Box::leak(Box::new(MockBootServices::new()));
+        let boot_services: &'static StandardBootServices =
+            unsafe { &*(mock_bs as *const MockBootServices as *const StandardBootServices) };
+
+        // Create SmbiosImpl
+        let manager = SmbiosManager::new(3, 0).unwrap();
+        let smbios_impl =
+            SmbiosImpl { manager: RefCell::new(manager), boot_services, major_version: 3, minor_version: 0 };
+
+        // Hold a mutable borrow to the manager to block other borrows
+        let _blocking_borrow = smbios_impl.manager.borrow_mut();
+
+        // Now try to call a method that needs to borrow - it should fail gracefully
+        let result = smbios_impl.add_from_bytes(None, &[127, 4, 0, 0, 0, 0]);
+
+        // Verify we get AlreadyBorrowed error instead of a panic
+        assert!(result.is_err());
+        assert_eq!(result.unwrap_err(), crate::error::SmbiosError::AlreadyBorrowed);
+    }
+
+    #[test]
+    fn test_smbios_impl_update_string_already_borrowed() {
+        let mock_bs = Box::leak(Box::new(MockBootServices::new()));
+        let boot_services: &'static StandardBootServices =
+            unsafe { &*(mock_bs as *const MockBootServices as *const StandardBootServices) };
+
+        let manager = SmbiosManager::new(3, 0).unwrap();
+        let smbios_impl =
+            SmbiosImpl { manager: RefCell::new(manager), boot_services, major_version: 3, minor_version: 0 };
+
+        // Hold a mutable borrow
+        let _blocking_borrow = smbios_impl.manager.borrow_mut();
+
+        // Try to update string - should fail with AlreadyBorrowed
+        let result = smbios_impl.update_string(1, 1, "test");
+        assert!(result.is_err());
+        assert_eq!(result.unwrap_err(), crate::error::SmbiosError::AlreadyBorrowed);
+    }
+
+    #[test]
+    fn test_smbios_impl_remove_already_borrowed() {
+        let mock_bs = Box::leak(Box::new(MockBootServices::new()));
+        let boot_services: &'static StandardBootServices =
+            unsafe { &*(mock_bs as *const MockBootServices as *const StandardBootServices) };
+
+        let manager = SmbiosManager::new(3, 0).unwrap();
+        let smbios_impl =
+            SmbiosImpl { manager: RefCell::new(manager), boot_services, major_version: 3, minor_version: 0 };
+
+        // Hold a mutable borrow
+        let _blocking_borrow = smbios_impl.manager.borrow_mut();
+
+        // Try to remove - should fail with AlreadyBorrowed
+        let result = smbios_impl.remove(1);
+        assert!(result.is_err());
+        assert_eq!(result.unwrap_err(), crate::error::SmbiosError::AlreadyBorrowed);
+    }
+
+    #[test]
+    fn test_smbios_impl_publish_table_already_borrowed() {
+        let mock_bs = Box::leak(Box::new(MockBootServices::new()));
+        let boot_services: &'static StandardBootServices =
+            unsafe { &*(mock_bs as *const MockBootServices as *const StandardBootServices) };
+
+        let manager = SmbiosManager::new(3, 0).unwrap();
+        let smbios_impl =
+            SmbiosImpl { manager: RefCell::new(manager), boot_services, major_version: 3, minor_version: 0 };
+
+        // Hold a mutable borrow
+        let _blocking_borrow = smbios_impl.manager.borrow_mut();
+
+        // Try to publish table - should fail with AlreadyBorrowed
+        let result = smbios_impl.publish_table();
+        assert!(result.is_err());
+        assert_eq!(result.unwrap_err(), crate::error::SmbiosError::AlreadyBorrowed);
+    }
+
+    #[test]
+    fn test_smbios_records_iter_filter_continues_on_mismatch() {
+        // Create records with different types
+        let records = RefCell::new(vec![
+            SmbiosRecord::new(SmbiosTableHeader::new(0, 24, 0x0001), None, vec![], 0),
+            SmbiosRecord::new(SmbiosTableHeader::new(1, 32, 0x0002), None, vec![], 0),
+            SmbiosRecord::new(SmbiosTableHeader::new(2, 16, 0x0003), None, vec![], 0),
+            SmbiosRecord::new(SmbiosTableHeader::new(1, 32, 0x0004), None, vec![], 0),
+        ]);
+
+        let borrowed = records.borrow();
+        let mut iter = SmbiosRecordsIter::new(borrowed, Some(1));
+
+        // First Type 1 record
+        let first = iter.next().unwrap();
+        assert_eq!(first.0.record_type, 1);
+        let handle = first.0.handle;
+        assert_eq!(handle, 0x0002);
+
+        // Second Type 1 record (skips Type 2)
+        let second = iter.next().unwrap();
+        assert_eq!(second.0.record_type, 1);
+        let handle = second.0.handle;
+        assert_eq!(handle, 0x0004);
+
+        // No more Type 1 records
+        assert!(iter.next().is_none());
     }
 }

--- a/components/patina_smbios/src/smbios_record.rs
+++ b/components/patina_smbios/src/smbios_record.rs
@@ -467,9 +467,12 @@ pub struct Type3SystemEnclosure {
 /// - Type: 127
 /// - Length: 4 (header only)
 /// - No strings
+///
+/// **Note**: This type is automatically managed by the SMBIOS manager and should not be
+/// added manually by platform code. The manager adds it during initialization.
 #[derive(patina_macro::SmbiosRecord)]
 #[smbios(record_type = 127)]
-pub struct Type127EndOfTable {
+pub(crate) struct Type127EndOfTable {
     /// SMBIOS header
     pub header: SmbiosTableHeader,
 
@@ -784,5 +787,169 @@ mod tests {
         let bytes = type1.to_bytes();
         // Should have double null terminator even with no strings
         assert!(bytes.ends_with(&[0, 0]));
+    }
+
+    #[test]
+    fn test_type0_to_bytes() {
+        let type0 = Type0PlatformFirmwareInformation {
+            header: SmbiosTableHeader { record_type: 0, length: 0, handle: 1 },
+            vendor: 1,
+            firmware_version: 2,
+            bios_starting_address_segment: 0xE800,
+            firmware_release_date: 3,
+            firmware_rom_size: 0xFF,
+            characteristics: 0x08,
+            characteristics_ext1: 0x03,
+            characteristics_ext2: 0x03,
+            system_bios_major_release: 1,
+            system_bios_minor_release: 0,
+            embedded_controller_major_release: 0xFF,
+            embedded_controller_minor_release: 0xFF,
+            extended_bios_rom_size: 0,
+            string_pool: vec![String::from("Vendor"), String::from("1.0"), String::from("2025")],
+        };
+
+        let bytes = type0.to_bytes();
+
+        // Verify header
+        assert_eq!(bytes[0], 0); // Type 0
+        // Verify string pool is present
+        assert!(bytes.len() > 24); // Header + fields + strings
+        // Verify ends with double null
+        assert!(bytes.ends_with(&[0, 0]));
+    }
+
+    #[test]
+    fn test_type1_to_bytes_with_uuid() {
+        let type1 = Type1SystemInformation {
+            header: SmbiosTableHeader { record_type: 1, length: 0, handle: 2 },
+            manufacturer: 1,
+            product_name: 2,
+            version: 3,
+            serial_number: 4,
+            uuid: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16],
+            wake_up_type: 0x06,
+            sku_number: 5,
+            family: 6,
+            string_pool: vec![
+                String::from("Mfg"),
+                String::from("Prod"),
+                String::from("Ver"),
+                String::from("SN"),
+                String::from("SKU"),
+                String::from("Fam"),
+            ],
+        };
+
+        let bytes = type1.to_bytes();
+
+        // Verify type
+        assert_eq!(bytes[0], 1);
+        // Verify string pool
+        assert!(bytes.len() > 27);
+    }
+
+    #[test]
+    fn test_type2_to_bytes() {
+        let type2 = Type2BaseboardInformation {
+            header: SmbiosTableHeader { record_type: 2, length: 0, handle: 3 },
+            manufacturer: 1,
+            product: 2,
+            version: 3,
+            serial_number: 4,
+            asset_tag: 5,
+            feature_flags: 0x01,
+            location_in_chassis: 6,
+            chassis_handle: 0x0003,
+            board_type: 0x0A,
+            contained_object_handles: 0,
+            string_pool: vec![
+                String::from("Board Mfg"),
+                String::from("Board Prod"),
+                String::from("1.0"),
+                String::from("SN123"),
+                String::from("Asset"),
+                String::from("Location"),
+            ],
+        };
+
+        let bytes = type2.to_bytes();
+
+        // Verify type
+        assert_eq!(bytes[0], 2);
+        // Verify strings are present
+        assert!(bytes.len() > 15);
+    }
+
+    #[test]
+    fn test_type127_to_bytes() {
+        let type127 = Type127EndOfTable::new();
+        let bytes = type127.to_bytes();
+
+        // Type 127 should have: 4-byte header + double null
+        assert_eq!(bytes.len(), 6);
+        assert_eq!(bytes[0], 127); // Type
+        assert_eq!(bytes[1], 4); // Length
+        // Handle (bytes 2-3)
+        // Double null terminator
+        assert_eq!(bytes[4], 0);
+        assert_eq!(bytes[5], 0);
+    }
+
+    #[test]
+    fn test_type0_validate_string_with_null() {
+        let type0_valid = Type0PlatformFirmwareInformation {
+            header: SmbiosTableHeader { record_type: 0, length: 0, handle: 0 },
+            vendor: 1,
+            firmware_version: 2,
+            bios_starting_address_segment: 0xE800,
+            firmware_release_date: 3,
+            firmware_rom_size: 0xFF,
+            characteristics: 0x08,
+            characteristics_ext1: 0x03,
+            characteristics_ext2: 0x03,
+            system_bios_major_release: 1,
+            system_bios_minor_release: 0,
+            embedded_controller_major_release: 0xFF,
+            embedded_controller_minor_release: 0xFF,
+            extended_bios_rom_size: 0,
+            string_pool: vec![String::from("Valid")],
+        };
+
+        assert!(type0_valid.validate().is_ok());
+
+        // Create a record with a string containing null byte
+        // Note: We can't actually create a String with embedded nulls in safe Rust
+        // The validation will catch this during the to_bytes() serialization
+        // This test verifies that validation works for already-valid strings
+        let type0_long = Type0PlatformFirmwareInformation {
+            header: SmbiosTableHeader { record_type: 0, length: 0, handle: 0 },
+            vendor: 1,
+            firmware_version: 2,
+            bios_starting_address_segment: 0xE800,
+            firmware_release_date: 3,
+            firmware_rom_size: 0xFF,
+            characteristics: 0x08,
+            characteristics_ext1: 0x03,
+            characteristics_ext2: 0x03,
+            system_bios_major_release: 1,
+            system_bios_minor_release: 0,
+            embedded_controller_major_release: 0xFF,
+            embedded_controller_minor_release: 0xFF,
+            extended_bios_rom_size: 0,
+            string_pool: vec![String::from("x").repeat(SMBIOS_STRING_MAX_LENGTH + 1)],
+        };
+
+        // This should fail validation for being too long
+        assert_eq!(type0_long.validate(), Err(SmbiosError::StringTooLong));
+    }
+
+    #[test]
+    fn test_record_type_constants() {
+        assert_eq!(Type0PlatformFirmwareInformation::RECORD_TYPE, 0);
+        assert_eq!(Type1SystemInformation::RECORD_TYPE, 1);
+        assert_eq!(Type2BaseboardInformation::RECORD_TYPE, 2);
+        assert_eq!(Type3SystemEnclosure::RECORD_TYPE, 3);
+        assert_eq!(Type127EndOfTable::RECORD_TYPE, 127);
     }
 }

--- a/docs/src/rfc/text/0019-smbios.md
+++ b/docs/src/rfc/text/0019-smbios.md
@@ -278,9 +278,9 @@ The primary and only API for adding records is `add_from_bytes()`.
 Provides `update_string()` to modify strings in existing records. Parses the record, updates the targeted string,
 and rebuilds the record with proper SMBIOS formatting.
 
-#### Thread Safety
+#### Interior Mutability
 
-Mutable operations protected by spin::Mutex.
+Mutable operations use RefCell for interior mutability.
 
 #### Trait Object Safety
 


### PR DESCRIPTION
Replace TplMutex with RefCell to fix deadlocks when event handlers at elevated TPL call GetNext(). Auto-add Type 127 End-of-Table marker and maintain invariant that it always appears last. Publish table immediately during initialization so it's available to drivers during DXE phase.

## Description

This change replaces `TplMutex` with `RefCell` in the SMBIOS manager to fix deadlocks that occur when UEFI event handlers at elevated TPL (Task Priority Level) call the SMBIOS protocol's `GetNext()` function. The deadlock occurred because `TplMutex` would attempt to raise TPL while already at an elevated TPL, causing the system to hang.

  **Key Changes:**
  1. **RefCell replaces TplMutex**: Uses Rust's borrow checking instead of TPL-based locking. Methods now return `AlreadyBorrowed` error if a borrow conflict occurs instead of deadlocking.

  2. **Pre-allocated buffers**: Allocates SMBIOS table and entry point buffers upfront during component initialization to avoid
  memory allocation at elevated TPL during protocol calls.

  3. **Auto-add Type 127 End-of-Table marker**: Automatically adds the required SMBIOS Type 127 (End-of-Table) marker and maintains the invariant that it always appears last, even when records are added out of order.

  4. **Early table publication**: Publishes the SMBIOS table immediately during initialization (with the Type 127 marker) so it's available to drivers throughout the DXE phase, with dynamic updates when records are added.

  **Rationale for RefCell:**
  - UEFI event handlers can run at elevated TPL and need to query SMBIOS data
  - MfciDxe was found to call SMBIOS protocol at TPL_NOTIFY (violating UEFI spec), triggering deadlock with TplMutex
  - TplMutex's design assumes callers are at lower TPL and can raise TPL safely
  - RefCell provides interior mutability without TPL constraints
  - Error handling via `AlreadyBorrowed` allows graceful degradation instead of system hangs

  **Checklist:**
  - [x] Impacts functionality?
  - [ ] Impacts security?
  - [ ] Breaking change?
  - [x] Includes tests?
  - [x] Includes documentation?

  ## How This Was Tested

  - Unit tests for RefCell borrow checking and `AlreadyBorrowed` error handling
  - Unit tests for Type 127 auto-addition and last-position invariant
  - Unit tests for manager core functionality with pre-allocated buffers
  - Integration testing with both Rust DXE Core and TianoCore DXE Core on QEMU platform
    - Verified SMBIOS table is published and accessible during DXE phase
    - Verified no deadlocks when SMBIOS protocol is called from event handlers
    - Verified dynamic table updates work correctly when drivers add records

  ## Integration Instructions

No special integration steps required. The change is internal to the patina_smbios component and maintains API compatibility with existing SMBIOS protocol consumers.
