### PR TITLE
config_tables: Use zerocopy crate to reduce unsafe code blocks

### DIFF
--- a/patina_dxe_core/Cargo.toml
+++ b/patina_dxe_core/Cargo.toml
@@ -36,6 +36,7 @@ patina_debugger = { workspace = true }
 patina_internal_device_path = { workspace = true }
 patina_internal_depex = { workspace = true}
 patina_performance = { workspace = true }
+zerocopy = { workspace = true, features = ["derive"] }
 
 [dev-dependencies]
 # To avoid circular dependencies, cargo-release skips dev dependencies when evaluating the release order for


### PR DESCRIPTION
Please see issue #893 for _why_ this change was needed.

I'm marking this as draft because I have some cleanup to do, but to give early visibility in case I've done something obviously dumb, I'm raising the draft PR anyways.