### PR TITLE
[Partial Revert]: Do not include the console logger for tests

### DIFF
--- a/patina_dxe_core/src/image.rs
+++ b/patina_dxe_core/src/image.rs
@@ -1432,7 +1432,6 @@ mod tests {
     fn with_locked_state<F: Fn() + std::panic::RefUnwindSafe>(f: F) {
         // SAFETY: Test code only - initializing test infrastructure within the global test lock.
         test_support::with_global_lock(|| unsafe {
-            test_support::init_test_logger();
             test_support::init_test_gcd(None);
             test_support::init_test_protocol_db();
             init_system_table();

--- a/patina_dxe_core/src/test_support.rs
+++ b/patina_dxe_core/src/test_support.rs
@@ -525,28 +525,6 @@ pub(crate) fn build_test_hob_list(mem_size: u64) -> *const c_void {
     mem.as_ptr() as *const c_void
 }
 
-struct ConsoleLogger;
-
-impl log::Log for ConsoleLogger {
-    fn enabled(&self, _metadata: &log::Metadata) -> bool {
-        true
-    }
-
-    fn log(&self, record: &log::Record) {
-        if self.enabled(record.metadata()) {
-            println!("[{}] {}", record.level(), record.args());
-        }
-    }
-
-    fn flush(&self) {}
-}
-
-pub(crate) fn init_test_logger() {
-    static LOGGER: ConsoleLogger = ConsoleLogger;
-    let _ = log::set_logger(&LOGGER);
-    log::set_max_level(log::LevelFilter::Info);
-}
-
 #[cfg(test)]
 #[coverage(off)]
 mod tests {


### PR DESCRIPTION
## Description

- The console logger was added to tests to improve code coverage for the `log::*` APIs in #1069.
- However, the `patina_dxe_core` crate currently has a few tests (`uefi_memory_map`) that use their own logger for custom behavior.
- Since both loggers end up in the same test binary (`patina_dxe_core-0fa2c65cbd247021.exe`), we cannot have two loggers in the same process (the `uefi_memory_map` logger initialization can panic if the console logger is already enabled).
- Until we finalize a proper mechanism that supports both scenarios(code coverage + uefi_memory_map debug logs), this
PR reverts the previously added console logger.

===
- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

`cargo make all`

## Integration Instructions

NA