### PR TITLE
patina_performance: Update the FBPT buffer size from 64KB to 256KB

### DIFF
--- a/sdk/patina/src/performance/table.rs
+++ b/sdk/patina/src/performance/table.rs
@@ -37,7 +37,6 @@ use scroll::Pwrite;
 
 /// The number of extra space in byte that will be allocated when publishing the performance buffer.
 /// This is used for every performance records that will be added to the table after it is published.
-// const PUBLISHED_FBPT_EXTRA_SPACE: usize = 0x400_000;
 const PUBLISHED_FBPT_EXTRA_SPACE: usize = 0x40_000;
 
 /// Interface for a Firmware Basic Boot Performance Table.


### PR DESCRIPTION
## Description

patina_performance: Update the FBPT buffer size from 64KB to 256KB
After [updating the perf record struct to improve debuggability](https://github.com/OpenDevicePartnership/patina/commit/f7410f3e8f32653eeb1c24513728c39601807632#diff-33b609012fef38176911d438ed4fe2b29d70a6c0141b465bf630cdf7ea3e1727), we need to update the record buffer size to make sure we can still log all entries. The new buffer size should be able to log 10000 entries, which should be enough for most platforms.

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Tested with real hardware, before change I can get 3700 entries and there will be 1000 error msgs of `Performance: FBPT is full, can't add more performance records !`. 
After this change, it will no longer be seen in the UEFI log and I can get 4700 entries correctly.