### PR TITLE
Replace AtomicPtr with Cell in patina_internal_collections.

### DIFF
--- a/core/patina_internal_collections/src/bst.rs
+++ b/core/patina_internal_collections/src/bst.rs
@@ -8,10 +8,7 @@
 //!
 #[cfg(feature = "alloc")]
 extern crate alloc;
-use core::{
-    cmp::Ordering,
-    sync::atomic::{self, AtomicPtr},
-};
+use core::{cell::Cell, cmp::Ordering};
 
 use crate::{
     Error, Result, SliceKey,
@@ -24,7 +21,7 @@ where
     D: SliceKey,
 {
     storage: Storage<'a, D>,
-    root: AtomicPtr<Node<D>>,
+    root: Cell<*mut Node<D>>,
 }
 
 impl<'a, D> Bst<'a, D>
@@ -37,12 +34,12 @@ where
     /// [with_capacity](Self::with_capacity) to create a tree with a given slice of memory immediately. Otherwise use
     /// [resize](Self::resize) to replace the memory later.
     pub const fn new() -> Self {
-        Bst { storage: Storage::new(), root: AtomicPtr::new(core::ptr::null_mut()) }
+        Bst { storage: Storage::new(), root: Cell::new(core::ptr::null_mut()) }
     }
 
     /// Creates a new binary tree with a given slice of memory.
     pub fn with_capacity(slice: &'a mut [u8]) -> Self {
-        Self { storage: Storage::with_capacity(slice), root: AtomicPtr::default() }
+        Self { storage: Storage::with_capacity(slice), root: Cell::default() }
     }
 
     /// Returns the number of elements in the tree.
@@ -68,11 +65,9 @@ where
 
     /// Returns the current root of the tree.
     fn root(&self) -> Option<&Node<D>> {
-        let root_ptr = self.root.load(atomic::Ordering::SeqCst);
-
         // SAFETY: The root pointer is either null or points to a valid Node<D> allocated in self.storage.
         // as_ref() handles the null check internally.
-        unsafe { root_ptr.as_ref() }
+        unsafe { self.root.get().as_ref() }
     }
 
     /// Adds a value into the tree.
@@ -90,14 +85,14 @@ where
     pub fn add(&mut self, data: D) -> Result<usize> {
         let (idx, node) = self.storage.add(data)?;
 
-        if self.root.load(atomic::Ordering::SeqCst).is_null() {
-            self.root.store(node.as_mut_ptr(), atomic::Ordering::SeqCst);
+        if self.root.get().is_null() {
+            self.root.set(node.as_mut_ptr());
             return Ok(idx);
         }
 
         // SAFETY: root was checked for null above. The pointer points to a valid Node<D>
         // allocated in self.storage.
-        let root = unsafe { &*self.root.load(atomic::Ordering::SeqCst) };
+        let root = unsafe { self.root.get().as_mut().expect("root is not null") };
         Self::add_node(root, node)?;
         Ok(idx)
     }
@@ -552,18 +547,18 @@ where
     }
 
     /// Removes a node in the tree.
-    fn remove_node_from_tree<'b>(root: &'b AtomicPtr<Node<D>>, to_delete: &'b Node<D>) {
+    fn remove_node_from_tree<'b>(root: &'b Cell<*mut Node<D>>, to_delete: &'b Node<D>) {
         if to_delete.left().is_none() || to_delete.right().is_none() {
             let moved_up = Self::remove_node_with_zero_or_one_child(to_delete);
             if to_delete.parent().is_none() {
-                root.store(moved_up.as_mut_ptr(), atomic::Ordering::SeqCst);
+                root.set(moved_up.as_mut_ptr());
                 moved_up.set_parent(None);
             }
         } else {
             let successor = Node::successor(to_delete).expect("to_delete has both children");
             Node::swap(to_delete, successor);
             if successor.parent().is_none() {
-                root.store(successor.as_mut_ptr(), atomic::Ordering::SeqCst);
+                root.set(successor.as_mut_ptr());
                 successor.set_parent(None);
             }
             let _ = Self::remove_node_with_zero_or_one_child(to_delete);
@@ -619,13 +614,12 @@ where
 {
     /// Replaces the memory of the tree with a new slice, copying the data from the old slice to the new slice.
     pub fn resize(&mut self, slice: &'a mut [u8]) {
-        let root = (!self.root.load(atomic::Ordering::SeqCst).is_null())
-            .then(|| self.storage.idx(self.root.load(atomic::Ordering::SeqCst)));
+        let root = { if self.root.get().is_null() { None } else { Some(self.storage.idx(self.root.get())) } };
 
         self.storage.resize(slice);
 
         if let Some(idx) = root {
-            self.root.store(self.storage.get_mut(idx).expect("Pointer Exists."), atomic::Ordering::SeqCst);
+            self.root.set(self.storage.get_mut(idx).expect("Pointer Exists."));
         }
     }
 

--- a/core/patina_internal_collections/src/node.rs
+++ b/core/patina_internal_collections/src/node.rs
@@ -6,12 +6,7 @@
 //!
 //! SPDX-License-Identifier: Apache-2.0
 //!
-use core::{
-    mem,
-    ptr::NonNull,
-    slice,
-    sync::atomic::{AtomicBool, AtomicPtr, Ordering},
-};
+use core::{cell::Cell, mem, ptr::NonNull, slice};
 
 use crate::{Error, Result, SliceKey};
 
@@ -35,7 +30,7 @@ where
     /// The number of nodes in the tree.
     length: usize,
     /// A linked list of free nodes in the storage container.
-    available: AtomicPtr<Node<D>>,
+    available: Cell<*mut Node<D>>,
 }
 
 impl<'a, D> Storage<'a, D>
@@ -50,7 +45,7 @@ where
             // no invalid memory accesses occur.
             data: unsafe { slice::from_raw_parts_mut(ptr.as_ptr(), 0) },
             length: 0,
-            available: AtomicPtr::new(core::ptr::null_mut()),
+            available: Cell::new(core::ptr::null_mut()),
         }
     }
 
