### PR TITLE
LocateHandle() search type ByRegisterNotify update

### DIFF
--- a/patina_dxe_core/src/protocol_db.rs
+++ b/patina_dxe_core/src/protocol_db.rs
@@ -2038,7 +2038,7 @@ mod tests {
             let existing_handle =
                 SPIN_LOCKED_PROTOCOL_DB.install_protocol_interface(None, guid1, interface1).unwrap().0;
 
-            // Register for notificaiton
+            // Register for notification
             let event = 0x8765 as *mut c_void;
             let reg = SPIN_LOCKED_PROTOCOL_DB.register_protocol_notify(guid1, event).unwrap();
 

--- a/patina_dxe_core/src/protocol_db.rs
+++ b/patina_dxe_core/src/protocol_db.rs
@@ -2038,6 +2038,7 @@ mod tests {
             let existing_handle =
                 SPIN_LOCKED_PROTOCOL_DB.install_protocol_interface(None, guid1, interface1).unwrap().0;
 
+            // Register for notificaiton
             let event = 0x8765 as *mut c_void;
             let reg = SPIN_LOCKED_PROTOCOL_DB.register_protocol_notify(guid1, event).unwrap();
 

--- a/patina_dxe_core/src/protocol_db.rs
+++ b/patina_dxe_core/src/protocol_db.rs
@@ -513,7 +513,6 @@ impl ProtocolDb {
     }
 
     fn register_protocol_notify(&mut self, protocol: efi::Guid, event: efi::Event) -> Result<*mut c_void, EfiError> {
-
         // Modeling EDK2 behavior, enumerate handles *already* installed, not only future installs
         let mut fresh_handles = BTreeSet::new();
         for (key, handle_data) in self.handles.iter() {
@@ -2036,7 +2035,8 @@ mod tests {
             let interface1: *mut c_void = 0x1234 as *mut c_void;
 
             // Create existing protocol
-            let existing_handle = SPIN_LOCKED_PROTOCOL_DB.install_protocol_interface(None, guid1, interface1).unwrap().0;
+            let existing_handle =
+                SPIN_LOCKED_PROTOCOL_DB.install_protocol_interface(None, guid1, interface1).unwrap().0;
 
             let event = 0x8765 as *mut c_void;
             let reg = SPIN_LOCKED_PROTOCOL_DB.register_protocol_notify(guid1, event).unwrap();

--- a/patina_dxe_core/src/protocol_db.rs
+++ b/patina_dxe_core/src/protocol_db.rs
@@ -513,9 +513,18 @@ impl ProtocolDb {
     }
 
     fn register_protocol_notify(&mut self, protocol: efi::Guid, event: efi::Event) -> Result<*mut c_void, EfiError> {
+
+        // Modeling EDK2 behavior, enumerate handles *already* installed, not only future installs
+        let mut fresh_handles = BTreeSet::new();
+        for (key, handle_data) in self.handles.iter() {
+            if handle_data.contains_key(&OrdGuid(protocol)) {
+                fresh_handles.insert(*key as efi::Handle);
+            }
+        }
+
         let registration = self.next_registration as *mut c_void;
         self.next_registration += 1;
-        let protocol_notify = ProtocolNotify { event, registration, fresh_handles: BTreeSet::new() };
+        let protocol_notify = ProtocolNotify { event, registration, fresh_handles };
 
         if let Some(existing_key) = self.notifications.get_mut(&OrdGuid(protocol)) {
             existing_key.push(protocol_notify);
@@ -2014,6 +2023,31 @@ mod tests {
             assert_eq!(notify_list[1].fresh_handles.len(), 1);
             assert!(notify_list[1].fresh_handles.contains(&result.0));
             assert_eq!(notify_list[1].registration, reg2);
+        });
+    }
+
+    #[test]
+    fn register_protocol_notify_should_seed_existing_handles() {
+        with_locked_state(|| {
+            static SPIN_LOCKED_PROTOCOL_DB: SpinLockedProtocolDb = SpinLockedProtocolDb::new();
+
+            let uuid1 = Uuid::from_str("0e896c7a-57dc-4987-bc22-abc3a8263210").unwrap();
+            let guid1 = efi::Guid::from_bytes(uuid1.as_bytes());
+            let interface1: *mut c_void = 0x1234 as *mut c_void;
+
+            // Create existing protocol
+            let existing_handle = SPIN_LOCKED_PROTOCOL_DB.install_protocol_interface(None, guid1, interface1).unwrap().0;
+
+            let event = 0x8765 as *mut c_void;
+            let reg = SPIN_LOCKED_PROTOCOL_DB.register_protocol_notify(guid1, event).unwrap();
+
+            // First call after register should return handle to existing protocol
+            let next = SPIN_LOCKED_PROTOCOL_DB.next_handle_for_registration(reg);
+            assert_eq!(next, Some(existing_handle));
+
+            // Second call should return no more protocols
+            let next = SPIN_LOCKED_PROTOCOL_DB.next_handle_for_registration(reg);
+            assert_eq!(next, None);
         });
     }
 

--- a/sdk/patina/src/boot_services.rs
+++ b/sdk/patina/src/boot_services.rs
@@ -1258,7 +1258,7 @@ impl BootServices for StandardBootServices {
             _ => ptr::null_mut(),
         };
 
-        // Expect locate to return BUFFER_TOO_SMALL to get the buffer_size
+        // Expect locate_handle to return BUFFER_TOO_SMALL along with the proper buffer_size
         let mut buffer_size = 0;
         match locate_handle(search_type.into(), protocol, search_key, ptr::addr_of_mut!(buffer_size), ptr::null_mut()) {
             s if s == efi::Status::BUFFER_TOO_SMALL => (),

--- a/sdk/patina/src/boot_services.rs
+++ b/sdk/patina/src/boot_services.rs
@@ -1260,16 +1260,10 @@ impl BootServices for StandardBootServices {
 
         // Expect locate to return BUFFER_TOO_SMALL to get the buffer_size
         let mut buffer_size = 0;
-        match locate_handle(
-            search_type.into(),
-            protocol,
-            search_key,
-            ptr::addr_of_mut!(buffer_size),
-            ptr::null_mut(),
-        ) {
+        match locate_handle(search_type.into(), protocol, search_key, ptr::addr_of_mut!(buffer_size), ptr::null_mut()) {
             s if s == efi::Status::BUFFER_TOO_SMALL => (),
             s if s.is_error() => return Err(s),
-            _ => return Err(efi::Status::PROTOCOL_ERROR),
+            _ => (),
         }
 
         let buffer = self.allocate_pool(EfiMemoryType::BootServicesData, buffer_size)?;

--- a/sdk/patina/src/boot_services.rs
+++ b/sdk/patina/src/boot_services.rs
@@ -1258,9 +1258,19 @@ impl BootServices for StandardBootServices {
             _ => ptr::null_mut(),
         };
 
-        // Use to get the buffer_size
+        // Expect locate to return BUFFER_TOO_SMALL to get the buffer_size
         let mut buffer_size = 0;
-        locate_handle(search_type.into(), protocol, search_key, ptr::addr_of_mut!(buffer_size), ptr::null_mut());
+        match locate_handle(
+            search_type.into(),
+            protocol,
+            search_key,
+            ptr::addr_of_mut!(buffer_size),
+            ptr::null_mut(),
+        ) {
+            s if s == efi::Status::BUFFER_TOO_SMALL => (),
+            s if s.is_error() => return Err(s),
+            _ => return Err(efi::Status::PROTOCOL_ERROR),
+        }
 
         let buffer = self.allocate_pool(EfiMemoryType::BootServicesData, buffer_size)?;
 


### PR DESCRIPTION
## Description

The current EDK II implementation performs an immediate callback when registering through LocateHandle using ByRegisterNotify and will provide each handle normally for protocols installed prior to the registration.  The Patina code was written to start caching handles only after the registration is performed.  This change will seed the cache with prior registered protocols at the registration to match the EDK II implementation.

During debug, found a location where locate_handle() was calling the underlying layer first for buffer size, but not handling the error paths.  Updated that call to return an error if encountered.

- [X] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [X] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Performing a port of a private UEFI to use Patina which requires the LocateHandle call to have knowledge of previously installed protocols.  Tested with my current code and tested with the added test functions.

## Integration Instructions

N/A
