### PR TITLE
Signal memory map change on set memory capabilities

### DIFF
--- a/patina_dxe_core/src/events.rs
+++ b/patina_dxe_core/src/events.rs
@@ -319,8 +319,9 @@ pub fn gcd_map_change(map_change_type: gcd::MapChangeType) {
         gcd::MapChangeType::AddMemorySpace
         | gcd::MapChangeType::AllocateMemorySpace
         | gcd::MapChangeType::FreeMemorySpace
-        | gcd::MapChangeType::RemoveMemorySpace => EVENT_DB.signal_group(efi::EVENT_GROUP_MEMORY_MAP_CHANGE),
-        gcd::MapChangeType::SetMemoryAttributes | gcd::MapChangeType::SetMemoryCapabilities => (),
+        | gcd::MapChangeType::RemoveMemorySpace
+        | gcd::MapChangeType::SetMemoryCapabilities => EVENT_DB.signal_group(efi::EVENT_GROUP_MEMORY_MAP_CHANGE),
+        gcd::MapChangeType::SetMemoryAttributes => (),
     }
 }
 


### PR DESCRIPTION
## Description

Signal EVENT_GROUP_MEMORY_MAP_CHANGE on SetMemoryCapabilities operations.

Closes https://github.com/OpenDevicePartnership/patina/issues/1113

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Booted to OS on AARCH64 hardware.

## Integration Instructions

N/A