### PR TITLE
Update events::wait_for_event() semantics

### DIFF
--- a/core/patina_internal_cpu/src/cpu/aarch64/cpu.rs
+++ b/core/patina_internal_cpu/src/cpu/aarch64/cpu.rs
@@ -100,6 +100,19 @@ impl EfiCpuAarch64 {
             }
         }
     }
+
+    /// Causes the CPU to enter a low power state until the next interrupt.
+    // This routine only does bare-metal hardware access, so no coverage.
+    #[coverage(off)]
+    pub fn sleep() {
+        #[cfg(all(not(test), target_arch = "aarch64"))]
+        {
+            // SAFETY: The caller is expected to ensure that they want to wait for an interrupt
+            unsafe {
+                asm!("wfi", options(nostack));
+            }
+        }
+    }
 }
 
 impl Cpu for EfiCpuAarch64 {

--- a/core/patina_internal_cpu/src/cpu/stub.rs
+++ b/core/patina_internal_cpu/src/cpu/stub.rs
@@ -26,6 +26,10 @@ impl EfiCpuStub {
     pub fn initialize(&mut self) -> Result<(), EfiError> {
         Ok(())
     }
+    /// Causes the CPU to enter a low power state until the next interrupt.
+    // Trivial emulation of hardware access, so no coverage.
+    #[coverage(off)]
+    pub fn sleep() {}
 }
 
 impl Cpu for EfiCpuStub {

--- a/core/patina_internal_cpu/src/cpu/x64/cpu.rs
+++ b/core/patina_internal_cpu/src/cpu/x64/cpu.rs
@@ -94,6 +94,19 @@ impl EfiCpuX64 {
         0
     }
 
+    /// Causes the CPU to enter a low power state until the next interrupt.
+    // This routine only does bare-metal hardware access, so no coverage.
+    #[coverage(off)]
+    pub fn sleep() {
+        #[cfg(all(not(test), target_arch = "x86_64"))]
+        {
+            // SAFETY: The caller is expected to ensure that they want to halt the CPU until the next interrupt
+            unsafe {
+                asm!("hlt");
+            }
+        }
+    }
+
     fn microsecond_delay(&self, _microseconds: u64) {
         // unimplemented!();
     }


### PR DESCRIPTION
## Description

Adjusts wait_for_event semantics to better match historical behavior of core:
* make `out_index` parameter optional
* invoke CPU sleep function during idle loop.

Closes https://github.com/OpenDevicePartnership/patina/issues/791

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Boot to OS on AARCH64 hardware.

## Integration Instructions

N/A