### PR TITLE
Add new `Handle` param for patina components

### DIFF
--- a/patina_dxe_core/src/lib.rs
+++ b/patina_dxe_core/src/lib.rs
@@ -565,16 +565,16 @@ impl<P: PlatformInfo> Core<P> {
 
     /// Starts the core, dispatching all drivers.
     fn start_dispatcher(&'static self, physical_hob_list: *mut c_void) -> Result<()> {
+        log::info!("Initializing System Table");
+        self.initialize_system_table(physical_hob_list)?;
+        log::info!("Finished.");
+
         log::info!("Registering platform components");
         self.apply_component_info();
         log::info!("Finished.");
 
         log::info!("Registering default components");
         self.add_core_components();
-        log::info!("Finished.");
-
-        log::info!("Initializing System Table");
-        self.initialize_system_table(physical_hob_list)?;
         log::info!("Finished.");
 
         log::info!("Parsing HOB list for Guided HOBs.");

--- a/sdk/patina/src/component/params.rs
+++ b/sdk/patina/src/component/params.rs
@@ -105,7 +105,7 @@ use core::{
 use alloc::{borrow::Cow, boxed::Box};
 
 use crate::{
-    boot_services::StandardBootServices,
+    boot_services::{BootServices, StandardBootServices},
     component::{
         metadata::MetaData,
         service::IntoService,
@@ -708,6 +708,80 @@ unsafe impl Param for StandardRuntimeServices {
 
     fn init_state(_storage: &mut Storage, _meta: &mut MetaData) -> Result<Self::State, Cow<'static, str>> {
         Ok(())
+    }
+}
+
+/// A handle for self-identification of a component.
+///
+/// Currently only contains an EFI handle used for direct interaction with UEFI services.
+#[derive(Debug, Clone, Copy)]
+pub struct Handle(r_efi::efi::Handle);
+
+impl Handle {
+    /// Creates an instance of Handle from the given EFI handle.
+    ///
+    /// This function is intended for testing purposes only.
+    pub fn mock(handle: r_efi::efi::Handle) -> Self {
+        Self(handle)
+    }
+
+    /// Returns Self as the EFI handle associated with the component.
+    ///
+    /// ## Example
+    ///
+    /// ```rust
+    /// use patina::component::params::Handle;
+    /// use patina::boot_services::{BootServices, StandardBootServices};
+    ///
+    /// fn my_component(handle: Handle, bs: StandardBootServices) {
+    ///    unsafe {
+    ///      assert!(bs.handle_protocol::<r_efi::protocols::disk_io::Protocol>(handle.efi_handle()).is_err_and(|e| {
+    ///        matches!(e, r_efi::efi::Status::NOT_FOUND)
+    ///      }));
+    ///    }
+    /// }
+    /// ```
+    pub fn efi_handle(&self) -> r_efi::efi::Handle {
+        self.0
+    }
+}
+
+// SAFETY: Handle parameter does not require storage access, so no tracking is needed.
+unsafe impl Param for Handle {
+    type State = usize;
+    type Item<'storage, 'state> = Self;
+
+    unsafe fn get_param<'state>(
+        state: &'state Self::State,
+        _storage: UnsafeStorageCell<'_>,
+    ) -> Self::Item<'static, 'state> {
+        let state = *state;
+        Self(state as r_efi::efi::Handle)
+    }
+
+    fn validate(_state: &Self::State, _storage: UnsafeStorageCell) -> bool {
+        true
+    }
+
+    fn init_state(storage: &mut Storage, _meta: &mut MetaData) -> Result<Self::State, Cow<'static, str>> {
+        const PATINA_COMPONENT_GUID: crate::BinaryGuid =
+            crate::BinaryGuid::from_string("3346877B-C962-4A34-A42D-50B8437B827D");
+
+        // SAFETY: We are installing a marker protocol, so the interface is expected to be null.
+        let result = unsafe {
+            storage.boot_services().install_protocol_interface_unchecked(
+                None,
+                &PATINA_COMPONENT_GUID,
+                core::ptr::null_mut(),
+            )
+        };
+
+        match result {
+            Ok(handle) => Ok(handle as usize),
+            Err(e) => {
+                Err(Cow::from(alloc::format!("Failed to install Patina component marker protocol interface: {:?}", e)))
+            }
+        }
     }
 }
 


### PR DESCRIPTION
## Description

This commit adds a new `Handle` param that can be requested by patina components. This component is currently only an on-demand wrapper around a r_efi::efi::Handle, which can be used by components when interacting with UEFI services. However future enhancements may include additional metadata useful from within the patina-component context.

This commit required that the system tables were setup before components added, so that protocols can be added to the protocol db without breaking the current API barrier.

I plan on adding unit tests if this is the route we wish to go.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Continued boot to shell.

## Integration Instructions

Users may use the provided `Handle`.
