### PR TITLE
bugfix: Enable compat mode for EFI_APPLICATION

### DIFF
--- a/patina_dxe_core/src/pi_dispatcher/image.rs
+++ b/patina_dxe_core/src/pi_dispatcher/image.rs
@@ -1224,7 +1224,8 @@ fn core_load_pe_image(
 
     private_info.load_resource_section(image)?;
 
-    // If we are not NX compatible and a runtime driver, we need to attempt to activate compatibility mode.
+    // If we are not NX compatible and a EFI Application, we need to attempt to activate compatibility mode.
+    // Compatability mode may or may not actually activate depending on how we are configured.
     // Otherwise apply the memory protections.
     if private_info.pe_info.image_type == EFI_IMAGE_SUBSYSTEM_EFI_APPLICATION && !private_info.pe_info.nx_compat {
         private_info.activate_compatibility_mode()?;


### PR DESCRIPTION
## Description

In bde612d (written by me), I updated the logic around when to apply compatibility mode from being for a EFI_APPLICATION to a EFI_RUNTIME_DRIVER. Not sure how or why, but it was completely my fault. This fixes that.

This was caught during my work to created nightly "boot to os" github workflow.

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

N/A

## Integration Instructions

N/A
