### PR TITLE
[feature/patina-boot] patina_boot: Add boot orchestration crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,7 @@ patina_lzma_rs = { version = "0.3.1", default-features = false }
 patina_macro = { version = "19.0.2", path = "sdk/patina_macro" }
 patina_mm = { version = "19.0.2", path = "components/patina_mm" }
 patina_mtrr = { version = "^1.1.4" }
+patina_boot = { version = "19.0.2", path = "components/patina_boot" }
 patina_paging = { version = "10" }
 patina_performance = { version = "19.0.2", path = "components/patina_performance" }
 patina_smbios = { version = "19.0.2", path = "components/patina_smbios" }

--- a/components/patina_boot/Cargo.toml
+++ b/components/patina_boot/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "patina_boot"
+resolver = "2"
+version.workspace = true
+repository.workspace = true
+license.workspace = true
+edition.workspace = true
+description = "Boot orchestration components for Patina firmware."
+
+[lints]
+workspace = true
+
+[dependencies]
+log = { workspace = true }
+patina = { workspace = true, features = ["unstable-device-path"] }
+patina_macro = { workspace = true }
+r-efi = { workspace = true }
+
+[dev-dependencies]
+patina = { path = "../../sdk/patina", features = ["mockall", "unstable-device-path"] }
+mockall = { workspace = true }
+
+[features]
+default = []
+std = []

--- a/components/patina_boot/README.md
+++ b/components/patina_boot/README.md
@@ -1,0 +1,33 @@
+# Patina Boot
+
+Boot orchestration component for Patina-based firmware implementing UEFI boot manager functionality.
+
+## Components
+
+- **BootOrchestrator**: Orchestrates device enumeration, BDS phase events, and boot option execution.
+- **ConsoleDiscovery**: Discovers console devices and populates UEFI console variables.
+
+## Usage
+
+```rust
+use patina_boot::{component::BootOrchestrator, config::BootOptions};
+
+// Configure boot options (devices are tried in order)
+let config = BootOptions::new()
+    .with_device(primary_boot_path)
+    .with_device(fallback_boot_path)
+    .with_failure_handler(|| { /* handle boot failure */ });
+
+// Add BootOrchestrator as a platform component
+add.component(BootOrchestrator);
+```
+
+## Helper Functions
+
+For custom boot flows, use the helper functions in the `helpers` module:
+
+- `connect_all()` - Connect all controllers for device enumeration
+- `signal_bds_phase_entry()` - Signal EndOfDxe event
+- `signal_ready_to_boot()` - Signal ReadyToBoot event
+- `discover_console_devices()` - Populate console variables
+- `boot_from_device_path()` - Load and start a boot image

--- a/components/patina_boot/src/component.rs
+++ b/components/patina_boot/src/component.rs
@@ -1,0 +1,18 @@
+//! Boot orchestration components.
+//!
+//! This module provides the core boot components:
+//! - [`ConsoleDiscovery`]: Discovers console devices and populates ConIn/ConOut/ErrOut variables
+//! - [`BootOrchestrator`]: Orchestrates the boot flow with device enumeration, event signaling, and boot execution
+//!
+//! ## License
+//!
+//! Copyright (c) Microsoft Corporation.
+//!
+//! SPDX-License-Identifier: Apache-2.0
+//!
+
+mod boot_orchestrator;
+mod console_discovery;
+
+pub use boot_orchestrator::BootOrchestrator;
+pub use console_discovery::ConsoleDiscovery;

--- a/components/patina_boot/src/component/boot_orchestrator.rs
+++ b/components/patina_boot/src/component/boot_orchestrator.rs
@@ -1,0 +1,104 @@
+//! Boot orchestrator component.
+//!
+//! Orchestrates the boot flow with device enumeration, event signaling, and boot execution.
+//!
+//! ## Rationale
+//!
+//! Boot orchestration is a component that represents the primary platform customization
+//! point. Platforms provide boot options as configuration data, allowing different boot policies
+//! without changing orchestration logic. Platforms needing entirely different boot flows can
+//! replace the component.
+//!
+//! ## License
+//!
+//! Copyright (c) Microsoft Corporation.
+//!
+//! SPDX-License-Identifier: Apache-2.0
+//!
+use patina::{
+    boot_services::{BootServices, StandardBootServices, protocol_handler::HandleSearchType},
+    component::{
+        component,
+        params::{Config, Handle},
+    },
+    error::{EfiError, Result},
+    runtime_services::StandardRuntimeServices,
+};
+use r_efi::efi;
+
+use crate::{config::BootOptions, helpers};
+
+/// Boot orchestrator component.
+///
+/// Orchestrates boot execution using boot options provided via [`Config<BootOptions>`].
+/// Connects all controllers for device topology enumeration, signals BDS phase events
+/// (EndOfDxe, ReadyToBoot), and executes boot options via `LoadImage()`/`StartImage()`
+/// with 5-minute watchdog per UEFI Section 3.1.2.
+///
+/// Handles boot failures by attempting subsequent options. Never returns on success.
+pub struct BootOrchestrator;
+
+#[component]
+impl BootOrchestrator {
+    /// Entry point for the boot orchestrator component.
+    ///
+    /// # Flow
+    ///
+    /// 1. Connect all controllers for device enumeration
+    /// 2. Signal EndOfDxe (security components perform lockdown)
+    /// 3. Discover consoles
+    /// 4. Signal ReadyToBoot
+    /// 5. Execute boot options from config
+    /// 6. If all boot options fail, call failure handler
+    #[coverage(off)] // Component integration - tested via integration tests
+    fn entry_point(
+        self,
+        boot_services: StandardBootServices,
+        runtime_services: StandardRuntimeServices,
+        boot_options: Config<BootOptions>,
+        image_handle: Option<Handle>,
+    ) -> Result<()> {
+        helpers::connect_all(boot_services.as_ref())?;
+        helpers::signal_bds_phase_entry(boot_services.as_ref())?;
+        helpers::discover_console_devices(boot_services.as_ref(), runtime_services.as_ref())?;
+        helpers::signal_ready_to_boot(boot_services.as_ref())?;
+
+        // Use the provided image handle, or fall back to finding one via LocateHandleBuffer.
+        // Per UEFI spec, the parent handle must be a valid image handle (has LoadedImage protocol).
+        let parent_handle = if let Some(handle) = image_handle {
+            *handle
+        } else {
+            log::warn!("Handle not provided, falling back to LocateHandleBuffer");
+            let image_handles = boot_services
+                .locate_handle_buffer(HandleSearchType::ByProtocol(&efi::protocols::loaded_image::PROTOCOL_GUID))
+                .map_err(|status| {
+                    log::error!("Failed to locate image handles: {:?}", status);
+                    EfiError::from(status)
+                })?;
+
+            image_handles.first().copied().ok_or_else(|| {
+                log::error!("No image handles available for parent handle");
+                EfiError::NotReady
+            })?
+        };
+
+        for device_path in boot_options.devices() {
+            match helpers::boot_from_device_path(boot_services.as_ref(), parent_handle, device_path) {
+                Ok(()) => {
+                    // Boot image returned control (e.g., EFI application exited).
+                    // Continue to try next boot option.
+                    log::warn!("Boot option returned, trying next...");
+                }
+                Err(_) => {
+                    log::warn!("Boot option failed, trying next...");
+                }
+            }
+        }
+
+        boot_options.handle_failure();
+        log::error!("All boot options exhausted and failure handler returned");
+        loop {
+            core::hint::spin_loop();
+        }
+    }
+}

--- a/components/patina_boot/src/component/console_discovery.rs
+++ b/components/patina_boot/src/component/console_discovery.rs
@@ -1,0 +1,42 @@
+//! Console discovery component.
+//!
+//! Locates GOP and SimpleTextInput protocol handles, creates device paths,
+//! and writes ConIn/ConOut/ErrOut variables.
+//!
+//! ## Rationale
+//!
+//! Console setup is a component because platforms may need custom console configuration
+//! (serial-only, specific GOP preference, headless operation). As a component, platforms
+//! can replace it entirely without modifying orchestration code.
+//!
+//! ## Prerequisites
+//!
+//! Device controllers exposing GOP and input protocols must be connected before
+//! this component runs.
+//!
+//! ## License
+//!
+//! Copyright (c) Microsoft Corporation.
+//!
+//! SPDX-License-Identifier: Apache-2.0
+//!
+use patina::{
+    boot_services::StandardBootServices, component::component, error::Result, runtime_services::StandardRuntimeServices,
+};
+
+use crate::helpers;
+
+/// Console discovery component.
+///
+/// Scans for GOP and SimpleTextInput protocol handles, creates device paths,
+/// and writes `ConIn`/`ConOut`/`ErrOut` UEFI variables.
+pub struct ConsoleDiscovery;
+
+#[component]
+impl ConsoleDiscovery {
+    /// Entry point for the console discovery component.
+    #[coverage(off)] // Component integration - tested via integration tests
+    fn entry_point(self, boot_services: StandardBootServices, runtime_services: StandardRuntimeServices) -> Result<()> {
+        helpers::discover_console_devices(boot_services.as_ref(), runtime_services.as_ref())
+    }
+}

