### PR TITLE
Patina Dxe Core: Add a default environment based test logger

### DIFF
--- a/patina_dxe_core/src/allocator.rs
+++ b/patina_dxe_core/src/allocator.rs
@@ -1251,6 +1251,7 @@ mod tests {
     fn with_locked_state<F: Fn() + std::panic::RefUnwindSafe>(gcd_size: usize, f: F) {
         test_support::with_global_lock(|| {
             unsafe {
+                test_support::init_test_logger();
                 test_support::init_test_gcd(Some(gcd_size));
                 test_support::init_test_protocol_db();
                 test_support::reset_allocators();

--- a/patina_dxe_core/src/allocator/fixed_size_block_allocator.rs
+++ b/patina_dxe_core/src/allocator/fixed_size_block_allocator.rs
@@ -897,6 +897,7 @@ mod tests {
 
     fn with_locked_state<F: Fn() + std::panic::RefUnwindSafe>(f: F) {
         test_support::with_global_lock(|| {
+            test_support::init_test_logger();
             f();
         })
         .unwrap();

--- a/patina_dxe_core/src/allocator/uefi_allocator.rs
+++ b/patina_dxe_core/src/allocator/uefi_allocator.rs
@@ -315,6 +315,7 @@ mod tests {
 
     fn with_locked_state<F: Fn() + std::panic::RefUnwindSafe>(f: F) {
         test_support::with_global_lock(|| {
+            test_support::init_test_logger();
             f();
         })
         .unwrap();

--- a/patina_dxe_core/src/allocator/usage_tests/uefi_memory_map.rs
+++ b/patina_dxe_core/src/allocator/usage_tests/uefi_memory_map.rs
@@ -159,24 +159,6 @@ mod tests {
     use serial_test::serial;
     use std::panic::RefUnwindSafe;
 
-    // Logger initialization
-    fn init_logger() {
-        use std::sync::OnceLock;
-        static INIT: OnceLock<()> = OnceLock::new();
-
-        INIT.get_or_init(|| {
-            // Default to no logging unless RUST_LOG environment variable is set
-            let mut builder = env_logger::Builder::from_default_env();
-
-            // If RUST_LOG is not set, default to Off (no logging)
-            if std::env::var("RUST_LOG").is_err() {
-                builder.filter_level(log::LevelFilter::Off);
-            }
-
-            builder.init();
-        });
-    }
-
     /// HOB configuration structures to simplify building test scenarios.
     ///
     /// These simplified configuration structs provide a convenient test API without requiring
@@ -324,6 +306,7 @@ mod tests {
         /// Execute the test scenario and validate results
         pub fn run_test(&self) {
             test_support::with_global_lock(|| {
+                test_support::init_test_logger();
                 let hob_list_ptr = self.build_custom_hob_list();
 
                 // SAFETY: This is a test environment where the initialization order is controlled per
@@ -673,7 +656,6 @@ mod tests {
     #[test]
     #[serial]
     fn test_simple_memory_scenario() {
-        init_logger();
         let scenario = MemoryMapTestScenario::new("Simple Memory Test", SIZE_64MB as u64)
             .with_resource_descriptor(ResourceDescriptorConfig {
                 resource_type: hob::EFI_RESOURCE_SYSTEM_MEMORY,
@@ -695,7 +677,6 @@ mod tests {
     #[test]
     #[serial]
     fn test_mmio_and_memory_scenario() {
-        init_logger();
         let scenario = MemoryMapTestScenario::new("MMIO and Memory Test", SIZE_128MB as u64) // 128MB
             .with_resource_descriptor(ResourceDescriptorConfig {
                 resource_type: hob::EFI_RESOURCE_SYSTEM_MEMORY,
@@ -741,7 +722,6 @@ mod tests {
     #[test]
     #[serial]
     fn test_runtime_services_memory() {
-        init_logger();
         let scenario = MemoryMapTestScenario::new("Runtime Services Test", SIZE_256MB as u64)
             .with_resource_descriptor(ResourceDescriptorConfig {
                 resource_type: hob::EFI_RESOURCE_SYSTEM_MEMORY,
@@ -781,7 +761,6 @@ mod tests {
     #[test]
     #[serial]
     fn test_complex_real_world_hob_scenario() {
-        init_logger();
         let scenario = create_complex_hob_scenario().with_validation(|descriptors| {
             MemoryMapValidation::new()
                 .expect_min_descriptors(5)
@@ -802,7 +781,6 @@ mod tests {
     #[test]
     #[serial]
     fn test_memory_map_descriptor_merging() {
-        init_logger();
         let scenario = MemoryMapTestScenario::new("Descriptor Merging Test", SIZE_128MB as u64)
             .with_resource_descriptor(ResourceDescriptorConfig {
                 resource_type: hob::EFI_RESOURCE_SYSTEM_MEMORY,
@@ -853,7 +831,6 @@ mod tests {
     #[test]
     #[serial]
     fn test_zero_length_allocation() {
-        init_logger();
         let scenario = MemoryMapTestScenario::new("Zero Length Allocation Test", SIZE_64MB as u64)
             .with_resource_descriptor(ResourceDescriptorConfig {
                 resource_type: hob::EFI_RESOURCE_SYSTEM_MEMORY,
@@ -890,7 +867,6 @@ mod tests {
     #[test]
     #[serial]
     fn test_unaligned_memory_allocation() {
-        init_logger();
         let scenario = MemoryMapTestScenario::new("Unaligned Allocation Test", SIZE_64MB as u64)
             .with_resource_descriptor(ResourceDescriptorConfig {
                 resource_type: hob::EFI_RESOURCE_SYSTEM_MEMORY,
@@ -952,7 +928,6 @@ mod tests {
     #[test]
     #[serial]
     fn test_mmio_wo_rt_attribute_is_not_reported() {
-        init_logger();
         let scenario = MemoryMapTestScenario::new("MMIO Without RT Attribute Test", SIZE_64MB as u64)
             .with_resource_descriptor(ResourceDescriptorConfig {
                 resource_type: hob::EFI_RESOURCE_SYSTEM_MEMORY,

--- a/patina_dxe_core/src/cpu/cpu_arch_protocol.rs
+++ b/patina_dxe_core/src/cpu/cpu_arch_protocol.rs
@@ -215,6 +215,8 @@ impl CpuArchProtocolInstaller {
 #[cfg(test)]
 #[coverage(off)]
 mod tests {
+    use crate::test_support;
+
     use super::*;
 
     use mockall::{mock, predicate::*};
@@ -248,6 +250,7 @@ mod tests {
 
     fn with_locked_state<F: Fn() + std::panic::RefUnwindSafe>(f: F) {
         crate::test_support::with_global_lock(|| {
+            test_support::init_test_logger();
             f();
         })
         .unwrap();

--- a/patina_dxe_core/src/driver_services.rs
+++ b/patina_dxe_core/src/driver_services.rs
@@ -553,6 +553,7 @@ mod tests {
     // =================== TEST HELPERS ===================
     fn with_locked_state<F: Fn() + std::panic::RefUnwindSafe>(f: F) {
         test_support::with_global_lock(|| {
+            test_support::init_test_logger();
             unsafe {
                 test_support::init_test_protocol_db();
             }

--- a/patina_dxe_core/src/dxe_services.rs
+++ b/patina_dxe_core/src/dxe_services.rs
@@ -490,6 +490,7 @@ mod tests {
 
     fn with_locked_state<F: Fn() + std::panic::RefUnwindSafe>(f: F) {
         test_support::with_global_lock(|| {
+            test_support::init_test_logger();
             unsafe {
                 crate::test_support::init_test_gcd(None);
                 crate::test_support::init_test_protocol_db();

--- a/patina_dxe_core/src/event_db.rs
+++ b/patina_dxe_core/src/event_db.rs
@@ -830,6 +830,7 @@ mod tests {
 
     fn with_locked_state<F: Fn() + std::panic::RefUnwindSafe>(f: F) {
         test_support::with_global_lock(|| {
+            test_support::init_test_logger();
             f();
         })
         .unwrap();

--- a/patina_dxe_core/src/events.rs
+++ b/patina_dxe_core/src/events.rs
@@ -355,6 +355,7 @@ mod tests {
 
     fn with_locked_state<F: Fn() + std::panic::RefUnwindSafe>(f: F) {
         test_support::with_global_lock(|| {
+            test_support::init_test_logger();
             unsafe {
                 crate::test_support::init_test_gcd(None);
                 crate::test_support::reset_allocators();

--- a/patina_dxe_core/src/gcd.rs
+++ b/patina_dxe_core/src/gcd.rs
@@ -711,6 +711,7 @@ mod tests {
 
     fn with_locked_state<F: Fn() + std::panic::RefUnwindSafe>(f: F) {
         test_support::with_global_lock(|| {
+            test_support::init_test_logger();
             // SAFETY: Test code - resetting the global GCD state for test isolation.
             // The test lock is used to prevent concurrent access.
             unsafe {

--- a/patina_dxe_core/src/gcd/spin_locked_gcd.rs
+++ b/patina_dxe_core/src/gcd/spin_locked_gcd.rs
@@ -2977,6 +2977,7 @@ mod tests {
 
     fn with_locked_state<F: Fn() + std::panic::RefUnwindSafe>(f: F) {
         test_support::with_global_lock(|| {
+            test_support::init_test_logger();
             f();
         })
         .unwrap();

--- a/patina_dxe_core/src/image.rs
+++ b/patina_dxe_core/src/image.rs
@@ -2651,10 +2651,21 @@ mod tests {
         // overflows in apply_image_memory_protections, the error is propagated and the
         // image load fails (Task #1030 coverage improvement).
         //
-        // We craft a malformed PE image with a section virtual_size that will cause
-        // align_up() to overflow when aligning to section_alignment.
-
-        test_support::with_global_lock(|| {
+        // For this test case, do not create malformed PE with overflow section virtual size before
+        // parsing with goblin, because goblin will panic depending on whether logging is enabled or
+        // not! This happens because goblin contains debug!(...) statements like the one below,
+        // which are only active when logging is enabled:
+        //
+        // debug!(
+        //     "Checking {} for {:#x} ∈ {:#x}..{:#x}",
+        //     ...
+        //     section.virtual_address + section.virtual_size <-- This will panic on overflow
+        // );
+        //
+        // So, the plan is to parse a valid PE image first with goblin to get the UefiPeInfo
+        // structure, then modify the section virtual_size to trigger the overflow during
+        // apply_image_memory_protections().
+        let result = test_support::with_global_lock(|| {
             // SAFETY: These test initialization functions require unsafe because they
             // manipulate global state (GCD, protocol DB, system table)
             unsafe {
@@ -2670,32 +2681,45 @@ mod tests {
             let mut image: Vec<u8> = Vec::new();
             test_file.read_to_end(&mut image).expect("failed to read test file");
 
-            // PE header starts at offset 0x78 for this image
-            // Section headers start after the optional header
-            // For PE32+: COFF (20 bytes) + Optional header size
-            let pe_offset = 0x78;
-            let opt_header_size_offset = pe_offset + 4 + 16; // After signature + COFF header fields
-            let opt_header_size =
-                u16::from_le_bytes([image[opt_header_size_offset], image[opt_header_size_offset + 1]]) as usize;
-            let section_table_offset = pe_offset + 4 + 20 + opt_header_size;
-
-            // Each section header is 40 bytes
-            // Modify the first section's VirtualSize (offset 8 in section header) to cause overflow
-            // Set it to u32::MAX - 0x800 so that align_up(u32::MAX - 0x800, 0x1000) will overflow
-            let first_section_offset = section_table_offset;
-            let virtual_size_offset = first_section_offset + 8;
-
-            // Set VirtualSize to a value that will overflow when aligned to 0x1000
-            let overflow_value: u32 = u32::MAX - 0x800;
-            image[virtual_size_offset..virtual_size_offset + 4].copy_from_slice(&overflow_value.to_le_bytes());
-
             // Try to load the malformed image by calling core_load_pe_image directly
-            let image_info = empty_image_info();
-            let result = super::core_load_pe_image(&image, image_info);
+            let mut image_info = empty_image_info();
 
-            assert!(matches!(result, Err(EfiError::LoadError)), "Expected LoadError from alignment overflow");
-        })
-        .unwrap();
+            // Parse and validate the header and retrieve the image data from it.
+            let mut pe_info = UefiPeInfo::parse(&image).unwrap();
+
+            let size = pe_info.size_of_image as usize;
+
+            image_info.image_size = size as u64;
+            image_info.image_code_type = efi::BOOT_SERVICES_CODE;
+            image_info.image_data_type = efi::BOOT_SERVICES_DATA;
+
+            // Modify the first section’s VirtualSize to intentionally trigger an overflow. Set it
+            // to u32::MAX - 0x800 so that align_up(u32::MAX - 0x800, 0x1000) overflows inside
+            // apply_image_memory_protections(). The image load still succeeds because the section
+            // size is clipped to size_of_raw_data, while still allowing us to hit the overflow
+            // check in apply_image_memory_protections().
+            pe_info.sections[0].virtual_size = u32::MAX - 0x800;
+
+            // Allocate a buffer to hold the image (also updates private_info.image_info.image_base)
+            let mut private_info = PrivateImageData::new(image_info, pe_info).unwrap();
+
+            private_info.load_image(&image).unwrap();
+            private_info.relocate_image().unwrap();
+            private_info.load_resource_section(&image).unwrap();
+
+            let result = private_info.apply_image_memory_protections();
+
+            // In release builds, we expect LoadError error
+            assert!(matches!(result, Err(EfiError::LoadError)), "Expected LoadError from section size overflow");
+        });
+
+        // In debug builds, debug_assert!(false) panics and with_global_lock catches it
+        #[cfg(debug_assertions)]
+        assert!(result.is_err(), "Expected panic from debug_assert! in debug build");
+
+        // In release builds, debug_assert is compiled away and function returns error normally
+        #[cfg(not(debug_assertions))]
+        assert!(result.is_ok(), "Expected successful test execution in release build");
     }
 
     #[test]

--- a/patina_dxe_core/src/memory_attributes_protocol.rs
+++ b/patina_dxe_core/src/memory_attributes_protocol.rs
@@ -321,6 +321,7 @@ mod tests {
 
     fn with_locked_state<F: Fn() + std::panic::RefUnwindSafe>(f: F) {
         test_support::with_global_lock(|| {
+            test_support::init_test_logger();
             // SAFETY: Test code - resetting the global GCD state for test isolation.
             // The test lock is used to prevent concurrent access.
             unsafe {

--- a/patina_dxe_core/src/misc_boot_services.rs
+++ b/patina_dxe_core/src/misc_boot_services.rs
@@ -315,6 +315,7 @@ mod tests {
         F: Fn(&mut EfiSystemTable) + std::panic::RefUnwindSafe,
     {
         test_support::with_global_lock(|| {
+            test_support::init_test_logger();
             // SAFETY: Test code only - initializing test infrastructure with the test lock held
             // to prevent concurrent access during initialization.
             unsafe {

--- a/patina_dxe_core/src/pecoff.rs
+++ b/patina_dxe_core/src/pecoff.rs
@@ -497,6 +497,8 @@ pub fn load_resource_section(pe_info: &UefiPeInfo, image: &[u8]) -> error::Resul
 #[cfg(test)]
 #[coverage(off)]
 mod tests {
+    use crate::test_support;
+
     use super::*;
     extern crate std;
 
@@ -504,6 +506,7 @@ mod tests {
 
     #[test]
     fn test_image_bad_signature() {
+        test_support::init_test_logger();
         let image = include_bytes!("../resources/test/pe32/test_image.pe32");
         let mut image = *image;
         image.as_mut()[0] = 00;
@@ -514,6 +517,7 @@ mod tests {
 
     #[test]
     fn te_image_info_should_be_correct() {
+        test_support::init_test_logger();
         let image = include_bytes!("../resources/test/te/test_image.te");
         let image_info = UefiPeInfo::parse(image).unwrap();
 
@@ -526,6 +530,7 @@ mod tests {
 
     #[test]
     fn pe_image_info_should_be_correct() {
+        test_support::init_test_logger();
         let image = include_bytes!("../resources/test/pe32/test_image.pe32");
         let image_info = UefiPeInfo::parse(image).unwrap();
 
@@ -538,6 +543,7 @@ mod tests {
 
     #[test]
     fn msvc_pe_image_info_should_be_correct() {
+        test_support::init_test_logger();
         let image = include_bytes!("../resources/test/pe32/DisplayEngine512BFileAlignment.efi");
         let image_info = UefiPeInfo::parse(image).unwrap();
 
@@ -552,6 +558,7 @@ mod tests {
 
     #[test]
     fn clangpdb_pe_image_info_should_be_correct() {
+        test_support::init_test_logger();
         let image = include_bytes!("../resources/test/pe32/DisplayEngine32BFileAlignment.efi");
         let image_info = UefiPeInfo::parse(image).unwrap();
 
@@ -566,6 +573,7 @@ mod tests {
 
     #[test]
     fn te_load_image_should_load_the_image() {
+        test_support::init_test_logger();
         let image = include_bytes!("../resources/test/te/test_image.te");
         let image_info = UefiPeInfo::parse(image).unwrap();
 
@@ -583,6 +591,7 @@ mod tests {
 
     #[test]
     fn te_load_image_should_have_same_info() {
+        test_support::init_test_logger();
         let image = include_bytes!("../resources/test/te/test_image_with_reloc_section.te");
         let image_info = UefiPeInfo::parse(image).unwrap();
 
@@ -596,6 +605,7 @@ mod tests {
 
     #[test]
     fn pe_load_image_should_load_the_image() {
+        test_support::init_test_logger();
         let image = include_bytes!("../resources/test/pe32/test_image.pe32");
         let image_info = UefiPeInfo::parse(image).unwrap();
 
@@ -613,6 +623,7 @@ mod tests {
 
     #[test]
     fn pe_load_image_should_have_same_image_info() {
+        test_support::init_test_logger();
         let image = include_bytes!("../resources/test/pe32/test_image.pe32");
         let mut image_info = UefiPeInfo::parse(image).unwrap();
 
@@ -628,6 +639,7 @@ mod tests {
 
     #[test]
     fn test_load_image_with_bad_image_too_short() {
+        test_support::init_test_logger();
         let image = include_bytes!("../resources/test/pe32/test_image.pe32");
         let pe_info = UefiPeInfo::parse(image).unwrap();
         let edit_image = &image[0..image.len() - 0x1000];
@@ -642,6 +654,7 @@ mod tests {
 
     #[test]
     fn te_relocate_image_with_reloc_sections_should_work() {
+        test_support::init_test_logger();
         let image = include_bytes!("../resources/test/te/test_image_with_reloc_section.te");
         let reference_image = include_bytes!("../resources/test/te/test_image_with_reloc_section_relocated.bin");
 
@@ -659,6 +672,7 @@ mod tests {
 
     #[test]
     fn te_relocate_to_same_address_should_do_nothing() {
+        test_support::init_test_logger();
         let image1 = include_bytes!("../resources/test/te/test_image_with_reloc_section.te");
 
         let image_info = UefiPeInfo::parse(image1).unwrap();
@@ -678,6 +692,7 @@ mod tests {
 
     #[test]
     fn pe_relocate_image_should_relocate_the_image() {
+        test_support::init_test_logger();
         let image = include_bytes!("../resources/test/pe32/test_image.pe32");
         let image_info = UefiPeInfo::parse(image).unwrap();
 
@@ -699,6 +714,7 @@ mod tests {
 
     #[test]
     fn pe_relocate_image_should_work_multiple_times() {
+        test_support::init_test_logger();
         let image = include_bytes!("../resources/test/pe32/test_image.pe32");
         let image_info = UefiPeInfo::parse(image).unwrap();
 
@@ -721,6 +737,7 @@ mod tests {
 
     #[test]
     fn test_relocate_image_with_missing_reloc_dir() {
+        test_support::init_test_logger();
         let image = include_bytes!("../resources/test/te/test_image_with_reloc_section.te");
         let image_info = UefiPeInfo::parse(image).unwrap();
         let mut loaded_image = vec![0; image_info.size_of_image as usize];
@@ -737,6 +754,7 @@ mod tests {
 
     #[test]
     fn pe_load_resource_section_should_succeed() {
+        test_support::init_test_logger();
         // test_image_<toolchain>_hii.pe32 file is just a copy of TftpDynamicCommand.efi module copied and renamed.
         // the HII resource section layout slightly varies between Linux (GCC) and Windows (MSVC) bulids so both are
         // tested here.
@@ -777,6 +795,7 @@ mod tests {
 
     #[test]
     fn te_load_resource_section_should_succeed() {
+        test_support::init_test_logger();
         let image = include_bytes!("../resources/test/te/test_image.te");
         let image_info = UefiPeInfo::parse(image).unwrap();
 
@@ -789,6 +808,7 @@ mod tests {
 
     #[test]
     fn test_load_resource_section_using_size_of_raw_data() {
+        test_support::init_test_logger();
         const RELOC_DIR_ENTRY_INDEX: usize = 5;
         let image = include_bytes!("../resources/test/pe32/test_image_msvc_hii.pe32");
         let mut image_info = UefiPeInfo::parse(image).unwrap();
@@ -800,6 +820,7 @@ mod tests {
 
     #[test]
     fn test_load_resource_section_with_malformed_resource_dir() {
+        test_support::init_test_logger();
         const RELOC_DIR_ENTRY_INDEX: usize = 5;
         let image = include_bytes!("../resources/test/pe32/test_image_msvc_hii.pe32");
         let image_info = UefiPeInfo::parse(image).unwrap();

--- a/patina_dxe_core/src/protocol_db.rs
+++ b/patina_dxe_core/src/protocol_db.rs
@@ -919,6 +919,7 @@ mod tests {
 
     fn with_locked_state<F: Fn() + std::panic::RefUnwindSafe>(f: F) {
         test_support::with_global_lock(|| {
+            test_support::init_test_logger();
             f();
         })
         .unwrap();

--- a/patina_dxe_core/src/runtime.rs
+++ b/patina_dxe_core/src/runtime.rs
@@ -211,6 +211,7 @@ mod tests {
 
     fn with_locked_state<F: Fn() + std::panic::RefUnwindSafe>(f: F) {
         test_support::with_global_lock(|| {
+            test_support::init_test_logger();
             // SAFETY: Test code only - initializing test infrastructure with the test lock held
             // prevents concurrent access during initialization.
             unsafe {

--- a/patina_dxe_core/src/systemtables.rs
+++ b/patina_dxe_core/src/systemtables.rs
@@ -778,6 +778,7 @@ mod tests {
 
     fn with_locked_state<F: Fn() + std::panic::RefUnwindSafe>(f: F) {
         test_support::with_global_lock(|| {
+            test_support::init_test_logger();
             // SAFETY: Test code only - initializing the test GCD with the test lock held
             // prevents concurrent access during initialization.
             unsafe { test_support::init_test_gcd(Some(0x4000000)) };

--- a/patina_dxe_core/src/test_support.rs
+++ b/patina_dxe_core/src/test_support.rs
@@ -555,6 +555,38 @@ pub(crate) fn build_test_hob_list(mem_size: u64) -> *const c_void {
     mem.as_ptr() as *const c_void
 }
 
+/// To enable logging, set the `RUST_LOG` environment variable to the desired
+/// log level (e.g., `debug`, `info`, `warn`, `error`) before running the tests.
+///
+/// For example:
+///
+/// ```sh
+/// RUST_LOG=debug cargo test -p patina_dxe_core allocator::usage_tests::uefi_memory_map -- --nocapture
+/// ```
+///
+/// PowerShell example:
+///
+/// ```powershell
+/// $env:RUST_LOG="debug"; cargo test -p patina_dxe_core allocator::usage_tests::uefi_memory_map -- --nocapture
+/// ```
+pub(crate) fn init_test_logger() {
+    use std::sync::OnceLock;
+    static INIT: OnceLock<()> = OnceLock::new();
+
+    INIT.get_or_init(|| {
+        // Default to no logging unless RUST_LOG environment variable is set
+        let mut builder = env_logger::Builder::from_default_env();
+
+        // If RUST_LOG is not set, default to Off (no logging), otherwise errors
+        // are logged even without --nocapture
+        if std::env::var("RUST_LOG").is_err() {
+            builder.filter_level(log::LevelFilter::Off);
+        }
+
+        builder.init();
+    });
+}
+
 #[cfg(test)]
 #[coverage(off)]
 mod tests {

--- a/patina_dxe_core/src/tpl_mutex.rs
+++ b/patina_dxe_core/src/tpl_mutex.rs
@@ -136,13 +136,17 @@ impl<T: ?Sized> Drop for TplGuard<'_, T> {
 #[coverage(off)]
 mod tests {
 
-    use crate::events::{raise_tpl, restore_tpl};
+    use crate::{
+        events::{raise_tpl, restore_tpl},
+        test_support,
+    };
 
     use super::TplMutex;
     use r_efi::efi;
 
     fn with_reset_state<F: Fn() + std::panic::RefUnwindSafe>(f: F) {
         let result = crate::test_support::with_global_lock(|| {
+            test_support::init_test_logger();
             raise_tpl(efi::TPL_HIGH_LEVEL);
             restore_tpl(efi::TPL_APPLICATION);
             f();


### PR DESCRIPTION
## Description

Since Patina relies on the `log::*` API for logging, not configuring a default
logger can cause `log::*` calls to appear completely uncovered in llvm-cov
reports, slightly reducing overall coverage. Adding a simple environment based
logger avoids this issue. Although this change enables coverage for `log::*`,
there are still cases that cannot be covered. For example, in the function
below, there is no way to get coverage for lines 6 and 7.

```
1   1   fn print() {
2   1       let mut i = 0;
3   11      for _ in 0..10 {
4   10          log::info!(
5   10              "This will be covered {} {}",
6                   i,
7                   "This and the above line will not be covered."
8               );
9   10          i = i + 1;
10          }
11  1   }
```

The environment logger can be enabled as shown below:
To enable logging, set the `RUST_LOG` environment variable to the desired
log level (e.g., `debug`, `info`, `warn`, `error`) before running the tests.

```bash
$ RUST_LOG=debug cargo test -p patina_dxe_core allocator::usage_tests::uefi_memory_map -- --nocapture
or
PS:> $env:RUST_LOG="debug"; cargo test -p patina_dxe_core allocator::usage_tests::uefi_memory_map -- --nocapture
```

For `cargo make coverage` a corresponding `Makefile.toml` change will be added
from patina-devops
```
[tasks.test]
description = "Run tests and collect coverage data without generating reports."
env = { "RUST_LOG" = "info" }  <---
...
```

## How This Was Tested

`cargo make all`

## Integration Instructions

NA