### PR TITLE
Update to patina-paging v11.0.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ patina_lzma_rs = { version = "0.3.1", default-features = false }
 patina_macro = { version = "19.0.2", path = "sdk/patina_macro" }
 patina_mm = { version = "19.0.2", path = "components/patina_mm" }
 patina_mtrr = { version = "^1.1.4" }
-patina_paging = { version = "10" }
+patina_paging = { version = "11" }
 patina_performance = { version = "19.0.2", path = "components/patina_performance" }
 patina_smbios = { version = "19.0.2", path = "components/patina_smbios" }
 patina_stacktrace = { version = "19.0.2", path = "core/patina_stacktrace" }

--- a/core/patina_internal_cpu/src/paging/aarch64.rs
+++ b/core/patina_internal_cpu/src/paging/aarch64.rs
@@ -97,7 +97,7 @@ mod tests {
 
         let mut paging = EfiCpuPagingAArch64 { paging: mock_page_table };
 
-        let result = paging.map_memory_region(0x1000, 0x1000, MemoryAttributes::Uncacheable);
+        let result = paging.map_memory_region(0x1000, 0x1000, MemoryAttributes::Uncached);
         assert!(result.is_ok());
     }
 
@@ -121,7 +121,7 @@ mod tests {
 
         let mut paging = EfiCpuPagingAArch64 { paging: mock_page_table };
 
-        let result = paging.map_memory_region(0x1000, 0x1000, MemoryAttributes::Uncacheable);
+        let result = paging.map_memory_region(0x1000, 0x1000, MemoryAttributes::Uncached);
         assert!(result.is_ok());
     }
 
@@ -131,13 +131,13 @@ mod tests {
 
         mock_page_table
             .expect_query_memory_region()
-            .returning(|_, _| Ok(MemoryAttributes::Writeback | MemoryAttributes::Uncacheable));
+            .returning(|_, _| Ok(MemoryAttributes::Writeback | MemoryAttributes::Uncached));
 
         let paging = EfiCpuPagingAArch64 { paging: mock_page_table };
 
         let result = paging.query_memory_region(0x1000, 0x1000);
         assert!(result.is_ok());
-        assert_eq!(result.unwrap(), MemoryAttributes::Writeback | MemoryAttributes::Uncacheable);
+        assert_eq!(result.unwrap(), MemoryAttributes::Writeback | MemoryAttributes::Uncached);
     }
 
     #[test]