--- a/components/patina_boot/src/config.rs
+++ b/components/patina_boot/src/config.rs
@@ -1,0 +1,174 @@
+//! Boot configuration types.
+//!
+//! This module provides configuration types for boot orchestration, including
+//! [`BootOptions`] which specifies platform-provided boot paths.
+//!
+//! ## License
+//!
+//! Copyright (c) Microsoft Corporation.
+//!
+//! SPDX-License-Identifier: Apache-2.0
+//!
+extern crate alloc;
+
+use alloc::{boxed::Box, vec::Vec};
+use patina::uefi_protocol::device_path::DevicePathBuf;
+
+/// Boot options provided by the platform.
+///
+/// Platforms configure boot behavior by providing this configuration to the
+/// [`BootOrchestrator`](crate::component::BootOrchestrator) component.
+///
+/// ## Example
+///
+/// ```rust,ignore
+/// use patina_boot::config::BootOptions;
+///
+/// let options = BootOptions::new()
+///     .with_device(nvme_device_path)
+///     .with_device(usb_device_path)
+///     .with_failure_handler(|| show_error_screen());
+/// ```
+#[derive(Default)]
+pub struct BootOptions {
+    /// Boot device paths in priority order.
+    devices: Vec<DevicePathBuf>,
+    /// Optional hotkey for boot override (e.g., F12 for boot menu).
+    hotkey: Option<u16>,
+    /// Handler called when all boot options fail.
+    failure_handler: Option<Box<dyn Fn() + Send + Sync>>,
+}
+
+impl BootOptions {
+    /// Create new empty boot options.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Add a boot device path.
+    ///
+    /// Device paths are tried in the order they are added.
+    pub fn with_device(mut self, device: DevicePathBuf) -> Self {
+        self.devices.push(device);
+        self
+    }
+
+    /// Add a hotkey scancode for boot override (not yet implemented).
+    ///
+    /// This field is reserved for future boot menu functionality.
+    /// Currently, the hotkey is stored but not acted upon.
+    pub fn with_hotkey(mut self, scancode: u16) -> Self {
+        self.hotkey = Some(scancode);
+        self
+    }
+
+    /// Add a failure handler called when all boot options fail.
+    pub fn with_failure_handler<F>(mut self, handler: F) -> Self
+    where
+        F: Fn() + Send + Sync + 'static,
+    {
+        self.failure_handler = Some(Box::new(handler));
+        self
+    }
+
+    /// Get the hotkey scancode, if configured.
+    pub fn hotkey(&self) -> Option<u16> {
+        self.hotkey
+    }
+
+    /// Returns an iterator over all configured boot device paths.
+    pub fn devices(&self) -> impl Iterator<Item = &DevicePathBuf> {
+        self.devices.iter()
+    }
+
+    /// Call the failure handler if configured.
+    ///
+    /// This is called when all boot options have been exhausted.
+    pub fn handle_failure(&self) {
+        if let Some(handler) = &self.failure_handler {
+            handler();
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    extern crate alloc;
+    extern crate std;
+
+    use super::*;
+    use alloc::sync::Arc;
+    use core::sync::atomic::{AtomicBool, Ordering};
+    use patina::uefi_protocol::device_path::nodes::EndEntire;
+
+    fn create_test_device_path() -> DevicePathBuf {
+        DevicePathBuf::from_device_path_node_iter(core::iter::once(EndEntire))
+    }
+
+    #[test]
+    fn test_default_boot_options() {
+        let options = BootOptions::default();
+        assert!(options.hotkey().is_none());
+        assert_eq!(options.devices().count(), 0);
+    }
+
+    #[test]
+    fn test_new_boot_options() {
+        let options = BootOptions::new();
+        assert_eq!(options.devices().count(), 0);
+    }
+
+    #[test]
+    fn test_with_single_device() {
+        let device = create_test_device_path();
+        let options = BootOptions::new().with_device(device);
+        assert_eq!(options.devices().count(), 1);
+    }
+
+    #[test]
+    fn test_with_multiple_devices() {
+        let device1 = create_test_device_path();
+        let device2 = create_test_device_path();
+        let device3 = create_test_device_path();
+        let options = BootOptions::new().with_device(device1).with_device(device2).with_device(device3);
+        assert_eq!(options.devices().count(), 3);
+    }
+
+    #[test]
+    fn test_with_hotkey() {
+        let options = BootOptions::new().with_hotkey(0x86); // F12
+        assert_eq!(options.hotkey(), Some(0x86));
+    }
+
+    #[test]
+    fn test_failure_handler_called() {
+        let called = Arc::new(AtomicBool::new(false));
+        let called_clone = called.clone();
+
+        let device = create_test_device_path();
+        let options = BootOptions::new().with_device(device).with_failure_handler(move || {
+            called_clone.store(true, Ordering::SeqCst);
+        });
+
+        assert!(!called.load(Ordering::SeqCst));
+        options.handle_failure();
+        assert!(called.load(Ordering::SeqCst));
+    }
+
+    #[test]
+    fn test_failure_handler_not_configured() {
+        let options = BootOptions::default();
+        // Should not panic when no handler is configured
+        options.handle_failure();
+    }
+
+    #[test]
+    fn test_devices_iterator_order() {
+        let device1 = create_test_device_path();
+        let device2 = create_test_device_path();
+        let options = BootOptions::new().with_device(device1).with_device(device2);
+
+        let devices: Vec<_> = options.devices().collect();
+        assert_eq!(devices.len(), 2);
+    }
+}

--- a/components/patina_boot/src/helpers.rs
+++ b/components/patina_boot/src/helpers.rs
@@ -1,0 +1,430 @@
+//! Helper functions for boot orchestration.
+//!
+//! This module provides helper functions for platforms implementing custom boot flows.
+//! The [`BootOrchestrator`](crate::component::BootOrchestrator) component uses these
+//! internally, and platforms can use them directly for custom orchestration.
+//!
+//! ## License
+//!
+//! Copyright (c) Microsoft Corporation.
+//!
+//! SPDX-License-Identifier: Apache-2.0
+//!
+extern crate alloc;
+
+use alloc::vec::Vec;
+use core::ptr;
+
+use patina::{
+    boot_services::{BootServices, event::EventType, protocol_handler::HandleSearchType, tpl::Tpl},
+    error::{EfiError, Result},
+    guids::EVENT_GROUP_END_OF_DXE,
+    runtime_services::RuntimeServices,
+    uefi_protocol::device_path::DevicePathBuf,
+};
+use r_efi::{efi, system::EVENT_GROUP_READY_TO_BOOT};
+
+/// Watchdog timeout in seconds per UEFI Specification Section 3.1.2.
+const WATCHDOG_TIMEOUT_SECONDS: usize = 300; // 5 minutes
+
+/// Load and start a boot image with UEFI spec compliance.
+///
+/// Enables a 5-minute watchdog timer before `StartImage()` per UEFI Specification
+/// Section 3.1.2. Disables watchdog when boot returns control.
+///
+/// # Arguments
+///
+/// * `boot_services` - Boot services interface
+/// * `parent_handle` - Parent image handle for the loaded image (typically the calling image's handle)
+/// * `device_path` - Device path to the boot image
+///
+/// # Returns
+///
+/// Returns `Ok(())` if the boot image was successfully started (which typically
+/// means it returned control). Returns an error if loading or starting fails.
+pub fn boot_from_device_path<B: BootServices>(
+    boot_services: &B,
+    parent_handle: efi::Handle,
+    device_path: &DevicePathBuf,
+) -> Result<()> {
+    // Load the image
+    let device_path_ptr = device_path.as_ref() as *const _ as *mut efi::protocols::device_path::Protocol;
+    let image_handle = match boot_services.load_image(true, parent_handle, device_path_ptr, None) {
+        Ok(handle) => handle,
+        Err(status) => {
+            log::error!("LoadImage failed with status: {:?}", status);
+            return Err(EfiError::from(status));
+        }
+    };
+
+    // Enable 5-minute watchdog timer per UEFI spec Section 3.1.2
+    boot_services.set_watchdog_timer(WATCHDOG_TIMEOUT_SECONDS).map_err(EfiError::from)?;
+
+    // Start the image
+    let result = boot_services.start_image(image_handle);
+
+    // Disable watchdog timer when boot option returns control
+    let _ = boot_services.set_watchdog_timer(0);
+
+    match result {
+        Ok(()) => Ok(()),
+        Err((status, _exit_data)) => Err(EfiError::from(status)),
+    }
+}
+
+/// Connect all controllers recursively for device enumeration.
+///
+/// Connects all handles in the system recursively until the device topology
+/// stabilizes (no new handles are created).
+///
+/// # Arguments
+///
+/// * `boot_services` - Boot services interface
+///
+/// # Returns
+///
+/// Returns `Ok(())` when device topology enumeration is complete.
+pub fn connect_all<B: BootServices>(boot_services: &B) -> Result<()> {
+    // Loop until the number of handles stabilizes, indicating device topology is complete.
+    // This is needed because connecting a PCI bus creates new handles for PCI devices,
+    // which then need to be connected to bind drivers like NVMe, which creates namespace
+    // handles, etc.
+    const MAX_ITERATIONS: usize = 10;
+    let mut prev_handle_count = 0;
+
+    for _iteration in 0..MAX_ITERATIONS {
+        // Get all handles in the system
+        let handles = boot_services.locate_handle_buffer(HandleSearchType::AllHandle).map_err(EfiError::from)?;
+        let current_handle_count = handles.len();
+
+        // Connect each handle recursively
+        for &handle in handles.iter() {
+            // SAFETY: Empty driver handle list and null device path are valid per UEFI spec
+            let _ = unsafe { boot_services.connect_controller(handle, Vec::new(), ptr::null_mut(), true) };
+        }
+
+        // Check if handle count has stabilized
+        if current_handle_count == prev_handle_count {
+            break;
+        }
+
+        prev_handle_count = current_handle_count;
+    }
+
+    Ok(())
+}
+
+/// Signal EndOfDxe event for platforms implementing custom orchestration.
+///
+/// Signals `gEfiEndOfDxeEventGroupGuid` to notify security components that
+/// DXE phase initialization is complete. Security components (e.g., SMM/MM)
+/// register for this event and perform lockdown.
+///
+/// # Arguments
+///
+/// * `boot_services` - Boot services interface
+pub fn signal_bds_phase_entry<B: BootServices>(boot_services: &B) -> Result<()> {
+    // Create and signal EndOfDxe event
+    // SAFETY: Null context is valid for signal-only events
+    let event = unsafe {
+        boot_services.create_event_ex_unchecked::<()>(
+            EventType::NOTIFY_SIGNAL,
+            Tpl::CALLBACK,
+            signal_event_noop,
+            ptr::null_mut(),
+            &EVENT_GROUP_END_OF_DXE,
+        )
+    }
+    .map_err(EfiError::from)?;
+
+    let signal_result = boot_services.signal_event(event);
+    // Always close the event, even if signal failed
+    let close_result = boot_services.close_event(event);
+
+    signal_result.map_err(EfiError::from)?;
+    close_result.map_err(EfiError::from)?;
+
+    Ok(())
+}
+
+/// Signal ReadyToBoot event for platforms implementing custom orchestration.
+///
+/// Signals `gEfiEventReadyToBootGuid` immediately before attempting the first
+/// boot option. This event notifies drivers that boot is imminent.
+///
+/// # Arguments
+///
+/// * `boot_services` - Boot services interface
+pub fn signal_ready_to_boot<B: BootServices>(boot_services: &B) -> Result<()> {
+    // Create and signal ReadyToBoot event
+    // SAFETY: Null context is valid for signal-only events
+    let event = unsafe {
+        boot_services.create_event_ex_unchecked::<()>(
+            EventType::NOTIFY_SIGNAL,
+            Tpl::CALLBACK,
+            signal_event_noop,
+            ptr::null_mut(),
+            &EVENT_GROUP_READY_TO_BOOT,
+        )
+    }
+    .map_err(EfiError::from)?;
+
+    let signal_result = boot_services.signal_event(event);
+    // Always close the event, even if signal failed
+    let close_result = boot_services.close_event(event);
+
+    signal_result.map_err(EfiError::from)?;
+    close_result.map_err(EfiError::from)?;
+
+    Ok(())
+}
+
+/// Discover console devices (stub implementation).
+///
+/// This is a placeholder that locates GOP and SimpleTextInput handles but does
+/// not yet write the `ConIn`, `ConOut`, and `ErrOut` UEFI variables.
+///
+/// Platforms requiring full console variable support should implement this
+/// functionality or use platform-specific console initialization.
+///
+/// # Arguments
+///
+/// * `boot_services` - Boot services interface
+/// * `runtime_services` - Runtime services interface (unused in stub)
+#[allow(unused_variables)]
+pub fn discover_console_devices<B: BootServices, R: RuntimeServices>(
+    boot_services: &B,
+    runtime_services: &R,
+) -> Result<()> {
+    // Stub: Locate handles to verify protocols exist, but don't write variables.
+    // Full implementation would create multi-instance device paths and write
+    // ConIn/ConOut/ErrOut variables via runtime_services.set_variable().
+    let _gop_handles = boot_services
+        .locate_handle_buffer(HandleSearchType::ByProtocol(&efi::protocols::graphics_output::PROTOCOL_GUID))
+        .ok();
+
+    let _input_handles = boot_services
+        .locate_handle_buffer(HandleSearchType::ByProtocol(&efi::protocols::simple_text_input::PROTOCOL_GUID))
+        .ok();
+
+    Ok(())
+}
+
+/// No-op event callback for signal-only events.
+extern "efiapi" fn signal_event_noop(_event: *mut core::ffi::c_void, _context: *mut ()) {}
+
+#[cfg(test)]
+mod tests {
+    extern crate alloc;
+    extern crate std;
+
+    use super::*;
+    use core::sync::atomic::{AtomicUsize, Ordering};
+    use patina::{boot_services::MockBootServices, uefi_protocol::device_path::nodes::EndEntire};
+
+    fn create_test_device_path() -> DevicePathBuf {
+        DevicePathBuf::from_device_path_node_iter(core::iter::once(EndEntire))
+    }
+
+    fn dummy_parent_handle() -> efi::Handle {
+        std::ptr::dangling_mut::<core::ffi::c_void>()
+    }
+
+    #[test]
+    fn test_boot_from_device_path_success() {
+        let device_path = create_test_device_path();
+        let mut mock = MockBootServices::new();
+
+        // Expect load_image to succeed
+        mock.expect_load_image().returning(|_, _, _, _| Ok(core::ptr::null_mut()));
+
+        // Expect watchdog to be set to 5 minutes
+        mock.expect_set_watchdog_timer().withf(|timeout| *timeout == WATCHDOG_TIMEOUT_SECONDS).returning(|_| Ok(()));
+
+        // Expect start_image to succeed (return Ok)
+        mock.expect_start_image().returning(|_| Ok(()));
+
+        // Expect watchdog to be disabled after boot returns
+        mock.expect_set_watchdog_timer().withf(|timeout| *timeout == 0).returning(|_| Ok(()));
+
+        let result = boot_from_device_path(&mock, dummy_parent_handle(), &device_path);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_boot_from_device_path_load_failure() {
+        let device_path = create_test_device_path();
+        let mut mock = MockBootServices::new();
+
+        // Expect load_image to fail
+        mock.expect_load_image().returning(|_, _, _, _| Err(efi::Status::NOT_FOUND));
+
+        let result = boot_from_device_path(&mock, dummy_parent_handle(), &device_path);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_boot_from_device_path_start_failure() {
+        let device_path = create_test_device_path();
+        let mut mock = MockBootServices::new();
+
+        // Expect load_image to succeed
+        mock.expect_load_image().returning(|_, _, _, _| Ok(core::ptr::null_mut()));
+
+        // Expect watchdog to be set
+        mock.expect_set_watchdog_timer().returning(|_| Ok(()));
+
+        // Expect start_image to fail
+        mock.expect_start_image().returning(|_| Err((efi::Status::LOAD_ERROR, None)));
+
+        // Expect watchdog to be disabled even on failure
+        mock.expect_set_watchdog_timer().returning(|_| Ok(()));
+
+        let result = boot_from_device_path(&mock, dummy_parent_handle(), &device_path);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_boot_from_device_path_watchdog_disabled_on_failure() {
+        let device_path = create_test_device_path();
+        let mut mock = MockBootServices::new();
+
+        static WATCHDOG_DISABLE_CALLED: AtomicUsize = AtomicUsize::new(0);
+
+        mock.expect_load_image().returning(|_, _, _, _| Ok(core::ptr::null_mut()));
+
+        mock.expect_set_watchdog_timer().returning(|timeout| {
+            if timeout == 0 {
+                WATCHDOG_DISABLE_CALLED.fetch_add(1, Ordering::SeqCst);
+            }
+            Ok(())
+        });
+
+        mock.expect_start_image().returning(|_| Err((efi::Status::ABORTED, None)));
+
+        let _ = boot_from_device_path(&mock, dummy_parent_handle(), &device_path);
+
+        // Verify watchdog was disabled (timeout=0 was called)
+        assert!(WATCHDOG_DISABLE_CALLED.load(Ordering::SeqCst) >= 1);
+    }
+
+    #[test]
+    fn test_signal_bds_phase_entry_signals_end_of_dxe() {
+        let mut mock = MockBootServices::new();
+
+        // Expect event creation with proper type annotation
+        mock.expect_create_event_ex_unchecked::<()>().returning(|_, _, _, _, _| Ok(core::ptr::null_mut()));
+
+        // Expect event to be signaled
+        mock.expect_signal_event().returning(|_| Ok(()));
+
+        // Expect event to be closed
+        mock.expect_close_event().returning(|_| Ok(()));
+
+        let result = signal_bds_phase_entry(&mock);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_signal_ready_to_boot() {
+        let mut mock = MockBootServices::new();
+
+        mock.expect_create_event_ex_unchecked::<()>().returning(|_, _, _, _, _| Ok(core::ptr::null_mut()));
+        mock.expect_signal_event().returning(|_| Ok(()));
+        mock.expect_close_event().returning(|_| Ok(()));
+
+        let result = signal_ready_to_boot(&mock);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_connect_all_locate_failure() {
+        let mut mock = MockBootServices::new();
+
+        // locate_handle_buffer fails on first call
+        mock.expect_locate_handle_buffer().returning(|_| Err(efi::Status::NOT_FOUND));
+
+        let result = connect_all(&mock);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_discover_console_devices_handles_missing_protocols() {
+        use patina::runtime_services::MockRuntimeServices;
+
+        let mut boot_mock = MockBootServices::new();
+        let runtime_mock = MockRuntimeServices::new();
+
+        // Protocols not found - returns error but function should still succeed
+        boot_mock.expect_locate_handle_buffer().returning(|_| Err(efi::Status::NOT_FOUND));
+
+        // Function should still succeed even with no console devices
+        let result = discover_console_devices(&boot_mock, &runtime_mock);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_signal_bds_phase_entry_create_event_failure() {
+        let mut mock = MockBootServices::new();
+
+        // Event creation fails
+        mock.expect_create_event_ex_unchecked::<()>().returning(|_, _, _, _, _| Err(efi::Status::OUT_OF_RESOURCES));
+
+        let result = signal_bds_phase_entry(&mock);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_signal_bds_phase_entry_signal_failure() {
+        let mut mock = MockBootServices::new();
+
+        mock.expect_create_event_ex_unchecked::<()>().returning(|_, _, _, _, _| Ok(core::ptr::null_mut()));
+
+        // Signal fails
+        mock.expect_signal_event().returning(|_| Err(efi::Status::INVALID_PARAMETER));
+
+        // close_event is always called, even on signal failure
+        mock.expect_close_event().returning(|_| Ok(()));
+
+        let result = signal_bds_phase_entry(&mock);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_signal_bds_phase_entry_close_event_failure() {
+        let mut mock = MockBootServices::new();
+
+        mock.expect_create_event_ex_unchecked::<()>().returning(|_, _, _, _, _| Ok(core::ptr::null_mut()));
+        mock.expect_signal_event().returning(|_| Ok(()));
+
+        // Close fails
+        mock.expect_close_event().returning(|_| Err(efi::Status::INVALID_PARAMETER));
+
+        let result = signal_bds_phase_entry(&mock);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_signal_ready_to_boot_create_event_failure() {
+        let mut mock = MockBootServices::new();
+
+        mock.expect_create_event_ex_unchecked::<()>().returning(|_, _, _, _, _| Err(efi::Status::OUT_OF_RESOURCES));
+
+        let result = signal_ready_to_boot(&mock);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_boot_from_device_path_watchdog_set_failure() {
+        let device_path = create_test_device_path();
+        let mut mock = MockBootServices::new();
+
+        mock.expect_load_image().returning(|_, _, _, _| Ok(core::ptr::null_mut()));
+
+        // Watchdog set fails
+        mock.expect_set_watchdog_timer().returning(|_| Err(efi::Status::DEVICE_ERROR));
+
+        let result = boot_from_device_path(&mock, dummy_parent_handle(), &device_path);
+        assert!(result.is_err());
+    }
+}

--- a/components/patina_boot/src/lib.rs
+++ b/components/patina_boot/src/lib.rs
@@ -1,0 +1,30 @@
+//! Boot Orchestration Components
+//!
+//! This crate provides boot orchestration components for Patina firmware, implementing
+//! UEFI Specification 2.11 Chapter 3 (Boot Manager) and PI Specification BDS phase requirements.
+//!
+//! ## Components
+//!
+//! - [`component::ConsoleDiscovery`]: Discovers console devices and populates ConIn/ConOut/ErrOut variables
+//! - [`component::BootOrchestrator`]: Orchestrates the boot flow with device enumeration, event signaling, and boot execution
+//!
+//! ## Configuration
+//!
+//! - [`config::BootOptions`]: Platform-provided boot options as device paths
+//!
+//! ## Helper Functions
+//!
+//! The [`helpers`] module provides helper functions for platforms implementing custom boot flows.
+//!
+//! ## License
+//!
+//! Copyright (c) Microsoft Corporation.
+//!
+//! SPDX-License-Identifier: Apache-2.0
+//!
+#![cfg_attr(not(feature = "std"), no_std)]
+#![feature(coverage_attribute)]
+
+pub mod component;
+pub mod config;
+pub mod helpers;

--- a/cspell.yml
+++ b/cspell.yml
@@ -41,6 +41,8 @@ words:
   - armasm
   - autocfg
   - bitvec
+  - bootaa
+  - bootx
   - bucketize
   - bumpalo
   - cbindgen

--- a/patina_dxe_core/src/component_dispatcher.rs
+++ b/patina_dxe_core/src/component_dispatcher.rs
@@ -120,9 +120,12 @@ unsafe impl Send for ComponentDispatcher {}
 
 impl ComponentDispatcher {
     /// Creates a new locked ComponentDispatcher.
+    ///
+    /// Uses TPL_APPLICATION so that component entry points can use boot services
+    /// that are restricted at higher TPL levels (per UEFI spec Section 7.1).
     #[inline(always)]
     pub(crate) const fn new_locked() -> TplMutex<Self> {
-        TplMutex::new(efi::TPL_NOTIFY, Self::new(), "ComponentDispatcher")
+        TplMutex::new(efi::TPL_APPLICATION, Self::new(), "ComponentDispatcher")
     }
 
     /// Creates a new ComponentDispatcher.

--- a/sdk/patina/src/boot_services.rs
+++ b/sdk/patina/src/boot_services.rs
@@ -63,7 +63,7 @@ impl StandardBootServices {
         this
     }
 
-    /// Create a new StandarBootServices that has not been initialized.
+    /// Create a new StandardBootServices that has not been initialized.
     pub const fn new_uninit() -> Self {
         StandardBootServices { efi_boot_services: Once::new() }
     }

--- a/sdk/patina/src/component.rs
+++ b/sdk/patina/src/component.rs
@@ -205,7 +205,7 @@ pub mod prelude {
         component::{
             IntoComponent,
             hob::{FromHob, Hob},
-            params::{Commands, Config, ConfigMut},
+            params::{Commands, Config, ConfigMut, Handle},
             service::{IntoService, Service},
         },
         error::{EfiError, Result},

--- a/sdk/patina/src/component/params.rs
+++ b/sdk/patina/src/component/params.rs
@@ -711,6 +711,83 @@ unsafe impl Param for StandardRuntimeServices {
     }
 }
 
+/// A UEFI handle that can be used in various UEFI boot service calls.
+///
+/// This is commonly used as the parent image handle for `LoadImage()` calls when loading
+/// boot applications. Per the UEFI specification, the parent image handle must be a valid
+/// image handle (one that has the LoadedImage protocol installed).
+///
+/// ## Example
+///
+/// ```rust,ignore
+/// use patina::component::{component, params::Handle};
+/// use patina::boot_services::BootServices;
+/// use patina::error::Result;
+///
+/// struct BootLoader;
+///
+/// #[component]
+/// impl BootLoader {
+///     fn entry_point(self, bs: StandardBootServices, image_handle: Handle) -> Result<()> {
+///         // Use image_handle as the parent when loading a boot application
+///         let loaded_image = bs.load_image(
+///             false,
+///             *image_handle,
+///             device_path,
+///             None,
+///             0,
+///         )?;
+///         Ok(())
+///     }
+/// }
+/// ```
+#[derive(Debug, Clone, Copy)]
+pub struct Handle {
+    handle: r_efi::efi::Handle,
+}
+
+impl Handle {
+    /// Creates a mock Handle for testing purposes.
+    #[cfg(any(test, feature = "mockall"))]
+    pub fn mock(handle: r_efi::efi::Handle) -> Self {
+        Self { handle }
+    }
+}
+
+impl core::ops::Deref for Handle {
+    type Target = r_efi::efi::Handle;
+
+    fn deref(&self) -> &Self::Target {
+        &self.handle
+    }
+}
+
+// SAFETY: Handle parameter provides access to the DXE Core's image handle.
+// Access is validated by checking if the handle has been set in storage.
+unsafe impl Param for Handle {
+    type State = ();
+    type Item<'storage, 'state> = Self;
+
+    unsafe fn get_param<'state>(
+        _state: &'state Self::State,
+        storage: UnsafeStorageCell<'_>,
+    ) -> Self::Item<'static, 'state> {
+        // SAFETY: Image handle is immutably borrowed from storage.
+        // validate() ensures the handle is set before get_param is called.
+        let handle = unsafe { storage.storage() }.image_handle().expect("image_handle validated as Some in validate()");
+        Handle { handle }
+    }
+
+    fn validate(_state: &Self::State, storage: UnsafeStorageCell) -> bool {
+        // Safety: Storage access is valid - UnsafeStorageCell ensures proper synchronization.
+        unsafe { storage.storage() }.image_handle().is_some()
+    }
+
+    fn init_state(_storage: &mut Storage, _meta: &mut MetaData) -> Result<Self::State, Cow<'static, str>> {
+        Ok(())
+    }
+}
+
 macro_rules! impl_component_param_tuple {
     ($($param: ident), *) => {
         #[allow(non_snake_case)]
@@ -816,11 +893,14 @@ mod tests {
     }
 
     #[test]
-    fn test_config_can_be_accessed_while_unlocked() {
+    fn test_config_can_be_accessed_when_locked() {
         let mut storage = Storage::new();
         let mut mock_metadata = MetaData::new::<i32>();
 
         let id = Config::<i32>::init_state(&mut storage, &mut mock_metadata).unwrap();
+
+        // Config<T> requires configs to be locked
+        storage.lock_configs();
 
         assert!(Config::<i32>::try_validate(&id, (&storage).into()).is_ok());
 
@@ -850,6 +930,10 @@ mod tests {
         let mut mock_metadata = MetaData::new::<i32>();
 
         let id = Config::<i32>::init_state(&mut storage, &mut mock_metadata).unwrap();
+
+        // Lock configs so ConfigMut cannot access
+        storage.lock_configs();
+
         assert!(
             ConfigMut::<i32>::try_validate(&id, (&storage).into())
                 .is_err_and(|err| err == "patina::component::params::ConfigMut<'_, i32> not available.")
@@ -1006,6 +1090,10 @@ mod tests {
         storage.add_config(42u32);
 
         let state = <Option<Config<u32>> as Param>::init_state(&mut storage, &mut mock_metadata).unwrap();
+
+        // Config<T> requires configs to be locked
+        storage.lock_configs();
+
         assert!(<Option<Config<u32>> as Param>::try_validate(&state, (&storage).into()).is_ok());
         // SAFETY: Test code - Option<Config<u32>> parameter has been validated.
         assert!(unsafe {

--- a/sdk/patina/src/component/storage.rs
+++ b/sdk/patina/src/component/storage.rs
@@ -214,6 +214,8 @@ pub struct Storage {
     boot_services: StandardBootServices,
     // Standard Runtime Services.
     runtime_services: StandardRuntimeServices,
+    // Image handle for the DXE Core (used as parent for LoadImage calls).
+    image_handle: Option<r_efi::efi::Handle>,
 }
 
 impl Default for Storage {
@@ -236,6 +238,7 @@ impl Storage {
             hob_indices: BTreeMap::new(),
             boot_services: StandardBootServices::new_uninit(),
             runtime_services: StandardRuntimeServices::new_uninit(),
+            image_handle: None,
         }
     }
 
@@ -277,6 +280,19 @@ impl Storage {
         &self.runtime_services
     }
 
+    /// Sets the image handle for the DXE Core.
+    ///
+    /// This handle is used as the parent image handle for `LoadImage()` calls
+    /// when loading boot applications.
+    pub fn set_image_handle(&mut self, handle: r_efi::efi::Handle) {
+        self.image_handle = Some(handle);
+    }
+
+    /// Returns the image handle for the DXE Core, if set.
+    pub fn image_handle(&self) -> Option<r_efi::efi::Handle> {
+        self.image_handle
+    }
+
     /// Registers a config type with the storage and returns its global id.
     pub(crate) fn register_config<C: Default + 'static>(&mut self) -> usize {
         let idx = self.config_indices.len();
@@ -284,18 +300,24 @@ impl Storage {
     }
 
     /// Adds a default valued config datum to the storage if it does not exist.
+    ///
+    /// Default configs are created unlocked so that `ConfigMut<T>` can modify them.
     pub(crate) fn add_config_default_if_not_present<C: Default + 'static>(&mut self) -> usize {
         let idx = self.register_config::<C>();
         if !self.configs.contains(idx) {
-            self.configs.insert(idx, RefCell::new(ConfigRaw::new(true, Box::<C>::default())));
+            self.configs.insert(idx, RefCell::new(ConfigRaw::new(false, Box::<C>::default())));
         }
         idx
     }
 
     /// Adds a config datum to the storage, overwriting an existing value if it exists.
+    ///
+    /// Configs are created unlocked so that components with `ConfigMut<T>` can modify them
+    /// during the first dispatch phase. Call `lock_configs()` to lock all configs before
+    /// dispatching components that require `Config<T>` (immutable access).
     pub fn add_config<C: Default + 'static>(&mut self, config: C) {
         let id = self.register_config::<C>();
-        self.configs.insert(id, RefCell::new(ConfigRaw::new(true, Box::new(config))));
+        self.configs.insert(id, RefCell::new(ConfigRaw::new(false, Box::new(config))));
     }
 
     /// Attempts to retrieve a config datum from the storage.

--- a/sdk/patina/src/component/struct_component.rs
+++ b/sdk/patina/src/component/struct_component.rs
@@ -190,14 +190,21 @@ mod tests {
     fn test_component_run_handling_works_as_expected() {
         let mut storage = crate::component::storage::Storage::new();
 
+        // Test component with Config<i32> - requires locked configs
         let mut test_struct = TestStructSuccess { x: 5 }.into_component();
         test_struct.initialize(&mut storage);
+        storage.lock_configs(); // Lock configs so Config<i32> is accessible
         assert!(test_struct.run(&mut storage).is_ok_and(|res| res));
 
         let mut test_enum = TestEnumSuccess::A.into_component();
         test_enum.initialize(&mut storage);
         assert!(test_enum.run(&mut storage).is_ok_and(|res| res));
 
+        // Unlock configs for the next test
+        let config_id = storage.register_config::<u32>();
+        storage.unlock_config(config_id);
+
+        // Test component with ConfigMut<u32> - configs are now locked, so it should fail
         let mut test_struct = TestStructNotDispatched { x: 5 }.into_component();
         test_struct.initialize(&mut storage);
         storage.lock_configs(); // Lock it so the ConfigMut can't be accessed

--- a/sdk/patina/src/test.rs
+++ b/sdk/patina/src/test.rs
@@ -641,6 +641,9 @@ mod tests {
         storage.add_config(1_i32);
         storage.add_service(Recorder::default());
 
+        // Lock configs so Config<i32> is accessible
+        storage.lock_configs();
+
         let test_case = &TEST_CASE1;
         let mut test_data = TestData::new(&storage, false, test_case, None);
 

--- a/sdk/patina/src/uefi_protocol/device_path/nodes.rs
+++ b/sdk/patina/src/uefi_protocol/device_path/nodes.rs
@@ -19,96 +19,159 @@ use super::device_path_node::{DevicePathNode, UnknownDevicePathNode};
 
 use crate::device_path_node;
 
+/// Device path type values as defined in UEFI specification.
 #[derive(Debug, Eq, PartialEq, Clone, Copy)]
 #[repr(u8)]
 pub enum DevicePathType {
+    /// Hardware device path.
     Hardware = 1,
+    /// ACPI device path.
     Acpi = 2,
+    /// Messaging device path.
     Messaging = 3,
+    /// Media device path.
     Media = 4,
+    /// BIOS Boot Specification device path.
     Bios = 5,
+    /// End of hardware device path.
     End = 0x7F,
 }
 
+/// Hardware device path sub-types.
 #[derive(Debug, Eq, PartialEq, Clone, Copy)]
 #[repr(u8)]
 pub enum HardwareSubType {
+    /// PCI device path.
     Pci = 1,
+    /// PC Card device path.
     Pccard = 2,
+    /// Memory-mapped device path.
     MemoryMapped = 3,
+    /// Vendor-defined device path.
     Vendor = 4,
+    /// Controller device path.
     Controller = 5,
+    /// BMC device path.
     Bmc = 6,
 }
 
+/// ACPI device path sub-types.
 #[derive(Debug, Eq, PartialEq, Clone, Copy)]
 #[repr(u8)]
 pub enum AcpiSubType {
+    /// ACPI device path.
     Acpi = 1,
+    /// Extended ACPI device path.
     ExtendedAcpi = 2,
 }
 
+/// Messaging device path sub-types.
 #[derive(Debug, Eq, PartialEq, Clone, Copy)]
 #[repr(u8)]
 pub enum MessagingSubType {
+    /// ATAPI device path.
     Atapi = 1,
+    /// SCSI device path.
     Scsi = 2,
+    /// Fibre Channel device path.
     FiberChannel = 3,
+    /// Fibre Channel Ex device path.
     FiberChannelEx = 21,
+    /// 1394 device path.
     _1394 = 4,
+    /// USB device path.
     Usb = 5,
+    /// SATA device path.
     Sata = 18,
+    /// USB WWID device path.
     UsbWwid = 16,
+    /// Device Logical Unit device path.
     DeviceLogicalUnit = 17,
+    /// USB Class device path.
     UsbClass = 15,
+    /// I2O Random Block Storage Class device path.
     I2oRandomBlockStorageClass = 6,
+    /// MAC Address device path.
     MacAddress = 11,
+    /// IPv4 device path.
     IpV4 = 12,
+    /// IPv6 device path.
     IpV6 = 13,
+    /// VLAN device path.
     Vlan = 20,
+    /// InfiniBand device path.
     InfiniBand = 9,
+    /// UART device path.
     Uart = 14,
+    /// Vendor-defined device path.
     Vendor = 10,
+    /// SAS Ex device path.
     SasEx = 22,
+    /// iSCSI device path.
     Iscsi = 19,
+    /// NVM Express device path.
     NvmExpress = 23,
+    /// URI device path.
     Uri = 24,
+    /// UFS device path.
     Ufs = 25,
+    /// SD device path.
     Sd = 26,
+    /// Bluetooth device path.
     Bluetooth = 27,
+    /// WiFi device path.
     WiFi = 28,
-    /// Embedded Multi-Media Card
+    /// Embedded Multi-Media Card device path.
     Emmc = 29,
+    /// Bluetooth LE device path.
     BluetoothLE = 30,
+    /// DNS device path.
     Dns = 31,
+    /// NVDIMM device path.
     Nvdimm = 32,
+    /// REST Service device path.
     RestService = 33,
-    /// MVMe over Fabric
+    /// NVMe over Fabric device path.
     NvmeOf = 34,
 }
 
+/// Media device path sub-types.
 #[derive(Debug, Eq, PartialEq, Clone, Copy)]
 #[repr(u8)]
 pub enum MediaSubType {
+    /// Hard drive device path.
     HardDrive = 1,
+    /// CD-ROM device path.
     CdRom = 2,
+    /// Vendor-defined device path.
     Vendor = 3,
+    /// File path device path.
     FilePath = 4,
+    /// Media protocol device path.
     MediaProtocol = 5,
+    /// PIWG firmware file device path.
     PiwgFirmwareFile = 6,
+    /// PIWG firmware volume device path.
     PiwgFirmwareVolume = 7,
+    /// Relative offset range device path.
     RelativeOffsetRange = 8,
+    /// RAM disk device path.
     RamDisk = 9,
 }
 
+/// BIOS Boot Specification device path sub-types.
 #[derive(Debug, Eq, PartialEq, Clone, Copy)]
 #[repr(u8)]
 pub enum BiosSubType {
+    /// BIOS Boot Specification device path.
     BiosBootSpecification = 1,
 }
 
+/// End device path sub-types.
 pub enum EndSubType {
+    /// End of entire device path.
     Entire = 0xFF,
+    /// End of device path instance.
     Instance = 0x01,
 }
 
@@ -144,7 +207,9 @@ pub fn cast_to_dyn_device_path_node(unknown: UnknownDevicePathNode<'_>) -> Box<d
         // ACPI nodes.
         Acpi,
         // Messaging nodes.
+        NvmExpress,
         // Media nodes.
+        FilePath,
         // BIOS nodes.
         Bios,
         // End nodes
@@ -186,7 +251,7 @@ device_path_node! {
     @[DevicePathNodeDerive(Debug, Display)]
     #[derive(Pwrite, Pread, Clone)]
     pub struct MemoryMapped {
-        // EFI memory type.
+        /// EFI memory type.
         pub memory_type: u32,
         /// Starting memory Address.
         pub start_address: u64,
@@ -201,18 +266,20 @@ device_path_node! {
     @[DevicePathNodeDerive(Debug, Display)]
     #[derive(Pwrite, Pread, Clone)]
     pub struct Controller {
-        // Controller Number.
+        /// Controller Number.
         pub number: u32,
     }
 }
 
 device_path_node! {
-    /// <https://uefi.org/specs/UEFI/2.10/10_Protocols_Device_Path_Protocol.html#controller-device-path>
+    /// <https://uefi.org/specs/UEFI/2.10/10_Protocols_Device_Path_Protocol.html#bmc-device-path>
     @[DevicePathNode(DevicePathType::Hardware, HardwareSubType::Bmc)]
     @[DevicePathNodeDerive(Debug, Display)]
     #[derive(Pwrite, Pread, Clone)]
     pub struct Bmc {
+        /// BMC interface type.
         pub interface_type: u8,
+        /// BMC base address.
         pub base_address: u64,
     }
 }
@@ -231,9 +298,12 @@ device_path_node! {
 }
 
 impl Acpi {
+    /// PCI Root Bridge HID (PNP0A03).
     pub const PCI_ROOT_HID: u32 = Acpi::eisa_id("PNP0A03");
+    /// PCIe Root Bridge HID (PNP0A08).
     pub const PCIE_ROOT_HID: u32 = Acpi::eisa_id("PNP0A08");
 
+    /// Create a new PCI root bridge ACPI device path node.
     pub fn new_pci_root(uid: u32) -> Self {
         Self { hid: Acpi::PCI_ROOT_HID, uid }
     }
@@ -275,8 +345,11 @@ device_path_node! {
     @[DevicePathNode(DevicePathType::Bios, BiosSubType::BiosBootSpecification)]
     @[DevicePathNodeDerive(Debug, Display)]
     pub struct Bios {
+        /// BIOS device type.
         pub device_type: u16,
+        /// Status flags.
         pub status_flag: u16,
+        /// Description string.
         pub description_str: String,
     }
 }
@@ -311,6 +384,7 @@ impl TryFromCtx<'_, scroll::Endian> for Bios {
 }
 
 device_path_node! {
+    /// End of entire device path node.
     @[DevicePathNode(DevicePathType::End, EndSubType::Entire)]
     @[DevicePathNodeDerive(Debug)]
     #[derive(Clone, Copy)]
@@ -340,6 +414,7 @@ impl TryFromCtx<'_, scroll::Endian> for EndEntire {
 }
 
 device_path_node! {
+    /// End of device path instance node.
     @[DevicePathNode(DevicePathType::End, EndSubType::Instance)]
     @[DevicePathNodeDerive(Debug)]
     #[derive(Clone, Copy)]
@@ -365,5 +440,454 @@ impl TryFromCtx<'_, scroll::Endian> for EndInstance {
 
     fn try_from_ctx(_: &[u8], _: scroll::Endian) -> Result<(Self, usize), Self::Error> {
         Ok((Self, 0))
+    }
+}
+
+/// SATA Device Path.
+///
+/// <https://uefi.org/specs/UEFI/2.10/10_Protocols_Device_Path_Protocol.html#sata-device-path>
+#[derive(Clone)]
+pub struct Sata {
+    /// HBA Port Number.
+    pub hba_port: u16,
+    /// Port Multiplier Port Number.
+    pub port_multiplier_port: u16,
+    /// Logical Unit Number.
+    pub lun: u16,
+}
+
+#[coverage(off)]
+impl Sata {
+    /// The on-wire size of Sata data (without header): 2 + 2 + 2 = 6 bytes.
+    const DATA_SIZE: usize = 6;
+
+    /// Create a new SATA device path node.
+    ///
+    /// # Arguments
+    /// * `hba_port` - HBA port number
+    /// * `port_multiplier_port` - Port multiplier port number (0xFFFF if not present)
+    /// * `lun` - Logical unit number
+    pub fn new(hba_port: u16, port_multiplier_port: u16, lun: u16) -> Self {
+        Self { hba_port, port_multiplier_port, lun }
+    }
+}
+
+#[coverage(off)]
+impl super::device_path_node::DevicePathNode for Sata {
+    fn header(&self) -> super::device_path_node::Header {
+        super::device_path_node::Header {
+            r#type: DevicePathType::Messaging as u8,
+            sub_type: MessagingSubType::Sata as u8,
+            length: super::device_path_node::Header::size_of_header() + Self::DATA_SIZE,
+        }
+    }
+
+    fn is_type(r#type: u8, sub_type: u8) -> bool {
+        r#type == DevicePathType::Messaging as u8 && sub_type == MessagingSubType::Sata as u8
+    }
+
+    fn write_into(self, buffer: &mut [u8]) -> Result<usize, scroll::Error> {
+        let header = self.header();
+        let mut offset = 0;
+        buffer.gwrite_with(header, &mut offset, scroll::Endian::Little)?;
+        buffer.gwrite_with(self.hba_port, &mut offset, scroll::Endian::Little)?;
+        buffer.gwrite_with(self.port_multiplier_port, &mut offset, scroll::Endian::Little)?;
+        buffer.gwrite_with(self.lun, &mut offset, scroll::Endian::Little)?;
+        Ok(offset)
+    }
+}
+
+#[coverage(off)]
+impl core::fmt::Debug for Sata {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("Sata")
+            .field("hba_port", &self.hba_port)
+            .field("port_multiplier_port", &self.port_multiplier_port)
+            .field("lun", &self.lun)
+            .finish()
+    }
+}
+
+#[coverage(off)]
+impl Display for Sata {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_tuple("Sata").field(&self.hba_port).field(&self.port_multiplier_port).field(&self.lun).finish()
+    }
+}
+
+#[coverage(off)]
+impl TryIntoCtx<scroll::Endian> for Sata {
+    type Error = scroll::Error;
+
+    fn try_into_ctx(self, dest: &mut [u8], ctx: scroll::Endian) -> Result<usize, Self::Error> {
+        let mut offset = 0;
+        dest.gwrite_with(self.hba_port, &mut offset, ctx)?;
+        dest.gwrite_with(self.port_multiplier_port, &mut offset, ctx)?;
+        dest.gwrite_with(self.lun, &mut offset, ctx)?;
+        Ok(offset)
+    }
+}
+
+#[coverage(off)]
+impl TryFromCtx<'_, scroll::Endian> for Sata {
+    type Error = scroll::Error;
+
+    fn try_from_ctx(buffer: &[u8], ctx: scroll::Endian) -> Result<(Self, usize), Self::Error> {
+        let mut offset = 0;
+        let hba_port = buffer.gread_with(&mut offset, ctx)?;
+        let port_multiplier_port = buffer.gread_with(&mut offset, ctx)?;
+        let lun = buffer.gread_with(&mut offset, ctx)?;
+        Ok((Self { hba_port, port_multiplier_port, lun }, offset))
+    }
+}
+
+/// NVM Express Namespace Device Path.
+///
+/// <https://uefi.org/specs/UEFI/2.10/10_Protocols_Device_Path_Protocol.html#nvme-namespace-device-path>
+#[derive(Clone)]
+pub struct NvmExpress {
+    /// Namespace Identifier (NSID).
+    pub namespace_id: u32,
+    /// IEEE Extended Unique Identifier (EUI-64).
+    pub eui64: u64,
+}
+
+#[coverage(off)]
+impl NvmExpress {
+    /// The on-wire size of NvmExpress data (without header): 4 bytes NSID + 8 bytes EUI64.
+    const DATA_SIZE: usize = 4 + 8;
+
+    /// Create a new NvmExpress device path node.
+    ///
+    /// # Arguments
+    /// * `namespace_id` - The namespace identifier (typically 1 for the first namespace)
+    /// * `eui64` - The IEEE Extended Unique Identifier (can be 0 if not specified)
+    pub fn new(namespace_id: u32, eui64: u64) -> Self {
+        Self { namespace_id, eui64 }
+    }
+}
+
+#[coverage(off)]
+impl super::device_path_node::DevicePathNode for NvmExpress {
+    fn header(&self) -> super::device_path_node::Header {
+        super::device_path_node::Header {
+            r#type: DevicePathType::Messaging as u8,
+            sub_type: MessagingSubType::NvmExpress as u8,
+            length: super::device_path_node::Header::size_of_header() + Self::DATA_SIZE,
+        }
+    }
+
+    fn is_type(r#type: u8, sub_type: u8) -> bool {
+        r#type == DevicePathType::Messaging as u8 && sub_type == MessagingSubType::NvmExpress as u8
+    }
+
+    fn write_into(self, buffer: &mut [u8]) -> Result<usize, scroll::Error> {
+        let header = self.header();
+        let mut offset = 0;
+        buffer.gwrite_with(header, &mut offset, scroll::Endian::Little)?;
+        buffer.gwrite_with(self.namespace_id, &mut offset, scroll::Endian::Little)?;
+        buffer.gwrite_with(self.eui64, &mut offset, scroll::Endian::Little)?;
+        Ok(offset)
+    }
+}
+
+#[coverage(off)]
+impl core::fmt::Debug for NvmExpress {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("NvmExpress").field("namespace_id", &self.namespace_id).field("eui64", &self.eui64).finish()
+    }
+}
+
+#[coverage(off)]
+impl Display for NvmExpress {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_tuple("NvmExpress").field(&self.namespace_id).field(&self.eui64).finish()
+    }
+}
+
+#[coverage(off)]
+impl TryIntoCtx<scroll::Endian> for NvmExpress {
+    type Error = scroll::Error;
+
+    fn try_into_ctx(self, dest: &mut [u8], ctx: scroll::Endian) -> Result<usize, Self::Error> {
+        let mut offset = 0;
+        dest.gwrite_with(self.namespace_id, &mut offset, ctx)?;
+        dest.gwrite_with(self.eui64, &mut offset, ctx)?;
+        Ok(offset)
+    }
+}
+
+#[coverage(off)]
+impl TryFromCtx<'_, scroll::Endian> for NvmExpress {
+    type Error = scroll::Error;
+
+    fn try_from_ctx(buffer: &[u8], ctx: scroll::Endian) -> Result<(Self, usize), Self::Error> {
+        let mut offset = 0;
+        let namespace_id = buffer.gread_with(&mut offset, ctx)?;
+        let eui64 = buffer.gread_with(&mut offset, ctx)?;
+        Ok((Self { namespace_id, eui64 }, offset))
+    }
+}
+
+/// Hard Drive Media Device Path.
+///
+/// Represents a partition on a hard drive or similar storage device.
+/// <https://uefi.org/specs/UEFI/2.10/10_Protocols_Device_Path_Protocol.html#hard-drive-media-device-path>
+#[derive(Clone)]
+pub struct HardDrive {
+    /// Partition number (1-based).
+    pub partition_number: u32,
+    /// Starting LBA of the partition.
+    pub partition_start: u64,
+    /// Size of the partition in blocks.
+    pub partition_size: u64,
+    /// Partition signature (GUID for GPT, 4-byte signature for MBR).
+    pub partition_signature: [u8; 16],
+    /// Partition format: 0x01 = PC-AT MBR, 0x02 = GPT.
+    pub partition_format: u8,
+    /// Signature type: 0x00 = None, 0x01 = 32-bit MBR, 0x02 = GUID.
+    pub signature_type: u8,
+}
+
+#[coverage(off)]
+impl HardDrive {
+    /// The on-wire size of HardDrive data (without header).
+    const DATA_SIZE: usize = 4 + 8 + 8 + 16 + 1 + 1; // 38 bytes
+
+    /// Partition format: GPT
+    pub const FORMAT_GPT: u8 = 0x02;
+    /// Partition format: MBR
+    pub const FORMAT_MBR: u8 = 0x01;
+
+    /// Signature type: GUID
+    pub const SIGNATURE_TYPE_GUID: u8 = 0x02;
+    /// Signature type: MBR 32-bit signature
+    pub const SIGNATURE_TYPE_MBR: u8 = 0x01;
+
+    /// Create a new HardDrive device path node for a GPT partition.
+    ///
+    /// # Arguments
+    /// * `partition_number` - 1-based partition number
+    /// * `partition_start` - Starting LBA
+    /// * `partition_size` - Size in blocks
+    /// * `partition_guid` - The unique GUID of the partition
+    pub fn new_gpt(partition_number: u32, partition_start: u64, partition_size: u64, partition_guid: [u8; 16]) -> Self {
+        Self {
+            partition_number,
+            partition_start,
+            partition_size,
+            partition_signature: partition_guid,
+            partition_format: Self::FORMAT_GPT,
+            signature_type: Self::SIGNATURE_TYPE_GUID,
+        }
+    }
+}
+
+#[coverage(off)]
+impl super::device_path_node::DevicePathNode for HardDrive {
+    fn header(&self) -> super::device_path_node::Header {
+        super::device_path_node::Header {
+            r#type: DevicePathType::Media as u8,
+            sub_type: MediaSubType::HardDrive as u8,
+            length: super::device_path_node::Header::size_of_header() + Self::DATA_SIZE,
+        }
+    }
+
+    fn is_type(r#type: u8, sub_type: u8) -> bool {
+        r#type == DevicePathType::Media as u8 && sub_type == MediaSubType::HardDrive as u8
+    }
+
+    fn write_into(self, buffer: &mut [u8]) -> Result<usize, scroll::Error> {
+        let header = self.header();
+        let mut offset = 0;
+        buffer.gwrite_with(header, &mut offset, scroll::Endian::Little)?;
+        buffer.gwrite_with(self.partition_number, &mut offset, scroll::Endian::Little)?;
+        buffer.gwrite_with(self.partition_start, &mut offset, scroll::Endian::Little)?;
+        buffer.gwrite_with(self.partition_size, &mut offset, scroll::Endian::Little)?;
+        for byte in &self.partition_signature {
+            buffer.gwrite_with(*byte, &mut offset, scroll::Endian::Little)?;
+        }
+        buffer.gwrite_with(self.partition_format, &mut offset, scroll::Endian::Little)?;
+        buffer.gwrite_with(self.signature_type, &mut offset, scroll::Endian::Little)?;
+        Ok(offset)
+    }
+}
+
+#[coverage(off)]
+impl core::fmt::Debug for HardDrive {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("HardDrive")
+            .field("partition_number", &self.partition_number)
+            .field("partition_start", &self.partition_start)
+            .field("partition_size", &self.partition_size)
+            .field("partition_format", &self.partition_format)
+            .field("signature_type", &self.signature_type)
+            .finish()
+    }
+}
+
+#[coverage(off)]
+impl Display for HardDrive {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(f, "HD({}, GPT, ...)", self.partition_number)
+    }
+}
+
+#[coverage(off)]
+impl TryIntoCtx<scroll::Endian> for HardDrive {
+    type Error = scroll::Error;
+
+    fn try_into_ctx(self, dest: &mut [u8], ctx: scroll::Endian) -> Result<usize, Self::Error> {
+        let mut offset = 0;
+        dest.gwrite_with(self.partition_number, &mut offset, ctx)?;
+        dest.gwrite_with(self.partition_start, &mut offset, ctx)?;
+        dest.gwrite_with(self.partition_size, &mut offset, ctx)?;
+        for byte in &self.partition_signature {
+            dest.gwrite_with(*byte, &mut offset, ctx)?;
+        }
+        dest.gwrite_with(self.partition_format, &mut offset, ctx)?;
+        dest.gwrite_with(self.signature_type, &mut offset, ctx)?;
+        Ok(offset)
+    }
+}
+
+#[coverage(off)]
+impl TryFromCtx<'_, scroll::Endian> for HardDrive {
+    type Error = scroll::Error;
+
+    fn try_from_ctx(buffer: &[u8], ctx: scroll::Endian) -> Result<(Self, usize), Self::Error> {
+        let mut offset = 0;
+        let partition_number = buffer.gread_with(&mut offset, ctx)?;
+        let partition_start = buffer.gread_with(&mut offset, ctx)?;
+        let partition_size = buffer.gread_with(&mut offset, ctx)?;
+        let mut partition_signature = [0u8; 16];
+        for byte in &mut partition_signature {
+            *byte = buffer.gread_with(&mut offset, ctx)?;
+        }
+        let partition_format = buffer.gread_with(&mut offset, ctx)?;
+        let signature_type = buffer.gread_with(&mut offset, ctx)?;
+        Ok((
+            Self {
+                partition_number,
+                partition_start,
+                partition_size,
+                partition_signature,
+                partition_format,
+                signature_type,
+            },
+            offset,
+        ))
+    }
+}
+
+/// File Path Media Device Path.
+///
+/// The file path is a null-terminated string that describes a file path.
+/// <https://uefi.org/specs/UEFI/2.10/10_Protocols_Device_Path_Protocol.html#file-path-media-device-path>
+#[derive(Clone)]
+pub struct FilePath {
+    /// The file path string (stored as UTF-8, serialized as UTF-16).
+    pub path: String,
+}
+
+#[coverage(off)]
+impl FilePath {
+    /// Create a new FilePath device path node from a path string.
+    pub fn new(path: impl Into<String>) -> Self {
+        Self { path: path.into() }
+    }
+
+    /// Calculate the UTF-16 encoded size of the path including null terminator.
+    fn utf16_size(&self) -> usize {
+        // Each char becomes one UTF-16 code unit (2 bytes), plus null terminator (2 bytes)
+        // Note: This assumes BMP characters only (no surrogate pairs)
+        (self.path.chars().count() + 1) * 2
+    }
+}
+
+#[coverage(off)]
+impl super::device_path_node::DevicePathNode for FilePath {
+    fn header(&self) -> super::device_path_node::Header {
+        super::device_path_node::Header {
+            r#type: DevicePathType::Media as u8,
+            sub_type: MediaSubType::FilePath as u8,
+            length: super::device_path_node::Header::size_of_header() + self.utf16_size(),
+        }
+    }
+
+    fn is_type(r#type: u8, sub_type: u8) -> bool {
+        r#type == DevicePathType::Media as u8 && sub_type == MediaSubType::FilePath as u8
+    }
+
+    fn write_into(self, buffer: &mut [u8]) -> Result<usize, scroll::Error> {
+        let header = self.header();
+        let mut offset = 0;
+        buffer.gwrite_with(header, &mut offset, scroll::Endian::Little)?;
+        // Write the path as UTF-16LE (UCS-2)
+        for c in self.path.chars() {
+            let code_point = c as u16;
+            buffer.gwrite_with(code_point, &mut offset, scroll::LE)?;
+        }
+        // Write null terminator (UTF-16)
+        buffer.gwrite_with(0u16, &mut offset, scroll::LE)?;
+        Ok(offset)
+    }
+}
+
+#[coverage(off)]
+impl core::fmt::Debug for FilePath {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("FilePath").field("path", &self.path).finish()
+    }
+}
+
+#[coverage(off)]
+impl Display for FilePath {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(f, "{}", self.path)
+    }
+}
+
+#[coverage(off)]
+impl TryIntoCtx<scroll::Endian> for FilePath {
+    type Error = scroll::Error;
+
+    fn try_into_ctx(self, dest: &mut [u8], _ctx: scroll::Endian) -> Result<usize, Self::Error> {
+        let mut offset = 0;
+        // Write the path as UTF-16LE (UCS-2)
+        for c in self.path.chars() {
+            let code_point = c as u16;
+            dest.gwrite_with(code_point, &mut offset, scroll::LE)?;
+        }
+        // Write null terminator (UTF-16)
+        dest.gwrite_with(0u16, &mut offset, scroll::LE)?;
+        Ok(offset)
+    }
+}
+
+#[coverage(off)]
+impl TryFromCtx<'_, scroll::Endian> for FilePath {
+    type Error = scroll::Error;
+
+    fn try_from_ctx(buffer: &[u8], _ctx: scroll::Endian) -> Result<(Self, usize), Self::Error> {
+        let mut offset = 0;
+        let mut path = String::new();
+
+        // Read UTF-16LE characters until null terminator
+        loop {
+            if offset + 2 > buffer.len() {
+                break;
+            }
+            let code_point: u16 = buffer.gread_with(&mut offset, scroll::LE)?;
+            if code_point == 0 {
+                break;
+            }
+            // Convert UTF-16 code point to char
+            if let Some(c) = char::from_u32(code_point as u32) {
+                path.push(c);
+            }
+        }
+
+        Ok((Self { path }, offset))
     }
 }


### PR DESCRIPTION
## Description

Adds BootOrchestration component, simple console discovery, simple BootOption Config

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [x] Includes tests?
- [x] Includes documentation?

## How This Was Tested

QEMU Platform Integration:
- Q35
- SBSA

## Integration Instructions

N/A
