### PR TITLE
Add compile-time validation for Storage parameter conflicts

### DIFF
--- a/sdk/patina/tests/compile_fail_tests.rs
+++ b/sdk/patina/tests/compile_fail_tests.rs
@@ -20,4 +20,8 @@ fn compile_fail_tests() {
     t.compile_fail("tests/ui/duplicate_commands.rs");
     t.compile_fail("tests/ui/duplicate_boot_services.rs");
     t.compile_fail("tests/ui/duplicate_runtime_services.rs");
+    t.compile_fail("tests/ui/duplicate_storage_mut.rs");
+    t.compile_fail("tests/ui/storage_and_storage_mut_conflict.rs");
+    t.compile_fail("tests/ui/storage_mut_and_storage_conflict.rs");
+    t.pass("tests/ui/multiple_storage_allowed.rs");
 }

--- a/sdk/patina/tests/ui/duplicate_storage_mut.rs
+++ b/sdk/patina/tests/ui/duplicate_storage_mut.rs
@@ -1,0 +1,14 @@
+//! Test that duplicate &mut Storage parameters are rejected at compile time.
+
+use patina::{component::{component, Storage}, error::Result};
+
+pub struct TestComponent;
+
+#[component]
+impl TestComponent {
+    fn entry_point(self, _s1: &mut Storage, _s2: &mut Storage) -> Result<()> {
+        Ok(())
+    }
+}
+
+fn main() {}

--- a/sdk/patina/tests/ui/duplicate_storage_mut.stderr
+++ b/sdk/patina/tests/ui/duplicate_storage_mut.stderr
@@ -1,0 +1,11 @@
+error: Patina component parameter conflict detected: parameter '_s2' (position 2) conflicts with parameter '_s1' (position 1). Only one &mut Storage parameter is allowed.
+ --> tests/ui/duplicate_storage_mut.rs:9:45
+  |
+9 |     fn entry_point(self, _s1: &mut Storage, _s2: &mut Storage) -> Result<()> {
+  |                                             ^^^^^^^^^^^^^^^^^
+
+error: conflicts with '_s1' parameter here
+ --> tests/ui/duplicate_storage_mut.rs:9:26
+  |
+9 |     fn entry_point(self, _s1: &mut Storage, _s2: &mut Storage) -> Result<()> {
+  |                          ^^^^^^^^^^^^^^^^^

--- a/sdk/patina/tests/ui/multiple_storage_allowed.rs
+++ b/sdk/patina/tests/ui/multiple_storage_allowed.rs
@@ -1,0 +1,15 @@
+//! Test that multiple &Storage parameters are allowed (compile-success test).
+//! Note: This should compile successfully.
+
+use patina::{component::{component, Storage}, error::Result};
+
+pub struct TestComponent;
+
+#[component]
+impl TestComponent {
+    fn entry_point(self, _s1: &Storage, _s2: &Storage, _s3: &Storage) -> Result<()> {
+        Ok(())
+    }
+}
+
+fn main() {}

--- a/sdk/patina/tests/ui/storage_and_storage_mut_conflict.rs
+++ b/sdk/patina/tests/ui/storage_and_storage_mut_conflict.rs
@@ -1,0 +1,14 @@
+//! Test that &Storage and &mut Storage parameters cannot be mixed.
+
+use patina::{component::{component, Storage}, error::Result};
+
+pub struct TestComponent;
+
+#[component]
+impl TestComponent {
+    fn entry_point(self, _s1: &Storage, _s2: &mut Storage) -> Result<()> {
+        Ok(())
+    }
+}
+
+fn main() {}

--- a/sdk/patina/tests/ui/storage_and_storage_mut_conflict.stderr
+++ b/sdk/patina/tests/ui/storage_and_storage_mut_conflict.stderr
@@ -1,0 +1,11 @@
+error: Patina component parameter conflict detected: parameter '_s2' (position 2) conflicts with parameter '_s1' (position 1). You cannot use &mut Storage together with &Storage parameters.
+ --> tests/ui/storage_and_storage_mut_conflict.rs:9:41
+  |
+9 |     fn entry_point(self, _s1: &Storage, _s2: &mut Storage) -> Result<()> {
+  |                                         ^^^^^^^^^^^^^^^^^
+
+error: conflicts with '_s1' parameter here
+ --> tests/ui/storage_and_storage_mut_conflict.rs:9:26
+  |
+9 |     fn entry_point(self, _s1: &Storage, _s2: &mut Storage) -> Result<()> {
+  |                          ^^^^^^^^^^^^^

--- a/sdk/patina/tests/ui/storage_mut_and_storage_conflict.rs
+++ b/sdk/patina/tests/ui/storage_mut_and_storage_conflict.rs
@@ -1,0 +1,14 @@
+//! Test that &mut Storage and &Storage parameters cannot be mixed (reverse order).
+
+use patina::{component::{component, Storage}, error::Result};
+
+pub struct TestComponent;
+
+#[component]
+impl TestComponent {
+    fn entry_point(self, _s1: &mut Storage, _s2: &Storage) -> Result<()> {
+        Ok(())
+    }
+}
+
+fn main() {}

--- a/sdk/patina/tests/ui/storage_mut_and_storage_conflict.stderr
+++ b/sdk/patina/tests/ui/storage_mut_and_storage_conflict.stderr
@@ -1,0 +1,11 @@
+error: Patina component parameter conflict detected: parameter '_s2' (position 2) conflicts with parameter '_s1' (position 1). You cannot use &mut Storage together with &Storage parameters.
+ --> tests/ui/storage_mut_and_storage_conflict.rs:9:45
+  |
+9 |     fn entry_point(self, _s1: &mut Storage, _s2: &Storage) -> Result<()> {
+  |                                             ^^^^^^^^^^^^^
+
+error: conflicts with '_s1' parameter here
+ --> tests/ui/storage_mut_and_storage_conflict.rs:9:26
+  |
+9 |     fn entry_point(self, _s1: &mut Storage, _s2: &Storage) -> Result<()> {
+  |                          ^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
## Description

Implement validation rules for component `Storage`` parameters that follow normal Rust borrowing semantics:

- Allow multiple `&Storage` parameters (multiple immutable references)
- Allow a single `&mut Storage` parameter (exclusive mutable reference)
- Prevent mixing `&Storage` with `&mut Storage`
- Prevent duplicate `&mut Storage` parameters

Adds macro unit tests and UI compilation failure message tests.

---

Note: This was not clearly handled in the past (since component inception). An error would have been thrown but it would have misrepresented the problem to a conflicting `ConfigMut<T>` instead of the real issue which is a conflicting `&mut Storage` parameter.

---

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [x] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

- `cargo make all`
- QEMU platform boot

## Integration Instructions

- N/A - These rules should already be followed by components