### PR TITLE
Update zerocopy derive imports

### DIFF
--- a/components/patina_mm/tests/patina_mm_integration/common/handlers.rs
+++ b/components/patina_mm/tests/patina_mm_integration/common/handlers.rs
@@ -21,7 +21,7 @@ use crate::patina_mm_integration::common::constants::*;
 extern crate alloc;
 use alloc::{string::String, vec::Vec};
 use zerocopy::{FromBytes, IntoBytes};
-use zerocopy_derive::{FromBytes as DeriveFromBytes, Immutable, IntoBytes as DeriveIntoBytes};
+use zerocopy_derive::*;
 
 /// Standardized error type for MM handlers
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -110,7 +110,7 @@ impl MmHandler for VersionInfoHandler {
 }
 
 /// MM Supervisor request header
-#[derive(Debug, Clone, Copy, DeriveIntoBytes, DeriveFromBytes, Immutable)]
+#[derive(Debug, Clone, Copy, IntoBytes, FromBytes, Immutable)]
 #[repr(C)]
 pub struct MmSupervisorRequestHeader {
     pub signature: u32,
@@ -141,7 +141,7 @@ impl MmSupervisorRequestHeader {
 }
 
 /// MM Supervisor version information
-#[derive(Debug, Clone, Copy, DeriveIntoBytes, DeriveFromBytes, Immutable)]
+#[derive(Debug, Clone, Copy, IntoBytes, FromBytes, Immutable)]
 #[repr(C)]
 pub struct MmSupervisorVersionInfo {
     pub version: u32,

--- a/components/patina_smbios/src/manager/core.rs
+++ b/components/patina_smbios/src/manager/core.rs
@@ -24,7 +24,7 @@ use r_efi::{
     efi::{Handle, PhysicalAddress},
 };
 use zerocopy::{IntoBytes, Ref};
-use zerocopy_derive::{Immutable, IntoBytes as DeriveIntoBytes};
+use zerocopy_derive::*;
 
 use crate::{
     error::SmbiosError,
@@ -47,7 +47,7 @@ pub const SMBIOS_3_X_TABLE_GUID: efi::Guid =
 /// SMBIOS 3.0 entry point structure (64-bit)
 /// Per SMBIOS 3.0+ specification section 5.2.2
 #[repr(C, packed)]
-#[derive(Clone, Copy, DeriveIntoBytes, Immutable)]
+#[derive(Clone, Copy, IntoBytes, Immutable)]
 pub struct Smbios30EntryPoint {
     /// Anchor string "_SM3_" (0x00)
     pub anchor_string: [u8; 5],

--- a/components/patina_smbios/src/service.rs
+++ b/components/patina_smbios/src/service.rs
@@ -14,7 +14,8 @@ extern crate alloc;
 use alloc::vec::Vec;
 use core::cell::Ref;
 use r_efi::efi::Handle;
-use zerocopy_derive::{FromBytes, Immutable, IntoBytes as DeriveIntoBytes, KnownLayout};
+use zerocopy::IntoBytes;
+use zerocopy_derive::*;
 
 #[cfg(any(test, feature = "mockall"))]
 use mockall::automock;
@@ -36,7 +37,7 @@ pub const SMBIOS_STRING_MAX_LENGTH: usize = 64;
 /// This is the standard 4-byte header that appears at the start of every SMBIOS record.
 /// It contains the record type, length of structured data, and a unique handle.
 #[repr(C, packed)]
-#[derive(Debug, Clone, PartialEq, FromBytes, DeriveIntoBytes, Immutable, KnownLayout)]
+#[derive(Debug, Clone, PartialEq, FromBytes, IntoBytes, Immutable, KnownLayout)]
 pub struct SmbiosTableHeader {
     /// SMBIOS record type
     pub record_type: SmbiosType,
@@ -182,7 +183,7 @@ pub trait Smbios {
 /// ) -> Result<()> {
 ///     // Add structured records using generic extension method
 ///     smbios.add_record(None, &bios_info)?;
-///     
+///
 ///     // Publish to configuration table
 ///     smbios.publish_table()?;
 ///     Ok(())

--- a/sdk/patina/src/performance/record.rs
+++ b/sdk/patina/src/performance/record.rs
@@ -15,7 +15,8 @@ use crate::{BinaryGuid, performance::error::Error, performance_debug_assert};
 use alloc::vec::Vec;
 use core::{fmt, fmt::Debug, mem};
 use scroll::Pread;
-use zerocopy::{FromBytes, Immutable, IntoBytes};
+use zerocopy::{FromBytes, IntoBytes};
+use zerocopy_derive::*;
 
 /// Maximum size in byte that a performance record can have.
 pub const FPDT_MAX_PERF_RECORD_SIZE: usize = u8::MAX as usize;


### PR DESCRIPTION
## Description

We opted to depend on `zerocopy` and `zerocopy-derive` directly instead of using the re-export of the derive macros in the `zerocopy` crate using the `derives` feature.

In this case, the documentation states:

> derive Provides derives for the core marker traits via the
> zerocopy-derive crate. These derives are re-exported from
> zerocopy, so it is not necessary to depend on zerocopy-derive
> directly.
>
> However, you may experience better compile times if you instead
> directly depend on both zerocopy and zerocopy-derive in your
> Cargo.toml, since doing so will allow Rust to compile these crates
> in parallel. To do so, do not enable the derive feature, and list
> both dependencies in your Cargo.toml with the same leading non-zero
> version number; e.g:
>
> [dependencies]
> zerocopy = "0.X"
> zerocopy-derive = "0.X"
>
> To avoid the risk of duplicate import errors if one of your
> dependencies enables zerocopy’s derive feature, import derives as
> use zerocopy_derive::* rather than by name
> (e.g., use zerocopy_derive::FromBytes).

From: https://docs.rs/zerocopy/latest/zerocopy/#cargo-features

This follows the advice there to import derives from `zerocopy_derive` using a wildcard.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

- `cargo make all`

## Integration Instructions

- N/A