### PR TITLE
patina_debugger/x64: Fix FPU and ST register index calculation

### DIFF
--- a/core/patina_debugger/src/arch/x64.rs
+++ b/core/patina_debugger/src/arch/x64.rs
@@ -432,8 +432,8 @@ impl RegId for X64CoreRegId {
             17 => (Self::Eflags, 8),
             18..=23 => (Self::Segment((id - 18) as u8), 4),
             24..=28 => (Self::Control((id - 24) as u8), 8),
-            29..=35 => (Self::Fpu((id - 24) as u8), 4),
-            36..=44 => (Self::St((id - 31) as u8), 10),
+            29..=35 => (Self::Fpu((id - 29) as u8), 4),
+            36..=44 => (Self::St((id - 36) as u8), 10),
             _ => return None,
         };
 


### PR DESCRIPTION
## Description

Correct the register ID offset calculation for FPU (registers 29-35) and ST (registers 36-44) to properly map to array indices 0-6 and 0-8 respectively.

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

- `cargo make all`

## Integration Instructions

- N/A