### PR TITLE
TplMutex: own BootServices instead of borrowing

### DIFF
--- a/components/patina_smbios/src/manager.rs
+++ b/components/patina_smbios/src/manager.rs
@@ -51,7 +51,7 @@ use self::protocol::{SmbiosProtocol, SmbiosProtocolInternal};
 pub fn install_smbios_protocol(
     major_version: u8,
     minor_version: u8,
-    manager_mutex: &'static TplMutex<'static, SmbiosManager, StandardBootServices>,
+    manager_mutex: &'static TplMutex<SmbiosManager, StandardBootServices>,
     boot_services: &'static StandardBootServices,
 ) -> Result<efi::Handle, SmbiosError> {
     // Create the protocol instance with internal struct

--- a/components/patina_smbios/src/manager/protocol.rs
+++ b/components/patina_smbios/src/manager/protocol.rs
@@ -42,7 +42,7 @@ pub(super) struct SmbiosProtocolInternal {
     pub(super) protocol: SmbiosProtocol,
 
     // Internal component access only! Does not exist in C definition
-    pub(super) manager: &'static TplMutex<'static, SmbiosManager>,
+    pub(super) manager: &'static TplMutex<SmbiosManager, patina::boot_services::StandardBootServices>,
 
     // Boot services needed for table republishing after Add/Update/Remove
     pub(super) boot_services: &'static patina::boot_services::StandardBootServices,
@@ -93,7 +93,7 @@ impl SmbiosProtocolInternal {
     pub(super) fn new(
         major_version: u8,
         minor_version: u8,
-        manager: &'static TplMutex<'static, SmbiosManager>,
+        manager: &'static TplMutex<SmbiosManager, patina::boot_services::StandardBootServices>,
         boot_services: &'static patina::boot_services::StandardBootServices,
     ) -> Self {
         Self { protocol: SmbiosProtocol::new(major_version, minor_version), manager, boot_services }

--- a/sdk/patina/src/performance/globals.rs
+++ b/sdk/patina/src/performance/globals.rs
@@ -21,18 +21,18 @@ static LOAD_IMAGE_COUNT: AtomicU32 = AtomicU32::new(0);
 static PERF_MEASUREMENT_MASK: AtomicU32 = AtomicU32::new(0);
 
 /// Static state for the performance component.
-struct StaticState<'a> {
+struct StaticState {
     /// Boot Services instance
     boot_services: OnceCell<StandardBootServices>,
     /// The FBPT protected by a TPL mutex.
-    fbpt: OnceCell<TplMutex<'a, FBPT>>,
+    fbpt: OnceCell<TplMutex<FBPT>>,
     /// Flag to indicate if the static state is in the process of being initialized.
     initializing: AtomicBool,
     /// Timer service for performance measurements.
     timer: Service<dyn ArchTimerFunctionality>,
 }
 
-impl<'a> StaticState<'a> {
+impl StaticState {
     /// Creates a new uninitialized static state.
     const fn uninit() -> Self {
         Self {
@@ -49,15 +49,15 @@ impl<'a> StaticState<'a> {
     ///
     /// Returns `Already initialized` if the static state has already been initialized.
     /// Returns `Currently initializing somewhere else` if another thread is currently initializing the static state.
-    fn init(
-        &'a self,
-        bs: StandardBootServices,
-        timer: Service<dyn ArchTimerFunctionality>,
-    ) -> Result<(), &'static str> {
+    fn init(&self, bs: StandardBootServices, timer: Service<dyn ArchTimerFunctionality>) -> Result<(), &'static str> {
         if self.initializing.compare_exchange(false, true, Ordering::Acquire, Ordering::Relaxed).is_ok() {
             self.boot_services.set(bs).map_err(|_| "Already initialized")?;
             self.fbpt
-                .set(TplMutex::new(self.boot_services.get().expect("Boot Services Just Set"), Tpl::NOTIFY, FBPT::new()))
+                .set(TplMutex::new(
+                    self.boot_services.get().expect("Boot Services Just Set").clone(),
+                    Tpl::NOTIFY,
+                    FBPT::new(),
+                ))
                 .map_err(|_| "Failed to set FBPT")?;
             self.timer.replace(&timer);
             self.initializing.store(false, Ordering::Release);
@@ -72,7 +72,7 @@ impl<'a> StaticState<'a> {
     /// Returns `None` if the state is not yet initialized.
     /// Returns `None` if the state is currently being initialized.
     /// Returns `Some` with references to the `StandardBootServices` and `TplMutex<FBPT>` if initialized.
-    fn inner(&self) -> Option<(&StandardBootServices, &TplMutex<'a, FBPT>, &Service<dyn ArchTimerFunctionality>)> {
+    fn inner(&self) -> Option<(&StandardBootServices, &TplMutex<FBPT>, &Service<dyn ArchTimerFunctionality>)> {
         if !self.initializing.load(Ordering::Acquire)
             && let Some(bs) = self.boot_services.get()
             && let Some(fbpt) = self.fbpt.get()
@@ -86,14 +86,14 @@ impl<'a> StaticState<'a> {
 /// SAFETY: Initializing the `OnceCell`s via the atomic `initialize` flag satisfies the `Send` requirement for
 /// synchronization on the `set` calls inside `init`. Both the `StandardBootServices` and `TplMutex` types are `Send`
 /// as well, so the only other usage of the `OnceCell`s `get` method is safe.
-unsafe impl Send for StaticState<'static> {}
+unsafe impl Send for StaticState {}
 
 /// SAFETY: Initializing the `OnceCell`s via the atomic `initialize` flag satisfies the `Sync` requirement for
 /// synchronization on the `set` calls inside `init`. Both the `StandardBootServices` and `TplMutex` types are `Sync`
 /// as well, so the only other usage of the `OnceCell`s `get` method is safe.
-unsafe impl Sync for StaticState<'static> {}
+unsafe impl Sync for StaticState {}
 
-static STATIC_STATE: StaticState<'static> = StaticState::uninit();
+static STATIC_STATE: StaticState = StaticState::uninit();
 
 /// Set performance component static state.
 pub fn set_perf_measurement_mask(mask: u32) {
@@ -131,11 +131,8 @@ pub fn set_static_state(
 
 /// Get performance component static state.
 #[coverage(off)]
-pub fn get_static_state() -> Option<(
-    &'static StandardBootServices,
-    &'static TplMutex<'static, FBPT>,
-    &'static Service<dyn ArchTimerFunctionality>,
-)> {
+pub fn get_static_state()
+-> Option<(&'static StandardBootServices, &'static TplMutex<FBPT>, &'static Service<dyn ArchTimerFunctionality>)> {
     STATIC_STATE.inner()
 }
 


### PR DESCRIPTION
## Description

This eliminates the lifetime parameter from TplMutex, removing the need for unsafe lifetime casts when creating static TplMutex instances.

- [x] Impacts functionality?
- [ ] Impacts security?
- [x] Breaking change?
- [x] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

`cargo make all`

Integrated this branch into patina-dxe-core-qemu and tested that it boots to UEFI shell in patina-qemu

## Integration Instructions

Update all TplMutex::new call sites to pass an owned BootServices instead of a reference:

```
// Before
let mutex = TplMutex::new(&boot_services, Tpl::NOTIFY, data);

// After
let mutex = TplMutex::new(boot_services.clone(), Tpl::NOTIFY, data);
```

Remove any 'static lifetime parameters from TplMutex type annotations:

```
// Before
TplMutex<'static, MyData, StandardBootServices>

// After
TplMutex<MyData, StandardBootServices>
```