### PR TITLE
patina_dxe_core: Tests: Fix Intermittent Test Failure

### DIFF
--- a/patina_dxe_core/src/gcd/spin_locked_gcd.rs
+++ b/patina_dxe_core/src/gcd/spin_locked_gcd.rs
@@ -2045,6 +2045,7 @@ impl SpinLockedGcd {
         mem.memory_blocks = Rbt::new();
         io.maximum_address = 0;
         io.io_blocks = Rbt::new();
+        self.page_table.lock().take();
     }
 
     /// Adds a page table for testing purposes


### PR DESCRIPTION
## Description

Recent tests added a MockPageTable to the static GCD, but this is not cleaned up on GCD.reset(). As a result, there is a race condition where certain tests that expect there not to be a page table installed in the GCD can fail. This fixes that by removing the page table if installed in GCD.reset().

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Had a 100% repro with `cargo test` after this no repro. Confirmed this was the issue under the debugger.

## Integration Instructions

N/A.
