### PR TITLE
Update child handle validation in core_disconnect_controller() [Rebase & FF]

### DIFF
--- a/patina_dxe_core/src/driver_services.rs
+++ b/patina_dxe_core/src/driver_services.rs
@@ -531,12 +531,15 @@ pub unsafe fn core_disconnect_controller(
         child_handles.retain(|x| child_set.insert(*x));
 
         let total_children = child_handles.len();
-        let mut is_only_child = false;
         if let Some(handle) = child_handle {
-            // if the child was specified, but was the only child, then the driver should be disconnected.
-            // if the child was specified, but other children were present, then the driver should not be disconnected.
-            child_handles.retain(|x| x == &handle);
-            is_only_child = total_children == child_handles.len();
+            // A specific child was requested so keep only that child. `child_handles` was deduplicated
+            // above, so this leaves at most one entry.
+            child_handles.retain(|x| *x == handle);
+
+            // If the requested child isn't managed by this driver, skip it.
+            if child_handles.is_empty() {
+                continue;
+            }
         }
 
         // resolve the handle to the driver_binding.
@@ -570,7 +573,7 @@ pub unsafe fn core_disconnect_controller(
                 )
             };
         }
-        if status == efi::Status::SUCCESS && (child_handle.is_none() || is_only_child) {
+        if status == efi::Status::SUCCESS && (child_handle.is_none() || total_children == child_handles.len()) {
             // SAFETY: driver_binding_interface is a valid pointer to a driver binding protocol instance
             // as ensured by the construction of driver_candidates above.
             status =
@@ -1842,6 +1845,469 @@ mod tests {
                     "Should return InvalidParameter for invalid driver handle"
                 );
             }
+        });
+    }
+
+    #[test]
+    fn test_disconnect_specific_child_not_managed_by_driver() {
+        // Verifies that when a specific child handle is requested but not managed by
+        // any driver, the driver is skipped and returns not found
+        with_locked_state(|| {
+            use std::sync::atomic::{AtomicUsize, Ordering};
+
+            static STOP_CALLS: AtomicUsize = AtomicUsize::new(0);
+
+            extern "efiapi" fn mock_stop_tracking(
+                _this: *mut efi::protocols::driver_binding::Protocol,
+                _controller_handle: efi::Handle,
+                _num_children: usize,
+                _child_handle_buffer: *mut efi::Handle,
+            ) -> efi::Status {
+                STOP_CALLS.fetch_add(1, Ordering::SeqCst);
+                efi::Status::SUCCESS
+            }
+
+            let guid1 = patina::Guid::from_string("0e896c7a-57dc-4987-bc22-abc3a8263210");
+            let interface1: *mut c_void = 0x1234 as *mut c_void;
+            let (handle1, _) = PROTOCOL_DB.install_protocol_interface(None, guid1.to_efi_guid(), interface1).unwrap();
+
+            // Create controller handle
+            let (controller_handle, _) = PROTOCOL_DB
+                .install_protocol_interface(
+                    None,
+                    efi::protocols::device_path::PROTOCOL_GUID,
+                    0x1111 as *mut core::ffi::c_void,
+                )
+                .unwrap();
+
+            // Create driver handle
+            let (driver_handle, _) = PROTOCOL_DB
+                .install_protocol_interface(
+                    None,
+                    efi::protocols::device_path::PROTOCOL_GUID,
+                    0x2222 as *mut core::ffi::c_void,
+                )
+                .unwrap();
+
+            // Create a child handle that is managed by the driver
+            let (managed_child_handle, _) = PROTOCOL_DB
+                .install_protocol_interface(
+                    None,
+                    efi::protocols::device_path::PROTOCOL_GUID,
+                    0x3333 as *mut core::ffi::c_void,
+                )
+                .unwrap();
+
+            // Create a child handle that is not managed by the driver
+            let (unmanaged_child_handle, _) = PROTOCOL_DB
+                .install_protocol_interface(
+                    None,
+                    efi::protocols::device_path::PROTOCOL_GUID,
+                    0x4444 as *mut core::ffi::c_void,
+                )
+                .unwrap();
+
+            // Create driver binding protocol
+            let binding = Box::new(efi::protocols::driver_binding::Protocol {
+                version: 10,
+                supported: mock_supported_success,
+                start: mock_start_success,
+                stop: mock_stop_tracking,
+                driver_binding_handle: driver_handle,
+                image_handle: DXE_CORE_HANDLE,
+            });
+            let binding_ptr = Box::into_raw(binding) as *mut core::ffi::c_void;
+
+            PROTOCOL_DB
+                .install_protocol_interface(
+                    Some(driver_handle),
+                    efi::protocols::driver_binding::PROTOCOL_GUID,
+                    binding_ptr,
+                )
+                .unwrap();
+
+            // Have the driver manage the controller
+            PROTOCOL_DB
+                .add_protocol_usage(
+                    controller_handle,
+                    efi::protocols::device_path::PROTOCOL_GUID,
+                    Some(driver_handle),
+                    Some(handle1),
+                    efi::OPEN_PROTOCOL_BY_DRIVER,
+                )
+                .unwrap();
+
+            // The driver only manages managed_child_handle, not unmanaged_child_handle
+            PROTOCOL_DB
+                .add_protocol_usage(
+                    controller_handle,
+                    efi::protocols::device_path::PROTOCOL_GUID,
+                    Some(driver_handle),
+                    Some(managed_child_handle),
+                    efi::OPEN_PROTOCOL_BY_CHILD_CONTROLLER,
+                )
+                .unwrap();
+
+            STOP_CALLS.store(0, Ordering::SeqCst);
+
+            // Attempt to disconnect unmanaged_child_handle (not managed by this driver)
+            // SAFETY: No concurrent driver unload occurs in this single-threaded test. The
+            // driver binding remains valid for the duration of the call.
+            let result = unsafe { core_disconnect_controller(controller_handle, None, Some(unmanaged_child_handle)) };
+            // Should return not found since no driver manages this child
+            assert_eq!(
+                result,
+                Err(EfiError::NotFound),
+                "disconnect should fail when child is not managed by any driver"
+            );
+
+            // Driver's stop function should not have been called since the child wasn't found
+            assert_eq!(
+                STOP_CALLS.load(Ordering::SeqCst),
+                0,
+                "Driver stop should not be called when specified child is not managed by driver"
+            );
+        });
+    }
+
+    #[test]
+    fn test_disconnect_specific_child_among_multiple_children() {
+        // Checks that when a specific child is requested and the driver has multiple children,
+        // only that specific child is disconnected (not the entire driver).
+        with_locked_state(|| {
+            use std::sync::atomic::{AtomicUsize, Ordering};
+
+            static CHILD_STOP_CALLS: AtomicUsize = AtomicUsize::new(0);
+            static DRIVER_STOP_CALLS: AtomicUsize = AtomicUsize::new(0);
+
+            extern "efiapi" fn mock_stop_tracking(
+                _this: *mut efi::protocols::driver_binding::Protocol,
+                _controller_handle: efi::Handle,
+                num_children: usize,
+                _child_handle_buffer: *mut efi::Handle,
+            ) -> efi::Status {
+                if num_children == 0 {
+                    DRIVER_STOP_CALLS.fetch_add(1, Ordering::SeqCst);
+                } else {
+                    CHILD_STOP_CALLS.fetch_add(1, Ordering::SeqCst);
+                }
+                efi::Status::SUCCESS
+            }
+
+            let guid1 = patina::Guid::from_string("0e896c7a-57dc-4987-bc22-abc3a8263210");
+            let interface1: *mut c_void = 0x1234 as *mut c_void;
+            let (handle1, _) = PROTOCOL_DB.install_protocol_interface(None, guid1.to_efi_guid(), interface1).unwrap();
+
+            // Create controller handle
+            let (controller_handle, _) = PROTOCOL_DB
+                .install_protocol_interface(
+                    None,
+                    efi::protocols::device_path::PROTOCOL_GUID,
+                    0x1111 as *mut core::ffi::c_void,
+                )
+                .unwrap();
+
+            // Create driver handle
+            let (driver_handle, _) = PROTOCOL_DB
+                .install_protocol_interface(
+                    None,
+                    efi::protocols::device_path::PROTOCOL_GUID,
+                    0x2222 as *mut core::ffi::c_void,
+                )
+                .unwrap();
+
+            // Create multiple child handles
+            let (child_handle_a, _) = PROTOCOL_DB
+                .install_protocol_interface(
+                    None,
+                    efi::protocols::device_path::PROTOCOL_GUID,
+                    0x3333 as *mut core::ffi::c_void,
+                )
+                .unwrap();
+
+            let (child_handle_b, _) = PROTOCOL_DB
+                .install_protocol_interface(
+                    None,
+                    efi::protocols::device_path::PROTOCOL_GUID,
+                    0x4444 as *mut core::ffi::c_void,
+                )
+                .unwrap();
+
+            let (child_handle_c, _) = PROTOCOL_DB
+                .install_protocol_interface(
+                    None,
+                    efi::protocols::device_path::PROTOCOL_GUID,
+                    0x5555 as *mut core::ffi::c_void,
+                )
+                .unwrap();
+
+            // Create driver binding protocol
+            let binding = Box::new(efi::protocols::driver_binding::Protocol {
+                version: 10,
+                supported: mock_supported_success,
+                start: mock_start_success,
+                stop: mock_stop_tracking,
+                driver_binding_handle: driver_handle,
+                image_handle: DXE_CORE_HANDLE,
+            });
+            let binding_ptr = Box::into_raw(binding) as *mut core::ffi::c_void;
+
+            PROTOCOL_DB
+                .install_protocol_interface(
+                    Some(driver_handle),
+                    efi::protocols::driver_binding::PROTOCOL_GUID,
+                    binding_ptr,
+                )
+                .unwrap();
+
+            // Have the driver manage the controller
+            PROTOCOL_DB
+                .add_protocol_usage(
+                    controller_handle,
+                    efi::protocols::device_path::PROTOCOL_GUID,
+                    Some(driver_handle),
+                    Some(handle1),
+                    efi::OPEN_PROTOCOL_BY_DRIVER,
+                )
+                .unwrap();
+
+            // Add all three child handles as managed by this driver
+            PROTOCOL_DB
+                .add_protocol_usage(
+                    controller_handle,
+                    efi::protocols::device_path::PROTOCOL_GUID,
+                    Some(driver_handle),
+                    Some(child_handle_a),
+                    efi::OPEN_PROTOCOL_BY_CHILD_CONTROLLER,
+                )
+                .unwrap();
+
+            PROTOCOL_DB
+                .add_protocol_usage(
+                    controller_handle,
+                    efi::protocols::device_path::PROTOCOL_GUID,
+                    Some(driver_handle),
+                    Some(child_handle_b),
+                    efi::OPEN_PROTOCOL_BY_CHILD_CONTROLLER,
+                )
+                .unwrap();
+
+            PROTOCOL_DB
+                .add_protocol_usage(
+                    controller_handle,
+                    efi::protocols::device_path::PROTOCOL_GUID,
+                    Some(driver_handle),
+                    Some(child_handle_c),
+                    efi::OPEN_PROTOCOL_BY_CHILD_CONTROLLER,
+                )
+                .unwrap();
+
+            CHILD_STOP_CALLS.store(0, Ordering::SeqCst);
+            DRIVER_STOP_CALLS.store(0, Ordering::SeqCst);
+
+            // Disconnect only child_handle_a (one of the three children)
+            // Because total_children != child_handles.len(), the driver should not be fully stopped
+            // SAFETY: No concurrent driver unload occurs in this single-threaded test. The
+            // driver binding remains valid for the duration of the call.
+            let result = unsafe { core_disconnect_controller(controller_handle, None, Some(child_handle_a)) };
+            assert!(result.is_ok(), "disconnect should succeed");
+
+            assert_eq!(
+                CHILD_STOP_CALLS.load(Ordering::SeqCst),
+                1,
+                "Child stop should be called once for the specified child"
+            );
+            assert_eq!(
+                DRIVER_STOP_CALLS.load(Ordering::SeqCst),
+                0,
+                "Driver stop should not be called when other children still exist"
+            );
+        });
+    }
+
+    #[test]
+    fn test_disconnect_specific_child_not_owned_by_either_driver() {
+        // Two drivers manage the same controller and each owns a distinct child. A specific child
+        // owned by neither driver is requested. Every driver in the loop must be skipped (its stop
+        // function must never be called) and the call must return NotFound.
+        with_locked_state(|| {
+            use std::sync::atomic::{AtomicUsize, Ordering};
+
+            static A_STOP_CALLS: AtomicUsize = AtomicUsize::new(0);
+            static B_STOP_CALLS: AtomicUsize = AtomicUsize::new(0);
+
+            extern "efiapi" fn mock_stop_driver_a(
+                _this: *mut efi::protocols::driver_binding::Protocol,
+                _controller_handle: efi::Handle,
+                _num_children: usize,
+                _child_handle_buffer: *mut efi::Handle,
+            ) -> efi::Status {
+                A_STOP_CALLS.fetch_add(1, Ordering::SeqCst);
+                efi::Status::SUCCESS
+            }
+
+            extern "efiapi" fn mock_stop_driver_b(
+                _this: *mut efi::protocols::driver_binding::Protocol,
+                _controller_handle: efi::Handle,
+                _num_children: usize,
+                _child_handle_buffer: *mut efi::Handle,
+            ) -> efi::Status {
+                B_STOP_CALLS.fetch_add(1, Ordering::SeqCst);
+                efi::Status::SUCCESS
+            }
+
+            // Arbitrary valid handle recorded in the controller field of the BY_DRIVER usages.
+            let guid1 = patina::Guid::from_string("0e896c7a-57dc-4987-bc22-abc3a8263210");
+            let (handle1, _) =
+                PROTOCOL_DB.install_protocol_interface(None, guid1.to_efi_guid(), 0x1234 as *mut c_void).unwrap();
+
+            // Controller managed by both drivers. Driver A opens the device path protocol BY_DRIVER.
+            // Driver B opens a second protocol BY_DRIVER, because BY_DRIVER is exclusive per protocol interface.
+            let (controller_handle, _) = PROTOCOL_DB
+                .install_protocol_interface(
+                    None,
+                    efi::protocols::device_path::PROTOCOL_GUID,
+                    0x1111 as *mut core::ffi::c_void,
+                )
+                .unwrap();
+            let driver_b_protocol = patina::Guid::from_string("2f7d3b1e-9c4a-4f8b-8a2d-1e6c5b4a3f21");
+            PROTOCOL_DB
+                .install_protocol_interface(
+                    Some(controller_handle),
+                    driver_b_protocol.to_efi_guid(),
+                    0x2211 as *mut core::ffi::c_void,
+                )
+                .unwrap();
+
+            // Driver handles.
+            let (driver_a_handle, _) = PROTOCOL_DB
+                .install_protocol_interface(
+                    None,
+                    efi::protocols::device_path::PROTOCOL_GUID,
+                    0x2222 as *mut core::ffi::c_void,
+                )
+                .unwrap();
+            let (driver_b_handle, _) = PROTOCOL_DB
+                .install_protocol_interface(
+                    None,
+                    efi::protocols::device_path::PROTOCOL_GUID,
+                    0x3333 as *mut core::ffi::c_void,
+                )
+                .unwrap();
+
+            // Child handles: child_a owned by driver A, child_b owned by driver B, and orphan_child
+            // owned by neither driver (this is the handle that will be requested for disconnect).
+            let (child_a, _) = PROTOCOL_DB
+                .install_protocol_interface(
+                    None,
+                    efi::protocols::device_path::PROTOCOL_GUID,
+                    0x4444 as *mut core::ffi::c_void,
+                )
+                .unwrap();
+            let (child_b, _) = PROTOCOL_DB
+                .install_protocol_interface(
+                    None,
+                    efi::protocols::device_path::PROTOCOL_GUID,
+                    0x5555 as *mut core::ffi::c_void,
+                )
+                .unwrap();
+            let (orphan_child, _) = PROTOCOL_DB
+                .install_protocol_interface(
+                    None,
+                    efi::protocols::device_path::PROTOCOL_GUID,
+                    0x6666 as *mut core::ffi::c_void,
+                )
+                .unwrap();
+
+            // Install both driver binding protocols.
+            let binding_a = Box::new(efi::protocols::driver_binding::Protocol {
+                version: 10,
+                supported: mock_supported_success,
+                start: mock_start_success,
+                stop: mock_stop_driver_a,
+                driver_binding_handle: driver_a_handle,
+                image_handle: DXE_CORE_HANDLE,
+            });
+            PROTOCOL_DB
+                .install_protocol_interface(
+                    Some(driver_a_handle),
+                    efi::protocols::driver_binding::PROTOCOL_GUID,
+                    Box::into_raw(binding_a) as *mut core::ffi::c_void,
+                )
+                .unwrap();
+
+            let binding_b = Box::new(efi::protocols::driver_binding::Protocol {
+                version: 10,
+                supported: mock_supported_success,
+                start: mock_start_success,
+                stop: mock_stop_driver_b,
+                driver_binding_handle: driver_b_handle,
+                image_handle: DXE_CORE_HANDLE,
+            });
+            PROTOCOL_DB
+                .install_protocol_interface(
+                    Some(driver_b_handle),
+                    efi::protocols::driver_binding::PROTOCOL_GUID,
+                    Box::into_raw(binding_b) as *mut core::ffi::c_void,
+                )
+                .unwrap();
+
+            // Driver A manages the controller (BY_DRIVER on the device path protocol) with child_a.
+            PROTOCOL_DB
+                .add_protocol_usage(
+                    controller_handle,
+                    efi::protocols::device_path::PROTOCOL_GUID,
+                    Some(driver_a_handle),
+                    Some(handle1),
+                    efi::OPEN_PROTOCOL_BY_DRIVER,
+                )
+                .unwrap();
+            PROTOCOL_DB
+                .add_protocol_usage(
+                    controller_handle,
+                    efi::protocols::device_path::PROTOCOL_GUID,
+                    Some(driver_a_handle),
+                    Some(child_a),
+                    efi::OPEN_PROTOCOL_BY_CHILD_CONTROLLER,
+                )
+                .unwrap();
+
+            // Driver B manages the controller (BY_DRIVER on the second protocol) with child_b.
+            PROTOCOL_DB
+                .add_protocol_usage(
+                    controller_handle,
+                    driver_b_protocol.to_efi_guid(),
+                    Some(driver_b_handle),
+                    Some(handle1),
+                    efi::OPEN_PROTOCOL_BY_DRIVER,
+                )
+                .unwrap();
+            PROTOCOL_DB
+                .add_protocol_usage(
+                    controller_handle,
+                    driver_b_protocol.to_efi_guid(),
+                    Some(driver_b_handle),
+                    Some(child_b),
+                    efi::OPEN_PROTOCOL_BY_CHILD_CONTROLLER,
+                )
+                .unwrap();
+
+            A_STOP_CALLS.store(0, Ordering::SeqCst);
+            B_STOP_CALLS.store(0, Ordering::SeqCst);
+
+            // Disconnect orphan_child, which is owned by neither driver.
+            // SAFETY: No concurrent driver unload occurs in this single-threaded test. The
+            // driver bindings remain valid for the duration of the call.
+            let result = unsafe { core_disconnect_controller(controller_handle, None, Some(orphan_child)) };
+            assert_eq!(
+                result,
+                Err(EfiError::NotFound),
+                "disconnect should return NotFound when no driver owns the requested child"
+            );
+
+            // Neither driver owns the requested child, so neither stop function may be called.
+            assert_eq!(A_STOP_CALLS.load(Ordering::SeqCst), 0, "Driver A should be skipped. It does not own the child");
+            assert_eq!(B_STOP_CALLS.load(Ordering::SeqCst), 0, "Driver B should be skipped.t does not own the child");
         });
     }
 

