### PR TITLE
Implement `AcpiGet` (to enable custom ACPI SDT protocol split)

### DIFF
--- a/components/patina_acpi/src/acpi_protocol.rs
+++ b/components/patina_acpi/src/acpi_protocol.rs
@@ -35,7 +35,7 @@ unsafe impl ProtocolInterface for AcpiTableProtocol {
         efi::Guid::from_fields(0xffe06bdd, 0x6107, 0x46a6, 0x7b, 0xb2, &[0x5a, 0x9c, 0x7e, 0xc5, 0x27, 0x5c]);
 }
 
-// C function interfaces for ACPI Table Protocol and ACPI SDT Protocol.
+// C function interfaces for ACPI Table Protocol and ACPI Get Protocol.
 type AcpiTableInstall = extern "efiapi" fn(*const AcpiTableProtocol, *const c_void, usize, *mut usize) -> efi::Status;
 type AcpiTableUninstall = extern "efiapi" fn(*const AcpiTableProtocol, usize) -> efi::Status;
 type AcpiTableGet = extern "efiapi" fn(usize, *mut *mut AcpiTableHeader, *mut u32, *mut usize) -> efi::Status;
@@ -160,21 +160,21 @@ impl AcpiTableProtocol {
     }
 }
 
-/// Corresponds to the ACPI SDT Protocol as defined in PI spec.
+/// Custom protocol to enable non-AML ACPI SDT functionality.
 #[repr(C)]
