### PR TITLE
Standardize SAFETY formatting

### DIFF
--- a/core/patina_internal_cpu/src/cpu/x64/cpu.rs
+++ b/core/patina_internal_cpu/src/cpu/x64/cpu.rs
@@ -113,7 +113,7 @@ impl EfiCpuX64 {
 
     fn initialize_fpu(&self) {
         #[cfg(all(not(test), target_arch = "x86_64"))]
-        // Safety: This assembly writes only hard coded values to CR4 register, and MMX and FPU control words. No
+        // SAFETY: This assembly writes only hard coded values to CR4 register, and MMX and FPU control words. No
         // inputs are used that could violate memory safety.
         unsafe {
             // sdm vol. 1, x87 FPU Control Word configuration

--- a/core/patina_internal_cpu/src/interrupts/aarch64/gic_manager.rs
+++ b/core/patina_internal_cpu/src/interrupts/aarch64/gic_manager.rs
@@ -105,7 +105,7 @@ impl AArch64InterruptInitializer {
         }
 
         // Convert raw GIC address pointers to appropriate types.
-        // Safety: function safety requirements guarantee exclusive access to the GICR registers.
+        // SAFETY: function safety requirements guarantee exclusive access to the GICR registers.
         let (gicd, gicr) = unsafe {
             let gicd = UniqueMmioPointer::new(NonNull::new(gicd_base as _).ok_or(EfiError::InvalidParameter)?);
             let gicr = NonNull::new(gicr_base as _).ok_or(EfiError::InvalidParameter)?;
@@ -119,7 +119,7 @@ impl AArch64InterruptInitializer {
         let mpidr = read_sysreg!(MPIDR_EL1) & MPIDR_AFFINITY_MASK;
         log::debug!("Current CPU MPIDR: {:#x}", mpidr);
         // Support for GIC v4 is backward compatible with GIC v3, so always enable it.
-        // Safety: function safety requirements guarantee exclusive access to the GICR registers.
+        // SAFETY: function safety requirements guarantee exclusive access to the GICR registers.
         for (index, redistributor) in unsafe { GicRedistributorIterator::new(gicr, true) }.enumerate() {
             r_count = index + 1;
             if redistributor.typer().core_mpidr() == mpidr {
@@ -153,12 +153,12 @@ impl AArch64InterruptInitializer {
         // Enable gic distributor
         // Enable support for GICv4; this is backward compatible with GICv3, so always enable it.
 
-        // Safety: function safety requirements guarantee exclusive access to the GICR registers.
+        // SAFETY: function safety requirements guarantee exclusive access to the GICR registers.
         let mut gic_v3 = unsafe { GicV3::new(gicd, gicr, r_count, true) };
         gic_v3.setup(cpu_r_idx);
 
         // Set binary point reg to 0x7 (no preemption)
-        // Safety: this is a legal value for BPR1 register.
+        // SAFETY: this is a legal value for BPR1 register.
         // Refer to "Arm Generic Interrupt Controller Architecture Specification GIC
         // architecture version 3 and Version 4" (Arm IHI 0069H.b ID041224)
         // 12.2.5: "ICC_BPR1_EL1, Interrupt Controller Binary Point Register 1"

--- a/docs/src/background/uefi_memory_safety_case_studies.md
+++ b/docs/src/background/uefi_memory_safety_case_studies.md
@@ -16,17 +16,17 @@ production systems and required security patches.
 
 The are actual CVEs found in UEFI firmware that could have been prevented with the memory safety features in Rust.
 
-| CVE ID | CVSS Score | Vulnerability Type | Potential Rust Prevention Mechanism |
-|--------|------------|-------------------|------------------------------------|
-| [CVE-2023-45230](https://nvd.nist.gov/vuln/detail/CVE-2023-45230) | 8.3 (HIGH) | Buffer Overflow in DHCPv6 | Automatic slice bounds checking |
-| [CVE-2022-36765](https://nvd.nist.gov/vuln/detail/CVE-2022-36765) | 7.0 (HIGH) | Integer Overflow in CreateHob() | Checked arithmetic operations |
-| [CVE-2023-45229](https://nvd.nist.gov/vuln/detail/CVE-2023-45229) | 6.5 (MEDIUM) | Out-of-Bounds Read in DHCPv6 | Slice bounds verification |
-| [CVE-2014-8271](https://nvd.nist.gov/vuln/detail/CVE-2014-8271) | 6.8 (MEDIUM) | Buffer Overflow in Variable Processing | Dynamic Vec sizing eliminates fixed buffers |
-| [CVE-2023-45233](https://nvd.nist.gov/vuln/detail/CVE-2023-45233) | 7.5 (HIGH) | Infinite Loop in IPv6 Parsing | Iterator patterns with explicit termination |
-| [CVE-2021-38575](https://nvd.nist.gov/vuln/detail/CVE-2021-38575) | 8.1 (HIGH) | Remote Buffer Overflow in iSCSI | Slice-based network parsing with bounds checking |
-| [CVE-2019-14563](https://nvd.nist.gov/vuln/detail/CVE-2019-14563) | 7.8 (HIGH) | Integer Truncation | Explicit type conversions with error handling |
-| [CVE-2024-1298](https://nvd.nist.gov/vuln/detail/CVE-2024-1298) | 6.0 (MEDIUM) | Division by Zero from Integer Overflow | Checked arithmetic prevents overflow-induced division by zero |
-| [CVE-2014-4859](https://nvd.nist.gov/vuln/detail/CVE-2014-4859) | Not specified | Integer Overflow in Capsule Update | Safe arithmetic with explicit overflow checking |
+| CVE ID                                                            | CVSS Score    | Vulnerability Type                     | Potential Rust Prevention Mechanism                           |
+| ----------------------------------------------------------------- | ------------- | -------------------------------------- | ------------------------------------------------------------- |
+| [CVE-2023-45230](https://nvd.nist.gov/vuln/detail/CVE-2023-45230) | 8.3 (HIGH)    | Buffer Overflow in DHCPv6              | Automatic slice bounds checking                               |
+| [CVE-2022-36765](https://nvd.nist.gov/vuln/detail/CVE-2022-36765) | 7.0 (HIGH)    | Integer Overflow in CreateHob()        | Checked arithmetic operations                                 |
+| [CVE-2023-45229](https://nvd.nist.gov/vuln/detail/CVE-2023-45229) | 6.5 (MEDIUM)  | Out-of-Bounds Read in DHCPv6           | Slice bounds verification                                     |
+| [CVE-2014-8271](https://nvd.nist.gov/vuln/detail/CVE-2014-8271)   | 6.8 (MEDIUM)  | Buffer Overflow in Variable Processing | Dynamic Vec sizing eliminates fixed buffers                   |
+| [CVE-2023-45233](https://nvd.nist.gov/vuln/detail/CVE-2023-45233) | 7.5 (HIGH)    | Infinite Loop in IPv6 Parsing          | Iterator patterns with explicit termination                   |
+| [CVE-2021-38575](https://nvd.nist.gov/vuln/detail/CVE-2021-38575) | 8.1 (HIGH)    | Remote Buffer Overflow in iSCSI        | Slice-based network parsing with bounds checking              |
+| [CVE-2019-14563](https://nvd.nist.gov/vuln/detail/CVE-2019-14563) | 7.8 (HIGH)    | Integer Truncation                     | Explicit type conversions with error handling                 |
+| [CVE-2024-1298](https://nvd.nist.gov/vuln/detail/CVE-2024-1298)   | 6.0 (MEDIUM)  | Division by Zero from Integer Overflow | Checked arithmetic prevents overflow-induced division by zero |
+| [CVE-2014-4859](https://nvd.nist.gov/vuln/detail/CVE-2014-4859)   | Not specified | Integer Overflow in Capsule Update     | Safe arithmetic with explicit overflow checking               |
 
 ## Vulnerability Classes Eliminated by Rust
 
@@ -342,7 +342,7 @@ fn safe_wrapper(ptr: *const u8) -> Option<u8> {
     }
 
     unsafe {
-        // Safety: We checked for null above
+        // SAFETY: We checked for null above
         Some(*ptr)
     }
 }
@@ -373,7 +373,7 @@ The Rust compiler and tools in the ecosystem enforce that unsafe functions docum
 unsafe fn parse_network_packet(data_ptr: *const u8, len: usize) -> Result<Packet, ParseError> {
     // Implementation that works with raw bytes from network
     let slice = unsafe {
-        // Safety: Caller guarantees ptr and len are valid
+        // SAFETY: Caller guarantees ptr and len are valid
         std::slice::from_raw_parts(data_ptr, len)
     };
 
@@ -423,7 +423,7 @@ impl NetworkBuffer {
 
         // All unsafe operations are contained within this implementation
         unsafe {
-            // Safety: We verified bounds above and self.data is always valid
+            // SAFETY: We verified bounds above and self.data is always valid
             let ptr = self.data.as_ptr().add(offset);
             let remaining = self.len() - offset;
             parse_network_packet(ptr, remaining).map_err(|_| NetworkError::OffsetOutOfBounds())

--- a/docs/src/rfc/text/0022-core-static.md
+++ b/docs/src/rfc/text/0022-core-static.md
@@ -348,7 +348,7 @@ impl <P: Platform> Core<P> {
             return efi::Status::INVALID_PARAMETER;
         }
 
-        // Safety: caller must ensure that file_name is a valid pointer. It is null-checked above.
+        // SAFETY: caller must ensure that file_name is a valid pointer. It is null-checked above.
         let file_name = unsafe { file_name.read_unaligned() };
 
         match Self::instance().uefi_state.dispatcher_context.trust(firmware_volume_handle, &file_name) {

--- a/patina_dxe_core/src/allocator.rs
+++ b/patina_dxe_core/src/allocator.rs
@@ -592,7 +592,7 @@ extern "efiapi" fn allocate_pool(pool_type: efi::MemoryType, size: usize, buffer
 
     match core_allocate_pool(pool_type, size) {
         Err(err) => err.into(),
-        // Safety: caller must ensure that buffer is a valid pointer. It is null-checked above.
+        // SAFETY: caller must ensure that buffer is a valid pointer. It is null-checked above.
         Ok(allocation) => unsafe {
             buffer.write_unaligned(allocation);
             efi::Status::SUCCESS
@@ -678,12 +678,12 @@ pub fn core_allocate_pages(
             let result = match allocation_type {
                 efi::ALLOCATE_ANY_PAGES => allocator.allocate_pages(DEFAULT_ALLOCATION_STRATEGY, pages, alignment),
                 efi::ALLOCATE_MAX_ADDRESS => {
-                    // Safety: caller must ensure that "memory" is a valid pointer. It is null-checked above.
+                    // SAFETY: caller must ensure that "memory" is a valid pointer. It is null-checked above.
                     let address = unsafe { memory.read_unaligned() };
                     allocator.allocate_pages(AllocationStrategy::TopDown(Some(address as usize)), pages, alignment)
                 }
                 efi::ALLOCATE_ADDRESS => {
-                    // Safety: caller must ensure that "memory" is a valid pointer. It is null-checked above.
+                    // SAFETY: caller must ensure that "memory" is a valid pointer. It is null-checked above.
                     let address = unsafe { memory.read_unaligned() };
                     allocator.allocate_pages(AllocationStrategy::Address(address as usize), pages, alignment)
                 }
@@ -691,7 +691,7 @@ pub fn core_allocate_pages(
             };
 
             if let Ok(ptr) = result {
-                // Safety: caller must ensure that "memory" is a valid pointer. It is null-checked above.
+                // SAFETY: caller must ensure that "memory" is a valid pointer. It is null-checked above.
                 unsafe { memory.write_unaligned(ptr.expose_provenance().get() as u64) }
                 Ok(())
             } else {
@@ -785,12 +785,12 @@ pub fn core_free_pages(memory: efi::PhysicalAddress, pages: usize) -> Result<(),
 }
 
 extern "efiapi" fn copy_mem(destination: *mut c_void, source: *mut c_void, length: usize) {
-    // Safety: caller must ensure that the source and destination are valid for length bytes.
+    // SAFETY: caller must ensure that the source and destination are valid for length bytes.
     unsafe { core::ptr::copy(source as *mut u8, destination as *mut u8, length) }
 }
 
 extern "efiapi" fn set_mem(buffer: *mut c_void, size: usize, value: u8) {
-    // Safety: caller must ensure that the buffer is valid for size bytes.
+    // SAFETY: caller must ensure that the buffer is valid for size bytes.
     unsafe {
         let dst_buffer = from_raw_parts_mut(buffer as *mut u8, size);
         dst_buffer.fill(value);
@@ -809,16 +809,16 @@ extern "efiapi" fn get_memory_map(
     }
 
     if !descriptor_size.is_null() {
-        // Safety: caller must ensure that descriptor_size is a valid pointer if it is not null.
+        // SAFETY: caller must ensure that descriptor_size is a valid pointer if it is not null.
         unsafe { descriptor_size.write_unaligned(mem::size_of::<efi::MemoryDescriptor>()) };
     }
 
     if !descriptor_version.is_null() {
-        // Safety: caller must ensure that descriptor_version is a valid pointer if it is not null.
+        // SAFETY: caller must ensure that descriptor_version is a valid pointer if it is not null.
         unsafe { descriptor_version.write_unaligned(efi::MEMORY_DESCRIPTOR_VERSION) };
     }
 
-    // Safety: caller must ensure that memory_map_size is a valid pointer. It is null-checked above.
+    // SAFETY: caller must ensure that memory_map_size is a valid pointer. It is null-checked above.
     let map_size = unsafe { memory_map_size.read_unaligned() };
 
     let required_map_size = GCD.memory_descriptor_count_for_efi_memory_map() * mem::size_of::<efi::MemoryDescriptor>();
@@ -835,7 +835,7 @@ extern "efiapi" fn get_memory_map(
 
     let descriptor_count = map_size / mem::size_of::<efi::MemoryDescriptor>();
 
-    // Safety: caller must ensure that memory_map is a valid pointer for at least descriptor_count elements.
+    // SAFETY: caller must ensure that memory_map is a valid pointer for at least descriptor_count elements.
     // It is null-checked above and the size has been validated.
     let buffer = unsafe { slice::from_raw_parts_mut(memory_map, descriptor_count) };
 
@@ -846,10 +846,10 @@ extern "efiapi" fn get_memory_map(
     let actual_map_size = actual_count * mem::size_of::<efi::MemoryDescriptor>();
 
     // Write back the actual map size after merging
-    // Safety: caller must ensure that memory_map_size is a valid pointer. It is null-checked above.
+    // SAFETY: caller must ensure that memory_map_size is a valid pointer. It is null-checked above.
     unsafe { memory_map_size.write_unaligned(actual_map_size) };
 
-    // Safety: caller must ensure that map_key is a valid pointer if it is not null.
+    // SAFETY: caller must ensure that map_key is a valid pointer if it is not null.
     unsafe {
         if !map_key.is_null() {
             let memory_map_as_bytes = slice::from_raw_parts(memory_map as *mut u8, actual_map_size);
@@ -1181,7 +1181,7 @@ pub fn init_memory_support(hob_list: &HobList) {
                 let memory_type_slice_ptr = data.as_ptr() as *const EFiMemoryTypeInformation;
                 let memory_type_slice_len = data.len() / mem::size_of::<EFiMemoryTypeInformation>();
 
-                // Safety: this structure comes from the hob list, so it must be 8-byte aligned (meets alignment
+                // SAFETY: this structure comes from the hob list, so it must be 8-byte aligned (meets alignment
                 // requirement for EfiMemoryTypeInformation), and length is calculated above to fit within the
                 // Guid HOB data. Assert if alignment is not as expected.
                 assert_eq!(memory_type_slice_ptr.align_offset(mem::align_of::<EFiMemoryTypeInformation>()), 0);
@@ -1754,7 +1754,7 @@ mod tests {
             let allocator = &EFI_BOOT_SERVICES_DATA_ALLOCATOR;
             let mut buffer_ptr = core::ptr::null_mut();
 
-            // Safety: allocator is valid for the duration of the test and these asserts are grouped
+            // SAFETY: allocator is valid for the duration of the test and these asserts are grouped
             // in one block to simplify test structure.
             unsafe {
                 assert!(allocator.allocate_pool(0x1000, core::ptr::addr_of_mut!(buffer_ptr)).is_ok());
@@ -1771,7 +1771,7 @@ mod tests {
             let allocator = &EFI_BOOT_SERVICES_CODE_ALLOCATOR;
             let mut buffer_ptr = core::ptr::null_mut();
 
-            // Safety: allocator is valid for the duration of the test and these asserts are grouped
+            // SAFETY: allocator is valid for the duration of the test and these asserts are grouped
             // in one block to simplify test structure.
             unsafe {
                 assert!(allocator.allocate_pool(0x1000, core::ptr::addr_of_mut!(buffer_ptr)).is_ok());
@@ -1791,7 +1791,7 @@ mod tests {
             let allocator = &EFI_RUNTIME_SERVICES_DATA_ALLOCATOR;
             let mut buffer_ptr = core::ptr::null_mut();
 
-            // Safety: allocator is valid for the duration of the test and these asserts are grouped
+            // SAFETY: allocator is valid for the duration of the test and these asserts are grouped
             // in one block to simplify test structure.
             unsafe {
                 assert!(allocator.allocate_pool(0x1000, core::ptr::addr_of_mut!(buffer_ptr)).is_ok());

--- a/patina_dxe_core/src/allocator/uefi_allocator.rs
+++ b/patina_dxe_core/src/allocator/uefi_allocator.rs
@@ -440,7 +440,7 @@ mod tests {
 
                 let mut buffer: *mut c_void = core::ptr::null_mut();
 
-                // Safety: The allocator has been setup and the buffer pointer is valid for the allocation.
+                // SAFETY: The allocator has been setup and the buffer pointer is valid for the allocation.
                 assert!(unsafe { ua.allocate_pool(0x1000, core::ptr::addr_of_mut!(buffer)) }.is_ok());
 
                 // Corrupt the signature to test validation
@@ -452,7 +452,7 @@ mod tests {
                     .unwrap_or_else(|err| panic!("Allocation layout error: {err:#?}"));
 
                 let allocation_info: *mut AllocationInfo = ((buffer as usize) - offset) as *mut AllocationInfo;
-                // Safety: The allocation_info pointer is valid. It was derived from a buffer pointer above.
+                // SAFETY: The allocation_info pointer is valid. It was derived from a buffer pointer above.
                 unsafe {
                     (*allocation_info).signature = 0x01010101; // Corrupt the signature
                 }

--- a/patina_dxe_core/src/component_dispatcher.rs
+++ b/patina_dxe_core/src/component_dispatcher.rs
@@ -115,7 +115,7 @@ impl Default for ComponentDispatcher {
     }
 }
 
-/// Safety: The ComponentDispatcher is `Send` as all data stored within this structure is owned by it, and not shared.
+/// SAFETY: The ComponentDispatcher is `Send` as all data stored within this structure is owned by it, and not shared.
 unsafe impl Send for ComponentDispatcher {}
 
 impl ComponentDispatcher {

--- a/patina_dxe_core/src/config_tables.rs
+++ b/patina_dxe_core/src/config_tables.rs
@@ -28,7 +28,7 @@ extern "efiapi" fn install_configuration_table(table_guid: *mut efi::Guid, table
         return efi::Status::INVALID_PARAMETER;
     }
 
-    // Safety: caller must ensure that table_guid is a valid pointer. It is null-checked above.
+    // SAFETY: caller must ensure that table_guid is a valid pointer. It is null-checked above.
     let table_guid = unsafe { table_guid.read_unaligned() };
 
     let mut st_guard = SYSTEM_TABLE.lock();
@@ -135,7 +135,7 @@ pub fn get_configuration_table(table_guid: &efi::Guid) -> Option<NonNull<c_void>
         return None;
     }
 
-    // Safety: system table exists, and configuration is non-null, and number_of_table_entries is non-zero.
+    // SAFETY: system table exists, and configuration is non-null, and number_of_table_entries is non-zero.
     let ct_slice = unsafe { from_raw_parts(system_table.configuration_table, system_table.number_of_table_entries) };
 
     for entry in ct_slice {

--- a/patina_dxe_core/src/cpu.rs
+++ b/patina_dxe_core/src/cpu.rs
@@ -142,7 +142,7 @@ mod tests {
         impl CpuInfo for TestPlatform {
             #[cfg(target_arch = "aarch64")]
             fn gic_bases() -> GicBases {
-                // Safety: Call is exclusive to the GicBases instance.
+                // SAFETY: Call is exclusive to the GicBases instance.
                 unsafe { GicBases::new(0, 0) }
             }
         }

--- a/patina_dxe_core/src/cpu/cpu_arch_protocol.rs
+++ b/patina_dxe_core/src/cpu/cpu_arch_protocol.rs
@@ -88,7 +88,7 @@ extern "efiapi" fn get_interrupt_state(this: *const Protocol, state: *mut bool) 
     }
     interrupts::get_interrupt_state()
         .map(|interrupt_state| {
-            // Safety: caller must ensure that state is a valid pointer. It is null-checked above.
+            // SAFETY: caller must ensure that state is a valid pointer. It is null-checked above.
             unsafe {
                 state.write_unaligned(interrupt_state);
             }
@@ -141,7 +141,7 @@ extern "efiapi" fn get_timer_value(
 
     match result {
         Ok((value, period)) => {
-            // Safety: caller must ensure that timer_value and timer_period are valid pointers. They are null-checked above.
+            // SAFETY: caller must ensure that timer_value and timer_period are valid pointers. They are null-checked above.
             unsafe {
                 timer_value.write_unaligned(value);
                 timer_period.write_unaligned(period);

--- a/patina_dxe_core/src/cpu/hw_interrupt_protocol.rs
+++ b/patina_dxe_core/src/cpu/hw_interrupt_protocol.rs
@@ -74,7 +74,7 @@ impl<'a> EfiHardwareInterruptProtocol<'a> {
             return efi::Status::INVALID_PARAMETER;
         }
 
-        // Safety: caller guarantees that *this is valid pointer to EfiHardwareInterruptProtocol.
+        // SAFETY: caller guarantees that *this is valid pointer to EfiHardwareInterruptProtocol.
         let hw_interrupt_protocol = unsafe { &mut *this };
 
         hw_interrupt_protocol.hw_interrupt_handler.register_interrupt_source(interrupt_source as usize, handler)
@@ -88,7 +88,7 @@ impl<'a> EfiHardwareInterruptProtocol<'a> {
             return efi::Status::INVALID_PARAMETER;
         }
 
-        // Safety: caller guarantees that *this is valid pointer to EfiHardwareInterruptProtocol.
+        // SAFETY: caller guarantees that *this is valid pointer to EfiHardwareInterruptProtocol.
         let hw_interrupt_protocol = unsafe { &mut *this };
 
         if let Err(err) =
@@ -108,7 +108,7 @@ impl<'a> EfiHardwareInterruptProtocol<'a> {
             return efi::Status::INVALID_PARAMETER;
         }
 
-        // Safety: caller guarantees that *this is valid pointer to EfiHardwareInterruptProtocol.
+        // SAFETY: caller guarantees that *this is valid pointer to EfiHardwareInterruptProtocol.
         let hw_interrupt_protocol = unsafe { &mut *this };
 
         if let Err(err) =
@@ -129,14 +129,14 @@ impl<'a> EfiHardwareInterruptProtocol<'a> {
             return efi::Status::INVALID_PARAMETER;
         }
 
-        // Safety: caller guarantees that *this is valid pointer to EfiHardwareInterruptProtocol.
+        // SAFETY: caller guarantees that *this is valid pointer to EfiHardwareInterruptProtocol.
         let hw_interrupt_protocol = unsafe { &mut *this };
 
         let enable =
             hw_interrupt_protocol.hw_interrupt_handler.aarch64_int.lock().get_interrupt_source_state(interrupt_source);
         match enable {
             Ok(enable) => {
-                // Safety: caller must ensure that state is a valid pointer. It is null-checked above.
+                // SAFETY: caller must ensure that state is a valid pointer. It is null-checked above.
                 unsafe { state.write_unaligned(enable) }
                 efi::Status::SUCCESS
             }
@@ -152,7 +152,7 @@ impl<'a> EfiHardwareInterruptProtocol<'a> {
             return efi::Status::INVALID_PARAMETER;
         }
 
-        // Safety: caller guarantees that *this is valid pointer to EfiHardwareInterruptProtocol.
+        // SAFETY: caller guarantees that *this is valid pointer to EfiHardwareInterruptProtocol.
         let hw_interrupt_protocol = unsafe { &mut *this };
 
         if let Err(err) =
@@ -225,7 +225,7 @@ impl<'a> EfiHardwareInterruptV2Protocol<'a> {
             return efi::Status::INVALID_PARAMETER;
         }
 
-        // Safety: caller guarantees that *this is valid pointer to EfiHardwareInterruptV2Protocol.
+        // SAFETY: caller guarantees that *this is valid pointer to EfiHardwareInterruptV2Protocol.
         let hw_interrupt2_protocol = unsafe { &mut *this };
         hw_interrupt2_protocol.hw_interrupt_handler.register_interrupt_source(interrupt_source as usize, handler)
     }
@@ -238,7 +238,7 @@ impl<'a> EfiHardwareInterruptV2Protocol<'a> {
             return efi::Status::INVALID_PARAMETER;
         }
 
-        // Safety: caller guarantees that *this is valid pointer to EfiHardwareInterruptV2Protocol.
+        // SAFETY: caller guarantees that *this is valid pointer to EfiHardwareInterruptV2Protocol.
         let hw_interrupt2_protocol = unsafe { &mut *this };
         if let Err(err) =
             hw_interrupt2_protocol.hw_interrupt_handler.aarch64_int.lock().enable_interrupt_source(interrupt_source)
@@ -257,7 +257,7 @@ impl<'a> EfiHardwareInterruptV2Protocol<'a> {
             return efi::Status::INVALID_PARAMETER;
         }
 
-        // Safety: caller guarantees that *this is valid pointer to EfiHardwareInterruptV2Protocol.
+        // SAFETY: caller guarantees that *this is valid pointer to EfiHardwareInterruptV2Protocol.
         let hw_interrupt2_protocol = unsafe { &mut *this };
         if let Err(err) =
             hw_interrupt2_protocol.hw_interrupt_handler.aarch64_int.lock().disable_interrupt_source(interrupt_source)
@@ -277,7 +277,7 @@ impl<'a> EfiHardwareInterruptV2Protocol<'a> {
             return efi::Status::INVALID_PARAMETER;
         }
 
-        // Safety: caller guarantees that *this is valid pointer to EfiHardwareInterruptV2Protocol.
+        // SAFETY: caller guarantees that *this is valid pointer to EfiHardwareInterruptV2Protocol.
         let hw_interrupt2_protocol = unsafe { &mut *this };
         let enable =
             hw_interrupt2_protocol.hw_interrupt_handler.aarch64_int.lock().get_interrupt_source_state(interrupt_source);
@@ -297,7 +297,7 @@ impl<'a> EfiHardwareInterruptV2Protocol<'a> {
         if this.is_null() {
             return efi::Status::INVALID_PARAMETER;
         }
-        // Safety: caller guarantees that *this is valid pointer to EfiHardwareInterruptV2Protocol.
+        // SAFETY: caller guarantees that *this is valid pointer to EfiHardwareInterruptV2Protocol.
         let hw_interrupt2_protocol = unsafe { &mut *this };
         if let Err(err) =
             hw_interrupt2_protocol.hw_interrupt_handler.aarch64_int.lock().end_of_interrupt(interrupt_source)
@@ -317,7 +317,7 @@ impl<'a> EfiHardwareInterruptV2Protocol<'a> {
             return efi::Status::INVALID_PARAMETER;
         }
 
-        // Safety: caller guarantees that *this is valid pointer to EfiHardwareInterruptV2Protocol.
+        // SAFETY: caller guarantees that *this is valid pointer to EfiHardwareInterruptV2Protocol.
         let hw_interrupt2_protocol = unsafe { &mut *this };
         let level = hw_interrupt2_protocol.hw_interrupt_handler.aarch64_int.lock().get_trigger_type(interrupt_source);
         match level {
@@ -338,7 +338,7 @@ impl<'a> EfiHardwareInterruptV2Protocol<'a> {
             return efi::Status::INVALID_PARAMETER;
         }
 
-        // Safety: caller guarantees that *this is valid pointer to EfiHardwareInterruptV2Protocol.
+        // SAFETY: caller guarantees that *this is valid pointer to EfiHardwareInterruptV2Protocol.
         let hw_interrupt2_protocol = unsafe { &mut *this };
         if let Err(err) = hw_interrupt2_protocol
             .hw_interrupt_handler

--- a/patina_dxe_core/src/driver_services.rs
+++ b/patina_dxe_core/src/driver_services.rs
@@ -289,7 +289,7 @@ fn core_connect_single_controller(
         return Ok(());
     }
 
-    // Safety: caller must ensure that the pointer contained in remaining_device_path is valid if it is Some(_).
+    // SAFETY: caller must ensure that the pointer contained in remaining_device_path is valid if it is Some(_).
     if let Some(device_path) = remaining_device_path
         && unsafe { (device_path.read_unaligned()).r#type == efi::protocols::device_path::TYPE_END }
     {
@@ -354,14 +354,14 @@ extern "efiapi" fn connect_controller(
         let mut current_ptr = driver_image_handle;
         let mut handles: Vec<efi::Handle> = Vec::new();
         loop {
-            // Safety: caller must ensure that driver_image_handle is a valid pointer to a null-terminated list of
+            // SAFETY: caller must ensure that driver_image_handle is a valid pointer to a null-terminated list of
             // handles if it is not null.
             let current_val = unsafe { current_ptr.read_unaligned() };
             if current_val.is_null() {
                 break;
             }
             handles.push(current_val);
-            // Safety: caller guarantees a null-terminated list, so safe to advance to the next pointer as the null-terminator
+            // SAFETY: caller guarantees a null-terminated list, so safe to advance to the next pointer as the null-terminator
             // has just been checked above.
             current_ptr = unsafe { current_ptr.add(1) };
         }
@@ -370,7 +370,7 @@ extern "efiapi" fn connect_controller(
     // remaining_device_path is passed in and may not have proper alignment.
     let device_path = if remaining_device_path.is_null() { None } else { Some(remaining_device_path) };
 
-    // Safety: caller must ensure that device_path is a valid pointer to a device path structure if it is not null.
+    // SAFETY: caller must ensure that device_path is a valid pointer to a device path structure if it is not null.
     unsafe {
         match core_connect_controller(handle, driver_handles, device_path, recursive.into()) {
             Err(err) => err.into(),

--- a/patina_dxe_core/src/dxe_services.rs
+++ b/patina_dxe_core/src/dxe_services.rs
@@ -49,19 +49,19 @@ extern "efiapi" fn allocate_memory_space(
 
     let allocate_type = match gcd_allocate_type {
         dxe_services::GcdAllocateType::Address => {
-            // Safety: caller must ensure that base_address is a valid pointer. It is null-checked above.
+            // SAFETY: caller must ensure that base_address is a valid pointer. It is null-checked above.
             let desired_address = unsafe { base_address.read_unaligned() };
             gcd::AllocateType::Address(desired_address as usize)
         }
         dxe_services::GcdAllocateType::AnySearchBottomUp => gcd::AllocateType::BottomUp(None),
         dxe_services::GcdAllocateType::AnySearchTopDown => gcd::AllocateType::TopDown(None),
         dxe_services::GcdAllocateType::MaxAddressSearchBottomUp => {
-            // Safety: caller must ensure that base_address is a valid pointer. It is null-checked above.
+            // SAFETY: caller must ensure that base_address is a valid pointer. It is null-checked above.
             let limit = unsafe { base_address.read_unaligned() };
             gcd::AllocateType::BottomUp(Some(limit as usize))
         }
         dxe_services::GcdAllocateType::MaxAddressSearchTopDown => {
-            // Safety: caller must ensure that base_address is a valid pointer. It is null-checked above.
+            // SAFETY: caller must ensure that base_address is a valid pointer. It is null-checked above.
             let limit = unsafe { base_address.read_unaligned() };
             gcd::AllocateType::TopDown(Some(limit as usize))
         }
@@ -79,7 +79,7 @@ extern "efiapi" fn allocate_memory_space(
 
     match result {
         Ok(allocated_addr) => {
-            // Safety: caller must ensure that base_address is a valid pointer. It is null-checked above.
+            // SAFETY: caller must ensure that base_address is a valid pointer. It is null-checked above.
             unsafe { base_address.write_unaligned(allocated_addr as u64) };
             efi::Status::SUCCESS
         }
@@ -115,7 +115,7 @@ extern "efiapi" fn get_memory_space_descriptor(
     match core_get_memory_space_descriptor(base_address) {
         Err(err) => return err.into(),
         Ok(target_descriptor) =>
-        // Safety: caller must ensure that descriptor is a valid pointer. It is null-checked above.
+        // SAFETY: caller must ensure that descriptor is a valid pointer. It is null-checked above.
         unsafe {
             descriptor.write_unaligned(target_descriptor);
         },
@@ -204,7 +204,7 @@ extern "efiapi" fn get_memory_space_map(
     match core_allocate_pool(efi::BOOT_SERVICES_DATA, buffer_size) {
         Err(err) => err.into(),
         Ok(allocation) =>
-        // Safety: caller must ensure that number_of_descriptors and memory_space_map are valid pointers. They are
+        // SAFETY: caller must ensure that number_of_descriptors and memory_space_map are valid pointers. They are
         // null-checked above.
         unsafe {
             memory_space_map.write_unaligned(allocation as *mut dxe_services::MemorySpaceDescriptor);
@@ -243,19 +243,19 @@ extern "efiapi" fn allocate_io_space(
 
     let allocate_type = match gcd_allocate_type {
         dxe_services::GcdAllocateType::Address => {
-            // Safety: caller must ensure that base_address is a valid pointer. It is null-checked above.
+            // SAFETY: caller must ensure that base_address is a valid pointer. It is null-checked above.
             let desired_address = unsafe { base_address.read_unaligned() };
             gcd::AllocateType::Address(desired_address as usize)
         }
         dxe_services::GcdAllocateType::AnySearchBottomUp => gcd::AllocateType::BottomUp(None),
         dxe_services::GcdAllocateType::AnySearchTopDown => gcd::AllocateType::TopDown(None),
         dxe_services::GcdAllocateType::MaxAddressSearchBottomUp => {
-            // Safety: caller must ensure that base_address is a valid pointer. It is null-checked above.
+            // SAFETY: caller must ensure that base_address is a valid pointer. It is null-checked above.
             let limit = unsafe { base_address.read_unaligned() };
             gcd::AllocateType::BottomUp(Some(limit as usize))
         }
         dxe_services::GcdAllocateType::MaxAddressSearchTopDown => {
-            // Safety: caller must ensure that base_address is a valid pointer. It is null-checked above.
+            // SAFETY: caller must ensure that base_address is a valid pointer. It is null-checked above.
             let limit = unsafe { base_address.read_unaligned() };
             gcd::AllocateType::TopDown(Some(limit as usize))
         }
@@ -273,7 +273,7 @@ extern "efiapi" fn allocate_io_space(
 
     match result {
         Ok(allocated_addr) => {
-            // Safety: caller must ensure that base_address is a valid pointer. It is null-checked above.
+            // SAFETY: caller must ensure that base_address is a valid pointer. It is null-checked above.
             unsafe { base_address.write_unaligned(allocated_addr as u64) };
             efi::Status::SUCCESS
         }
@@ -322,7 +322,7 @@ extern "efiapi" fn get_io_space_descriptor(
         descriptors.iter().find(|x| (x.base_address <= base_address) && (base_address < (x.base_address + x.length)));
 
     if let Some(target_descriptor) = target_descriptor {
-        // Safety: caller must ensure that descriptor is a valid pointer. It is null-checked above.
+        // SAFETY: caller must ensure that descriptor is a valid pointer. It is null-checked above.
         unsafe { descriptor.write_unaligned(*target_descriptor) };
         efi::Status::SUCCESS
     } else {
@@ -352,7 +352,7 @@ extern "efiapi" fn get_io_space_map(
     match core_allocate_pool(efi::BOOT_SERVICES_DATA, buffer_size) {
         Err(err) => err.into(),
         Ok(allocation) =>
-        // Safety: caller must ensure that number_of_descriptors and io_space_map are valid pointers. They are null-checked above.
+        // SAFETY: caller must ensure that number_of_descriptors and io_space_map are valid pointers. They are null-checked above.
         unsafe {
             io_space_map.write_unaligned(allocation as *mut dxe_services::IoSpaceDescriptor);
             number_of_descriptors.write_unaligned(descriptors.len());
@@ -420,12 +420,12 @@ impl<P: PlatformInfo> Core<P> {
         }
 
         // construct a FirmwareVolume to verify sanity
-        // Safety: caller must ensure that firmware_volume_header is a valid pointer. It is null-checked above.
+        // SAFETY: caller must ensure that firmware_volume_header is a valid pointer. It is null-checked above.
         let fv_slice = unsafe { slice::from_raw_parts(firmware_volume_header as *const u8, size) };
         if let Err(err) = VolumeRef::new(fv_slice) {
             return err.into();
         }
-        // Safety: caller must ensure that firmware_volume_header is a valid firmware volume that will not be freed
+        // SAFETY: caller must ensure that firmware_volume_header is a valid firmware volume that will not be freed
         // or moved after being sent to the core for processing.
         let res =
             unsafe { Self::instance().pi_dispatcher.install_firmware_volume(firmware_volume_header as u64, None) };
@@ -434,7 +434,7 @@ impl<P: PlatformInfo> Core<P> {
             Err(err) => return err.into(),
         };
 
-        // Safety: caller must ensure that firmware_volume_handle is a valid pointer. It is null-checked above.
+        // SAFETY: caller must ensure that firmware_volume_handle is a valid pointer. It is null-checked above.
         unsafe {
             firmware_volume_handle.write_unaligned(handle);
         }
@@ -457,7 +457,7 @@ impl<P: PlatformInfo> Core<P> {
         if file_name.is_null() {
             return efi::Status::INVALID_PARAMETER;
         }
-        // Safety: caller must ensure that file_name is a valid pointer. It is null-checked above.
+        // SAFETY: caller must ensure that file_name is a valid pointer. It is null-checked above.
         let file_name = unsafe { file_name.read_unaligned() };
 
         match Self::instance().pi_dispatcher.schedule(firmware_volume_handle, &file_name) {
@@ -470,7 +470,7 @@ impl<P: PlatformInfo> Core<P> {
         if file_name.is_null() {
             return efi::Status::INVALID_PARAMETER;
         }
-        // Safety: caller must ensure that file_name is a valid pointer. It is null-checked above.
+        // SAFETY: caller must ensure that file_name is a valid pointer. It is null-checked above.
         let file_name = unsafe { file_name.read_unaligned() };
 
         match Self::instance().pi_dispatcher.trust(firmware_volume_handle, &file_name) {

--- a/patina_dxe_core/src/events.rs
+++ b/patina_dxe_core/src/events.rs
@@ -52,7 +52,7 @@ extern "efiapi" fn create_event(
 
     match EVENT_DB.create_event(event_type, notify_tpl, notify_function, notify_context, event_group) {
         Ok(new_event) => {
-            // Safety: caller must ensure that event is a valid pointer. It is null-checked above.
+            // SAFETY: caller must ensure that event is a valid pointer. It is null-checked above.
             unsafe { event.write_unaligned(new_event) };
             efi::Status::SUCCESS
         }
@@ -81,12 +81,12 @@ extern "efiapi" fn create_event_ex(
         _ => (),
     }
 
-    // Safety: caller must ensure that event_group is a valid pointer if not null.
+    // SAFETY: caller must ensure that event_group is a valid pointer if not null.
     let event_group = if !event_group.is_null() { Some(unsafe { event_group.read_unaligned() }) } else { None };
 
     match EVENT_DB.create_event(event_type, notify_tpl, notify_function, notify_context, event_group) {
         Ok(new_event) => {
-            // Safety: caller must ensure that event is a valid pointer. It is null-checked above.
+            // SAFETY: caller must ensure that event is a valid pointer. It is null-checked above.
             unsafe { event.write_unaligned(new_event) };
             efi::Status::SUCCESS
         }
@@ -128,12 +128,12 @@ extern "efiapi" fn wait_for_event(
     loop {
         let mut event_ptr = event_array;
         for index in 0..number_of_events {
-            // Safety: caller must ensure that event_array is a valid pointer and number_of_events is correct. event_array is null-checked above.
+            // SAFETY: caller must ensure that event_array is a valid pointer and number_of_events is correct. event_array is null-checked above.
             let event = unsafe { event_ptr.read_unaligned() };
             match check_event(event) {
                 efi::Status::NOT_READY => (),
                 status => {
-                    // Safety: caller must ensure that out_index is a valid pointer if it is not null.
+                    // SAFETY: caller must ensure that out_index is a valid pointer if it is not null.
                     if !out_index.is_null() {
                         unsafe {
                             out_index.write_unaligned(index);
@@ -142,7 +142,7 @@ extern "efiapi" fn wait_for_event(
                     return status;
                 }
             }
-            // Safety: caller must ensure that event_array is a valid pointer and number_of_events is correct. event_array is null-checked above.
+            // SAFETY: caller must ensure that event_array is a valid pointer and number_of_events is correct. event_array is null-checked above.
             event_ptr = unsafe { event_ptr.add(1) };
         }
 

--- a/patina_dxe_core/src/memory_attributes_protocol.rs
+++ b/patina_dxe_core/src/memory_attributes_protocol.rs
@@ -75,7 +75,7 @@ extern "efiapi" fn get_memory_attributes(
     }
 
     if let Some(attrs) = found_attrs {
-        // Safety: caller must provide a valid pointer to receive the attributes. It is null-checked above.
+        // SAFETY: caller must provide a valid pointer to receive the attributes. It is null-checked above.
         unsafe { attributes.write_unaligned(attrs) };
         efi::Status::SUCCESS
     } else {

--- a/patina_dxe_core/src/misc_boot_services.rs
+++ b/patina_dxe_core/src/misc_boot_services.rs
@@ -34,14 +34,14 @@ impl<T> ArchProtocolPtr<T> {
         self.0.get().copied()
     }
 
-    // Safety: ptr must be a valid pointer to T and init must only be called once.
+    // SAFETY: ptr must be a valid pointer to T and init must only be called once.
     unsafe fn init(&self, ptr: *mut c_void) {
         assert!(!self.0.is_completed(), "Attempted to set ArchProtocolPtr more than once.");
         let _ = self.0.call_once(|| ptr as *mut T);
     }
 }
 
-// Safety: ArchProtocolPtr is Send/Sync because the pointer it wraps is initialized in a thread-safe manner (using
+// SAFETY: ArchProtocolPtr is Send/Sync because the pointer it wraps is initialized in a thread-safe manner (using
 // `Once`), and the pointer itself is never used to mutate data.
 unsafe impl<T> Send for ArchProtocolPtr<T> {}
 unsafe impl<T> Sync for ArchProtocolPtr<T> {}
@@ -64,7 +64,7 @@ extern "efiapi" fn calculate_crc32(data: *mut c_void, data_size: usize, crc_32: 
     if data.is_null() || data_size == 0 || crc_32.is_null() {
         return efi::Status::INVALID_PARAMETER;
     }
-    // Safety: caller must ensure that data and crc_32 are valid pointers. They are null-checked above.
+    // SAFETY: caller must ensure that data and crc_32 are valid pointers. They are null-checked above.
     unsafe {
         let buffer = from_raw_parts(data as *mut u8, data_size);
         crc_32.write_unaligned(crc32fast::hash(buffer));
@@ -77,7 +77,7 @@ extern "efiapi" fn calculate_crc32(data: *mut c_void, data_size: usize, crc_32: 
 // Execution of the processor is not yielded for the duration of the stall.
 extern "efiapi" fn stall(microseconds: usize) -> efi::Status {
     if let Some(metronome_ptr) = METRONOME_ARCH_PTR.get() {
-        // Safety: metronome_ptr is guaranteed to be a valid pointer to the metronome protocol if it is Some.
+        // SAFETY: metronome_ptr is guaranteed to be a valid pointer to the metronome protocol if it is Some.
         let metronome = unsafe { metronome_ptr.as_mut().unwrap() };
         let ticks_100ns: u128 = (microseconds as u128) * 10;
         let mut ticks = ticks_100ns / metronome.tick_period as u128;
@@ -117,7 +117,7 @@ extern "efiapi" fn set_watchdog_timer(
 ) -> efi::Status {
     const WATCHDOG_TIMER_CALIBRATE_PER_SECOND: u64 = 10000000;
     if let Some(watchdog_ptr) = WATCHDOG_ARCH_PTR.get() {
-        // Safety: watchdog_ptr is guaranteed to be a valid pointer to the watchdog protocol if it is Some.
+        // SAFETY: watchdog_ptr is guaranteed to be a valid pointer to the watchdog protocol if it is Some.
         let watchdog = unsafe { watchdog_ptr.as_mut().unwrap() };
         let timeout = (timeout as u64).saturating_mul(WATCHDOG_TIMER_CALIBRATE_PER_SECOND);
         let status = (watchdog.set_timer_period)(watchdog_ptr, timeout);
@@ -136,7 +136,7 @@ extern "efiapi" fn set_watchdog_timer(
 extern "efiapi" fn metronome_arch_available(event: efi::Event, _context: *mut c_void) {
     match PROTOCOL_DB.locate_protocol(protocols::metronome::PROTOCOL_GUID) {
         Ok(metronome_arch_ptr) => {
-            // Safety: metronome_arch_ptr is expected to be a valid pointer to the metronome protocol since it is
+            // SAFETY: metronome_arch_ptr is expected to be a valid pointer to the metronome protocol since it is
             // associated with the metronome arch guid.
             assert!(!metronome_arch_ptr.is_null(), "Located metronome protocol pointer is null.");
             unsafe { METRONOME_ARCH_PTR.init(metronome_arch_ptr) };
@@ -154,7 +154,7 @@ extern "efiapi" fn metronome_arch_available(event: efi::Event, _context: *mut c_
 extern "efiapi" fn watchdog_arch_available(event: efi::Event, _context: *mut c_void) {
     match PROTOCOL_DB.locate_protocol(protocols::watchdog::PROTOCOL_GUID) {
         Ok(watchdog_arch_ptr) => {
-            // Safety: watchdog_arch_ptr is expected to be a valid pointer to the watchdog protocol since it is
+            // SAFETY: watchdog_arch_ptr is expected to be a valid pointer to the watchdog protocol since it is
             // associated with the watchdog arch guid.
             assert!(!watchdog_arch_ptr.is_null(), "Located watchdog protocol pointer is null.");
             unsafe { WATCHDOG_ARCH_PTR.init(watchdog_arch_ptr) };

--- a/patina_dxe_core/src/pi_dispatcher.rs
+++ b/patina_dxe_core/src/pi_dispatcher.rs
@@ -334,7 +334,7 @@ impl<P: PlatformInfo> PiDispatcher<P> {
 
                         // Check if this FV is already installed (using the FV name GUID)
                         let fv_name_guid = {
-                            // Safety: fv_data is a valid FV section allocated above
+                            // SAFETY: fv_data is a valid FV section allocated above
                             let volume = match unsafe { VolumeRef::new_from_address(fv_data.as_ptr() as u64) } {
                                 Ok(vol) => vol,
                                 Err(e) => {
@@ -365,7 +365,7 @@ impl<P: PlatformInfo> PiDispatcher<P> {
                             dispatcher.fv_section_data.last().expect("freshly pushed fv section data must be valid");
 
                         let volume_address: u64 = data_ptr.as_ptr() as u64;
-                        // Safety: FV section data is stored in the dispatcher and is valid until end of UEFI (nothing drops it).
+                        // SAFETY: FV section data is stored in the dispatcher and is valid until end of UEFI (nothing drops it).
                         let res = unsafe {
                             self.fv_data
                                 .lock()
@@ -434,7 +434,7 @@ impl<P: PlatformInfo> PiDispatcher<P> {
             };
             let fvb_ptr = ptr as *mut firmware_volume_block::Protocol;
 
-            // Safety: fvb_ptr is obtained from a valid handle that has a FVB protocol instance
+            // SAFETY: fvb_ptr is obtained from a valid handle that has a FVB protocol instance
             // and the as_ref() call checks for null
             let Some(fvb) = (unsafe { fvb_ptr.as_ref() }) else {
                 continue;
@@ -446,7 +446,7 @@ impl<P: PlatformInfo> PiDispatcher<P> {
                 continue;
             }
 
-            // Safety: fv_address is checked for being non-zero above
+            // SAFETY: fv_address is checked for being non-zero above
             let Ok(volume) = (unsafe { VolumeRef::new_from_address(fv_address) }) else {
                 continue;
             };
@@ -632,7 +632,7 @@ impl DispatcherContext {
                 let fv_device_path =
                     fv_device_path.unwrap_or(core::ptr::null_mut()) as *mut efi::protocols::device_path::Protocol;
 
-                // Safety: this code assumes that the fv_address from FVB protocol yields a pointer to a real FV,
+                // SAFETY: this code assumes that the fv_address from FVB protocol yields a pointer to a real FV,
                 // and that the memory backing the FVB is essentially permanent while the dispatcher is running (i.e.
                 // that no one uninstalls the FVB protocol and frees the memory).
                 let fv = match unsafe { VolumeRef::new_from_address(fv_address) } {
@@ -928,7 +928,7 @@ mod tests {
         with_locked_state(|| {
             static CORE: MockCore = MockCore::new(NullSectionExtractor::new());
             CORE.override_instance();
-            // Safety: fv is leaked to ensure it is not freed and remains valid for the duration of the program.
+            // SAFETY: fv is leaked to ensure it is not freed and remains valid for the duration of the program.
             let handle = unsafe {
                 CORE.pi_dispatcher
                     .fv_data
@@ -975,7 +975,7 @@ mod tests {
             static CORE: MockCore = MockCore::new(NullSectionExtractor::new());
             CORE.override_instance();
 
-            // Safety: fv is leaked to ensure it is not freed and remains valid for the duration of the program.
+            // SAFETY: fv is leaked to ensure it is not freed and remains valid for the duration of the program.
             let handle = unsafe {
                 CORE.pi_dispatcher
                     .fv_data
@@ -1011,7 +1011,7 @@ mod tests {
             static CORE: MockCore = MockCore::new(NullSectionExtractor::new());
             CORE.override_instance();
 
-            // Safety: fv is leaked to ensure it is not freed and remains valid for the duration of the program.
+            // SAFETY: fv is leaked to ensure it is not freed and remains valid for the duration of the program.
             let handle = unsafe {
                 CORE.pi_dispatcher
                     .fv_data
@@ -1047,7 +1047,7 @@ mod tests {
             static CORE: MockCore = MockCore::new(NullSectionExtractor::new());
             CORE.override_instance();
 
-            // Safety: fv is leaked to ensure it is not freed and remains valid for the duration of the program.
+            // SAFETY: fv is leaked to ensure it is not freed and remains valid for the duration of the program.
             let fv_phys_addr = fv_raw.expose_provenance() as u64;
             let handle =
                 unsafe { CORE.pi_dispatcher.fv_data.lock().install_firmware_volume(fv_phys_addr, None).unwrap() };
@@ -1082,7 +1082,7 @@ mod tests {
             static CORE: MockCore = MockCore::new(NullSectionExtractor::new());
             CORE.override_instance();
 
-            // Safety: fv is leaked to ensure it is not freed and remains valid for the duration of the program.
+            // SAFETY: fv is leaked to ensure it is not freed and remains valid for the duration of the program.
             let handle = unsafe {
                 CORE.pi_dispatcher
                     .fv_data
@@ -1111,7 +1111,7 @@ mod tests {
             static CORE: MockCore = MockCore::new(NullSectionExtractor::new());
             CORE.override_instance();
 
-            // Safety: fv is leaked to ensure it is not freed and remains valid for the duration of the program.
+            // SAFETY: fv is leaked to ensure it is not freed and remains valid for the duration of the program.
             let handle = unsafe {
                 CORE.pi_dispatcher
                     .fv_data
@@ -1141,7 +1141,7 @@ mod tests {
             static CORE: MockCore = MockCore::new(NullSectionExtractor::new());
             CORE.override_instance();
 
-            // Safety: fv is leaked to ensure it is not freed and remains valid for the duration of the program.
+            // SAFETY: fv is leaked to ensure it is not freed and remains valid for the duration of the program.
             let _ = unsafe {
                 CORE.pi_dispatcher
                     .fv_data
@@ -1199,7 +1199,7 @@ mod tests {
             static CORE: MockCore = MockCore::new(NullSectionExtractor::new());
             CORE.override_instance();
 
-            // Safety: fv is leaked to ensure it is not freed and remains valid for the duration of the program.
+            // SAFETY: fv is leaked to ensure it is not freed and remains valid for the duration of the program.
             let handle = unsafe {
                 CORE.pi_dispatcher
                     .fv_data
@@ -1230,7 +1230,7 @@ mod tests {
         with_locked_state(|| {
             static CORE: MockCore = MockCore::new(NullSectionExtractor::new());
             CORE.override_instance();
-            // Safety: fv is leaked to ensure it is not freed and remains valid for the duration of the program.
+            // SAFETY: fv is leaked to ensure it is not freed and remains valid for the duration of the program.
             let handle = unsafe {
                 CORE.pi_dispatcher
                     .fv_data
@@ -1310,7 +1310,7 @@ mod tests {
                     &security_protocol as *const _ as *mut _,
                 )
                 .unwrap();
-            // Safety: fv is leaked to ensure it is not freed and remains valid for the duration of the program.
+            // SAFETY: fv is leaked to ensure it is not freed and remains valid for the duration of the program.
             let handle =
                 unsafe { CORE.pi_dispatcher.fv_data.lock().install_firmware_volume(fv.as_ptr() as u64, None).unwrap() };
 

--- a/patina_dxe_core/src/pi_dispatcher/fv.rs
+++ b/patina_dxe_core/src/pi_dispatcher/fv.rs
@@ -119,7 +119,7 @@ impl<P: PlatformInfo> FvProtocolData<P> {
     ) -> Result<fvb::attributes::EfiFvbAttributes2, EfiError> {
         let physical_address = self.get_fvb_address(protocol).ok_or(EfiError::NotFound)?;
 
-        // Safety: physical_address must point to a valid FV (i.e. private_data is correctly constructed and
+        // SAFETY: physical_address must point to a valid FV (i.e. private_data is correctly constructed and
         // its invariants - like not removing fv once installed - are upheld).
         let fv = unsafe { VolumeRef::new_from_address(physical_address)? };
         Ok(fv.attributes())
@@ -143,7 +143,7 @@ impl<P: PlatformInfo> FvProtocolData<P> {
     ) -> Result<(usize, usize), EfiError> {
         let physical_address = self.get_fvb_address(protocol).ok_or(EfiError::NotFound)?;
 
-        // Safety: physical_address must point to a valid FV (i.e. private_data is correctly constructed and
+        // SAFETY: physical_address must point to a valid FV (i.e. private_data is correctly constructed and
         // its invariants - like not removing fv once installed - are upheld).
         let fv = unsafe { VolumeRef::new_from_address(physical_address)? };
 
@@ -164,7 +164,7 @@ impl<P: PlatformInfo> FvProtocolData<P> {
     ) -> Result<&'static [u8], EfiError> {
         let physical_address = self.get_fvb_address(protocol).ok_or(EfiError::NotFound)?;
 
-        // Safety: physical_address must point to a valid FV (i.e. private_data is correctly constructed and
+        // SAFETY: physical_address must point to a valid FV (i.e. private_data is correctly constructed and
         // its invariants - like not removing fv once installed - are upheld).
         let fv = unsafe { VolumeRef::new_from_address(physical_address) }?;
         let Ok(lba) = lba.try_into() else {
@@ -180,7 +180,7 @@ impl<P: PlatformInfo> FvProtocolData<P> {
         }
 
         let lba_start = (physical_address as usize).saturating_add(lba_base_addr).saturating_add(offset) as *mut u8;
-        // Safety: lba_start is calculated from the base address of a valid FV, plus an offset and offset+num_bytes.
+        // SAFETY: lba_start is calculated from the base address of a valid FV, plus an offset and offset+num_bytes.
         // consistency of this data is guaranteed by checks on instantiation of the VolumeRef.
         // The FV data is expected to be 'static (i.e. permanently mapped) for the lifetime of the system.
         unsafe { Ok(slice::from_raw_parts(lba_start, bytes_to_read)) }
@@ -193,7 +193,7 @@ impl<P: PlatformInfo> FvProtocolData<P> {
     ) -> Result<fv::attributes::EfiFvAttributes, EfiError> {
         let physical_address = self.get_fv_address(protocol).ok_or(EfiError::NotFound)?;
 
-        // Safety: physical_address must point to a valid FV (i.e. private_data is correctly constructed and
+        // SAFETY: physical_address must point to a valid FV (i.e. private_data is correctly constructed and
         // its invariants - like not removing fv once installed - are upheld).
         let fv = unsafe { VolumeRef::new_from_address(physical_address)? };
 
@@ -208,7 +208,7 @@ impl<P: PlatformInfo> FvProtocolData<P> {
     ) -> Result<FileRef<'_>, EfiError> {
         let physical_address = self.get_fv_address(protocol).ok_or(EfiError::NotFound)?;
 
-        // Safety: physical_address must point to a valid FV (i.e. private_data is correctly constructed and
+        // SAFETY: physical_address must point to a valid FV (i.e. private_data is correctly constructed and
         // its invariants - like not removing fv once installed - are upheld).
         let fv = unsafe { VolumeRef::new_from_address(physical_address) }?;
 
@@ -254,7 +254,7 @@ impl<P: PlatformInfo> FvProtocolData<P> {
     ) -> Result<(efi::Guid, fv::file::EfiFvFileAttributes, usize, fv::EfiFvFileType), EfiError> {
         let physical_address = self.get_fv_address(protocol).ok_or(EfiError::NotFound)?;
 
-        // Safety: physical_address must point to a valid FV (i.e. private_data is correctly constructed and
+        // SAFETY: physical_address must point to a valid FV (i.e. private_data is correctly constructed and
         // its invariants - like not removing fv once installed - are upheld).
         let fv = unsafe { VolumeRef::new_from_address(physical_address) }?;
 
@@ -372,7 +372,7 @@ impl<P: PlatformInfo> FvProtocolData<P> {
         base_address: u64,
         parent_handle: Option<efi::Handle>,
     ) -> Result<efi::Handle, EfiError> {
-        // Safety: Caller must meet the safety requirements of this function.
+        // SAFETY: Caller must meet the safety requirements of this function.
         let handle = unsafe { self.install_fv_device_path_protocol(None, base_address)? };
         self.install_fvb_protocol(Some(handle), parent_handle, base_address)?;
         self.install_fv_protocol(Some(handle), parent_handle, base_address)?;
@@ -386,10 +386,10 @@ impl<P: PlatformInfo> FvProtocolData<P> {
 
         for fv in fv_hobs {
             // construct a FirmwareVolume struct to verify sanity.
-            // Safety: base addresses of FirmwareVolume HOBs are assumed to be valid and accessible.
+            // SAFETY: base addresses of FirmwareVolume HOBs are assumed to be valid and accessible.
             let fv_slice = unsafe { slice::from_raw_parts(fv.base_address as *const u8, fv.length as usize) };
             VolumeRef::new(fv_slice)?;
-            // Safety: base addresses of FirmwareVolume HOBs are assumed to be valid and accessible.
+            // SAFETY: base addresses of FirmwareVolume HOBs are assumed to be valid and accessible.
             unsafe { self.install_firmware_volume(fv.base_address, None) }?;
         }
         Ok(())
@@ -405,7 +405,7 @@ impl<P: PlatformInfo> FvProtocolData<P> {
         handle: Option<efi::Handle>,
         base_address: u64,
     ) -> Result<efi::Handle, EfiError> {
-        // Safety: caller must ensure that base_address is valid.
+        // SAFETY: caller must ensure that base_address is valid.
         let fv = unsafe { VolumeRef::new_from_address(base_address) }?;
 
         let device_path_ptr = match fv.fv_name() {
@@ -468,7 +468,7 @@ impl<P: PlatformInfo> FvProtocolData<P> {
 
         match Self::instance().fvb_get_attributes(protocol) {
             Err(err) => return err.into(),
-            // Safety: caller must provide a valid pointer to receive the attributes. It is null-checked above.
+            // SAFETY: caller must provide a valid pointer to receive the attributes. It is null-checked above.
             Ok(fvb_attributes) => unsafe { attributes.write_unaligned(fvb_attributes) },
         };
 
@@ -498,7 +498,7 @@ impl<P: PlatformInfo> FvProtocolData<P> {
 
         match Self::instance().fvb_get_physical_address(protocol) {
             Err(err) => return err.into(),
-            // Safety: caller must provide a valid pointer to receive the address. It is null-checked above.
+            // SAFETY: caller must provide a valid pointer to receive the address. It is null-checked above.
             Ok(physical_address) => unsafe { address.write_unaligned(physical_address) },
         };
 
@@ -525,7 +525,7 @@ impl<P: PlatformInfo> FvProtocolData<P> {
             Ok((size, remaining_blocks)) => (size, remaining_blocks),
         };
 
-        // Safety: caller must provide valid pointers to receive the block size and number of blocks. They are null-checked above.
+        // SAFETY: caller must provide valid pointers to receive the block size and number of blocks. They are null-checked above.
         unsafe {
             block_size.write_unaligned(size);
             number_of_blocks.write_unaligned(remaining_blocks);
@@ -550,7 +550,7 @@ impl<P: PlatformInfo> FvProtocolData<P> {
             return efi::Status::INVALID_PARAMETER;
         };
 
-        // Safety: caller must provide valid pointers for num_bytes and buffer. They are null-checked above.
+        // SAFETY: caller must provide valid pointers for num_bytes and buffer. They are null-checked above.
         let bytes_to_read = unsafe { *num_bytes };
 
         let data = match Self::instance().fvb_read(protocol, lba, offset, bytes_to_read) {
@@ -559,13 +559,13 @@ impl<P: PlatformInfo> FvProtocolData<P> {
         };
 
         if data.len() > bytes_to_read {
-            // Safety: caller must provide a valid pointer for num_bytes. It is null-checked above.
+            // SAFETY: caller must provide a valid pointer for num_bytes. It is null-checked above.
             unsafe { num_bytes.write_unaligned(data.len()) };
             return efi::Status::BUFFER_TOO_SMALL;
         }
 
         // copy from memory into the destination buffer to do the read.
-        // Safety: buffer must be valid for writes of at least bytes_to_read length. It is null-checked above, and
+        // SAFETY: buffer must be valid for writes of at least bytes_to_read length. It is null-checked above, and
         // the caller must ensure that the buffer is large enough to hold the data being read.
         unsafe {
             let dest_buffer = slice::from_raw_parts_mut(buffer as *mut u8, data.len());
@@ -613,7 +613,7 @@ impl<P: PlatformInfo> FvProtocolData<P> {
             Ok(attrs) => attrs,
         };
 
-        // Safety: caller must provide a valid pointer to receive the attributes. It is null-checked above.
+        // SAFETY: caller must provide a valid pointer to receive the attributes. It is null-checked above.
         unsafe { fv_attributes.write_unaligned(fv_attributes_data) };
 
         efi::Status::SUCCESS
@@ -650,9 +650,9 @@ impl<P: PlatformInfo> FvProtocolData<P> {
             return efi::Status::INVALID_PARAMETER;
         };
 
-        // Safety: caller must provide valid pointers for buffer_size and name_guid. They are null-checked above.
+        // SAFETY: caller must provide valid pointers for buffer_size and name_guid. They are null-checked above.
         let local_buffer_size = unsafe { buffer_size.read_unaligned() };
-        // Safety: caller must provide valid pointers for buffer_size and name_guid. They are null-checked above.
+        // SAFETY: caller must provide valid pointers for buffer_size and name_guid. They are null-checked above.
         let name = unsafe { name_guid.read_unaligned() };
 
         let this = Self::instance();
@@ -662,7 +662,7 @@ impl<P: PlatformInfo> FvProtocolData<P> {
         };
 
         // update file metadata output pointers (buffer_size is written later).
-        // Safety: caller must provide valid pointers for found_type and file_attributes. They are null-checked above.
+        // SAFETY: caller must provide valid pointers for found_type and file_attributes. They are null-checked above.
         unsafe {
             found_type.write_unaligned(file.file_type_raw());
             file_attributes.write_unaligned(file.fv_attributes());
@@ -672,14 +672,14 @@ impl<P: PlatformInfo> FvProtocolData<P> {
 
         if buffer.is_null() {
             // The caller just wants file meta data, no need to read file data.
-            // Safety: The caller must provide a valid pointer for buffer_size. It is null-checked above.
+            // SAFETY: The caller must provide a valid pointer for buffer_size. It is null-checked above.
             unsafe {
                 buffer_size.write_unaligned(file.content().len());
             }
             return efi::Status::SUCCESS;
         }
 
-        // Safety: caller must provide a valid pointer for buffer. It is null-checked above.
+        // SAFETY: caller must provide a valid pointer for buffer. It is null-checked above.
         let mut local_buffer_ptr = unsafe { buffer.read_unaligned() };
 
         // Determine the size to copy and the return status. For compatibility with existing callers to this function,
@@ -700,7 +700,7 @@ impl<P: PlatformInfo> FvProtocolData<P> {
             //allocate it via allocate_pool.
             match core_allocate_pool(efi::BOOT_SERVICES_DATA, file.content().len()) {
                 Err(err) => return err.into(),
-                // Safety: caller must provide a valid pointer for buffer. It is null-checked above.
+                // SAFETY: caller must provide a valid pointer for buffer. It is null-checked above.
                 Ok(allocation) => unsafe {
                     local_buffer_ptr = allocation;
                     buffer.write_unaligned(local_buffer_ptr);
@@ -714,13 +714,13 @@ impl<P: PlatformInfo> FvProtocolData<P> {
             (file.content().len(), efi::Status::SUCCESS)
         };
 
-        // Safety: The caller must provide a valid pointer for buffer_size. It is null-checked above.
+        // SAFETY: The caller must provide a valid pointer for buffer_size. It is null-checked above.
         unsafe {
             buffer_size.write_unaligned(copy_size);
         }
 
         // convert pointer+size into a slice and copy the file data (truncated if necessary).
-        // Safety: local_buffer_ptr is either provided by the caller (and null-checked above), or allocated via allocate pool
+        // SAFETY: local_buffer_ptr is either provided by the caller (and null-checked above), or allocated via allocate pool
         // and is of sufficient size to contain the data.
         let out_buffer = unsafe { slice::from_raw_parts_mut(local_buffer_ptr as *mut u8, copy_size) };
         out_buffer.copy_from_slice(&file.content()[..copy_size]);
@@ -746,7 +746,7 @@ impl<P: PlatformInfo> FvProtocolData<P> {
             return efi::Status::INVALID_PARAMETER;
         };
 
-        // Safety: caller must provide valid pointer for name_guid. It is null-checked above.
+        // SAFETY: caller must provide valid pointer for name_guid. It is null-checked above.
         let name = unsafe { name_guid.read_unaligned() };
 
         let extractor = &Core::<P>::instance().pi_dispatcher.section_extractor;
@@ -762,7 +762,7 @@ impl<P: PlatformInfo> FvProtocolData<P> {
         };
 
         // get the buffer_size and buffer parameters from caller.
-        // Safety: null-checks are at the start of the routine, but caller is required to guarantee that buffer_size and
+        // SAFETY: null-checks are at the start of the routine, but caller is required to guarantee that buffer_size and
         // buffer are valid.
         let mut local_buffer_size = unsafe { buffer_size.read_unaligned() };
         let mut local_buffer_ptr = unsafe { buffer.read_unaligned() };
@@ -774,7 +774,7 @@ impl<P: PlatformInfo> FvProtocolData<P> {
             //allocate it via allocate_pool.
             match core_allocate_pool(efi::BOOT_SERVICES_DATA, section_data.len()) {
                 Err(err) => return err.into(),
-                // Safety: caller is required to guarantee that buffer_size and buffer are valid.
+                // SAFETY: caller is required to guarantee that buffer_size and buffer are valid.
                 Ok(allocation) => unsafe {
                     local_buffer_size = section_data.len();
                     local_buffer_ptr = allocation;
@@ -784,7 +784,7 @@ impl<P: PlatformInfo> FvProtocolData<P> {
             }
         } else {
             // update buffer size output for the caller
-            // Safety: null-checked at the start of the routine, but caller is required to guarantee buffer_size is valid.
+            // SAFETY: null-checked at the start of the routine, but caller is required to guarantee buffer_size is valid.
             unsafe {
                 buffer_size.write_unaligned(section_data.len());
             }
@@ -798,7 +798,7 @@ impl<P: PlatformInfo> FvProtocolData<P> {
         // larger than the section_data, we could inadvertently copy beyond the section_data slice.
         let copy_size = core::cmp::min(section_data.len(), local_buffer_size);
 
-        // Safety: local_buffer_ptr is either provided by the caller (and null-checked above), or allocated via allocate pool and
+        // SAFETY: local_buffer_ptr is either provided by the caller (and null-checked above), or allocated via allocate pool and
         // is of sufficient size to contain the data. We copy the minimum of section_data.len() and local_buffer_size to ensure we do not
         // copy beyond the bounds of either buffer.
         let dest_buffer = unsafe { slice::from_raw_parts_mut(local_buffer_ptr as *mut u8, copy_size) };
@@ -836,9 +836,9 @@ impl<P: PlatformInfo> FvProtocolData<P> {
             return efi::Status::INVALID_PARAMETER;
         };
 
-        // Safety: caller must provide valid pointers for key and file_type. They are null-checked above.
+        // SAFETY: caller must provide valid pointers for key and file_type. They are null-checked above.
         let local_key = unsafe { (key as *mut usize).read_unaligned() };
-        // Safety: caller must provide valid pointers for key and file_type. They are null-checked above.
+        // SAFETY: caller must provide valid pointers for key and file_type. They are null-checked above.
         let local_file_type = unsafe { file_type.read_unaligned() };
 
         if local_file_type >= ffs::file::raw::r#type::FFS_MIN {
@@ -851,7 +851,7 @@ impl<P: PlatformInfo> FvProtocolData<P> {
                 Ok((name, attrs, size, file_type)) => (name, attrs, size, file_type),
             };
 
-        // Safety: caller must provide valid pointers for key, file_type, name_guid, attributes, and size. They are null-checked above.
+        // SAFETY: caller must provide valid pointers for key, file_type, name_guid, attributes, and size. They are null-checked above.
         unsafe {
             (key as *mut usize).write_unaligned(local_key.saturating_add(1));
             name_guid.write_unaligned(file_name);
@@ -1003,7 +1003,7 @@ mod tests {
     #[test]
     fn test_fv_init_core() {
         test_support::with_global_lock(|| {
-            // Safety: global lock ensures exclusive access to the private data.
+            // SAFETY: global lock ensures exclusive access to the private data.
             fn gen_firmware_volume2() -> hob::FirmwareVolume2 {
                 let header =
                     hob::header::Hob { r#type: hob::FV, length: size_of::<hob::FirmwareVolume2>() as u16, reserved: 0 };
@@ -1093,7 +1093,7 @@ mod tests {
 
             static CORE: MockCore = MockCore::new(CompositeSectionExtractor::new());
             CORE.override_instance();
-            // Safety: fv was leaked above to ensure that the buffer is valid and immutable for the rest of the test.
+            // SAFETY: fv was leaked above to ensure that the buffer is valid and immutable for the rest of the test.
             let _handle =
                 unsafe { CORE.pi_dispatcher.fv_data.lock().install_fv_device_path_protocol(None, base_address) };
 
@@ -1101,7 +1101,7 @@ mod tests {
              * for test_fv_functionality.
              * In case other functions/modules are written, clear the private global data again.
              */
-            // Safety: global lock ensures exclusive access to the private data.
+            // SAFETY: global lock ensures exclusive access to the private data.
             CORE.pi_dispatcher.fv_data.lock().fv_metadata.clear();
             assert!(CORE.pi_dispatcher.fv_data.lock().fv_metadata.is_empty());
 
@@ -1173,7 +1173,7 @@ mod tests {
             });
             let fvb_intf_data_n_mut = fvb_intf_data_n.as_mut() as *mut pi::protocols::firmware_volume_block::Protocol;
 
-            // Safety: the following test code must uphold the safety expectations of the unsafe
+            // SAFETY: the following test code must uphold the safety expectations of the unsafe
             // functions it calls. It uses direct memory allocations to create buffers for testing FFI
             // functions.
             unsafe {
@@ -1674,7 +1674,7 @@ mod tests {
              * for test_fv_functionality.
              * In case other functions/modules are written, clear the private global data again.
              */
-            // Safety: global lock ensures exclusive access to the private data.
+            // SAFETY: global lock ensures exclusive access to the private data.
             static CORE: MockCore = MockCore::new(CompositeSectionExtractor::new());
             CORE.override_instance();
 
@@ -1687,7 +1687,7 @@ mod tests {
             CORE.pi_dispatcher.fv_data.lock().fv_metadata.insert(fv_ptr.addr(), private_data);
             let fv_ptr1: *const pi::protocols::firmware_volume::Protocol = fv_ptr.as_ptr();
 
-            // Safety: the following test code must uphold the safety expectations of the unsafe
+            // SAFETY: the following test code must uphold the safety expectations of the unsafe
             // functions it calls. It uses direct memory management to test fv FFI primitives.
             unsafe {
                 let layout = Layout::from_size_align(1000, 8).unwrap();
@@ -1763,7 +1763,7 @@ mod tests {
 
             let fv_ptr1: *const pi::protocols::firmware_volume::Protocol = fv_ptr.as_ptr();
 
-            // Safety: the following test code must uphold the safety expectations of the unsafe
+            // SAFETY: the following test code must uphold the safety expectations of the unsafe
             // functions it calls. This unsafe section encompasses all of the logic for the remaining
             // test since this is test code.
             unsafe {
@@ -1892,7 +1892,7 @@ mod tests {
 
             let fv_ptr1 = fv_ptr.as_ptr();
 
-            // Safety: the following test code must uphold the safety expectations of the unsafe
+            // SAFETY: the following test code must uphold the safety expectations of the unsafe
             // functions it calls. This unsafe section encompasses all of the logic for the remaining
             // test since this is test code.
             unsafe {

--- a/patina_dxe_core/src/pi_dispatcher/image.rs
+++ b/patina_dxe_core/src/pi_dispatcher/image.rs
@@ -809,7 +809,7 @@ impl<P: super::PlatformInfo> super::PiDispatcher<P> {
                 Err(ImageStatus::LoadError(err)) => return err.into(),
             };
 
-        // Safety: Caller must ensure that image_handle is a valid pointer. It is null-checked above.
+        // SAFETY: Caller must ensure that image_handle is a valid pointer. It is null-checked above.
         unsafe { image_handle.write_unaligned(handle) };
         status
     }
@@ -926,7 +926,7 @@ impl<P: super::PlatformInfo> super::PiDispatcher<P> {
                 && !exit_data_size.is_null()
                 && !exit_data.is_null()
             {
-                // Safety: Caller must ensure that exit_data_size and exit_data are valid pointers if they are non-null.
+                // SAFETY: Caller must ensure that exit_data_size and exit_data are valid pointers if they are non-null.
                 unsafe {
                     exit_data_size.write_unaligned(image_exit_data.0);
                     exit_data.write_unaligned(image_exit_data.1);

--- a/patina_dxe_core/src/protocols.rs
+++ b/patina_dxe_core/src/protocols.rs
@@ -57,7 +57,7 @@ extern "efiapi" fn install_protocol_interface(
     if handle.is_null() || protocol.is_null() || interface_type != efi::NATIVE_INTERFACE {
         return efi::Status::INVALID_PARAMETER;
     }
-    // Safety: Caller must ensure that handle and protocol are valid pointers. They are null-checked above.
+    // SAFETY: Caller must ensure that handle and protocol are valid pointers. They are null-checked above.
     let caller_handle = unsafe { handle.read_unaligned() };
     let caller_protocol = unsafe { protocol.read_unaligned() };
 
@@ -169,7 +169,7 @@ extern "efiapi" fn uninstall_protocol_interface(
         return efi::Status::INVALID_PARAMETER;
     }
 
-    // Safety: Caller must ensure that protocol is a valid pointer. It is null-checked above.
+    // SAFETY: Caller must ensure that protocol is a valid pointer. It is null-checked above.
     let caller_protocol = unsafe { protocol.read_unaligned() };
 
     core_uninstall_protocol_interface(handle, caller_protocol, interface)
@@ -220,7 +220,7 @@ extern "efiapi" fn reinstall_protocol_interface(
         }
     }
 
-    // Safety: Caller must ensure that protocol is a valid pointer. It is null-checked above.
+    // SAFETY: Caller must ensure that protocol is a valid pointer. It is null-checked above.
     let protocol = unsafe { protocol.read_unaligned() };
 
     // Call install to install the new interface and trigger any notifies
@@ -251,7 +251,7 @@ extern "efiapi" fn register_protocol_notify(
     if protocol.is_null() || registration.is_null() || !EVENT_DB.is_valid(event) {
         return efi::Status::INVALID_PARAMETER;
     }
-    // Safety: Caller must ensure that protocol is a valid pointer. It is null-checked above.
+    // SAFETY: Caller must ensure that protocol is a valid pointer. It is null-checked above.
     match PROTOCOL_DB.register_protocol_notify(unsafe { protocol.read_unaligned() }, event) {
         Err(err) => err.into(),
         Ok(new_registration) => {
@@ -284,7 +284,7 @@ extern "efiapi" fn locate_handle(
             if protocol.is_null() {
                 return efi::Status::INVALID_PARAMETER;
             }
-            // Safety: Caller must ensure that protocol is a valid pointer. It is null-checked above.
+            // SAFETY: Caller must ensure that protocol is a valid pointer. It is null-checked above.
             PROTOCOL_DB.locate_handles(Some(unsafe { protocol.read_unaligned() }))
         }
         _ => return efi::Status::INVALID_PARAMETER,
@@ -301,9 +301,9 @@ extern "efiapi" fn locate_handle(
             }
 
             list.shrink_to_fit();
-            // Safety: Caller must ensure that buffer_size is a valid pointer. It is null-checked above.
+            // SAFETY: Caller must ensure that buffer_size is a valid pointer. It is null-checked above.
             let input_size = unsafe { buffer_size.read_unaligned() };
-            // Safety: Caller must ensure that buffer_size is a valid pointer. It is null-checked above.
+            // SAFETY: Caller must ensure that buffer_size is a valid pointer. It is null-checked above.
             unsafe {
                 buffer_size.write_unaligned(list.len() * size_of::<efi::Handle>());
             }
@@ -355,7 +355,7 @@ extern "efiapi" fn open_protocol(
         return efi::Status::INVALID_PARAMETER;
     }
 
-    // Safety: Caller must ensure that protocol is a valid pointer. It is null-checked above.
+    // SAFETY: Caller must ensure that protocol is a valid pointer. It is null-checked above.
     let protocol = unsafe { protocol.read_unaligned() };
 
     if interface.is_null() && attributes != efi::OPEN_PROTOCOL_TEST_PROTOCOL {
@@ -380,7 +380,7 @@ extern "efiapi" fn open_protocol(
                 && (x.attributes & efi::OPEN_PROTOCOL_EXCLUSIVE) == 0
                 && x.agent_handle != agent_handle
         }) {
-            // Safety: handles are validated above.
+            // SAFETY: handles are validated above.
             unsafe {
                 if core_disconnect_controller(handle, usage.agent_handle, None).is_err() {
                     return efi::Status::ACCESS_DENIED;
@@ -392,7 +392,7 @@ extern "efiapi" fn open_protocol(
     match PROTOCOL_DB.add_protocol_usage(handle, protocol, agent_handle, controller_handle, attributes) {
         Err(EfiError::Unsupported) => {
             if !interface.is_null() {
-                // Safety: Caller must ensure that interface is a valid pointer if it is non-null.
+                // SAFETY: Caller must ensure that interface is a valid pointer if it is non-null.
                 unsafe { interface.write_unaligned(core::ptr::null_mut()) };
             }
             return efi::Status::UNSUPPORTED;
@@ -403,7 +403,7 @@ extern "efiapi" fn open_protocol(
                 .get_interface_for_handle(handle, protocol)
                 .expect("Already Started can't happen if protocol doesn't exist.");
             if !interface.is_null() {
-                // Safety: Caller must ensure that interface is a valid pointer if it is non-null.
+                // SAFETY: Caller must ensure that interface is a valid pointer if it is non-null.
                 unsafe { interface.write_unaligned(desired_interface) };
             }
             return efi::Status::ALREADY_STARTED;
@@ -419,7 +419,7 @@ extern "efiapi" fn open_protocol(
     };
 
     if attributes != efi::OPEN_PROTOCOL_TEST_PROTOCOL {
-        // Safety: Caller must ensure that interface is a valid pointer if it is non-null.
+        // SAFETY: Caller must ensure that interface is a valid pointer if it is non-null.
         unsafe { interface.write_unaligned(desired_interface) };
     }
     efi::Status::SUCCESS
@@ -451,7 +451,7 @@ extern "efiapi" fn close_protocol(
 
     match PROTOCOL_DB.remove_protocol_usage(
         handle,
-        // Safety: Caller must ensure that protocol is a valid pointer. It is null-checked above.
+        // SAFETY: Caller must ensure that protocol is a valid pointer. It is null-checked above.
         unsafe { protocol.read_unaligned() },
         Some(agent_handle),
         controller_handle,
@@ -473,7 +473,7 @@ extern "efiapi" fn open_protocol_information(
     }
 
     let mut open_info: Vec<efi::OpenProtocolInformationEntry> =
-        // Safety: Caller must ensure that protocol is a valid pointer. It is null-checked above.
+        // SAFETY: Caller must ensure that protocol is a valid pointer. It is null-checked above.
         match PROTOCOL_DB.get_open_protocol_information_by_protocol(handle, unsafe { protocol.read_unaligned() }) {
             Err(err) => return err.into(),
             Ok(info) => info.into_iter().map(efi::OpenProtocolInformationEntry::from).collect(),
@@ -486,7 +486,7 @@ extern "efiapi" fn open_protocol_information(
     match core_allocate_pool(efi::BOOT_SERVICES_DATA, buffer_size) {
         Err(err) => err.into(),
         Ok(allocation) =>
-        // Safety: Caller must ensure that entry_buffer and entry_count are valid pointers. They are null-checked above.
+        // SAFETY: Caller must ensure that entry_buffer and entry_count are valid pointers. They are null-checked above.
         unsafe {
             entry_buffer.write_unaligned(allocation as *mut efi::OpenProtocolInformationEntry);
             entry_count.write_unaligned(open_info.len());
@@ -615,7 +615,7 @@ extern "efiapi" fn protocols_per_handle(
     //caller is supposed to free the entry buffer using free pool, so we need to allocate it using allocate pool.
     match core_allocate_pool(efi::BOOT_SERVICES_DATA, ptr_buffer_size + guid_buffer_size) {
         Err(err) => err.into(),
-        // Safety: Caller must ensure that protocol_buffer and protocol_buffer_count are valid pointers. They are null-checked above.
+        // SAFETY: Caller must ensure that protocol_buffer and protocol_buffer_count are valid pointers. They are null-checked above.
         Ok(allocation) => unsafe {
             protocol_buffer.write_unaligned(allocation as *mut *mut efi::Guid);
             protocol_buffer_count.write_unaligned(protocol_list.len());
@@ -645,7 +645,7 @@ extern "efiapi" fn locate_handle_buffer(
 
     //EDK2 C reference code unconditionally sets no_handles and buffer to default values regardless of success or failure
     //of the function, and some callers expect this behavior (and don't check return status before using no_handles).
-    // Safety: Caller must ensure that no_handles and buffer are valid pointers. They are null-checked above.
+    // SAFETY: Caller must ensure that no_handles and buffer are valid pointers. They are null-checked above.
     unsafe {
         no_handles.write_unaligned(0);
         buffer.write_unaligned(core::ptr::null_mut());
@@ -667,7 +667,7 @@ extern "efiapi" fn locate_handle_buffer(
             if protocol.is_null() {
                 return efi::Status::INVALID_PARAMETER;
             }
-            // Safety: Caller must ensure that protocol is a valid pointer. It is null-checked above.
+            // SAFETY: Caller must ensure that protocol is a valid pointer. It is null-checked above.
             unsafe { PROTOCOL_DB.locate_handles(Some(protocol.read_unaligned())) }
         }
         _ => return efi::Status::INVALID_PARAMETER,
@@ -684,7 +684,7 @@ extern "efiapi" fn locate_handle_buffer(
         let buffer_size = handles.len() * size_of::<efi::Handle>();
         match core_allocate_pool(efi::BOOT_SERVICES_DATA, buffer_size) {
             Err(err) => err.into(),
-            // Safety: Caller must ensure that no_handles and buffer are valid pointers. They are null-checked above.
+            // SAFETY: Caller must ensure that no_handles and buffer are valid pointers. They are null-checked above.
             Ok(allocation) => unsafe {
                 buffer.write_unaligned(allocation as *mut efi::Handle);
                 no_handles.write_unaligned(handles.len());
@@ -706,7 +706,7 @@ extern "efiapi" fn locate_protocol(
 
     if !registration.is_null() {
         if let Some(handle) = PROTOCOL_DB.next_handle_for_registration(registration) {
-            // Safety: Caller must ensure that protocol and interface are valid pointers. They are null-checked above.
+            // SAFETY: Caller must ensure that protocol and interface are valid pointers. They are null-checked above.
             let i_face = PROTOCOL_DB
                 .get_interface_for_handle(handle, unsafe { protocol.read_unaligned() })
                 .expect("Protocol should exist on handle if it is returned for registration key.");
@@ -717,11 +717,11 @@ extern "efiapi" fn locate_protocol(
     } else {
         match PROTOCOL_DB.locate_protocol(unsafe { protocol.read_unaligned() }) {
             Err(err) => {
-                // Safety: Caller must ensure that interface is a valid pointer. It is null-checked above.
+                // SAFETY: Caller must ensure that interface is a valid pointer. It is null-checked above.
                 unsafe { interface.write_unaligned(core::ptr::null_mut()) };
                 return err.into();
             }
-            // Safety: Caller must ensure that interface is a valid pointer. It is null-checked above.
+            // SAFETY: Caller must ensure that interface is a valid pointer. It is null-checked above.
             Ok(i_face) => unsafe { interface.write_unaligned(i_face) },
         }
     }
@@ -775,13 +775,13 @@ extern "efiapi" fn locate_device_path(
     device_path: *mut *mut r_efi::protocols::device_path::Protocol,
     device: *mut efi::Handle,
 ) -> efi::Status {
-    // Safety: Caller must ensure that protocol, device_path, and device are valid pointers. They are null-checked below.
+    // SAFETY: Caller must ensure that protocol, device_path, and device are valid pointers. They are null-checked below.
     if protocol.is_null() || device_path.is_null() || unsafe { device_path.read_unaligned() }.is_null() {
         return efi::Status::INVALID_PARAMETER;
     }
 
     let (best_remaining_path, best_device) =
-        // Safety: Caller must ensure that protocol and device_path are valid pointers. They are null-checked above.
+        // SAFETY: Caller must ensure that protocol and device_path are valid pointers. They are null-checked above.
         match core_locate_device_path(unsafe { protocol.read_unaligned() }, unsafe { device_path.read_unaligned() }) {
             Err(err) => return err.into(),
             Ok((path, device)) => (path, device),
@@ -789,7 +789,7 @@ extern "efiapi" fn locate_device_path(
     if device.is_null() {
         return efi::Status::INVALID_PARAMETER;
     }
-    // Safety: Caller must ensure that device_path and device are valid pointers. They are null-checked above.
+    // SAFETY: Caller must ensure that device_path and device are valid pointers. They are null-checked above.
     unsafe {
         device.write_unaligned(best_device);
         device_path.write_unaligned(best_remaining_path);

--- a/patina_dxe_core/src/tpl_mutex.rs
+++ b/patina_dxe_core/src/tpl_mutex.rs
@@ -111,7 +111,7 @@ impl<T: ?Sized + fmt::Display> fmt::Display for TplGuard<'_, T> {
 impl<'a, T: ?Sized> Deref for TplGuard<'a, T> {
     type Target = T;
     fn deref(&self) -> &'a T {
-        // Safety: data is only accessible through the guard, which guarantees mutual exclusion since no higher TPL can
+        // SAFETY: data is only accessible through the guard, which guarantees mutual exclusion since no higher TPL can
         // obtain the lock without panic, and no code at equal or lower TPL can interrupt while the lock is held.
         unsafe { self.mutex.data.get().as_ref().expect("TplMutex data pointer should not be null") }
     }
@@ -119,7 +119,7 @@ impl<'a, T: ?Sized> Deref for TplGuard<'a, T> {
 
 impl<'a, T: ?Sized> DerefMut for TplGuard<'a, T> {
     fn deref_mut(&mut self) -> &'a mut T {
-        // Safety: data is only accessible through the guard, which guarantees mutual exclusion since no higher TPL can
+        // SAFETY: data is only accessible through the guard, which guarantees mutual exclusion since no higher TPL can
         // obtain the lock without panic, and no code at equal or lower TPL can interrupt while the lock is held.
         unsafe { self.mutex.data.get().as_mut().expect("TplMutex data pointer should not be null") }
     }

--- a/sdk/patina/src/component/params.rs
+++ b/sdk/patina/src/component/params.rs
@@ -677,7 +677,7 @@ unsafe impl Param for StandardBootServices {
     }
 
     fn validate(_state: &Self::State, storage: UnsafeStorageCell) -> bool {
-        // Safety: Storage access is valid - UnsafeStorageCell ensures proper synchronization.
+        // SAFETY: Storage access is valid - UnsafeStorageCell ensures proper synchronization.
         unsafe { storage.storage() }.boot_services().is_init()
     }
 
@@ -702,7 +702,7 @@ unsafe impl Param for StandardRuntimeServices {
     }
 
     fn validate(_state: &Self::State, storage: UnsafeStorageCell) -> bool {
-        // Safety: Storage access is valid - UnsafeStorageCell ensures proper synchronization.
+        // SAFETY: Storage access is valid - UnsafeStorageCell ensures proper synchronization.
         unsafe { storage.storage() }.runtime_services().is_init()
     }
 

--- a/sdk/patina/src/component/storage.rs
+++ b/sdk/patina/src/component/storage.rs
@@ -432,12 +432,12 @@ impl Storage {
 #[derive(Copy, Clone)]
 pub struct UnsafeStorageCell<'s>(*mut Storage, PhantomData<(&'s Storage, &'s UnsafeCell<Storage>)>);
 
-// Safety: UnsafeStorageCell wraps a raw pointer but does not own the data. The lifetime specifier ensures the pointer
+// SAFETY: UnsafeStorageCell wraps a raw pointer but does not own the data. The lifetime specifier ensures the pointer
 // remains valid. Send is safe because the wrapper doesn't allow unsynchronized access. All access goes through
 // unsafe methods that require the caller to ensure proper synchronization. The PhantomData ties the lifetime
 // to the storage reference, preventing the cell from outliving the storage.
 unsafe impl Send for UnsafeStorageCell<'_> {}
-// Safety: Sync is safe because UnsafeStorageCell provides controlled access to storage through unsafe methods
+// SAFETY: Sync is safe because UnsafeStorageCell provides controlled access to storage through unsafe methods
 // that place the synchronization burden on the caller. The wrapper itself contains no mutable state - just a
 // raw pointer and phantom data. Multiple threads can hold UnsafeStorageCell instances safely as long as they
 // follow the access rules documented on storage() and storage_mut().
@@ -487,7 +487,7 @@ impl<'s> UnsafeStorageCell<'s> {
     ///     mutable borrow is active.
     #[inline]
     pub unsafe fn storage_mut(self) -> &'s mut Storage {
-        // Safety:
+        // SAFETY:
         // - caller ensures the created `&mut Storage` is the only borrow of the storage.
         unsafe { &mut *self.0 }
     }
@@ -503,7 +503,7 @@ impl<'s> UnsafeStorageCell<'s> {
     /// - there must be no live exclusive borrow of storage
     #[inline]
     pub unsafe fn storage(self) -> &'s Storage {
-        // Safety:
+        // SAFETY:
         // - caller ensures there is no `&mut Storage`
         // - caller ensures there is no mutable borrows of storage data. This means the caller
         //   cannot misuse the returned `&World`.
@@ -511,7 +511,7 @@ impl<'s> UnsafeStorageCell<'s> {
     }
 }
 
-// Safety: &mut Storage parameter provides exclusive access to the entire storage. The Param implementation
+// SAFETY: &mut Storage parameter provides exclusive access to the entire storage. The Param implementation
 // ensures exclusive access by tracking config reads/writes in MetaData. init_state() asserts no conflicting
 // config access exists and marks all configs as exclusively written. get_param() uses storage_mut() which
 // requires the UnsafeStorageCell was created from mutable storage access.
@@ -519,14 +519,14 @@ unsafe impl Param for &mut Storage {
     type State = ();
     type Item<'storage, 'state> = &'storage mut Storage;
 
-    // Safety: UnsafeStorageCell was created from &mut Storage (validated by init_state). storage_mut()
+    // SAFETY: UnsafeStorageCell was created from &mut Storage (validated by init_state). storage_mut()
     // returns the underlying mutable reference. The Param trait ensures this is the only active borrow
     // of storage data.
     unsafe fn get_param<'storage, 'state>(
         _state: &'state Self::State,
         storage: UnsafeStorageCell<'storage>,
     ) -> Self::Item<'storage, 'state> {
-        // Safety: UnsafeStorageCell was created with exclusive access. init_state ensured no conflicting
+        // SAFETY: UnsafeStorageCell was created with exclusive access. init_state ensured no conflicting
         // config access. storage_mut() safety requirements are met by the Param trait.
         unsafe { storage.storage_mut() }
     }
@@ -561,21 +561,21 @@ unsafe impl Param for &mut Storage {
     }
 }
 
-// Safety: &Storage parameter provides shared immutable access to the entire storage. The Param implementation
+// SAFETY: &Storage parameter provides shared immutable access to the entire storage. The Param implementation
 // ensures no conflicting mutable access exists by checking that no ConfigMut<T> parameters have been registered
 // (which would require mutable config access). get_param() uses storage() which only requires immutable access.
 unsafe impl Param for &Storage {
     type State = ();
     type Item<'storage, 'state> = &'storage Storage;
 
-    // Safety: UnsafeStorageCell provides access to storage. storage() returns an immutable reference.
+    // SAFETY: UnsafeStorageCell provides access to storage. storage() returns an immutable reference.
     // init_state() ensured no conflicting mutable config access exists. The Param protocol ensures this
     // shared access is safe.
     unsafe fn get_param<'storage, 'state>(
         _state: &'state Self::State,
         storage: UnsafeStorageCell<'storage>,
     ) -> Self::Item<'storage, 'state> {
-        // Safety: storage() requires no exclusive borrows of storage data. init_state verified no
+        // SAFETY: storage() requires no exclusive borrows of storage data. init_state verified no
         // ConfigMut<T> access exists that would create conflicting mutable access.
         unsafe { storage.storage() }
     }

--- a/sdk/patina/src/pi/hob.rs
+++ b/sdk/patina/src/pi/hob.rs
@@ -1105,38 +1105,38 @@ impl<'a> HobList<'a> {
         let mut hob_header: *const header::Hob = hob_list as *const header::Hob;
 
         loop {
-            // Safety: hob_header points to valid HOB data provided by firmware. Each HOB has a valid header.
+            // SAFETY: hob_header points to valid HOB data provided by firmware. Each HOB has a valid header.
             let current_header = unsafe { hob_header.cast::<header::Hob>().as_ref().expect(NOT_NULL) };
             match current_header.r#type {
                 HANDOFF => {
                     assert_hob_size::<PhaseHandoffInformationTable>(current_header);
-                    // Safety: HOB type is HANDOFF and size was validated. Cast to specific HOB type is valid.
+                    // SAFETY: HOB type is HANDOFF and size was validated. Cast to specific HOB type is valid.
                     let phit_hob =
                         unsafe { hob_header.cast::<PhaseHandoffInformationTable>().as_ref().expect(NOT_NULL) };
                     self.0.push(Hob::Handoff(phit_hob));
                 }
                 MEMORY_ALLOCATION => {
                     if current_header.length == mem::size_of::<MemoryAllocationModule>() as u16 {
-                        // Safety: HOB type is MEMORY_ALLOCATION with correct size for Module variant.
+                        // SAFETY: HOB type is MEMORY_ALLOCATION with correct size for Module variant.
                         let mem_alloc_hob =
                             unsafe { hob_header.cast::<MemoryAllocationModule>().as_ref().expect(NOT_NULL) };
                         self.0.push(Hob::MemoryAllocationModule(mem_alloc_hob));
                     } else {
                         assert_hob_size::<MemoryAllocation>(current_header);
-                        // Safety: HOB type is MEMORY_ALLOCATION and size was validated.
+                        // SAFETY: HOB type is MEMORY_ALLOCATION and size was validated.
                         let mem_alloc_hob = unsafe { hob_header.cast::<MemoryAllocation>().as_ref().expect(NOT_NULL) };
                         self.0.push(Hob::MemoryAllocation(mem_alloc_hob));
                     }
                 }
                 RESOURCE_DESCRIPTOR => {
                     assert_hob_size::<ResourceDescriptor>(current_header);
-                    // Safety: HOB type is RESOURCE_DESCRIPTOR and size was validated.
+                    // SAFETY: HOB type is RESOURCE_DESCRIPTOR and size was validated.
                     let resource_desc_hob =
                         unsafe { hob_header.cast::<ResourceDescriptor>().as_ref().expect(NOT_NULL) };
                     self.0.push(Hob::ResourceDescriptor(resource_desc_hob));
                 }
                 GUID_EXTENSION => {
-                    // Safety: HOB type is GUID_EXTENSION. GuidHob header is valid, and data follows immediately after.
+                    // SAFETY: HOB type is GUID_EXTENSION. GuidHob header is valid, and data follows immediately after.
                     // Data length is calculated from HOB length minus header size. Pointer arithmetic is within HOB bounds.
                     let (guid_hob, data) = unsafe {
                         let hob = hob_header.cast::<GuidHob>().as_ref().expect(NOT_NULL);
@@ -1148,37 +1148,37 @@ impl<'a> HobList<'a> {
                 }
                 FV => {
                     assert_hob_size::<FirmwareVolume>(current_header);
-                    // Safety: HOB type is FV and size was validated.
+                    // SAFETY: HOB type is FV and size was validated.
                     let fv_hob = unsafe { hob_header.cast::<FirmwareVolume>().as_ref().expect(NOT_NULL) };
                     self.0.push(Hob::FirmwareVolume(fv_hob));
                 }
                 FV2 => {
                     assert_hob_size::<FirmwareVolume2>(current_header);
-                    // Safety: HOB type is FV2 and size was validated.
+                    // SAFETY: HOB type is FV2 and size was validated.
                     let fv2_hob = unsafe { hob_header.cast::<FirmwareVolume2>().as_ref().expect(NOT_NULL) };
                     self.0.push(Hob::FirmwareVolume2(fv2_hob));
                 }
                 FV3 => {
                     assert_hob_size::<FirmwareVolume3>(current_header);
-                    // Safety: HOB type is FV3 and size was validated.
+                    // SAFETY: HOB type is FV3 and size was validated.
                     let fv3_hob = unsafe { hob_header.cast::<FirmwareVolume3>().as_ref().expect(NOT_NULL) };
                     self.0.push(Hob::FirmwareVolume3(fv3_hob));
                 }
                 CPU => {
                     assert_hob_size::<Cpu>(current_header);
-                    // Safety: HOB type is CPU and size was validated.
+                    // SAFETY: HOB type is CPU and size was validated.
                     let cpu_hob = unsafe { hob_header.cast::<Cpu>().as_ref().expect(NOT_NULL) };
                     self.0.push(Hob::Cpu(cpu_hob));
                 }
                 UEFI_CAPSULE => {
                     assert_hob_size::<Capsule>(current_header);
-                    // Safety: HOB type is UEFI_CAPSULE and size was validated.
+                    // SAFETY: HOB type is UEFI_CAPSULE and size was validated.
                     let capsule_hob = unsafe { hob_header.cast::<Capsule>().as_ref().expect(NOT_NULL) };
                     self.0.push(Hob::Capsule(capsule_hob));
                 }
                 RESOURCE_DESCRIPTOR2 => {
                     assert_hob_size::<ResourceDescriptorV2>(current_header);
-                    // Safety: HOB type is RESOURCE_DESCRIPTOR2 and size was validated.
+                    // SAFETY: HOB type is RESOURCE_DESCRIPTOR2 and size was validated.
                     let resource_desc_hob =
                         unsafe { hob_header.cast::<ResourceDescriptorV2>().as_ref().expect(NOT_NULL) };
                     self.0.push(Hob::ResourceDescriptorV2(resource_desc_hob));
@@ -1454,9 +1454,9 @@ impl<'a> Iterator for HobIter<'a> {
 
     fn next(&mut self) -> Option<Self::Item> {
         const NOT_NULL: &str = "Ptr should not be NULL";
-        // Safety: hob_ptr points to valid HOB data. The iterator maintains the pointer through the HOB chain.
+        // SAFETY: hob_ptr points to valid HOB data. The iterator maintains the pointer through the HOB chain.
         let hob_header = unsafe { *(self.hob_ptr) };
-        // Safety: HOB type determines the specific HOB structure. Each cast is to the appropriate type based
+        // SAFETY: HOB type determines the specific HOB structure. Each cast is to the appropriate type based
         // on the HOB header type field. as_ref() converts to a reference with the iterator's lifetime.
         let hob = unsafe {
             match hob_header.r#type {

--- a/sdk/patina/src/pi/protocols/firmware_volume.rs
+++ b/sdk/patina/src/pi/protocols/firmware_volume.rs
@@ -150,9 +150,9 @@ pub struct Protocol {
     pub set_info: SetInfo,
 }
 
-// Safety: The only non-send type in this structure is `Handle` which itself is actually `Send` as it is an opaque
+// SAFETY: The only non-send type in this structure is `Handle` which itself is actually `Send` as it is an opaque
 // pointer used purely as a token for identification purposes.
 unsafe impl Send for Protocol {}
-// Safety: The only non-sync type in this structure is `Handle` which itself is actually `Send` as it is an opaque
+// SAFETY: The only non-sync type in this structure is `Handle` which itself is actually `Send` as it is an opaque
 // pointer used purely as a token for identification purposes.
 unsafe impl Sync for Protocol {}

--- a/sdk/patina/src/pi/protocols/firmware_volume_block.rs
+++ b/sdk/patina/src/pi/protocols/firmware_volume_block.rs
@@ -100,9 +100,9 @@ pub struct Protocol {
     pub parent_handle: Handle,
 }
 
-// Safety: The only non-send type in this structure is `Handle` which itself is actually `Send` as it is an opaque
+// SAFETY: The only non-send type in this structure is `Handle` which itself is actually `Send` as it is an opaque
 // pointer used purely as a token for identification purposes.
 unsafe impl Send for Protocol {}
-// Safety: The only non-sync type in this structure is `Handle` which itself is actually `Send` as it is an opaque
+// SAFETY: The only non-sync type in this structure is `Handle` which itself is actually `Send` as it is an opaque
 // pointer used purely as a token for identification purposes.
 unsafe impl Sync for Protocol {}

--- a/sdk/patina/src/runtime_services.rs
+++ b/sdk/patina/src/runtime_services.rs
@@ -33,11 +33,11 @@ pub struct StandardRuntimeServices {
     efi_runtime_services: Once<*mut efi::RuntimeServices>,
 }
 
-// Safety: efi::RuntimeServices is not Sync/Send automatically due to the use of *mut c_void as part of function signatures
+// SAFETY: efi::RuntimeServices is not Sync/Send automatically due to the use of *mut c_void as part of function signatures
 // within the struct. Those pointers are only used by spec-defined APIs. With respect to the efi_runtime_services pointer
 // itself, that is protected by the Once wrapper and is not expected to change once initialized.
 unsafe impl Sync for StandardRuntimeServices {}
-// Safety: See Sync impl above.
+// SAFETY: See Sync impl above.
 unsafe impl Send for StandardRuntimeServices {}
 
 impl StandardRuntimeServices {

--- a/sdk/patina/src/runtime_services/variable_services.rs
+++ b/sdk/patina/src/runtime_services/variable_services.rs
@@ -121,7 +121,7 @@ impl<R: RuntimeServices> FallibleStreamingIterator for VariableNameIterator<'_, 
     type Error = efi::Status;
 
     fn advance(&mut self) -> Result<(), Self::Error> {
-        // Safety: get_next_variable_name_unchecked is called with valid variable name and namespace references.
+        // SAFETY: get_next_variable_name_unchecked is called with valid variable name and namespace references.
         // The iterator manages the state and ensures proper sequencing through the variable list.
         unsafe {
             // Don't do anything if we've reached the end already

--- a/sdk/patina/src/test/__private_api.rs
+++ b/sdk/patina/src/test/__private_api.rs
@@ -122,7 +122,7 @@ where
     pub fn run(&mut self, storage: UnsafeStorageCell) -> Result<bool, &'static str> {
         let mut metadata = MetaData::default();
 
-        // Safety: init_state requires mutable access to storage. UnsafeStorageCell provides controlled access.
+        // SAFETY: init_state requires mutable access to storage. UnsafeStorageCell provides controlled access.
         // This is the initialization phase before parameter validation.
         let param_state = match Func::Param::init_state(unsafe { storage.storage_mut() }, &mut metadata) {
             Ok(param_state) => param_state,
@@ -137,7 +137,7 @@ where
             return Ok(false);
         }
 
-        // Safety: Parameter was successfully validated by try_validate. get_param extracts the validated parameter
+        // SAFETY: Parameter was successfully validated by try_validate. get_param extracts the validated parameter
         // from storage using the param_state that was initialized above.
         let param_value = unsafe { Func::Param::get_param(&param_state, storage) };
 

--- a/sdk/patina/src/tpl_mutex.rs
+++ b/sdk/patina/src/tpl_mutex.rs
@@ -117,15 +117,15 @@ impl<T: ?Sized + fmt::Display, B: BootServices> fmt::Display for TplMutexGuard<'
     }
 }
 
-// Safety: TplMutex is Sync because it ensures exclusive access to T through TPL-based locking.
+// SAFETY: TplMutex is Sync because it ensures exclusive access to T through TPL-based locking.
 // The lock/unlock operations at TPL_HIGH_LEVEL prevent concurrent access. T must be Send to
 // allow transfer between threads, and the mutex ensures only one thread accesses T at a time.
 unsafe impl<T: ?Sized + Send, B: BootServices + Send> Sync for TplMutex<T, B> {}
-// Safety: TplMutex is Send because it owns T (which is Send) and uses TPL locking to ensure
+// SAFETY: TplMutex is Send because it owns T (which is Send) and uses TPL locking to ensure
 // thread-safe access. The mutex can be safely transferred between threads.
 unsafe impl<T: ?Sized + Send, B: BootServices + Send> Send for TplMutex<T, B> {}
 
-// Safety: TplMutexGuard is Sync when T is Sync because the guard represents exclusive access
+// SAFETY: TplMutexGuard is Sync when T is Sync because the guard represents exclusive access
 // to T through the TPL mutex. The guard can be shared across threads safely.
 unsafe impl<T: ?Sized + Sync, B: BootServices> Sync for TplMutexGuard<'_, T, B> {}
 

--- a/sdk/patina/src/uefi_protocol.rs
+++ b/sdk/patina/src/uefi_protocol.rs
@@ -30,7 +30,7 @@ pub unsafe trait ProtocolInterface {
 
 macro_rules! impl_r_efi_protocol {
     ($protocol:ident) => {
-        // Safety: This macro implements ProtocolInterface for r_efi protocol types. The PROTOCOL_GUID constant
+        // SAFETY: This macro implements ProtocolInterface for r_efi protocol types. The PROTOCOL_GUID constant
         // from r_efi matches the protocol interface layout by design - r_efi provides the canonical UEFI
         // protocol definitions and GUIDs from the UEFI specification. The Protocol struct layout matches
         // the UEFI protocol interface requirements.

--- a/sdk/patina/src/uefi_protocol/decompress.rs
+++ b/sdk/patina/src/uefi_protocol/decompress.rs
@@ -92,10 +92,10 @@ impl EfiDecompressProtocol {
         assert!(!source_buffer.is_null());
         assert!(!destination_buffer.is_null());
 
-        // Safety: source_buffer and destination_buffer pointers are validated as non-null.
+        // SAFETY: source_buffer and destination_buffer pointers are validated as non-null.
         // Sizes are provided by caller and trusted to match the buffer allocations.
         let src = unsafe { core::slice::from_raw_parts(source_buffer as *const u8, source_size as usize) };
-        // Safety: destination_buffer is validated as non-null and mutable access is exclusive.
+        // SAFETY: destination_buffer is validated as non-null and mutable access is exclusive.
         let dst = unsafe { core::slice::from_raw_parts_mut(destination_buffer as *mut u8, destination_size as usize) };
 
         match decompress_into_with_algo(src, dst, DecompressionAlgorithm::UefiDecompress) {
@@ -111,7 +111,7 @@ impl Default for EfiDecompressProtocol {
     }
 }
 
-// Safety: EfiDecompressProtocol implements the UEFI Decompress protocol interface.
+// SAFETY: EfiDecompressProtocol implements the UEFI Decompress protocol interface.
 // The PROTOCOL_GUID matches the UEFI specification for the Decompress protocol.
 // The protocol structure layout matches the UEFI protocol requirements.
 unsafe impl ProtocolInterface for EfiDecompressProtocol {

--- a/sdk/patina/src/uefi_protocol/performance_measurement.rs
+++ b/sdk/patina/src/uefi_protocol/performance_measurement.rs
@@ -67,7 +67,7 @@ pub struct EdkiiPerformanceMeasurement {
     pub create_performance_measurement: CreateMeasurementUefi,
 }
 
-// Safety: EdkiiPerformanceMeasurement implements the EDK II Performance Measurement protocol interface.
+// SAFETY: EdkiiPerformanceMeasurement implements the EDK II Performance Measurement protocol interface.
 // The PROTOCOL_GUID matches the EDK II defined value. The protocol structure layout matches the protocol
 // interface requirements.
 unsafe impl ProtocolInterface for EdkiiPerformanceMeasurement {

--- a/sdk/patina/src/uefi_protocol/status_code.rs
+++ b/sdk/patina/src/uefi_protocol/status_code.rs
@@ -31,7 +31,7 @@ pub struct StatusCodeRuntimeProtocol {
     protocol: status_code::Protocol,
 }
 
-// Safety: StatusCodeRuntimeProtocol implements the UEFI Status Code Runtime protocol interface.
+// SAFETY: StatusCodeRuntimeProtocol implements the UEFI Status Code Runtime protocol interface.
 // The PROTOCOL_GUID matches the PI specification. The repr(transparent) ensures that the
 // structure layout matches the underlying r_efi protocol definition.
 unsafe impl ProtocolInterface for StatusCodeRuntimeProtocol {

--- a/sdk/patina_ffs/src/section.rs
+++ b/sdk/patina_ffs/src/section.rs
@@ -278,7 +278,7 @@ impl Section {
             Err(FirmwareFileSystemError::InvalidHeader)?;
         }
 
-        // Safety: buffer is large enough to contain the header.
+        // SAFETY: buffer is large enough to contain the header.
         let section_header = unsafe { ptr::read_unaligned(buffer.as_ptr() as *const section::Header) };
 
         // Determine section size and start of section content
@@ -289,7 +289,7 @@ impl Section {
                 if buffer.len() < ext_header_size {
                     Err(FirmwareFileSystemError::InvalidHeader)?;
                 }
-                // Safety: buffer is large enough to contain extended header.
+                // SAFETY: buffer is large enough to contain extended header.
                 let ext_header = unsafe {
                     ptr::read_unaligned(buffer.as_ptr() as *const section::header::CommonSectionHeaderExtended)
                 };
@@ -316,7 +316,7 @@ impl Section {
                 if buffer.len() < section_data_offset + compression_header_size {
                     Err(FirmwareFileSystemError::InvalidHeader)?;
                 }
-                // Safety: buffer is large enough to hold the compression header.
+                // SAFETY: buffer is large enough to hold the compression header.
                 let compression_header = unsafe {
                     ptr::read_unaligned(buffer[section_data_offset..].as_ptr() as *const section::header::Compression)
                 };
@@ -334,7 +334,7 @@ impl Section {
                 if buffer.len() < section_data_offset + guid_header_size {
                     Err(FirmwareFileSystemError::InvalidHeader)?;
                 }
-                // Safety: buffer is large enough to hold the GuidDefined header.
+                // SAFETY: buffer is large enough to hold the GuidDefined header.
                 let guid_defined_header = unsafe {
                     ptr::read_unaligned(buffer[section_data_offset..].as_ptr() as *const section::header::GuidDefined)
                 };
@@ -356,7 +356,7 @@ impl Section {
                 if buffer.len() < section_data_offset + version_header_size {
                     Err(FirmwareFileSystemError::InvalidHeader)?;
                 }
-                // Safety: buffer is large enough to hold the version header.
+                // SAFETY: buffer is large enough to hold the version header.
                 let version_header = unsafe {
                     ptr::read_unaligned(buffer[section_data_offset..].as_ptr() as *const section::header::Version)
                 };
@@ -371,7 +371,7 @@ impl Section {
                 if buffer.len() < section_data_offset + freeform_subtype_size {
                     Err(FirmwareFileSystemError::InvalidHeader)?;
                 }
-                // Safety: buffer is large enough to hold the freeform header type
+                // SAFETY: buffer is large enough to hold the freeform header type
                 let freeform_header = unsafe {
                     ptr::read_unaligned(
                         buffer[section_data_offset..].as_ptr() as *const section::header::FreeformSubtypeGuid

--- a/sdk/patina_ffs/src/volume.rs
+++ b/sdk/patina_ffs/src/volume.rs
@@ -71,7 +71,7 @@ impl<'a> VolumeRef<'a> {
             Err(FirmwareFileSystemError::InvalidHeader)?;
         }
 
-        // Safety: buffer is large enough to contain the header.
+        // SAFETY: buffer is large enough to contain the header.
         let fv_header = unsafe { ptr::read_unaligned(buffer.as_ptr() as *const fv::Header) };
 
         // Signature must be ASCII '_FVH'


### PR DESCRIPTION
## Description
`// Safety` -> `// SAFETY`

Fix markdown formatting.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested
Passes formatting checks.

## Integration Instructions
N/A.