### PR TITLE
Additional zerocopy_derive imports

### DIFF
--- a/components/patina_mm/src/config.rs
+++ b/components/patina_mm/src/config.rs
@@ -24,7 +24,7 @@ use core::{fmt, pin::Pin, ptr::NonNull};
 
 use patina::{Guid, base::UEFI_PAGE_MASK};
 use r_efi::efi;
-use zerocopy::{FromBytes, Immutable, IntoBytes, KnownLayout};
+use zerocopy_derive::*;
 
 /// MM Communication Buffer Status
 ///

--- a/components/patina_mm/src/protocol/mm_comm_buffer_update.rs
+++ b/components/patina_mm/src/protocol/mm_comm_buffer_update.rs
@@ -11,7 +11,7 @@
 //!
 
 use patina::BinaryGuid;
-use zerocopy::{FromBytes, Immutable, IntoBytes, KnownLayout};
+use zerocopy_derive::{FromBytes, Immutable, IntoBytes, KnownLayout};
 
 /// GUID for the MM Communication Buffer Update Protocol
 pub const GUID: BinaryGuid = BinaryGuid::from_string("2a22e38f-9d1c-49d0-bdce-7ddac16da45d");

--- a/components/patina_performance/Cargo.toml
+++ b/components/patina_performance/Cargo.toml
@@ -20,7 +20,7 @@ mu_rust_helpers = { workspace = true }
 patina = { workspace = true }
 patina_internal_device_path = { workspace = true }
 patina_mm = { workspace = true }
-zerocopy = { workspace = true, features = ["derive"] }
+zerocopy = { workspace = true }
 zerocopy-derive = { workspace = true }
 
 [dev-dependencies]

--- a/components/patina_performance/src/mm.rs
+++ b/components/patina_performance/src/mm.rs
@@ -7,7 +7,8 @@
 //! SPDX-License-Identifier: Apache-2.0
 //!
 use r_efi::efi;
-use zerocopy::{FromBytes, Immutable, IntoBytes, LittleEndian, U64};
+use zerocopy::{IntoBytes, LittleEndian, U64};
+use zerocopy_derive::*;
 
 /// Errors that may occur when parsing MM structures.
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/components/patina_smbios/src/service.rs
+++ b/components/patina_smbios/src/service.rs
@@ -14,7 +14,6 @@ extern crate alloc;
 use alloc::vec::Vec;
 use core::cell::Ref;
 use r_efi::efi::Handle;
-use zerocopy::IntoBytes;
 use zerocopy_derive::*;
 
 #[cfg(any(test, feature = "mockall"))]

--- a/docs/src/background/uefi_memory_safety_case_studies.md
+++ b/docs/src/background/uefi_memory_safety_case_studies.md
@@ -90,8 +90,9 @@ Cursor = Dhcp6AppendOption (
 
 ```rust,no_run
 # extern crate zerocopy;
+# extern crate zerocopy_derive;
 use std::marker::PhantomData;
-use zerocopy::{FromBytes, Immutable, KnownLayout};
+use zerocopy_derive::*;
 
 // Type-safe DHCP6 option codes
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -528,7 +529,7 @@ a safe design available to developers:
 # extern crate zerocopy;
 # extern crate zerocopy_derive;
 use std::mem::size_of;
-use zerocopy_derive::{FromBytes, Immutable, KnownLayout};
+use zerocopy_derive::*;
 
 /// DHCPv6 IA option types - prevents option type confusion
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -811,7 +812,7 @@ checking:
 # extern crate zerocopy;
 # extern crate zerocopy_derive;
 use std::mem::size_of;
-use zerocopy_derive::{FromBytes, Immutable, KnownLayout};
+use zerocopy_derive::*;
 
 /// Zero-copy compatible UEFI variable header that matches the C structure layout
 #[derive(Debug, FromBytes, KnownLayout, Immutable)]

--- a/sdk/patina_macro/README.md
+++ b/sdk/patina_macro/README.md
@@ -63,7 +63,7 @@ impl Uart for SerialPort {
 ```rust
 use patina::component::hob::FromHob;
 
-#[derive(FromHob, zerocopy::FromBytes)]
+#[derive(FromHob, zerocopy_derive::FromBytes)]
 #[repr(C)]
 #[hob = "8be4df61-93ca-11d2-aa0d-00e098032b8c"]
 struct FirmwareVolumeHeader {


### PR DESCRIPTION
## Description

Adds more imports to those in e9bcdea.

We opted to depend on `zerocopy` and `zerocopy-derive` directly instead of using the re-export of the derive macros in the `zerocopy` crate using the `derives` feature.

In this case, the documentation states:

> derive Provides derives for the core marker traits via the
> zerocopy-derive crate. These derives are re-exported from
> zerocopy, so it is not necessary to depend on zerocopy-derive
> directly.
>
> However, you may experience better compile times if you instead
> directly depend on both zerocopy and zerocopy-derive in your
> Cargo.toml, since doing so will allow Rust to compile these crates
> in parallel. To do so, do not enable the derive feature, and list
> both dependencies in your Cargo.toml with the same leading non-zero
> version number; e.g:
>
> [dependencies]
> zerocopy = "0.X"
> zerocopy-derive = "0.X"
>
> To avoid the risk of duplicate import errors if one of your
> dependencies enables zerocopy’s derive feature, import derives as
> use zerocopy_derive::* rather than by name
> (e.g., use zerocopy_derive::FromBytes).

From: https://docs.rs/zerocopy/latest/zerocopy/#cargo-features

This follows the advice there to import derives from `zerocopy_derive` using a wildcard.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

- `cargo make all`
- `cargo make build` on each crate

## Integration Instructions

- N/A
