### PR TITLE
Bugfix for TPL change vs. interrupt enable

### DIFF
--- a/patina_dxe_core/src/events.rs
+++ b/patina_dxe_core/src/events.rs
@@ -281,10 +281,11 @@ pub extern "efiapi" fn restore_tpl(new_tpl: efi::Tpl) {
         }
     }
 
+    CURRENT_TPL.store(new_tpl, Ordering::SeqCst);
+
     if new_tpl < efi::TPL_HIGH_LEVEL {
         interrupts::enable_interrupts();
     }
-    CURRENT_TPL.store(new_tpl, Ordering::SeqCst);
 }
 
 extern "efiapi" fn timer_tick(time: u64) {


### PR DESCRIPTION
## Description

Bugfix: ensure that new TPL is written before enabling interrupts to avoid a scenario where an interrupt occurs and observe CURRENT_TPL in previous TPL state. 

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Booted aarch64 hardware. 

## Integration Instructions

N/A