### PR TITLE
Makefile.toml: Clean Coverage Artifacts Before Running Coverage

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -143,13 +143,20 @@ private = true
 command = "cargo"
 args = ["generate-lockfile"]
 
+[tasks.llvm-cov-clean]
+description = "Clean coverage data"
+private = true
+install_crate = false
+command = "cargo"
+args = ["llvm-cov", "clean", "--workspace"]
+
 [tasks.test]
 description = "Run tests and collect coverage data without generating reports."
 install_crate = false
 clear = true
 command = "cargo"
 args = ["llvm-cov", "@@split(COV_FLAGS, )", "--no-report"]
-dependencies = ["individual-package-targets"]
+dependencies = ["individual-package-targets", "llvm-cov-clean"]
 
 [tasks.coverage-lcov]
 description = "Generate an LCOV coverage report from collected data."


### PR DESCRIPTION
## Description

cargo-llvm-cov automatically cleans coverage artifacts before running in order to have accurate coverage results. However, if --no-report is passed, it does not automatically clean the coverage artifacts.

<img width="868" height="119" alt="image" src="https://github.com/user-attachments/assets/02e18922-08c7-49ba-9596-22c869b292eb" />


Commit da004c7e5b942660c9b0b15b788af3a31ea18434 added --no-report to cargo-llvm-cov when refactoring the report output, but did not add a call to cargo llvm-cov clean first. This is fine for CI builds, but for local runs, it will produce inaccurate coverage if there are existing coverage artifacts.

This fixes that by ensuring cargo llvm-cov clean is called first.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Tested with `cargo make coverage` locally showing bad results and this fixing it.

## Integration Instructions

N/A.