--- a/patina_dxe_core/src/driver_services.rs
+++ b/patina_dxe_core/src/driver_services.rs
@@ -806,6 +806,93 @@ mod tests {
         }
     }
 
+    /// Installs a device path protocol on a handle and returns that handle.
+    ///
+    /// Used to create controller and child handles for the driver services tests. `marker` is an
+    /// arbitrary non-null value stored as the (never dereferenced) protocol interface so handles are
+    /// easy to tell apart while debugging.
+    fn new_test_handle(marker: usize) -> efi::Handle {
+        PROTOCOL_DB
+            .install_protocol_interface(None, efi::protocols::device_path::PROTOCOL_GUID, marker as *mut c_void)
+            .unwrap()
+            .0
+    }
+
+    /// Installs a driver binding (using `stop_fn`) on a new driver handle, records that driver as
+    /// managing `controller_handle` through a BY_DRIVER open of `protocol`, and registers every handle
+    /// in `children` as a BY_CHILD_CONTROLLER child of that driver. Returns the new driver handle.
+    ///
+    /// `controller_handle` must already have `protocol` installed (a controller created with
+    /// [`new_test_handle`] already has the device path protocol installed).
+    ///
+    /// # Examples
+    ///
+    /// ```ignore
+    /// let controller = new_test_handle(0x1111);
+    /// let child = new_test_handle(0x3333);
+    /// setup_driver_managing_controller(
+    ///     controller,
+    ///     efi::protocols::device_path::PROTOCOL_GUID,
+    ///     mock_stop_success,
+    ///     &[child],
+    /// );
+    /// ```
+    fn setup_driver_managing_controller(
+        controller_handle: efi::Handle,
+        protocol: efi::Guid,
+        stop_fn: extern "efiapi" fn(
+            *mut efi::protocols::driver_binding::Protocol,
+            efi::Handle,
+            usize,
+            *mut efi::Handle,
+        ) -> efi::Status,
+        children: &[efi::Handle],
+    ) -> efi::Handle {
+        let driver_handle = new_test_handle(0x2222);
+
+        let binding = Box::new(efi::protocols::driver_binding::Protocol {
+            version: 10,
+            supported: mock_supported_success,
+            start: mock_start_success,
+            stop: stop_fn,
+            driver_binding_handle: driver_handle,
+            image_handle: DXE_CORE_HANDLE,
+        });
+        PROTOCOL_DB
+            .install_protocol_interface(
+                Some(driver_handle),
+                efi::protocols::driver_binding::PROTOCOL_GUID,
+                Box::into_raw(binding) as *mut core::ffi::c_void,
+            )
+            .unwrap();
+
+        // Mark the driver as managing the controller.
+        PROTOCOL_DB
+            .add_protocol_usage(
+                controller_handle,
+                protocol,
+                Some(driver_handle),
+                Some(controller_handle),
+                efi::OPEN_PROTOCOL_BY_DRIVER,
+            )
+            .unwrap();
+
+        // Register each child controller created by the driver.
+        for child in children {
+            PROTOCOL_DB
+                .add_protocol_usage(
+                    controller_handle,
+                    protocol,
+                    Some(driver_handle),
+                    Some(*child),
+                    efi::OPEN_PROTOCOL_BY_CHILD_CONTROLLER,
+                )
+                .unwrap();
+        }
+
+        driver_handle
+    }
+
     // =================== TESTS ===================
     #[test]
     fn test_get_bindings_for_handles_empty() {
@@ -1694,119 +1781,46 @@ mod tests {
         with_locked_state(|| {
             use std::sync::atomic::{AtomicUsize, Ordering};
 
-            // Track calls to the stop function and parameters
-            static STOP_CALLS: AtomicUsize = AtomicUsize::new(0);
-            static DRIVER_STOP_CALLED: AtomicUsize = AtomicUsize::new(0); // Track full driver stops
+            static DRIVER_STOP_CALLED: AtomicUsize = AtomicUsize::new(0); // Track full driver stops (num_children == 0)
 
-            let uuid1 = Uuid::from_str("0e896c7a-57dc-4987-bc22-abc3a8263210").unwrap();
-            let guid1 = efi::Guid::from_bytes(uuid1.as_bytes());
-            let interface1: *mut c_void = 0x1234 as *mut c_void;
-            let (handle1, _) = PROTOCOL_DB.install_protocol_interface(None, guid1, interface1).unwrap();
-
-            // Mock stop function that tracks different types of calls
             extern "efiapi" fn mock_stop_tracking(
                 _this: *mut efi::protocols::driver_binding::Protocol,
                 _controller_handle: efi::Handle,
                 num_children: usize,
                 _child_handle_buffer: *mut efi::Handle,
             ) -> efi::Status {
-                STOP_CALLS.fetch_add(1, Ordering::SeqCst);
                 if num_children == 0 {
                     DRIVER_STOP_CALLED.fetch_add(1, Ordering::SeqCst);
                 }
                 efi::Status::SUCCESS
             }
 
-            // Create controller handle
-            let (controller_handle, _) = PROTOCOL_DB
-                .install_protocol_interface(
-                    None,
-                    efi::protocols::device_path::PROTOCOL_GUID,
-                    0x1111 as *mut core::ffi::c_void,
-                )
-                .unwrap();
+            let controller_handle = new_test_handle(0x1111);
+            let child_handle = new_test_handle(0x3333);
 
-            // Create driver handle
-            let (driver_handle, _) = PROTOCOL_DB
-                .install_protocol_interface(
-                    None,
-                    efi::protocols::device_path::PROTOCOL_GUID,
-                    0x2222 as *mut core::ffi::c_void,
-                )
-                .unwrap();
+            // A single driver manages the controller with exactly one child.
+            setup_driver_managing_controller(
+                controller_handle,
+                efi::protocols::device_path::PROTOCOL_GUID,
+                mock_stop_tracking,
+                &[child_handle],
+            );
 
-            // Create only one child handle
-            let (child_handle, _) = PROTOCOL_DB
-                .install_protocol_interface(
-                    None,
-                    efi::protocols::device_path::PROTOCOL_GUID,
-                    0x3333 as *mut core::ffi::c_void,
-                )
-                .unwrap();
-
-            // Create driver binding protocol
-            let binding = Box::new(efi::protocols::driver_binding::Protocol {
-                version: 10,
-                supported: mock_supported_success,
-                start: mock_start_success,
-                stop: mock_stop_tracking,
-                driver_binding_handle: driver_handle,
-                image_handle: DXE_CORE_HANDLE,
-            });
-            let binding_ptr = Box::into_raw(binding) as *mut core::ffi::c_void;
-
-            // Install driver binding protocol
-            PROTOCOL_DB
-                .install_protocol_interface(
-                    Some(driver_handle),
-                    efi::protocols::driver_binding::PROTOCOL_GUID,
-                    binding_ptr,
-                )
-                .unwrap();
-
-            // Simulate driver managing controller
-            PROTOCOL_DB
-                .add_protocol_usage(
-                    controller_handle,
-                    efi::protocols::device_path::PROTOCOL_GUID,
-                    Some(driver_handle),
-                    Some(handle1),
-                    efi::OPEN_PROTOCOL_BY_DRIVER,
-                )
-                .unwrap();
-
-            // Simulate only ONE child controller managed by this driver
-            PROTOCOL_DB
-                .add_protocol_usage(
-                    controller_handle,
-                    efi::protocols::device_path::PROTOCOL_GUID,
-                    Some(driver_handle),
-                    Some(child_handle),
-                    efi::OPEN_PROTOCOL_BY_CHILD_CONTROLLER,
-                )
-                .unwrap();
-
-            // Reset counters
-            STOP_CALLS.store(0, Ordering::SeqCst);
             DRIVER_STOP_CALLED.store(0, Ordering::SeqCst);
 
-            // Test disconnect with specific child handle (which is the ONLY child)
-            // This should trigger: is_only_child = total_children == child_handles.len() = true
-            // Because: total_children = 1, child_handles.retain() keeps 1 child, so 1 == 1
-            // SAFETY: no concurrent driver unload can occur in this single-threaded test,
-            // so driver bindings remain valid for the duration of the call.
+            // Disconnecting the only child fully disconnects the driver, because after filtering to
+            // the requested child, total_children (1) == child_handles.len() (1).
+            // SAFETY: No concurrent driver unload occurs in this single-threaded test. The
+            // driver binding remains valid for the duration of the call.
             let result = unsafe { core_disconnect_controller(controller_handle, None, Some(child_handle)) };
             assert!(result.is_ok(), "disconnect should succeed");
 
-            // When child was specified and it was the only child, driver should be fully disconnected
-            // This means stop should be called twice: once for children, once for driver
-            let total_calls = STOP_CALLS.load(Ordering::SeqCst);
-            let driver_stops = DRIVER_STOP_CALLED.load(Ordering::SeqCst);
-
-            println!("Total stop calls: {total_calls}, Driver stops (num_children=0): {driver_stops}");
-
-            // Since we specified the only child, the driver should be disconnected completely
-            assert!(driver_stops > 0, "Driver should be fully stopped when specified child is the only child");
+            // Because the specified child was the only child, the driver is fully stopped
+            // (Stop() is called with zero children).
+            assert!(
+                DRIVER_STOP_CALLED.load(Ordering::SeqCst) > 0,
+                "Driver should be fully stopped when specified child is the only child"
+            );
         });
     }
 
@@ -1851,7 +1865,7 @@ mod tests {
     #[test]
     fn test_disconnect_specific_child_not_managed_by_driver() {
         // Verifies that when a specific child handle is requested but not managed by
-        // any driver, the driver is skipped and returns not found
+        // any driver, the driver is skipped and NotFound is returned.
         with_locked_state(|| {
             use std::sync::atomic::{AtomicUsize, Ordering};
 
@@ -1867,101 +1881,31 @@ mod tests {
                 efi::Status::SUCCESS
             }
 
-            let guid1 = patina::Guid::from_string("0e896c7a-57dc-4987-bc22-abc3a8263210");
-            let interface1: *mut c_void = 0x1234 as *mut c_void;
-            let (handle1, _) = PROTOCOL_DB.install_protocol_interface(None, guid1.to_efi_guid(), interface1).unwrap();
+            let controller_handle = new_test_handle(0x1111);
+            let managed_child_handle = new_test_handle(0x3333);
+            let unmanaged_child_handle = new_test_handle(0x4444);
 
-            // Create controller handle
-            let (controller_handle, _) = PROTOCOL_DB
-                .install_protocol_interface(
-                    None,
-                    efi::protocols::device_path::PROTOCOL_GUID,
-                    0x1111 as *mut core::ffi::c_void,
-                )
-                .unwrap();
-
-            // Create driver handle
-            let (driver_handle, _) = PROTOCOL_DB
-                .install_protocol_interface(
-                    None,
-                    efi::protocols::device_path::PROTOCOL_GUID,
-                    0x2222 as *mut core::ffi::c_void,
-                )
-                .unwrap();
-
-            // Create a child handle that is managed by the driver
-            let (managed_child_handle, _) = PROTOCOL_DB
-                .install_protocol_interface(
-                    None,
-                    efi::protocols::device_path::PROTOCOL_GUID,
-                    0x3333 as *mut core::ffi::c_void,
-                )
-                .unwrap();
-
-            // Create a child handle that is not managed by the driver
-            let (unmanaged_child_handle, _) = PROTOCOL_DB
-                .install_protocol_interface(
-                    None,
-                    efi::protocols::device_path::PROTOCOL_GUID,
-                    0x4444 as *mut core::ffi::c_void,
-                )
-                .unwrap();
-
-            // Create driver binding protocol
-            let binding = Box::new(efi::protocols::driver_binding::Protocol {
-                version: 10,
-                supported: mock_supported_success,
-                start: mock_start_success,
-                stop: mock_stop_tracking,
-                driver_binding_handle: driver_handle,
-                image_handle: DXE_CORE_HANDLE,
-            });
-            let binding_ptr = Box::into_raw(binding) as *mut core::ffi::c_void;
-
-            PROTOCOL_DB
-                .install_protocol_interface(
-                    Some(driver_handle),
-                    efi::protocols::driver_binding::PROTOCOL_GUID,
-                    binding_ptr,
-                )
-                .unwrap();
-
-            // Have the driver manage the controller
-            PROTOCOL_DB
-                .add_protocol_usage(
-                    controller_handle,
-                    efi::protocols::device_path::PROTOCOL_GUID,
-                    Some(driver_handle),
-                    Some(handle1),
-                    efi::OPEN_PROTOCOL_BY_DRIVER,
-                )
-                .unwrap();
-
-            // The driver only manages managed_child_handle, not unmanaged_child_handle
-            PROTOCOL_DB
-                .add_protocol_usage(
-                    controller_handle,
-                    efi::protocols::device_path::PROTOCOL_GUID,
-                    Some(driver_handle),
-                    Some(managed_child_handle),
-                    efi::OPEN_PROTOCOL_BY_CHILD_CONTROLLER,
-                )
-                .unwrap();
+            // The driver manages the controller and owns only `managed_child_handle`.
+            setup_driver_managing_controller(
+                controller_handle,
+                efi::protocols::device_path::PROTOCOL_GUID,
+                mock_stop_tracking,
+                &[managed_child_handle],
+            );
 
             STOP_CALLS.store(0, Ordering::SeqCst);
 
-            // Attempt to disconnect unmanaged_child_handle (not managed by this driver)
+            // Attempt to disconnect a child the driver does not own.
             // SAFETY: No concurrent driver unload occurs in this single-threaded test. The
             // driver binding remains valid for the duration of the call.
             let result = unsafe { core_disconnect_controller(controller_handle, None, Some(unmanaged_child_handle)) };
-            // Should return not found since no driver manages this child
             assert_eq!(
                 result,
                 Err(EfiError::NotFound),
                 "disconnect should fail when child is not managed by any driver"
             );
 
-            // Driver's stop function should not have been called since the child wasn't found
+            // The driver's stop function must not be called since the child wasn't found.
             assert_eq!(
                 STOP_CALLS.load(Ordering::SeqCst),
                 0,
@@ -1994,119 +1938,24 @@ mod tests {
                 efi::Status::SUCCESS
             }
 
-            let guid1 = patina::Guid::from_string("0e896c7a-57dc-4987-bc22-abc3a8263210");
-            let interface1: *mut c_void = 0x1234 as *mut c_void;
-            let (handle1, _) = PROTOCOL_DB.install_protocol_interface(None, guid1.to_efi_guid(), interface1).unwrap();
+            let controller_handle = new_test_handle(0x1111);
+            let child_handle_a = new_test_handle(0x3333);
+            let child_handle_b = new_test_handle(0x4444);
+            let child_handle_c = new_test_handle(0x5555);
 
-            // Create controller handle
-            let (controller_handle, _) = PROTOCOL_DB
-                .install_protocol_interface(
-                    None,
-                    efi::protocols::device_path::PROTOCOL_GUID,
-                    0x1111 as *mut core::ffi::c_void,
-                )
-                .unwrap();
-
-            // Create driver handle
-            let (driver_handle, _) = PROTOCOL_DB
-                .install_protocol_interface(
-                    None,
-                    efi::protocols::device_path::PROTOCOL_GUID,
-                    0x2222 as *mut core::ffi::c_void,
-                )
-                .unwrap();
-
-            // Create multiple child handles
-            let (child_handle_a, _) = PROTOCOL_DB
-                .install_protocol_interface(
-                    None,
-                    efi::protocols::device_path::PROTOCOL_GUID,
-                    0x3333 as *mut core::ffi::c_void,
-                )
-                .unwrap();
-
-            let (child_handle_b, _) = PROTOCOL_DB
-                .install_protocol_interface(
-                    None,
-                    efi::protocols::device_path::PROTOCOL_GUID,
-                    0x4444 as *mut core::ffi::c_void,
-                )
-                .unwrap();
-
-            let (child_handle_c, _) = PROTOCOL_DB
-                .install_protocol_interface(
-                    None,
-                    efi::protocols::device_path::PROTOCOL_GUID,
-                    0x5555 as *mut core::ffi::c_void,
-                )
-                .unwrap();
-
-            // Create driver binding protocol
-            let binding = Box::new(efi::protocols::driver_binding::Protocol {
-                version: 10,
-                supported: mock_supported_success,
-                start: mock_start_success,
-                stop: mock_stop_tracking,
-                driver_binding_handle: driver_handle,
-                image_handle: DXE_CORE_HANDLE,
-            });
-            let binding_ptr = Box::into_raw(binding) as *mut core::ffi::c_void;
-
-            PROTOCOL_DB
-                .install_protocol_interface(
-                    Some(driver_handle),
-                    efi::protocols::driver_binding::PROTOCOL_GUID,
-                    binding_ptr,
-                )
-                .unwrap();
-
-            // Have the driver manage the controller
-            PROTOCOL_DB
-                .add_protocol_usage(
-                    controller_handle,
-                    efi::protocols::device_path::PROTOCOL_GUID,
-                    Some(driver_handle),
-                    Some(handle1),
-                    efi::OPEN_PROTOCOL_BY_DRIVER,
-                )
-                .unwrap();
-
-            // Add all three child handles as managed by this driver
-            PROTOCOL_DB
-                .add_protocol_usage(
-                    controller_handle,
-                    efi::protocols::device_path::PROTOCOL_GUID,
-                    Some(driver_handle),
-                    Some(child_handle_a),
-                    efi::OPEN_PROTOCOL_BY_CHILD_CONTROLLER,
-                )
-                .unwrap();
-
-            PROTOCOL_DB
-                .add_protocol_usage(
-                    controller_handle,
-                    efi::protocols::device_path::PROTOCOL_GUID,
-                    Some(driver_handle),
-                    Some(child_handle_b),
-                    efi::OPEN_PROTOCOL_BY_CHILD_CONTROLLER,
-                )
-                .unwrap();
-
-            PROTOCOL_DB
-                .add_protocol_usage(
-                    controller_handle,
-                    efi::protocols::device_path::PROTOCOL_GUID,
-                    Some(driver_handle),
-                    Some(child_handle_c),
-                    efi::OPEN_PROTOCOL_BY_CHILD_CONTROLLER,
-                )
-                .unwrap();
+            // A single driver manages the controller with three children.
+            setup_driver_managing_controller(
+                controller_handle,
+                efi::protocols::device_path::PROTOCOL_GUID,
+                mock_stop_tracking,
+                &[child_handle_a, child_handle_b, child_handle_c],
+            );
 
             CHILD_STOP_CALLS.store(0, Ordering::SeqCst);
             DRIVER_STOP_CALLS.store(0, Ordering::SeqCst);
 
-            // Disconnect only child_handle_a (one of the three children)
-            // Because total_children != child_handles.len(), the driver should not be fully stopped
+            // Disconnect only child_handle_a (one of the three children). Because
+            // total_children != child_handles.len(), the driver is not fully stopped.
             // SAFETY: No concurrent driver unload occurs in this single-threaded test. The
             // driver binding remains valid for the duration of the call.
             let result = unsafe { core_disconnect_controller(controller_handle, None, Some(child_handle_a)) };
@@ -2156,20 +2005,21 @@ mod tests {
                 efi::Status::SUCCESS
             }
 
-            // Arbitrary valid handle recorded in the controller field of the BY_DRIVER usages.
-            let guid1 = patina::Guid::from_string("0e896c7a-57dc-4987-bc22-abc3a8263210");
-            let (handle1, _) =
-                PROTOCOL_DB.install_protocol_interface(None, guid1.to_efi_guid(), 0x1234 as *mut c_void).unwrap();
+            let controller_handle = new_test_handle(0x1111);
+            let child_a = new_test_handle(0x4444);
+            let child_b = new_test_handle(0x5555);
+            let orphan_child = new_test_handle(0x6666);
 
-            // Controller managed by both drivers. Driver A opens the device path protocol BY_DRIVER.
-            // Driver B opens a second protocol BY_DRIVER, because BY_DRIVER is exclusive per protocol interface.
-            let (controller_handle, _) = PROTOCOL_DB
-                .install_protocol_interface(
-                    None,
-                    efi::protocols::device_path::PROTOCOL_GUID,
-                    0x1111 as *mut core::ffi::c_void,
-                )
-                .unwrap();
+            // Both drivers manage the controller. Driver A opens the device path protocol BY_DRIVER.
+            // Driver B opens a second protocol BY_DRIVER, because BY_DRIVER is exclusive per protocol
+            // interface. Driver A owns child_a and driver B owns child_b and neither owns orphan_child.
+            setup_driver_managing_controller(
+                controller_handle,
+                efi::protocols::device_path::PROTOCOL_GUID,
+                mock_stop_driver_a,
+                &[child_a],
+            );
+
             let driver_b_protocol = patina::Guid::from_string("2f7d3b1e-9c4a-4f8b-8a2d-1e6c5b4a3f21");
             PROTOCOL_DB
                 .install_protocol_interface(
@@ -2178,119 +2028,12 @@ mod tests {
                     0x2211 as *mut core::ffi::c_void,
                 )
                 .unwrap();
-
-            // Driver handles.
-            let (driver_a_handle, _) = PROTOCOL_DB
-                .install_protocol_interface(
-                    None,
-                    efi::protocols::device_path::PROTOCOL_GUID,
-                    0x2222 as *mut core::ffi::c_void,
-                )
-                .unwrap();
-            let (driver_b_handle, _) = PROTOCOL_DB
-                .install_protocol_interface(
-                    None,
-                    efi::protocols::device_path::PROTOCOL_GUID,
-                    0x3333 as *mut core::ffi::c_void,
-                )
-                .unwrap();
-
-            // Child handles: child_a owned by driver A, child_b owned by driver B, and orphan_child
-            // owned by neither driver (this is the handle that will be requested for disconnect).
-            let (child_a, _) = PROTOCOL_DB
-                .install_protocol_interface(
-                    None,
-                    efi::protocols::device_path::PROTOCOL_GUID,
-                    0x4444 as *mut core::ffi::c_void,
-                )
-                .unwrap();
-            let (child_b, _) = PROTOCOL_DB
-                .install_protocol_interface(
-                    None,
-                    efi::protocols::device_path::PROTOCOL_GUID,
-                    0x5555 as *mut core::ffi::c_void,
-                )
-                .unwrap();
-            let (orphan_child, _) = PROTOCOL_DB
-                .install_protocol_interface(
-                    None,
-                    efi::protocols::device_path::PROTOCOL_GUID,
-                    0x6666 as *mut core::ffi::c_void,
-                )
-                .unwrap();
-
-            // Install both driver binding protocols.
-            let binding_a = Box::new(efi::protocols::driver_binding::Protocol {
-                version: 10,
-                supported: mock_supported_success,
-                start: mock_start_success,
-                stop: mock_stop_driver_a,
-                driver_binding_handle: driver_a_handle,
-                image_handle: DXE_CORE_HANDLE,
-            });
-            PROTOCOL_DB
-                .install_protocol_interface(
-                    Some(driver_a_handle),
-                    efi::protocols::driver_binding::PROTOCOL_GUID,
-                    Box::into_raw(binding_a) as *mut core::ffi::c_void,
-                )
-                .unwrap();
-
-            let binding_b = Box::new(efi::protocols::driver_binding::Protocol {
-                version: 10,
-                supported: mock_supported_success,
-                start: mock_start_success,
-                stop: mock_stop_driver_b,
-                driver_binding_handle: driver_b_handle,
-                image_handle: DXE_CORE_HANDLE,
-            });
-            PROTOCOL_DB
-                .install_protocol_interface(
-                    Some(driver_b_handle),
-                    efi::protocols::driver_binding::PROTOCOL_GUID,
-                    Box::into_raw(binding_b) as *mut core::ffi::c_void,
-                )
-                .unwrap();
-
-            // Driver A manages the controller (BY_DRIVER on the device path protocol) with child_a.
-            PROTOCOL_DB
-                .add_protocol_usage(
-                    controller_handle,
-                    efi::protocols::device_path::PROTOCOL_GUID,
-                    Some(driver_a_handle),
-                    Some(handle1),
-                    efi::OPEN_PROTOCOL_BY_DRIVER,
-                )
-                .unwrap();
-            PROTOCOL_DB
-                .add_protocol_usage(
-                    controller_handle,
-                    efi::protocols::device_path::PROTOCOL_GUID,
-                    Some(driver_a_handle),
-                    Some(child_a),
-                    efi::OPEN_PROTOCOL_BY_CHILD_CONTROLLER,
-                )
-                .unwrap();
-
-            // Driver B manages the controller (BY_DRIVER on the second protocol) with child_b.
-            PROTOCOL_DB
-                .add_protocol_usage(
-                    controller_handle,
-                    driver_b_protocol.to_efi_guid(),
-                    Some(driver_b_handle),
-                    Some(handle1),
-                    efi::OPEN_PROTOCOL_BY_DRIVER,
-                )
-                .unwrap();
-            PROTOCOL_DB
-                .add_protocol_usage(
-                    controller_handle,
-                    driver_b_protocol.to_efi_guid(),
-                    Some(driver_b_handle),
-                    Some(child_b),
-                    efi::OPEN_PROTOCOL_BY_CHILD_CONTROLLER,
-                )
-                .unwrap();
+            setup_driver_managing_controller(
+                controller_handle,
+                driver_b_protocol.to_efi_guid(),
+                mock_stop_driver_b,
+                &[child_b],
+            );
 
             A_STOP_CALLS.store(0, Ordering::SeqCst);
             B_STOP_CALLS.store(0, Ordering::SeqCst);
@@ -2307,7 +2050,7 @@ mod tests {
 
             // Neither driver owns the requested child, so neither stop function may be called.
             assert_eq!(A_STOP_CALLS.load(Ordering::SeqCst), 0, "Driver A should be skipped. It does not own the child");
-            assert_eq!(B_STOP_CALLS.load(Ordering::SeqCst), 0, "Driver B should be skipped.t does not own the child");
+            assert_eq!(B_STOP_CALLS.load(Ordering::SeqCst), 0, "Driver B should be skipped. It does not own the child");
         });
     }
 


### PR DESCRIPTION
## Description

The first commit is the actual change and the second consolidates and cleans up related test code.

---

**Update child handle validation in core_disconnect_controller()**

Previously, when a specific child handle was requested but was not a
child created by a driver managing the controller, that driver was not
skipped. When the driver had no children its `Stop()` was still
invoked, and the function reported success even though nothing was
disconnected.

This change:

1. Skips a driver when a specific child handle is requested but is not
   present in that driver's child list (checked via `child_handles`
   being empty after filtering). When no managing driver owns the
   child, the call returns `NotFound`.

2. Uses `total_children == child_handles.len()` to detect that the
   requested child was the driver's only child, in which case the
   driver itself is disconnected (`Stop()` with zero children). This
   matches the UEFI spec's "if ChildHandle is the only child ... the
   driver will be disconnected" behavior.

Three unit tests are added:

- `test_disconnect_specific_child_not_managed_by_driver()`: Checks
  that a specific child not owned by the single managing driver
  returns `NotFound` and `Stop()` is never called.

- `test_disconnect_specific_child_among_multiple_children()`: Checks
  that a specific child among several is destroyed (`Stop()` called
  with that one child) while the driver-level `Stop()` is not called,
  so the driver stays connected.

- `test_disconnect_specific_child_not_owned_by_either_driver()`: Checks
  that when two drivers are managing the controller and a child owned
  by neither is requested, that both drivers are skipped and `NotFound`
  is returned.

Note: `EFI_NOT_FOUND` is not listed as a return value in for
`DisconnectController()` in the UEFI 2.11 spec (section 7.3.13), but
returning it when the requested child is unmanaged matches EDK II
behavior.

---

**patina_dxe_core: Consolidate disconnect controller test setup logic**

The child-specific `core_disconnect_controller()` tests each repeated
a lot of related logic to install a driver binding, mark the driver as
managing the controller, and register its children.

This commit adds two test helpers, `new_test_handle()` and
`setup_driver_managing_controller()` to reduce the overall size of
test functions.

---

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [x] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

- Run all unit tests
- Check that `test_disconnect_specific_child_not_managed_by_driver()` fails without the change and passes with it
- QEMU boot to EFI shell

## Integration Instructions

- N/A