### PR TITLE
[REBASE&FF] Log bad components rather than panic

### DIFF
--- a/sdk/patina/src/component.rs
+++ b/sdk/patina/src/component.rs
@@ -183,7 +183,9 @@ pub trait Component {
     /// the metadata of the component. The scheduler uses this metadata when scheduling components in a multi-threaded
     /// context. Typically this method will pass the metadata to each parameter to register its access requirements,
     /// but that is not a requirement.
-    fn initialize(&mut self, storage: &mut storage::Storage);
+    ///
+    /// Returns true if the component was successfully initialized, otherwise false.
+    fn initialize(&mut self, storage: &mut storage::Storage) -> bool;
 
     /// Returns the metadata of the component. used in a multi-threaded context to schedule components.
     fn metadata(&self) -> &metadata::MetaData;

--- a/sdk/patina/src/component/hob.rs
+++ b/sdk/patina/src/component/hob.rs
@@ -59,7 +59,7 @@
 //! SPDX-License-Identifier: Apache-2.0
 extern crate alloc;
 
-use alloc::{boxed::Box, vec::Vec};
+use alloc::{borrow::Cow, boxed::Box, vec::Vec};
 
 use crate::OwnedGuid;
 use core::{any::Any, ops::Deref};
@@ -235,9 +235,9 @@ unsafe impl<T: FromHob + 'static> Param for Hob<'_, T> {
         !unsafe { storage.storage() }.get_raw_hob(*state).is_empty()
     }
 
-    fn init_state(storage: &mut Storage, _meta: &mut MetaData) -> Self::State {
+    fn init_state(storage: &mut Storage, _meta: &mut MetaData) -> Result<Self::State, Cow<'static, str>> {
         storage.add_hob_parser::<T>();
-        storage.register_hob::<T>()
+        Ok(storage.register_hob::<T>())
     }
 }
 

