### PR TITLE
patina_dxe_core: Make GicBases a field struct

### DIFF
--- a/patina_dxe_core/src/hw_interrupt_protocol.rs
+++ b/patina_dxe_core/src/hw_interrupt_protocol.rs
@@ -460,6 +460,7 @@ pub(crate) struct HwInterruptProtocolInstaller {
 
 impl HwInterruptProtocolInstaller {
     /// Creates a new `HwInterruptProtocolInstaller` instance.
+    #[coverage(off)]
     pub fn new(gic_bases: GicBases) -> Self {
         Self { gic_bases }
     }

--- a/patina_dxe_core/src/lib.rs
+++ b/patina_dxe_core/src/lib.rs
@@ -316,6 +316,7 @@ impl GicBases {
     /// Access to these registers are exclusive to this GicBases instance.
     ///
     /// Caller must guarantee that access to these registers is exclusive to this GicBases instance.
+    #[coverage(off)]
     pub unsafe fn new(gicd_base: u64, gicr_base: u64) -> Self {
         GicBases { gicd: gicd_base, gicr: gicr_base }
     }


### PR DESCRIPTION
## Description

Updates GicBases and HwInterruptProtocolInstaller to be field structs instead of tuple structs

Closes #1091

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

CI

## Integration Instructions

N/A