-pub struct AcpiSdtProtocol {
+pub struct AcpiGetProtocol {
     pub version: u32,
     pub get_table: AcpiTableGet,
     pub register_notify: AcpiTableRegisterNotify,
 }
 
-// SAFETY: `AcpiSdtProtocol` matches the C layout and behavior of the EFI_ACPI_SDT_PROTOCOL.
-unsafe impl ProtocolInterface for AcpiSdtProtocol {
+// SAFETY: `AcpiGetProtocol` matches the C layout and behavior of the custom-defined EFI_ACPI_GET_PROTOCOL. (Not a UEFI spec protocol.)
+unsafe impl ProtocolInterface for AcpiGetProtocol {
     const PROTOCOL_GUID: efi::Guid =
-        efi::Guid::from_fields(0xeb97088e, 0xcfdf, 0x49c6, 0xbe, 0x4b, &[0xd9, 0x06, 0xa5, 0xb2, 0x0e, 0x86]);
+        efi::Guid::from_fields(0x7f3c1a92, 0x8b4e, 0x4d2f, 0xa6, 0xc9, &[0x3e, 0x12, 0xf4, 0xb8, 0xd7, 0xc1]);
 }
 
-impl AcpiSdtProtocol {
+impl AcpiGetProtocol {
     pub(crate) fn new() -> Self {
         Self {
             version: ACPI_VERSIONS_GTE_2,
@@ -184,7 +184,7 @@ impl AcpiSdtProtocol {
     }
 }
 
-impl AcpiSdtProtocol {
+impl AcpiGetProtocol {
     /// Returns a requested ACPI table.
     ///
     /// This function generally matches the behavior of EFI_ACPI_SDT_PROTOCOL.GetAcpiTable() API in the PI spec 1.8
@@ -357,25 +357,25 @@ mod tests {
     }
 
     #[test]
-    fn test_acpi_sdt_init() {
-        let protocol = AcpiSdtProtocol::new();
+    fn test_acpi_get_init() {
+        let protocol = AcpiGetProtocol::new();
         assert_eq!(protocol.version, ACPI_VERSIONS_GTE_2);
-        assert_eq!(protocol.get_table as usize, AcpiSdtProtocol::get_acpi_table_ext as *const () as usize);
-        assert_eq!(protocol.register_notify as usize, AcpiSdtProtocol::register_notify_ext as *const () as usize);
+        assert_eq!(protocol.get_table as usize, AcpiGetProtocol::get_acpi_table_ext as *const () as usize);
+        assert_eq!(protocol.register_notify as usize, AcpiGetProtocol::register_notify_ext as *const () as usize);
     }
 
     #[test]
     fn test_get_table_ext_error_cases() {
         // Test null output parameters.
         let status =
-            AcpiSdtProtocol::get_acpi_table_ext(0, core::ptr::null_mut(), core::ptr::null_mut(), core::ptr::null_mut());
+            AcpiGetProtocol::get_acpi_table_ext(0, core::ptr::null_mut(), core::ptr::null_mut(), core::ptr::null_mut());
         assert_eq!(status, efi::Status::INVALID_PARAMETER);
     }
 
     #[test]
     fn test_register_notify_ext_error_cases() {
         // Test null notify function.
-        let status = AcpiSdtProtocol::register_notify_ext(true, core::ptr::null());
+        let status = AcpiGetProtocol::register_notify_ext(true, core::ptr::null());
         assert_eq!(status, efi::Status::INVALID_PARAMETER);
     }
 }

--- a/components/patina_acpi/src/component.rs
+++ b/components/patina_acpi/src/component.rs
@@ -27,7 +27,7 @@ use patina::{
 
 use crate::{
     acpi::ACPI_TABLE_INFO,
-    acpi_protocol::{AcpiSdtProtocol, AcpiTableProtocol},
+    acpi_protocol::{AcpiGetProtocol, AcpiTableProtocol},
     acpi_table::{AcpiRsdp, AcpiXsdt},
     signature::{
         self, ACPI_HEADER_LEN, ACPI_RESERVED_BYTE, ACPI_RSDP_REVISION, ACPI_XSDT_REVISION, MAX_INITIAL_ENTRIES,
@@ -193,9 +193,10 @@ impl AcpiSystemProtocolManager {
 
     /// Initializes the ACPI protocols.
     /// Ignore coverage due to the use of `StandardBootServices`.
+    #[coverage(off)]
     fn entry_point(self, boot_services: StandardBootServices) -> patina::error::Result<()> {
         boot_services.install_protocol_interface(None, Box::new(AcpiTableProtocol::new()))?;
-        boot_services.install_protocol_interface(None, Box::new(AcpiSdtProtocol::new()))?;
+        boot_services.install_protocol_interface(None, Box::new(AcpiGetProtocol::new()))?;
         Ok(())
     }
 }

--- a/components/patina_acpi/src/integration_test.rs
+++ b/components/patina_acpi/src/integration_test.rs
@@ -19,7 +19,7 @@ use r_efi::efi;
 
 use crate::{
     acpi::ACPI_TABLE_INFO,
-    acpi_protocol::{AcpiSdtProtocol, AcpiTableProtocol},
+    acpi_protocol::{AcpiGetProtocol, AcpiTableProtocol},
     acpi_table::{AcpiFacs, AcpiFadt, AcpiTableHeader},
     service::AcpiTableManager,
     signature::{
@@ -72,8 +72,9 @@ fn acpi_protocol_test(bs: StandardBootServices) -> patina::test::Result {
     // SAFETY: there is only one reference to the `AcpiTableProtocol` during this test.
     let table_protocol =
         unsafe { bs.locate_protocol::<AcpiTableProtocol>(None) }.expect("Locate protocol should succeed.");
-    // SAFETY: there is only one reference to the `AcpiSdtProtocol` during this test.
-    let sdt_protocol = unsafe { bs.locate_protocol::<AcpiSdtProtocol>(None) }.expect("Locate protocol should succeed.");
+    // SAFETY: there is only one reference to the `AcpiGetProtocol` during this test.
+    let acpi_get_protocol =
+        unsafe { bs.locate_protocol::<AcpiGetProtocol>(None) }.expect("Locate protocol should succeed.");
 
     let mut table_key_buf: usize = 0;
 
@@ -100,7 +101,7 @@ fn acpi_protocol_test(bs: StandardBootServices) -> patina::test::Result {
     let table_idx = 0; // We only installed one table, so index 0 should work.
     let mut get_supported_table_versions: u32 = 0;
     let mut get_table_key = 0;
-    let get_result = (sdt_protocol.get_table)(
+    let get_result = (acpi_get_protocol.get_table)(
         table_idx,
         &mut table_buf as *mut *mut AcpiTableHeader,
         &mut get_supported_table_versions,


### PR DESCRIPTION
## Description

The ACPI SDT protocol as defined in the UEFI spec includes two main functionalities: 1) get and register_notify, which integrate directly with the AcpiTableProtocol (uninstall, install), 2) AML manipulation. Due to the complexity of reimplementing AML functionality in Rust and its unrelatedness to general ACPI functionality (install, uninstall, publish, get), an intermediate step for ACPI Rust integration is to only integrate functionality related to installation and retrieval of tables, while keeping AML functionality in C. Doing this requires splitting the ACPI SDT protocol into two parts: table functionality and AML functionality. 

- [X] Impacts functionality?
- [ ] Impacts security?
- [ ] **Breaking change?** Note: this doesn't directly break anything because the ACPI component is not yet enabled, but sets up the ACPI component to be enabled (additional changes needed in Patina and physical platform repos). Once the component is enabled in patina-dxe-core-qemu builds will break until all changes are integrated.
- [X] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

- Boot Q35 to shell and Windows.
- TBD: test on physical Intel platform.

## Integration Instructions

- patina-dxe-core-qemu (or platform equivalent): turn on ACPI component
- patina-edk2: integrate new AcpiSdt split driver 
- patina-qemu (or platform equivalent): replace AcpiTableDxe with new AcpiSdt driver
- PatinaPkg: add modified AcpiSdt driver