### PR TITLE
patina_test: Support multiple event triggers

### DIFF
--- a/sdk/patina/src/test/__private_api.rs
+++ b/sdk/patina/src/test/__private_api.rs
@@ -58,7 +58,7 @@ pub enum TestTrigger {
 #[derive(Debug, Clone, Copy)]
 pub struct TestCase {
     pub name: &'static str,
-    pub trigger: TestTrigger,
+    pub triggers: &'static [TestTrigger],
     pub skip: bool,
     pub should_fail: bool,
     pub fail_msg: Option<&'static str>,
@@ -155,7 +155,7 @@ mod tests {
     fn test_should_run() {
         let test_case = TestCase {
             name: "test",
-            trigger: TestTrigger::Immediate,
+            triggers: &[TestTrigger::Immediate],
             skip: false,
             should_fail: false,
             fail_msg: None,
@@ -174,7 +174,7 @@ mod tests {
 
         let test_case_pass = TestCase {
             name: "test",
-            trigger: TestTrigger::Immediate,
+            triggers: &[TestTrigger::Immediate],
             skip: false,
             should_fail: false,
             fail_msg: None,
@@ -183,7 +183,7 @@ mod tests {
 
         let test_case_fail = TestCase {
             name: "test",
-            trigger: TestTrigger::Immediate,
+            triggers: &[TestTrigger::Immediate],
             skip: false,
             should_fail: false,
             fail_msg: None,
@@ -205,7 +205,7 @@ mod tests {
 
         let test_case_pass = TestCase {
             name: "test",
-            trigger: TestTrigger::Immediate,
+            triggers: &[TestTrigger::Immediate],
             skip: false,
             should_fail: true,
             fail_msg: None,
@@ -213,7 +213,7 @@ mod tests {
         };
         let test_case_fail = TestCase {
             name: "test",
-            trigger: TestTrigger::Immediate,
+            triggers: &[TestTrigger::Immediate],
             skip: false,
             should_fail: true,
             fail_msg: None,
@@ -236,7 +236,7 @@ mod tests {
         // Test that a test that fails with the expected message, should pass
         let test_case = TestCase {
             name: "test",
-            trigger: TestTrigger::Immediate,
+            triggers: &[TestTrigger::Immediate],
             skip: false,
             should_fail: true,
             fail_msg: Some("Failed to install protocol interface"),
@@ -249,7 +249,7 @@ mod tests {
         // Test that a test that fails with an unexpected message, should fail
         let test_case = TestCase {
             name: "test",
-            trigger: TestTrigger::Immediate,
+            triggers: &[TestTrigger::Immediate],
             skip: false,
             should_fail: true,
             fail_msg: Some("Other failure"),

--- a/sdk/patina_macro/src/lib.rs
+++ b/sdk/patina_macro/src/lib.rs
@@ -140,10 +140,21 @@ pub fn hob_config(item: proc_macro::TokenStream) -> proc_macro::TokenStream {
 /// fn x86_64_only_test_case(bs: StandardBootServices) -> Result {
 ///   todo!()
 /// }
+///
+/// #[patina_test]
+/// #[on(timer = 1000000)]
+/// #[on(event = patina::guids::EVENT_GROUP_END_OF_DXE)]
+/// fn multi_triggered_test_case() -> Result {
+///  todo!()
+/// }
 /// ```
 #[proc_macro_attribute]
 pub fn patina_test(_: proc_macro::TokenStream, item: proc_macro::TokenStream) -> proc_macro::TokenStream {
-    test_macro::patina_test2(item.into()).into()
+    if cfg!(feature = "enable_patina_tests") {
+        test_macro::patina_test2(item.into()).into()
+    } else {
+        test_macro::patina_test_feature_off(item.into()).into()
+    }
 }
 
 /// Derive Macro for implementing the `SmbiosRecordStructure` trait.


### PR DESCRIPTION
## Description

This commit does two things:

1. Adds support for multiple event triggers
2. Improves the ability to test macros by moving the feature flag conditional to a layer above, so we can consistently test the macro functionality, regardless of feature flags set.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [x] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

CI

## Integration Instructions

patina tests can now be annotated with multiple triggers:

```rust
#[patina_test]
#[on(timer = 1000000)]
#[on(event = patina::guids::EVENT_GROUP_END_OF_DXE)]
fn multi_triggered_test_case() -> Result {
  todo!()
}
```
