### PR TITLE
Ensure that free memory has XP attribute set to match initial free memory attributes from GCD init.

### DIFF
--- a/patina_dxe_core/src/gcd/spin_locked_gcd.rs
+++ b/patina_dxe_core/src/gcd/spin_locked_gcd.rs
@@ -600,7 +600,7 @@ impl GCD {
         match self.set_gcd_memory_attributes(
             base_address,
             len,
-            efi::MEMORY_RP | (desc.attributes & efi::CACHE_ATTRIBUTE_MASK),
+            efi::MEMORY_RP | efi::MEMORY_XP | (desc.attributes & efi::CACHE_ATTRIBUTE_MASK),
         ) {
             Ok(_) => Ok(()),
             Err(e) => {


### PR DESCRIPTION
## Description

Free memory regions created at GCD init have XP attribute set. If these are then allocated and freed back, they would have the XP attribute clear. This would cause adjacent "free" regions to have different attributes. They would be coalesced in GetMemoryMap(), but allocations to the whole region behind that descriptor would fail because of the underlying attribute mismatch.

This PR adds the XP attribute on freed space to ensure that the attributes of free memory remain consistent.

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Tested on hardware platform and confirmed that free memory is correctly coalesced after this change. 

## Integration Instructions

N/A