### PR TITLE
patina_smbios: Fix protocol installation and cleanup implementation

### DIFF
--- a/components/patina_samples/src/smbios_platform.rs
+++ b/components/patina_samples/src/smbios_platform.rs
@@ -40,7 +40,7 @@ use patina_smbios::{
     service::{SMBIOS_HANDLE_PI_RESERVED, Smbios, SmbiosExt, SmbiosTableHeader},
     smbios_record::{
         SmbiosRecordStructure, Type0PlatformFirmwareInformation, Type1SystemInformation, Type2BaseboardInformation,
-        Type3SystemEnclosure, Type127EndOfTable,
+        Type3SystemEnclosure,
     },
 };
 
@@ -128,12 +128,7 @@ impl SmbiosExampleComponent {
             return Err(e);
         }
 
-        // Type 127: End-of-table marker
-        if let Err(e) = Self::add_end_of_table(&smbios) {
-            log::error!("Failed to add end-of-table marker: {:?}", e);
-            return Err(e);
-        }
-
+        // Type 127 End-of-Table marker is automatically added by the manager during initialization
         log::info!("Platform SMBIOS records created successfully");
 
         // Publish the SMBIOS table to the UEFI Configuration Table
@@ -312,24 +307,6 @@ impl SmbiosExampleComponent {
         })?;
 
         log::info!("  Type 0x80 (Vendor OEM) - Handle 0x{:04X}", handle);
-        Ok(())
-    }
-
-    /// Add Type 127 (End of Table) marker
-    ///
-    /// Required marker to indicate the end of the SMBIOS table.
-    fn add_end_of_table(smbios: &Service<dyn Smbios>) -> Result<()> {
-        let end_of_table = Type127EndOfTable {
-            header: SmbiosTableHeader::new(127, 0, SMBIOS_HANDLE_PI_RESERVED),
-            string_pool: vec![],
-        };
-
-        let handle = smbios.add_record(None, &end_of_table).map_err(|e| {
-            log::error!("Failed to add end-of-table: {:?}", e);
-            patina::error::EfiError::DeviceError
-        })?;
-
-        log::info!("  Type 127 (End of Table) - Handle 0x{:04X}", handle);
         Ok(())
     }
 }

--- a/components/patina_smbios/src/manager.rs
+++ b/components/patina_smbios/src/manager.rs
@@ -21,7 +21,7 @@ mod protocol;
 mod record;
 
 // Re-export main types and functions
-pub use core::SmbiosManager;
+pub use core::{SMBIOS_3_X_TABLE_GUID, SmbiosManager};
 pub(crate) use record::SmbiosRecord;
 
 use alloc::boxed::Box;
@@ -55,7 +55,7 @@ pub fn install_smbios_protocol(
     boot_services: &'static StandardBootServices,
 ) -> Result<efi::Handle, SmbiosError> {
     // Create the protocol instance with internal struct
-    let internal = SmbiosProtocolInternal::new(major_version, minor_version, manager_mutex);
+    let internal = SmbiosProtocolInternal::new(major_version, minor_version, manager_mutex, boot_services);
     let interface = Box::into_raw(Box::new(internal));
 
     // Install the protocol using the unchecked interface since we have a raw pointer

--- a/components/patina_smbios/src/smbios_record.rs
+++ b/components/patina_smbios/src/smbios_record.rs
@@ -469,7 +469,7 @@ pub struct Type3SystemEnclosure {
 /// - No strings
 #[derive(patina_macro::SmbiosRecord)]
 #[smbios(record_type = 127)]
-pub struct Type127EndOfTable {
+pub(crate) struct Type127EndOfTable {
     /// SMBIOS header
     pub header: SmbiosTableHeader,
 


### PR DESCRIPTION
## Description
Fixes SMBIOS protocol initialization to prevent allocation failures during SmbiosAdd() operations.

## What changed

**Fixed initialization order:**
- Allocate SMBIOS buffers before installing protocol (was failing when SmbiosAdd() called during install)
- Publish initial table with Type 127 (End-Of-Table) marker immediately after protocol install
- Subsequent SmbiosAdd() calls update buffer in-place

**C protocol compatibility improvements:**
- GetNext now returns pointers into the published table (not internal buffer), ensuring RecordA != RecordB for different records
- Added checksum-based table integrity verification to detect direct modifications
- Returns `TableDirectlyModified` error if published table was modified directly instead of using protocol APIs
- Error message guides users to use Remove() + Add() or UpdateString() instead

**Safety improvements:**
- Scoped manager locks to prevent TplMutex re-entrant lock panic during republish
- Use write_unaligned() for FFI pointer writes
- Narrowed unsafe scopes in protocol layer

**Code cleanup:**
- Use MemoryManager service for allocations
- Replace hard-coded sizes with SIZE_(n)KB constants
- Enhanced error handling and debug_asserts

---
- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [x] Includes tests?
- [ ] Includes documentation?

## How This Was Tested
- Integrated with Tiano DXE Core to test C FFI protocol functions
- Integrated with patched branch in patina-dxe-core-qemu to ensure it also works with Patina DXE Core
- Verified direct modification detection with test in PatinaSmbiosDxe driver

## Integration Instructions
N/A