--- a/sdk/patina/src/component/metadata.rs
+++ b/sdk/patina/src/component/metadata.rs
@@ -21,14 +21,14 @@ pub struct MetaData {
     access: Access,
     /// The name of the component.
     name: Cow<'static, str>,
-    /// the name of the last param that failed to be set.
-    last_failed_param: Option<Cow<'static, str>>,
+    /// The error message preventing the component from being dispatched.
+    error_message: Option<Cow<'static, str>>,
 }
 
 impl MetaData {
     /// Creates a new metadata object for a component.
     pub fn new<S>() -> Self {
-        Self { access: Access::new(), name: Cow::from(core::any::type_name::<S>()), last_failed_param: None }
+        Self { access: Access::new(), name: Cow::from(core::any::type_name::<S>()), error_message: None }
     }
 
     /// Returns the name of the component, including the module path.
@@ -39,14 +39,14 @@ impl MetaData {
 
     /// Sets the name of the `param` that could not be retrieved from storage when attempting to dispatch the function.
     #[inline(always)]
-    pub fn set_failed_param(&mut self, param: Cow<'static, str>) {
-        self.last_failed_param = Some(param);
+    pub fn set_error_message(&mut self, error: Cow<'static, str>) {
+        self.error_message = Some(error);
     }
 
     /// Returns the name of the last `param` that could not be retrieved from storage.
     #[inline(always)]
-    pub fn failed_param(&self) -> Option<Cow<'static, str>> {
-        self.last_failed_param.clone()
+    pub fn error_message(&self) -> Option<Cow<'static, str>> {
+        self.error_message.clone()
     }
 
     /// Returns mutable access to the param usage metadata for the component.

--- a/sdk/patina/src/component/service.rs
+++ b/sdk/patina/src/component/service.rs
@@ -117,7 +117,7 @@
 //!
 extern crate alloc;
 
-use alloc::boxed::Box;
+use alloc::{borrow::Cow, boxed::Box};
 use core::{any::Any, cell::OnceCell, marker::PhantomData, ops::Deref};
 
 use crate::component::{
@@ -422,8 +422,8 @@ unsafe impl<T: ?Sized + 'static> Param for Service<T> {
         unsafe { storage.storage() }.get_raw_service(*state).is_some()
     }
 
-    fn init_state(storage: &mut Storage, _meta: &mut MetaData) -> Self::State {
-        storage.register_service::<T>()
+    fn init_state(storage: &mut Storage, _meta: &mut MetaData) -> Result<Self::State, Cow<'static, str>> {
+        Ok(storage.register_service::<T>())
     }
 }
 
@@ -510,7 +510,7 @@ mod tests {
         let mut storage = Storage::default();
         let mut mock_metadata = MetaData::new::<i32>();
 
-        let id = <Service<dyn MyService> as Param>::init_state(&mut storage, &mut mock_metadata);
+        let id = <Service<dyn MyService> as Param>::init_state(&mut storage, &mut mock_metadata).unwrap();
 
         storage.add_service(MyServiceImpl);
 
@@ -530,7 +530,7 @@ mod tests {
         let mut storage = Storage::default();
         let mut mock_metadata = MetaData::new::<i32>();
 
-        let id = <Service<dyn MyService> as Param>::init_state(&mut storage, &mut mock_metadata);
+        let id = <Service<dyn MyService> as Param>::init_state(&mut storage, &mut mock_metadata).unwrap();
         assert!(<Service<dyn MyService> as Param>::try_validate(&id, (&storage).into()).is_err());
     }
 

--- a/sdk/patina/src/test.rs
+++ b/sdk/patina/src/test.rs
@@ -484,6 +484,10 @@ mod tests {
         Err("Intentional Failure")
     }
 
+    fn test_function_invalid(_: &mut Storage, _: &mut Storage) -> Result {
+        Ok(())
+    }
+
     #[test]
     fn test_func_implements_into_component() {
         let _ = super::TestRunner::default().into_component();
@@ -552,6 +556,15 @@ mod tests {
         should_fail: false,
         fail_msg: None,
         func: |storage| crate::test::__private_api::FunctionTest::new(test_function_fail).run(storage.into()),
+    };
+
+    static TEST_CASE_INVALID: super::__private_api::TestCase = super::__private_api::TestCase {
+        name: "invalid_test",
+        trigger: super::__private_api::TestTrigger::Event(&Guid::from_bytes(&[0; 16])),
+        skip: false,
+        should_fail: false,
+        fail_msg: None,
+        func: |storage| crate::test::__private_api::FunctionTest::new(test_function_invalid).run(storage.into()),
     };
 
     #[test]
@@ -736,5 +749,13 @@ mod tests {
         // This test is not filtered out, but never run, so should log as such.
         println!("{}", output);
         assert!(output.contains("event_triggered_test ... not triggered"));
+    }
+
+    #[test]
+    fn test_test_with_invalid_param_combination_is_caught() {
+        assert_eq!(
+            TEST_CASE_INVALID.run(&mut Storage::new(), false),
+            Err("Test failed to run due to un-retrievable parameters.")
+        );
     }
 }

--- a/sdk/patina/src/test/__private_api.rs
+++ b/sdk/patina/src/test/__private_api.rs
@@ -124,7 +124,13 @@ where
 
         // Safety: init_state requires mutable access to storage. UnsafeStorageCell provides controlled access.
         // This is the initialization phase before parameter validation.
-        let param_state = unsafe { Func::Param::init_state(storage.storage_mut(), &mut metadata) };
+        let param_state = match Func::Param::init_state(unsafe { storage.storage_mut() }, &mut metadata) {
+            Ok(param_state) => param_state,
+            Err(error) => {
+                log::warn!("Failed to initialize test state: {error:?}");
+                return Ok(false);
+            }
+        };
 
         if let Err(bad_param) = Func::Param::try_validate(&param_state, storage) {
             log::warn!("Failed to retreive parameter: {bad_param:?}");


### PR DESCRIPTION
## Description

This change updates the logic of component initialization to track a component that failed to initialize, and log it towards the end of boot, rather than panic on debug builds or possibly have UB on release builds.

Example output:

```
INFO - WARN - Components not dispatched:
INFO - WARN - ------------------------------- -------------------------------------------------
INFO - WARN - name                            error message
INFO - WARN - qemu_q35_dxe_core::BadComponent ConflictingParam Param Conflicts with everything.
```

**Note**: While tests still need to be written, this is ready for review.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

1. CI passes
2. Created a test parameter that alwys fails to initialize. Ensured it was logged during boot
3. Q35 continues to boot.

## Integration Instructions

N/A