@@ -68,11 +63,11 @@ where
                 )
             },
             length: 0,
-            available: AtomicPtr::default(),
+            available: Cell::default(),
         };
 
         Self::build_linked_list(storage.data);
-        storage.available.store(storage.data[0].as_mut_ptr(), Ordering::SeqCst);
+        storage.available.set(storage.data[0].as_mut_ptr());
         storage
     }
 
@@ -102,11 +97,11 @@ where
     /// O(1)
     ///
     pub fn add(&mut self, data: D) -> Result<(usize, &mut Node<D>)> {
-        let available_ptr = self.available.load(Ordering::SeqCst);
+        let available_ptr = self.available.get();
         if !available_ptr.is_null() && self.length != self.capacity() {
             // SAFETY: available_ptr is checked to be non-null and points to a valid Node<D> in self.data.
             let node = unsafe { &mut *available_ptr };
-            self.available.store(node.right_ptr(), Ordering::SeqCst);
+            self.available.set(node.right_ptr());
             node.set_left(None);
             node.set_right(None);
             node.set_parent(None);
@@ -134,7 +129,7 @@ where
         let node = unsafe { &mut *node };
         node.set_parent(None);
         node.set_left(None);
-        let available_ptr = self.available.load(Ordering::SeqCst);
+        let available_ptr = self.available.get();
         if !available_ptr.is_null() {
             // SAFETY: available_ptr is non-null and points to the head of our free list,
             // which contains valid Node<D> pointers from self.data.
@@ -145,7 +140,7 @@ where
             node.set_right(None);
         }
 
-        self.available.store(node.as_mut_ptr(), Ordering::SeqCst);
+        self.available.set(node.as_mut_ptr());
         self.length -= 1;
     }
 
@@ -210,7 +205,7 @@ where
         if self.capacity() == 0 {
             self.data = buffer;
             Self::build_linked_list(self.data);
-            self.available.store(self.data[0].as_mut_ptr(), Ordering::SeqCst);
+            self.available.set(self.data[0].as_mut_ptr());
             return;
         }
 
@@ -243,14 +238,10 @@ where
             }
         }
 
