### PR TITLE
patina_dxe_core: Additional cleanup of image.rs

### DIFF
--- a/patina_dxe_core/src/image.rs
+++ b/patina_dxe_core/src/image.rs
@@ -3279,7 +3279,7 @@ mod tests {
                     reserved: [0; 4],
                 },
                 module_name: guids::DXE_CORE,
-                entry_point: entry_point as usize as u64,
+                entry_point: entry_point as *const () as u64,
             };
             let end_hob = patina::pi::hob::header::Hob {
                 r#type: patina::pi::hob::END_OF_HOB_LIST,


### PR DESCRIPTION
## Description

This commit performs some additional non-functional cleanup of image.rs to break up the larger functions into smaller chunks that only perform one operation each. This makes understanding and testing the code simpler.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [x] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

CI, Boots to shell.

## Integration Instructions

N/A