--- a/core/patina_internal_cpu/src/paging/x64.rs
+++ b/core/patina_internal_cpu/src/paging/x64.rs
@@ -72,7 +72,7 @@ where
         // start by getting the caching attributes as we need to return those even if the page is unmapped in the
         // page table
         let cache_attr = match self.mtrr.get_memory_attribute(address) {
-            MtrrMemoryCacheType::Uncacheable => CacheAttributeValue::Valid(MemoryAttributes::Uncacheable),
+            MtrrMemoryCacheType::Uncacheable => CacheAttributeValue::Valid(MemoryAttributes::Uncached),
             MtrrMemoryCacheType::WriteCombining => CacheAttributeValue::Valid(MemoryAttributes::WriteCombining),
             MtrrMemoryCacheType::WriteThrough => CacheAttributeValue::Valid(MemoryAttributes::WriteThrough),
             MtrrMemoryCacheType::WriteProtected => CacheAttributeValue::Valid(MemoryAttributes::WriteProtect),
@@ -109,7 +109,7 @@ fn apply_caching_attributes<M: Mtrr>(
         }
 
         let cache_type = match cache_attributes {
-            MemoryAttributes::Uncacheable => MtrrMemoryCacheType::Uncacheable,
+            MemoryAttributes::Uncached => MtrrMemoryCacheType::Uncacheable,
             MemoryAttributes::WriteCombining => MtrrMemoryCacheType::WriteCombining,
             MemoryAttributes::WriteThrough => MtrrMemoryCacheType::WriteThrough,
             MemoryAttributes::WriteProtect => MtrrMemoryCacheType::WriteProtected,
@@ -216,7 +216,7 @@ mod tests {
 
         let mut paging = EfiCpuPagingX64 { paging: mock_page_table, mtrr: mock_mtrr };
 
-        let result = paging.map_memory_region(0x1000, 0x1000, MemoryAttributes::Uncacheable);
+        let result = paging.map_memory_region(0x1000, 0x1000, MemoryAttributes::Uncached);
         assert!(result.is_ok());
     }
 
@@ -245,7 +245,7 @@ mod tests {
 
         let mut paging = EfiCpuPagingX64 { paging: mock_page_table, mtrr: mock_mtrr };
 
-        let result = paging.map_memory_region(0x1000, 0x1000, MemoryAttributes::Uncacheable);
+        let result = paging.map_memory_region(0x1000, 0x1000, MemoryAttributes::Uncached);
         assert!(result.is_ok());
     }
 
@@ -261,6 +261,6 @@ mod tests {
 
         let result = paging.query_memory_region(0x1000, 0x1000);
         assert!(result.is_ok());
-        assert_eq!(result.unwrap(), MemoryAttributes::Writeback | MemoryAttributes::Uncacheable);
+        assert_eq!(result.unwrap(), MemoryAttributes::Writeback | MemoryAttributes::Uncached);
     }
 }

--- a/patina_dxe_core/src/gcd/spin_locked_gcd.rs
+++ b/patina_dxe_core/src/gcd/spin_locked_gcd.rs
@@ -5142,7 +5142,7 @@ mod tests {
             let length = 0x1000;
 
             // Test Uncacheable
-            let result = GCD.set_paging_attributes(base_address, length, MemoryAttributes::Uncacheable.bits());
+            let result = GCD.set_paging_attributes(base_address, length, MemoryAttributes::Uncached.bits());
             assert!(result.is_ok());
 
             // Test WriteThrough - should overwrite the previous mapping
@@ -5163,7 +5163,7 @@ mod tests {
 
             // Should have 3 map operations recorded
             assert_eq!(mapped.len(), 3);
-            assert_eq!(mapped[0], (base_address as u64, length as u64, MemoryAttributes::Uncacheable));
+            assert_eq!(mapped[0], (base_address as u64, length as u64, MemoryAttributes::Uncached));
             assert_eq!(mapped[1], (base_address as u64, length as u64, MemoryAttributes::WriteThrough));
             assert_eq!(mapped[2], (base_address as u64, length as u64, MemoryAttributes::WriteCombining));
 
@@ -5294,7 +5294,7 @@ mod tests {
             // Map multiple non-overlapping regions
             let regions = [
                 (0x1000, 0x1000, MemoryAttributes::Writeback),
-                (0x3000, 0x2000, MemoryAttributes::Uncacheable),
+                (0x3000, 0x2000, MemoryAttributes::Uncached),
                 (0x6000, 0x1000, MemoryAttributes::WriteCombining),
             ];
 
@@ -5314,13 +5314,13 @@ mod tests {
             // Should have 3 map operations recorded
             assert_eq!(mapped.len(), 3);
             assert_eq!(mapped[0], (0x1000, 0x1000, MemoryAttributes::Writeback));
-            assert_eq!(mapped[1], (0x3000, 0x2000, MemoryAttributes::Uncacheable));
+            assert_eq!(mapped[1], (0x3000, 0x2000, MemoryAttributes::Uncached));
             assert_eq!(mapped[2], (0x6000, 0x1000, MemoryAttributes::WriteCombining));
 
             // Current mappings should show all 3 regions (no overlaps)
             assert_eq!(current_mappings.len(), 3);
             assert!(current_mappings.contains(&(0x1000, 0x1000, MemoryAttributes::Writeback)));
-            assert!(current_mappings.contains(&(0x3000, 0x2000, MemoryAttributes::Uncacheable)));
+            assert!(current_mappings.contains(&(0x3000, 0x2000, MemoryAttributes::Uncached)));
             assert!(current_mappings.contains(&(0x6000, 0x1000, MemoryAttributes::WriteCombining)));
         });
     }
@@ -5347,7 +5347,7 @@ mod tests {
             let overlapping_base = 0x1800;
             let overlapping_length = 0x1000;
             let result =
-                GCD.set_paging_attributes(overlapping_base, overlapping_length, MemoryAttributes::Uncacheable.bits());
+                GCD.set_paging_attributes(overlapping_base, overlapping_length, MemoryAttributes::Uncached.bits());
             assert!(result.is_ok());
 
             // Manually drop the page table to release the reference
@@ -5361,14 +5361,14 @@ mod tests {
             // Should have 2 map operations recorded
             assert_eq!(mapped.len(), 2);
             assert_eq!(mapped[0], (base_address as u64, length as u64, MemoryAttributes::Writeback));
-            assert_eq!(mapped[1], (overlapping_base as u64, overlapping_length as u64, MemoryAttributes::Uncacheable));
+            assert_eq!(mapped[1], (overlapping_base as u64, overlapping_length as u64, MemoryAttributes::Uncached));
 
             // Current mappings should show the overlapping region replaced the original
             // (MockPageTable removes overlapping regions when adding new ones)
             assert_eq!(current_mappings.len(), 1);
             assert_eq!(
                 current_mappings[0],
-                (overlapping_base as u64, overlapping_length as u64, MemoryAttributes::Uncacheable)
+                (overlapping_base as u64, overlapping_length as u64, MemoryAttributes::Uncached)
             );
         });
     }


### PR DESCRIPTION
## Description

patina-paging v11.0.0 includes a critical bugfix
(see https://github.com/OpenDevicePartnership/patina-paging/pull/168) that patina needs to pick up. In addition, there was a breaking change to rename an enum member, so that change is made.

- [x] Impacts functionality?
- [x] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Tested on an Intel physical platform experiencing the paging issue, Q35, and SBSA.

## Integration Instructions

N/A.