-        let idx = if !self.available.load(Ordering::SeqCst).is_null() {
-            self.idx(self.available.load(Ordering::SeqCst))
-        } else {
-            self.len()
-        };
+        let idx = if !self.available.get().is_null() { self.idx(self.available.get()) } else { self.len() };
 
         Self::build_linked_list(&buffer[idx..]);
-        self.available.store(buffer[idx].as_mut_ptr(), Ordering::SeqCst);
+        self.available.set(buffer[idx].as_mut_ptr());
 
         self.data = buffer;
     }
@@ -291,89 +282,80 @@ where
     D: SliceKey,
 {
     fn set_color(&self, color: bool) {
-        self.color.store(color, Ordering::SeqCst);
+        self.color.set(color);
     }
 
     fn is_red(&self) -> bool {
-        self.color.load(Ordering::SeqCst) == RED
+        self.color.get() == RED
     }
 
     fn is_black(&self) -> bool {
-        self.color.load(Ordering::SeqCst) == BLACK
+        self.color.get() == BLACK
     }
 
     fn color(&self) -> bool {
-        self.color.load(Ordering::SeqCst)
+        self.color.get()
     }
 
     fn parent(&self) -> Option<&Node<D>> {
-        let node = self.parent.load(Ordering::SeqCst);
-        match node.is_null() {
-            true => None,
-            // SAFETY: If the pointer is not null, it points to a valid Node<D> in the storage.
-            false => Some(unsafe { &*node }),
-        }
+        let node = self.parent.get();
+        // SAFETY: If the pointer is not null, it points to a valid Node<D> in the storage.
+        unsafe { node.as_ref() }
     }
 
     fn parent_ptr(&self) -> *mut Node<D> {
-        self.parent.load(Ordering::SeqCst)
+        self.parent.get()
     }
 
     fn set_parent(&self, node: Option<&Node<D>>) {
         match node {
             None => {
-                self.parent.store(core::ptr::null_mut(), Ordering::SeqCst);
+                self.parent.set(core::ptr::null_mut());
             }
             Some(node) => {
-                self.parent.store(node.as_mut_ptr(), Ordering::SeqCst);
+                self.parent.set(node.as_mut_ptr());
             }
         }
     }
 
     fn left(&self) -> Option<&Node<D>> {
-        let node = self.left.load(Ordering::SeqCst);
-        match node.is_null() {
-            true => None,
-            // SAFETY: If the pointer is not null, it points to a valid Node<D> in the storage.
-            false => Some(unsafe { &*node }),
-        }
+        let node = self.left.get();
+        // SAFETY: If the pointer is not null, it points to a valid Node<D> in the storage.
+        unsafe { node.as_ref() }
     }
 
     fn left_ptr(&self) -> *mut Node<D> {
-        self.left.load(Ordering::SeqCst)
+        self.left.get()
     }
 
     fn set_left(&self, node: Option<&Node<D>>) {
         match node {
             None => {
-                self.left.store(core::ptr::null_mut(), Ordering::SeqCst);
+                self.left.set(core::ptr::null_mut());
             }
             Some(node) => {
-                self.left.store(node.as_mut_ptr(), Ordering::SeqCst);
+                self.left.set(node.as_mut_ptr());
             }
         }
     }
 
     fn right(&self) -> Option<&Node<D>> {
-        let node = self.right.load(Ordering::SeqCst);
-        match node.is_null() {
-            true => None,
-            // SAFETY: If the pointer is not null, it points to a valid Node<D> in the storage.
-            false => Some(unsafe { &*node }),
-        }
+        let node = self.right.get();
+        // SAFETY: If the pointer is not null, it points to a valid Node<D> in the storage.
+        unsafe { node.as_ref() }
     }
 
     fn right_ptr(&self) -> *mut Node<D> {
-        self.right.load(Ordering::SeqCst)
+        self.right.get()
     }
 
     fn set_right(&self, node: Option<&Node<D>>) {
         match node {
             None => {
-                self.right.store(core::ptr::null_mut(), Ordering::SeqCst);
+                self.right.set(core::ptr::null_mut());
             }
             Some(node) => {
-                self.right.store(node.as_mut_ptr(), Ordering::SeqCst);
+                self.right.set(node.as_mut_ptr());
             }
         }
     }
@@ -479,10 +461,10 @@ where
     D: SliceKey,
 {
     pub data: D,
-    color: AtomicBool,
-    parent: AtomicPtr<Node<D>>,
-    left: AtomicPtr<Node<D>>,
-    right: AtomicPtr<Node<D>>,
+    color: Cell<bool>,
+    parent: Cell<*mut Node<D>>,
+    left: Cell<*mut Node<D>>,
+    right: Cell<*mut Node<D>>,
 }
 
 impl<D> Node<D>
@@ -490,13 +472,7 @@ where
     D: SliceKey,
 {
     pub fn new(data: D) -> Self {
-        Node {
-            data,
-            color: AtomicBool::new(RED),
-            parent: AtomicPtr::default(),
-            left: AtomicPtr::default(),
-            right: AtomicPtr::default(),
-        }
+        Node { data, color: Cell::new(RED), parent: Cell::default(), left: Cell::default(), right: Cell::default() }
     }
 
     pub fn height_and_balance(node: Option<&Node<D>>) -> (i32, bool) {
@@ -554,24 +530,24 @@ where
         }
 
         // Swap the colors
-        let tmp_color = node1.color.load(Ordering::SeqCst);
-        node1.color.store(node2.color.load(Ordering::SeqCst), Ordering::SeqCst);
-        node2.color.store(tmp_color, Ordering::SeqCst);
+        let tmp_color = node1.color.get();
+        node1.color.set(node2.color.get());
+        node2.color.set(tmp_color);
 
         // Swap the parent pointers
-        let tmp_parent = node1.parent.load(Ordering::SeqCst);
-        node1.parent.store(node2.parent.load(Ordering::SeqCst), Ordering::SeqCst);
-        node2.parent.store(tmp_parent, Ordering::SeqCst);
+        let tmp_parent = node1.parent.get();
+        node1.parent.set(node2.parent.get());
+        node2.parent.set(tmp_parent);
 
         // Swap the left pointers
-        let tmp_left = node1.left.load(Ordering::SeqCst);
-        node1.left.store(node2.left.load(Ordering::SeqCst), Ordering::SeqCst);
-        node2.left.store(tmp_left, Ordering::SeqCst);
+        let tmp_left = node1.left.get();
+        node1.left.set(node2.left.get());
+        node2.left.set(tmp_left);
 
         // Swap the right pointers
-        let tmp_right = node1.right.load(Ordering::SeqCst);
-        node1.right.store(node2.right.load(Ordering::SeqCst), Ordering::SeqCst);
-        node2.right.store(tmp_right, Ordering::SeqCst);
+        let tmp_right = node1.right.get();
+        node1.right.set(node2.right.get());
+        node2.right.set(tmp_right);
 
         // Update the parent pointers of the children
         if let Some(left) = node1.left() {


### PR DESCRIPTION
## Description

Switch internal collections implementation to `Cell` from `AtomicPtr` pursuant to RFC 0021 (https://github.com/OpenDevicePartnership/patina/pull/1036)


- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Boot-tested on platform hardware, measured performance delta (no regression, but no marked improvement performance-wise). 

## Integration Instructions

N/A
