### PR TITLE
[feature/patina-boot] Merge main into feature/patina-boot

### DIFF
--- a/.github/workflows/calculate-unsafe-code.yml
+++ b/.github/workflows/calculate-unsafe-code.yml
@@ -27,5 +27,5 @@ on:
 jobs:
   calculate_unsafe_code:
     name: Run
-    uses: OpenDevicePartnership/patina-devops/.github/workflows/CalculateUnsafeCode.yml@v0.3.6
+    uses: OpenDevicePartnership/patina-devops/.github/workflows/CalculateUnsafeCode.yml@v0.3.8
     secrets: inherit

--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -31,14 +31,14 @@ on:
 jobs:
   ci_workflow:
     name: Run
-    uses: OpenDevicePartnership/patina-devops/.github/workflows/CiWorkflow.yml@v0.3.6
+    uses: OpenDevicePartnership/patina-devops/.github/workflows/CiWorkflow.yml@v0.3.8
     with:
       build-tasks: build,build-x64,build-aarch64
       run-cargo-vet: false
     secrets: inherit
   mdbook_docs_test:
     name: Run
-    uses: OpenDevicePartnership/patina-devops/.github/workflows/MdbookWorkflow.yml@v0.3.6
+    uses: OpenDevicePartnership/patina-devops/.github/workflows/MdbookWorkflow.yml@v0.3.8
     with:
       mdbook-path: "docs"
       build-cmd: cargo make build-lib

--- a/.github/workflows/crate-version-update.yml
+++ b/.github/workflows/crate-version-update.yml
@@ -28,7 +28,7 @@ on:
 jobs:
   crate-version-update-pr:
     name: Run
-    uses: OpenDevicePartnership/patina-devops/.github/workflows/CrateVersionUpdater.yml@v0.3.6
+    uses: OpenDevicePartnership/patina-devops/.github/workflows/CrateVersionUpdater.yml@v0.3.8
     with:
       ignore-prefix: patina-v
       create-pr: ${{ github.event_name == 'workflow_dispatch' }}

--- a/.github/workflows/label-issues.yml
+++ b/.github/workflows/label-issues.yml
@@ -36,5 +36,5 @@ jobs:
       contents: read
       pull-requests: write
 
-    uses: OpenDevicePartnership/patina-devops/.github/workflows/Labeler.yml@v0.3.6
+    uses: OpenDevicePartnership/patina-devops/.github/workflows/Labeler.yml@v0.3.8
     secrets: inherit

--- a/.github/workflows/label-sync.yml
+++ b/.github/workflows/label-sync.yml
@@ -28,5 +28,5 @@ jobs:
     permissions:
       issues: write
 
-    uses: OpenDevicePartnership/patina-devops/.github/workflows/LabelSyncer.yml@v0.3.6
+    uses: OpenDevicePartnership/patina-devops/.github/workflows/LabelSyncer.yml@v0.3.8
     secrets: inherit

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -23,7 +23,7 @@ on:
 jobs:
   release:
     name: Release
-    uses: OpenDevicePartnership/patina-devops/.github/workflows/ReleaseWorkflow.yml@v0.3.6
+    uses: OpenDevicePartnership/patina-devops/.github/workflows/ReleaseWorkflow.yml@v0.3.8
     with:
       ignore-prefix: 'patina-v'
     secrets: inherit

--- a/.github/workflows/rust-version-check.yml
+++ b/.github/workflows/rust-version-check.yml
@@ -26,5 +26,5 @@ jobs:
         pull-requests: write
         contents: read
 
-      uses: OpenDevicePartnership/patina-devops/.github/workflows/RustVersionCheck.yml@v0.3.6
+      uses: OpenDevicePartnership/patina-devops/.github/workflows/RustVersionCheck.yml@v0.3.8
       secrets: inherit

--- a/.github/workflows/triage-issues.yml
+++ b/.github/workflows/triage-issues.yml
@@ -23,5 +23,5 @@ jobs:
       contents: read
       issues: write
 
-    uses: OpenDevicePartnership/patina-devops/.github/workflows/IssueTriager.yml@v0.3.6
+    uses: OpenDevicePartnership/patina-devops/.github/workflows/IssueTriager.yml@v0.3.8
     secrets: inherit

--- a/.github/workflows/update-release-draft.yml
+++ b/.github/workflows/update-release-draft.yml
@@ -29,5 +29,5 @@ jobs:
       contents: write
       pull-requests: write
 
-    uses: OpenDevicePartnership/patina-devops/.github/workflows/UpdateReleaseDraft.yml@v0.3.6
+    uses: OpenDevicePartnership/patina-devops/.github/workflows/UpdateReleaseDraft.yml@v0.3.8
     secrets: inherit

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "2"
 members = ["components/*", "core/*", "sdk/*", "patina_dxe_core"]
 
 [workspace.package]
-version = "19.0.2"
+version = "19.0.5"
 license = "Apache-2.0"
 edition = "2024"
 rust-version = "1.89"
@@ -31,23 +31,23 @@ linkme = { version = "^0.3.29" }
 log = { version = "0.4", default-features = false }
 mu_rust_helpers = { version = "3.0.2" }
 num-traits = { version = "0.2", default-features = false }
-patina = { version = "19.0.2", path = "sdk/patina" }
-patina_debugger = { version = "19.0.2", path = "core/patina_debugger" }
-patina_ffs = { version = "19.0.2", path = "sdk/patina_ffs" }
-patina_ffs_extractors = { version = "19.0.2", path = "sdk/patina_ffs_extractors" }
-patina_internal_collections = { version = "19.0.2", path = "core/patina_internal_collections", default-features = false }
-patina_internal_cpu = { version = "19.0.2", path = "core/patina_internal_cpu" }
-patina_internal_depex = { version = "19.0.2", path = "core/patina_internal_depex" }
-patina_internal_device_path = { version = "19.0.2", path = "core/patina_internal_device_path" }
+patina = { version = "19.0.5", path = "sdk/patina" }
+patina_debugger = { version = "19.0.5", path = "core/patina_debugger" }
+patina_ffs = { version = "19.0.5", path = "sdk/patina_ffs" }
+patina_ffs_extractors = { version = "19.0.5", path = "sdk/patina_ffs_extractors" }
+patina_internal_collections = { version = "19.0.5", path = "core/patina_internal_collections", default-features = false }
+patina_internal_cpu = { version = "19.0.5", path = "core/patina_internal_cpu" }
+patina_internal_depex = { version = "19.0.5", path = "core/patina_internal_depex" }
+patina_internal_device_path = { version = "19.0.5", path = "core/patina_internal_device_path" }
 patina_lzma_rs = { version = "0.3.1", default-features = false }
-patina_macro = { version = "19.0.2", path = "sdk/patina_macro" }
-patina_mm = { version = "19.0.2", path = "components/patina_mm" }
+patina_macro = { version = "19.0.5", path = "sdk/patina_macro" }
+patina_mm = { version = "19.0.5", path = "components/patina_mm" }
 patina_mtrr = { version = "^1.1.4" }
-patina_boot = { version = "19.0.2", path = "components/patina_boot" }
-patina_paging = { version = "10" }
-patina_performance = { version = "19.0.2", path = "components/patina_performance" }
-patina_smbios = { version = "19.0.2", path = "components/patina_smbios" }
-patina_stacktrace = { version = "19.0.2", path = "core/patina_stacktrace" }
+patina_boot = { version = "19.0.5", path = "components/patina_boot" }
+patina_paging = { version = "11" }
+patina_performance = { version = "19.0.5", path = "components/patina_performance" }
+patina_smbios = { version = "19.0.5", path = "components/patina_smbios" }
+patina_stacktrace = { version = "19.0.5", path = "core/patina_stacktrace" }
 proc-macro2 = { version = "1" }
 quote = { version = "1" }
 r-efi = { version = "5.0.0", default-features = false }

--- a/components/patina_mm/src/component/communicator/comm_buffer_update.rs
+++ b/components/patina_mm/src/component/communicator/comm_buffer_update.rs
@@ -298,10 +298,8 @@ mod tests {
         communicator_ptr: *const MmCommunicator,
     ) -> Box<ProtocolNotifyContext> {
         let mock_bs = Box::leak(Box::new([0u8; core::mem::size_of::<r_efi::system::BootServices>()]));
-        let bs_ptr = mock_bs.as_ptr() as *const r_efi::system::BootServices;
-        // SAFETY: bs_ptr points to an aligned mock buffer that was just created.
-        // This is only used for test purposes and the pointer lifetime is managed by the leaked Box.
-        let bs = StandardBootServices::new(unsafe { &*bs_ptr });
+        let bs_ptr = mock_bs.as_mut_ptr() as *mut r_efi::system::BootServices;
+        let bs = StandardBootServices::new(bs_ptr);
 
         Box::new(ProtocolNotifyContext {
             boot_services: bs,

--- a/components/patina_smbios/src/component.rs
+++ b/components/patina_smbios/src/component.rs
@@ -95,7 +95,7 @@ impl SmbiosProvider {
 
     /// Initialize the SMBIOS provider and register it as a service
     #[coverage(off)] // Component integration - tested via integration tests
-    fn entry_point(self, storage: &mut Storage) -> Result<()> {
+    pub fn entry_point(self, storage: &mut Storage) -> Result<()> {
         let cfg = self.config;
 
         let manager = SmbiosManager::new(cfg.major_version, cfg.minor_version)?;

--- a/components/patina_smbios/src/error.rs
+++ b/components/patina_smbios/src/error.rs
@@ -32,14 +32,18 @@ pub enum SmbiosError {
     InvalidStringPoolTermination,
     /// String pool area is too small (must be at least 2 bytes)
     StringPoolTooSmall,
+    /// Failed to find the record corresponding to the specified handle in the record table
+    RecordNotFound,
 
     // Handle management errors
     /// All available handles have been exhausted (reached 0xFFFE limit)
     HandleExhausted,
-    /// The specified handle was not found in the record table
-    HandleNotFound,
     /// String index is out of range for the specified record
     StringIndexOutOfRange,
+    /// The specified handle was already used by another record
+    HandleInUse,
+    /// The specified handle is out of range
+    HandleOutOfRange,
 
     // Resource allocation errors
     /// Failed to allocate memory for SMBIOS table or entry point
@@ -82,10 +86,12 @@ impl From<SmbiosError> for patina::error::EfiError {
             | SmbiosError::InvalidStringPoolTermination
             | SmbiosError::StringPoolTooSmall
             | SmbiosError::StringIndexOutOfRange
-            | SmbiosError::Type127Managed => patina::error::EfiError::InvalidParameter,
+            | SmbiosError::Type127Managed
+            | SmbiosError::HandleInUse
+            | SmbiosError::HandleOutOfRange => patina::error::EfiError::InvalidParameter,
 
             // Not found errors map to NOT_FOUND
-            SmbiosError::HandleNotFound | SmbiosError::NoRecordsAvailable => patina::error::EfiError::NotFound,
+            SmbiosError::NoRecordsAvailable | SmbiosError::RecordNotFound => patina::error::EfiError::NotFound,
 
             // Version and initialization errors map to UNSUPPORTED
             SmbiosError::UnsupportedVersion | SmbiosError::AlreadyInitialized | SmbiosError::NotInitialized => {
@@ -117,14 +123,17 @@ mod tests {
             SmbiosError::InvalidStringPoolTermination,
             SmbiosError::StringPoolTooSmall,
             SmbiosError::HandleExhausted,
-            SmbiosError::HandleNotFound,
+            SmbiosError::RecordNotFound,
             SmbiosError::StringIndexOutOfRange,
             SmbiosError::AllocationFailed,
+            SmbiosError::HandleExhausted,
             SmbiosError::NoRecordsAvailable,
             SmbiosError::AlreadyInitialized,
             SmbiosError::NotInitialized,
             SmbiosError::UnsupportedVersion,
             SmbiosError::Type127Managed,
+            SmbiosError::HandleInUse,
+            SmbiosError::HandleOutOfRange,
             SmbiosError::TableDirectlyModified,
         ];
 
@@ -174,8 +183,14 @@ mod tests {
         let efi_err: patina::error::EfiError = SmbiosError::Type127Managed.into();
         assert_eq!(efi_err, patina::error::EfiError::InvalidParameter);
 
+        let efi_err: patina::error::EfiError = SmbiosError::HandleInUse.into();
+        assert_eq!(efi_err, patina::error::EfiError::InvalidParameter);
+
+        let efi_err: patina::error::EfiError = SmbiosError::HandleOutOfRange.into();
+        assert_eq!(efi_err, patina::error::EfiError::InvalidParameter);
+
         // Test not found errors map to NOT_FOUND
-        let efi_err: patina::error::EfiError = SmbiosError::HandleNotFound.into();
+        let efi_err: patina::error::EfiError = SmbiosError::RecordNotFound.into();
         assert_eq!(efi_err, patina::error::EfiError::NotFound);
 
         let efi_err: patina::error::EfiError = SmbiosError::NoRecordsAvailable.into();

--- a/components/patina_smbios/src/manager/core.rs
+++ b/components/patina_smbios/src/manager/core.rs
@@ -12,7 +12,7 @@
 
 extern crate alloc;
 
-use alloc::{boxed::Box, string::String, vec::Vec};
+use alloc::{boxed::Box, collections::BTreeSet, string::String, vec::Vec};
 use core::cell::RefCell;
 use patina::{base::SIZE_64KB, uefi_size_to_pages};
 use r_efi::{
@@ -73,8 +73,7 @@ pub struct Smbios30EntryPoint {
 /// Manages SMBIOS records, handles, and table generation.
 pub struct SmbiosManager {
     pub(super) records: RefCell<Vec<SmbiosRecord>>,
-    pub(super) next_handle: RefCell<SmbiosHandle>,
-    pub(super) freed_handles: RefCell<Vec<SmbiosHandle>>,
+    pub(super) used_handles: RefCell<BTreeSet<SmbiosHandle>>,
     pub major_version: u8,
     pub minor_version: u8,
     entry_point_64: RefCell<Option<Box<Smbios30EntryPoint>>>,
@@ -114,8 +113,7 @@ impl SmbiosManager {
 
         Ok(Self {
             records: RefCell::new(Vec::new()),
-            next_handle: RefCell::new(1),
-            freed_handles: RefCell::new(Vec::new()),
+            used_handles: RefCell::new(BTreeSet::new()),
             major_version,
             minor_version,
             entry_point_64: RefCell::new(None),
@@ -175,7 +173,7 @@ impl SmbiosManager {
         // which rejects Type 127 to prevent external callers from adding it
         let type127 = Type127EndOfTable::new();
         let bytes = type127.to_bytes();
-        let header = SmbiosTableHeader::new(127, 4, self.allocate_handle()?);
+        let header = SmbiosTableHeader::new(127, 4, self.alloc_new_smbios_handle()?);
         let record = SmbiosRecord::new(header, None, bytes, 0);
         self.records.borrow_mut().push(record);
 
@@ -297,32 +295,82 @@ impl SmbiosManager {
         strings
     }
 
-    /// Allocate a new handle using a free list for efficient O(1) allocation
+    /// This function is called when the request handle is NOT FFFE.
     ///
-    /// This implementation maintains a free list of previously freed handles to avoid
-    /// O(n) searches through all records. The allocation strategy is:
-    /// 1. If freed_handles is non-empty, pop and reuse a freed handle
-    /// 2. Otherwise, use next_handle and increment it
-    /// 3. If next_handle reaches the reserved range (0xFFFE), wrap to 1
-    /// 4. If all handles are exhausted, return OutOfResources
-    pub(super) fn allocate_handle(&self) -> Result<SmbiosHandle, SmbiosError> {
-        // First, try to reuse a freed handle (most efficient)
-        if let Some(handle) = self.freed_handles.borrow_mut().pop() {
-            return Ok(handle);
+    /// Checks if the handle is within valid range (0..FFFE) and its availability.
+    ///
+    /// # Arguments
+    ///
+    /// * `&SmbiosHandle` - reference to the requested handle
+    ///
+    /// # Returns
+    ///
+    /// Returns `Ok(SmbiosHandle)` with if the handle is within range and not used.
+    ///
+    /// # Errors
+    ///
+    /// If the handle is not within valid range, returns SmbiosError::HandleOutOfRange.
+    /// If the handle is already in use, returns SmbiosError::HandleInUse.
+    fn add_request_handle(&self, request_handle: &SmbiosHandle) -> Result<SmbiosHandle, SmbiosError> {
+        if !(0..SMBIOS_HANDLE_PI_RESERVED).contains(request_handle) {
+            log::error!("add_request_handle - HandleOutOfRange");
+            return Err(SmbiosError::HandleOutOfRange);
         }
 
-        // No freed handles available, use next_handle
-        let candidate = *self.next_handle.borrow();
+        if self.used_handles.borrow_mut().insert(*request_handle) {
+            Ok(*request_handle)
+        } else {
+            log::error!("add_request_handle - HandleInUse");
+            Err(SmbiosError::HandleInUse)
+        }
+    }
 
-        // Check if we've exhausted the handle space
-        // Valid handles are 1..=0xFEFF (0xFFFE and 0xFFFF are reserved)
-        if candidate >= SMBIOS_HANDLE_PI_RESERVED {
-            // All handles exhausted
-            return Err(SmbiosError::HandleExhausted);
+    /// This function is called when the request handle is FFFE.
+    ///
+    /// Allocates a new unique handle if available.
+    ///
+    /// # Arguments
+    ///
+    /// * `&SmbiosHandle` - reference to the requested handle
+    ///
+    /// # Returns
+    ///
+    /// Returns `Ok(SmbiosHandle)` with if there is still an available handle.
+    ///
+    /// # Errors
+    ///
+    /// If there is no available handle, return SmbiosError::HandleExhausted.
+    fn alloc_new_smbios_handle(&self) -> Result<SmbiosHandle, SmbiosError> {
+        for handle in 0..SMBIOS_HANDLE_PI_RESERVED {
+            if self.used_handles.borrow_mut().insert(handle) {
+                return Ok(handle);
+            }
         }
 
-        *self.next_handle.borrow_mut() = candidate + 1;
-        Ok(candidate)
+        log::error!("alloc_new_smbios_handle - HandleExhausted");
+        Err(SmbiosError::HandleExhausted)
+    }
+
+    /// Get a SMBIOS handle based on the requested handle
+    ///
+    /// Follow PI spec, if the requested handle is FFFEh, then call alloc_new_smbios_handle to
+    /// get a unique handle. Otherwise, call add_request_handle to check if the handle is
+    /// already in use. If it is not, then use the requested handle as is.
+    ///
+    /// # Arguments
+    ///
+    /// * `&SmbiosHandle` - reference to the requested handle
+    ///
+    /// # Returns
+    ///
+    /// Returns `Ok(SmbiosHandle)` with the assigned handle, or an error if the handle is already
+    /// in use.
+    pub(crate) fn get_smbios_handle(&self, request_handle: &SmbiosHandle) -> Result<SmbiosHandle, SmbiosError> {
+        if *request_handle == SMBIOS_HANDLE_PI_RESERVED {
+            self.alloc_new_smbios_handle()
+        } else {
+            self.add_request_handle(request_handle)
+        }
     }
 
     /// Build SMBIOS table data and entry point using pre-allocated buffers
@@ -516,6 +564,7 @@ impl SmbiosManager {
     ) -> Result<SmbiosHandle, SmbiosError> {
         // Step 1: Validate minimum size for header (at least 4 bytes)
         if record_data.len() < core::mem::size_of::<SmbiosTableHeader>() {
+            log::error!("add_from_bytes - minimum size for header is too small");
             return Err(SmbiosError::RecordTooSmall);
         }
 
@@ -527,12 +576,14 @@ impl SmbiosManager {
         // Step 3: Reject Type 127 End-of-Table marker - it's automatically managed
         // The manager adds Type 127 during initialization, and it must remain unique and last
         if header.record_type == 127 {
+            log::error!("add_from_bytes - Reject Type 127 End-of-Table marker");
             return Err(SmbiosError::Type127Managed);
         }
 
         // Step 4: Validate header->length is <= (record_data.length - 2) for string pool
         // The string pool needs at least 2 bytes for the double-null terminator
         if (header.length as usize + 2) > record_data.len() {
+            log::error!("add_from_bytes - double terminator RecordTooSmall");
             return Err(SmbiosError::RecordTooSmall);
         }
 
@@ -541,14 +592,15 @@ impl SmbiosManager {
         let string_pool_area = &record_data[string_pool_start..];
 
         if string_pool_area.len() < 2 {
+            log::error!("add_from_bytes - string pool too small");
             return Err(SmbiosError::StringPoolTooSmall);
         }
 
         let string_count = Self::validate_and_count_strings(string_pool_area)?;
 
         // If all validation passes, allocate handle and build record
-        let smbios_handle = self.allocate_handle()?;
-
+        let request_handle = header.handle;
+        let smbios_handle = self.get_smbios_handle(&request_handle)?;
         let record_header =
             SmbiosTableHeader { record_type: header.record_type, length: header.length, handle: smbios_handle };
 
@@ -598,7 +650,7 @@ impl SmbiosManager {
             .borrow()
             .iter()
             .position(|r| r.header.handle == smbios_handle)
-            .ok_or(SmbiosError::HandleNotFound)?;
+            .ok_or(SmbiosError::RecordNotFound)?;
 
         // Borrow the record
         let mut records = self.records.borrow_mut();
@@ -654,21 +706,23 @@ impl SmbiosManager {
 
     /// Remove an SMBIOS record
     pub fn remove(&self, smbios_handle: SmbiosHandle) -> Result<(), SmbiosError> {
+        if !(0..SMBIOS_HANDLE_PI_RESERVED).contains(&smbios_handle) {
+            return Err(SmbiosError::HandleOutOfRange);
+        }
+
         let pos = self
             .records
             .borrow()
             .iter()
             .position(|r| r.header.handle == smbios_handle)
-            .ok_or(SmbiosError::HandleNotFound)?;
+            .ok_or(SmbiosError::RecordNotFound)?;
 
         self.records.borrow_mut().remove(pos);
 
-        // Add the freed handle to the free list for reuse
-        // Only add valid handles (1..0xFFFE) to the free list
-        if (1..SMBIOS_HANDLE_PI_RESERVED).contains(&smbios_handle) {
-            self.freed_handles.borrow_mut().push(smbios_handle);
-        }
-
+        // update the self.used_handles.
+        // remove() should never return false in this case because if a record exists, its handle
+        // was registered in used_handles when it was added via get_smbios_handle().
+        self.used_handles.borrow_mut().remove(&smbios_handle);
         Ok(())
     }
 
@@ -931,38 +985,71 @@ mod tests {
     }
 
     #[test]
-    fn test_allocate_handle_sequential() {
+    fn test_alloc_new_smbios_handle_sequential() {
         let manager = SmbiosManager::new(3, 9).expect("failed to create manager");
-        let handle1 = manager.allocate_handle().expect("allocation failed");
+        let handle0 = manager.alloc_new_smbios_handle().expect("allocation failed");
+        assert_eq!(handle0, 0);
+        let handle1 = manager.alloc_new_smbios_handle().expect("allocation failed");
         assert_eq!(handle1, 1);
-        let handle2 = manager.allocate_handle().expect("allocation failed");
-        assert_eq!(handle2, 2);
     }
 
     #[test]
-    fn test_allocate_handle_wraps_at_max() {
+    fn test_get_smbios_handle_sequential() {
         let manager = SmbiosManager::new(3, 9).expect("failed to create manager");
-        *manager.next_handle.borrow_mut() = 0xFFFD;
-        let handle1 = manager.allocate_handle().expect("allocation failed");
-        assert_eq!(handle1, 0xFFFD);
-        assert_eq!(manager.allocate_handle(), Err(SmbiosError::HandleExhausted));
+        let mut record_data = vec![1u8, 4, 0xFE, 0xFF];
+        record_data.extend_from_slice(b"\0\0");
+        let handle0 = manager.add_from_bytes(None, &record_data).expect("add failed");
+        assert_eq!(handle0, 0);
+        let mut record_data = vec![2u8, 4, 0xFE, 0xFF];
+        record_data.extend_from_slice(b"\0\0");
+        let handle1 = manager.add_from_bytes(None, &record_data).expect("add failed");
+        assert_eq!(handle1, 1);
     }
 
     #[test]
-    fn test_allocate_handle_uses_free_list() {
+    fn test_add_request_handle_error_handle_in_use() {
         let manager = SmbiosManager::new(3, 9).expect("failed to create manager");
-        manager.freed_handles.borrow_mut().push(100);
-        manager.freed_handles.borrow_mut().push(50);
-        let handle1 = manager.allocate_handle().expect("allocation failed");
-        assert_eq!(handle1, 50);
-        let handle2 = manager.allocate_handle().expect("allocation failed");
-        assert_eq!(handle2, 100);
-        let handle3 = manager.allocate_handle().expect("allocation failed");
-        assert_eq!(handle3, 1);
+        let mut record_data = vec![1u8, 4, 0xFE, 0xFF];
+        record_data.extend_from_slice(b"\0\0");
+        let handle0 = manager.add_from_bytes(None, &record_data).expect("add failed");
+        assert_eq!(handle0, 0);
+        let mut record_data = vec![2u8, 4, 0xFE, 0xFF];
+        record_data.extend_from_slice(b"\0\0");
+        let handle1 = manager.add_from_bytes(None, &record_data).expect("add failed");
+        assert_eq!(handle1, 1);
+        let mut record_data = vec![1u8, 4, 0x01, 0x00];
+        record_data.extend_from_slice(b"\0\0");
+        let result = manager.add_from_bytes(None, &record_data);
+        assert_eq!(SmbiosError::HandleInUse, result.expect_err("add duplicate failed"));
     }
 
     #[test]
-    fn test_allocate_handle_with_gaps() {
+    fn test_add_request_handle_error_handle_out_of_range() {
+        let manager = SmbiosManager::new(3, 9).expect("failed to create manager");
+        let mut record_data = vec![1u8, 4, 0xFF, 0xFF];
+        record_data.extend_from_slice(b"\0\0");
+        let result = manager.add_from_bytes(None, &record_data);
+        assert_eq!(SmbiosError::HandleOutOfRange, result.expect_err("add out of range failed"));
+    }
+
+    #[test]
+    fn test_alloc_new_smbios_handle_error_handle_exhausted() {
+        let manager = SmbiosManager::new(3, 9).expect("failed to create manager");
+        'outer: for i in 0..0xFE {
+            for j in 0..0xFF {
+                let mut record_data = vec![1u8, 4, i, j];
+                record_data.extend_from_slice(b"\0\0");
+                if i == 0xFE && j == 0xFF {
+                    assert_eq!(SmbiosError::HandleExhausted, manager.add_from_bytes(None, &record_data).unwrap_err());
+                    break 'outer;
+                }
+                manager.add_from_bytes(None, &record_data).expect("add failed");
+            }
+        }
+    }
+
+    #[test]
+    fn test_alloc_new_smbios_handle_with_gaps() {
         let manager = SmbiosManager::new(3, 9).expect("failed to create manager");
         let header1 = SmbiosTableHeader::new(1, 4, SMBIOS_HANDLE_PI_RESERVED);
         let bytes1 = build_test_record_with_strings(&header1, &[]);
@@ -983,11 +1070,11 @@ mod tests {
     #[test]
     fn test_handle_reuse_after_remove() {
         let manager = SmbiosManager::new(3, 9).expect("failed to create manager");
-        let mut record_data = vec![1u8, 4, 0, 0];
+        let mut record_data = vec![1u8, 4, 0xFE, 0xFF];
         record_data.extend_from_slice(b"\0\0");
         let handle1 = manager.add_from_bytes(None, &record_data).expect("add failed");
         manager.remove(handle1).expect("remove failed");
-        let mut record_data2 = vec![2u8, 4, 0, 0];
+        let mut record_data2 = vec![2u8, 4, 0xFE, 0xFF];
         record_data2.extend_from_slice(b"\0\0");
         let handle2 = manager.add_from_bytes(None, &record_data2).expect("add failed");
         assert_eq!(handle1, handle2);
@@ -1004,9 +1091,9 @@ mod tests {
     }
 
     #[test]
-    fn test_update_string_handle_not_found() {
+    fn test_update_string_record_not_found() {
         let manager = SmbiosManager::new(3, 9).expect("failed to create manager");
-        assert_eq!(manager.update_string(999, 1, "test"), Err(SmbiosError::HandleNotFound));
+        assert_eq!(manager.update_string(999, 1, "test"), Err(SmbiosError::RecordNotFound));
     }
 
     #[test]
@@ -1064,11 +1151,11 @@ mod tests {
     #[test]
     fn test_remove_success() {
         let manager = SmbiosManager::new(3, 9).expect("failed to create manager");
-        let mut record_data = vec![1u8, 4, 0, 0];
+        let mut record_data = vec![1u8, 4, 0xFE, 0xFF];
         record_data.extend_from_slice(b"\0\0");
         let handle = manager.add_from_bytes(None, &record_data).expect("add failed");
         assert!(manager.remove(handle).is_ok());
-        assert_eq!(manager.remove(handle), Err(SmbiosError::HandleNotFound));
+        assert_eq!(manager.remove(handle), Err(SmbiosError::RecordNotFound));
     }
 
     #[test]
@@ -1082,18 +1169,6 @@ mod tests {
     }
 
     #[test]
-    fn test_remove_reserved_handle_not_added_to_free_list() {
-        let manager = SmbiosManager::new(3, 9).expect("failed to create manager");
-        let mut record_data = vec![1u8, 4, 0, 0];
-        record_data.extend_from_slice(b"\0\0");
-        let handle = manager.add_from_bytes(None, &record_data).expect("add failed");
-        manager.remove(handle).expect("remove failed");
-        let freed = manager.freed_handles.borrow();
-        assert_eq!(freed.len(), 1);
-        assert_eq!(freed[0], handle);
-    }
-
-    #[test]
     fn test_iteration() {
         let manager = SmbiosManager::new(3, 9).expect("failed to create manager");
 
@@ -1102,7 +1177,7 @@ mod tests {
 
         // Add test records: types [1, 2, 1, 3, 1]
         for record_type in [1u8, 2, 1, 3, 1] {
-            let mut record_data = vec![record_type, 4, 0, 0];
+            let mut record_data = vec![record_type, 4, 0xFE, 0xFF];
             record_data.extend_from_slice(b"\0\0");
             manager.add_from_bytes(None, &record_data).expect("add failed");
         }
@@ -1127,7 +1202,7 @@ mod tests {
         let manager = SmbiosManager::new(3, 9).expect("failed to create manager");
         let handles: Vec<SmbiosHandle> = (1..=3)
             .map(|i| {
-                let mut record_data = vec![i, 4, 0, 0];
+                let mut record_data = vec![i, 4, i, 0];
                 record_data.extend_from_slice(b"\0\0");
                 manager.add_from_bytes(None, &record_data).expect("add failed")
             })
@@ -1212,7 +1287,7 @@ mod tests {
     #[test]
     fn test_add_from_bytes_updates_handle_in_data() {
         let manager = SmbiosManager::new(3, 9).expect("failed to create manager");
-        let mut record_data = vec![1u8, 4, 0xFF, 0xFF];
+        let mut record_data = vec![1u8, 4, 0xFE, 0xFF];
         record_data.extend_from_slice(b"\0\0");
         let assigned_handle = manager.add_from_bytes(None, &record_data).expect("add failed");
         let records = manager.records.borrow();
@@ -1364,12 +1439,12 @@ mod tests {
         // Manually add Type 127 to simulate allocate_buffers behavior
         let type127 = Type127EndOfTable::new();
         let bytes = type127.to_bytes();
-        let header = SmbiosTableHeader::new(127, 4, manager.allocate_handle().unwrap());
+        let header = SmbiosTableHeader::new(127, 4, manager.alloc_new_smbios_handle().unwrap());
         let record = SmbiosRecord::new(header, None, bytes, 0);
         manager.records.borrow_mut().push(record);
 
         // Now add a Type 1 record
-        let mut record_data = vec![1u8, 4, 0, 0];
+        let mut record_data = vec![1u8, 4, 0xFE, 0xFF];
         record_data.extend_from_slice(b"\0\0");
         manager.add_from_bytes(None, &record_data).expect("add failed");
 
@@ -1388,13 +1463,13 @@ mod tests {
         // Manually add Type 127
         let type127 = Type127EndOfTable::new();
         let bytes = type127.to_bytes();
-        let header = SmbiosTableHeader::new(127, 4, manager.allocate_handle().unwrap());
+        let header = SmbiosTableHeader::new(127, 4, manager.alloc_new_smbios_handle().unwrap());
         let record = SmbiosRecord::new(header, None, bytes, 0);
         manager.records.borrow_mut().push(record);
 
         // Add multiple records of different types
         for record_type in [1u8, 2, 3, 0, 4] {
-            let mut record_data = vec![record_type, 4, 0, 0];
+            let mut record_data = vec![record_type, 4, 0xFE, 0xFF];
             record_data.extend_from_slice(b"\0\0");
             manager.add_from_bytes(None, &record_data).expect("add failed");
         }
@@ -1416,14 +1491,14 @@ mod tests {
         // Add Type 127 in the middle
         let type127 = Type127EndOfTable::new();
         let bytes = type127.to_bytes();
-        let header = SmbiosTableHeader::new(127, 4, manager.allocate_handle().unwrap());
+        let header = SmbiosTableHeader::new(127, 4, manager.alloc_new_smbios_handle().unwrap());
         let record = SmbiosRecord::new(header, None, bytes, 0);
         manager.records.borrow_mut().push(record);
 
         // Add another non-Type-127 record after it (manually, bypassing add_from_bytes)
         let mut record_data = vec![1u8, 4, 0, 0];
         record_data.extend_from_slice(b"\0\0");
-        let header = SmbiosTableHeader::new(1, 4, manager.allocate_handle().unwrap());
+        let header = SmbiosTableHeader::new(1, 4, manager.alloc_new_smbios_handle().unwrap());
         let record = SmbiosRecord::new(header, None, record_data, 0);
         manager.records.borrow_mut().push(record);
 
@@ -1447,14 +1522,14 @@ mod tests {
         // Add Type 127 first
         let type127 = Type127EndOfTable::new();
         let bytes = type127.to_bytes();
-        let header = SmbiosTableHeader::new(127, 4, manager.allocate_handle().unwrap());
+        let header = SmbiosTableHeader::new(127, 4, manager.alloc_new_smbios_handle().unwrap());
         let record = SmbiosRecord::new(header, None, bytes, 0);
         manager.records.borrow_mut().push(record);
 
         // Add another record after Type 127 (violates invariant)
         let mut record_data = vec![1u8, 4, 0, 0];
         record_data.extend_from_slice(b"\0\0");
-        let header = SmbiosTableHeader::new(1, 4, manager.allocate_handle().unwrap());
+        let header = SmbiosTableHeader::new(1, 4, manager.alloc_new_smbios_handle().unwrap());
         let record = SmbiosRecord::new(header, None, record_data, 0);
         manager.records.borrow_mut().push(record);
 
@@ -1600,13 +1675,13 @@ mod tests {
         // Manually add Type 127
         let type127 = Type127EndOfTable::new();
         let bytes = type127.to_bytes();
-        let header = SmbiosTableHeader::new(127, 4, manager.allocate_handle().unwrap());
+        let header = SmbiosTableHeader::new(127, 4, manager.alloc_new_smbios_handle().unwrap());
         let record = SmbiosRecord::new(header, None, bytes, 0);
         let type127_handle = record.header.handle;
         manager.records.borrow_mut().push(record);
 
         // Add a regular record
-        let mut record_data = vec![1u8, 4, 0, 0];
+        let mut record_data = vec![1u8, 4, 0xFE, 0xFF];
         record_data.extend_from_slice(b"\0\0");
         let handle = manager.add_from_bytes(None, &record_data).expect("add failed");
 
@@ -1751,7 +1826,7 @@ mod tests {
         manager.allocate_buffers(memory_manager).expect("allocate_buffers failed");
 
         // Add a Type 1 record
-        let mut record_data = vec![1u8, 4, 0, 0];
+        let mut record_data = vec![1u8, 4, 0xFE, 0xFF];
         record_data.extend_from_slice(b"\0\0");
         manager.add_from_bytes(None, &record_data).expect("add failed");
 
@@ -1794,7 +1869,7 @@ mod tests {
 
         // Add multiple records
         for record_type in [1u8, 2, 3] {
-            let mut record_data = vec![record_type, 4, 0, 0];
+            let mut record_data = vec![record_type, 4, 0xFE, 0xFF];
             record_data.extend_from_slice(b"\0\0");
             manager.add_from_bytes(None, &record_data).expect("add failed");
         }

--- a/components/patina_smbios/src/manager/protocol.rs
+++ b/components/patina_smbios/src/manager/protocol.rs
@@ -206,6 +206,8 @@ impl SmbiosProtocol {
             Err(SmbiosError::InvalidStringPoolTermination) => efi::Status::INVALID_PARAMETER,
             Err(SmbiosError::StringPoolTooSmall) => efi::Status::BUFFER_TOO_SMALL,
             Err(SmbiosError::HandleExhausted) => efi::Status::OUT_OF_RESOURCES,
+            Err(SmbiosError::HandleOutOfRange) => efi::Status::INVALID_PARAMETER,
+            Err(SmbiosError::HandleInUse) => efi::Status::INVALID_PARAMETER,
             Err(SmbiosError::AllocationFailed) => efi::Status::OUT_OF_RESOURCES,
             Err(SmbiosError::StringTooLong) => efi::Status::INVALID_PARAMETER,
             Err(e) => {
@@ -262,7 +264,7 @@ impl SmbiosProtocol {
                 efi::Status::SUCCESS
             }
             Err(SmbiosError::StringContainsNull) => efi::Status::INVALID_PARAMETER,
-            Err(SmbiosError::HandleNotFound) => efi::Status::NOT_FOUND,
+            Err(SmbiosError::RecordNotFound) => efi::Status::NOT_FOUND,
             Err(SmbiosError::StringIndexOutOfRange) => efi::Status::INVALID_PARAMETER,
             Err(SmbiosError::StringTooLong) => efi::Status::INVALID_PARAMETER,
             Err(_) => efi::Status::DEVICE_ERROR,
@@ -295,7 +297,7 @@ impl SmbiosProtocol {
 
                 efi::Status::SUCCESS
             }
-            Err(SmbiosError::HandleNotFound) => efi::Status::NOT_FOUND,
+            Err(SmbiosError::RecordNotFound) => efi::Status::NOT_FOUND,
             Err(_) => efi::Status::DEVICE_ERROR,
         }
     }

--- a/core/patina_debugger/src/arch/aarch64.rs
+++ b/core/patina_debugger/src/arch/aarch64.rs
@@ -60,6 +60,8 @@ impl DebuggerArch for Aarch64Arch {
 
     #[inline(always)]
     fn breakpoint() {
+        // SAFETY: Executing breakpoint instruction will cause an exception, this has
+        // no direct impact on safety invariants.
         unsafe {
             asm!("brk 0", options(nostack));
         }
@@ -206,8 +208,8 @@ impl DebuggerArch for Aarch64Arch {
 
     fn reboot() {
         // reboot through PSCI SYSTEM_RESET
-        // this directly loads a value into x0, but this is safe here because we are rebooting anyway
-        // so this doesn't matter if we clobber x0
+        // SAFETY: This directly loads a value into x0, but this is safe here because we are rebooting anyway
+        // so this doesn't matter if we clobber x0.
         unsafe {
             asm!("ldr x0, =0x84000009", "smc 0");
         }
@@ -216,6 +218,10 @@ impl DebuggerArch for Aarch64Arch {
     fn get_page_table() -> Result<Self::PageTable, ()> {
         // TODO: Check for EL1?
         let ttbr0_el2 = read_sysreg!(ttbr0_el2);
+
+        // SAFETY: We are creating from the existing page table root, so the
+        // page tables should be a valid structure. Using PageAllocatorStub
+        // ensures that no allocations are attempted.
         unsafe {
             patina_paging::aarch64::AArch64PageTable::from_existing(
                 ttbr0_el2,

--- a/core/patina_internal_collections/src/bst.rs
+++ b/core/patina_internal_collections/src/bst.rs
@@ -32,7 +32,7 @@ where
     ///
     /// This is useful for creating a tree at compile time and replacing the memory later. Use
     /// [with_capacity](Self::with_capacity) to create a tree with a given slice of memory immediately. Otherwise use
-    /// [resize](Self::resize) to replace the memory later.
+    /// [expand](Self::expand) to replace the memory later.
     pub const fn new() -> Self {
         Bst { storage: Storage::new(), root: Cell::new(core::ptr::null_mut()) }
     }
@@ -612,11 +612,18 @@ impl<'a, D> Bst<'a, D>
 where
     D: Copy + SliceKey + 'a,
 {
-    /// Replaces the memory of the tree with a new slice, copying the data from the old slice to the new slice.
-    pub fn resize(&mut self, slice: &'a mut [u8]) {
+    /// Expands the tree's storage capacity to a new, larger buffer.
+    ///
+    /// This function cannot shrink the storage capacity - it only allows expansion.
+    /// All nodes are copied to the new buffer to preserve the tree structure.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the new slice is smaller than the current capacity.
+    pub fn expand(&mut self, slice: &'a mut [u8]) {
         let root = { if self.root.get().is_null() { None } else { Some(self.storage.idx(self.root.get())) } };
 
-        self.storage.resize(slice);
+        self.storage.expand(slice);
 
         if let Some(idx) = root {
             self.root.set(self.storage.get_mut(idx).expect("Pointer Exists."));
@@ -828,11 +835,11 @@ mod tests {
     }
 
     #[test]
-    fn test_simple_resize() {
+    fn test_simple_expand() {
         let mut bst = Bst::<usize>::new();
 
         let mut mem = [0; 20 * node_size::<usize>()];
-        bst.resize(&mut mem);
+        bst.expand(&mut mem);
 
         for i in 0..10 {
             assert!(bst.add(i).is_ok());
@@ -844,7 +851,7 @@ mod tests {
     }
 
     #[test]
-    fn test_resize_with_existing_data() {
+    fn test_expand_with_existing_data() {
         let mut mem = [0; 10 * node_size::<usize>()];
         let mut bst = Bst::<usize>::with_capacity(&mut mem);
 
@@ -856,7 +863,7 @@ mod tests {
         }
 
         let mut new_mem = [0; 20 * node_size::<usize>()];
-        bst.resize(&mut new_mem);
+        bst.expand(&mut new_mem);
 
         assert_eq!(bst.len(), 10);
         assert_eq!(bst.capacity(), 20);

--- a/core/patina_internal_collections/src/node.rs
+++ b/core/patina_internal_collections/src/node.rs
@@ -178,16 +178,19 @@ impl<'a, D> Storage<'a, D>
 where
     D: SliceKey + Copy,
 {
-    /// Resizes the storage container to a new slice of memory.
+    /// Expands the storage capacity by moving nodes to a new, larger buffer.
+    ///
+    /// This function cannot shrink the storage capacity - it only allows expansion.
+    /// All nodes (including gaps from deleted nodes) are copied to preserve the tree structure.
     ///
     /// # Panics
     ///
-    /// Panics if the new slice is smaller than the current length of the storage container.
+    /// Panics if the new slice is smaller than the current capacity of the storage container.
     ///
     /// # Time Complexity
     ///
     /// O(n)
-    pub fn resize(&mut self, slice: &'a mut [u8]) {
+    pub fn expand(&mut self, slice: &'a mut [u8]) {
         // SAFETY: This is reinterpreting a byte slice as a Node<D> slice.
         // 1. The alignment is handled by slice casting rules
         // 2. The correct number of Node<D> elements that fit in the byte slice is calculated
@@ -199,7 +202,7 @@ where
             )
         };
 
-        assert!(buffer.len() >= self.len());
+        assert!(buffer.len() >= self.capacity());
 
         // When current capacity is 0, we just need to copy the data and build the available list
         if self.capacity() == 0 {
@@ -210,7 +213,7 @@ where
         }
 
         // Copy the data from the old buffer to the new buffer. Update the pointers to the new buffer
-        for i in 0..self.len() {
+        for i in 0..self.capacity() {
             let old = &self.data[i];
 
             buffer[i].data = old.data;
@@ -240,8 +243,12 @@ where
 
         let idx = if !self.available.get().is_null() { self.idx(self.available.get()) } else { self.len() };
 
-        Self::build_linked_list(&buffer[idx..]);
-        self.available.set(buffer[idx].as_mut_ptr());
+        if idx < buffer.len() {
+            Self::build_linked_list(&buffer[idx..]);
+            self.available.set(buffer[idx].as_mut_ptr());
+        } else {
+            self.available.set(core::ptr::null_mut());
+        }
 
         self.data = buffer;
     }
@@ -701,6 +708,29 @@ mod tests {
     }
 
     #[test]
+    fn test_expand_with_no_free_space() {
+        const CAPACITY: usize = 5;
+        let mut memory = [0; CAPACITY * node_size::<usize>()];
+        let mut storage = Storage::<usize>::with_capacity(&mut memory);
+
+        // Fill all the storage
+        for i in 0..CAPACITY {
+            storage.add(i).unwrap();
+        }
+
+        // Expand to the exact same capacity (no free space)
+        let mut new_memory = [0; CAPACITY * node_size::<usize>()];
+        storage.expand(&mut new_memory);
+
+        // Verify that available is null indicating no free space
+        assert!(storage.available.get().is_null());
+
+        // Verify that no more nodes can be added
+        assert!(storage.add(99).is_err());
+        assert_eq!(storage.len(), CAPACITY);
+    }
+
+    #[test]
     fn test_swap_works() {
         let p1 = Node::new(1);
         let p2 = Node::new(2);
@@ -752,5 +782,80 @@ mod tests {
         assert_eq!(l1.parent_ptr(), node2.as_mut_ptr());
         assert_eq!(node2.right_ptr(), r1.as_mut_ptr());
         assert_eq!(r1.parent_ptr(), node2.as_mut_ptr());
+    }
+
+    #[test]
+    #[should_panic(expected = "assertion failed: buffer.len() >= self.capacity()")]
+    fn test_expand_prevents_capacity_shrink() {
+        // Verify that expand() prevents shrinking capacity
+        const INITIAL_SIZE: usize = 10;
+        let mut initial_memory = [0; INITIAL_SIZE * node_size::<usize>()];
+        let mut storage = Storage::<usize>::with_capacity(&mut initial_memory);
+
+        // Add some nodes
+        storage.add(100).unwrap();
+        storage.add(200).unwrap();
+        storage.add(300).unwrap();
+
+        // Now storage has capacity=10, length=3
+        assert_eq!(storage.capacity(), 10);
+        assert_eq!(storage.len(), 3);
+
+        // Try to expand to smaller capacity (5 < 10)
+        // This should panic because we're shrinking capacity
+        const SMALLER_SIZE: usize = 5;
+        let mut smaller_memory = [0; SMALLER_SIZE * node_size::<usize>()];
+        storage.expand(&mut smaller_memory); // Should panic here
+    }
+
+    #[test]
+    fn test_expand_copies_all_nodes_including_gaps() {
+        // Test that expand copies ALL nodes (capacity), not just len() nodes
+        // Buffer layout: [VALID | VALID | INVALID | VALID | INVALID]
+        const INITIAL_SIZE: usize = 10;
+        let mut initial_memory = [0; INITIAL_SIZE * node_size::<usize>()];
+        let mut storage = Storage::<usize>::with_capacity(&mut initial_memory);
+
+        // Add 5 nodes at indices 0-4
+        storage.add(100).unwrap(); // idx 0
+        storage.add(200).unwrap(); // idx 1
+        storage.add(300).unwrap(); // idx 2
+        storage.add(400).unwrap(); // idx 3
+        storage.add(500).unwrap(); // idx 4
+
+        // Delete nodes at indices 2 and 3 to create gaps
+        let node2_ptr = storage.get_mut(2).unwrap().as_mut_ptr();
+        let node3_ptr = storage.get_mut(3).unwrap().as_mut_ptr();
+        storage.delete(node2_ptr);
+        storage.delete(node3_ptr);
+
+        // Now add nodes that will use higher indices
+        storage.add(600).unwrap(); // Reuses idx 3
+        storage.add(700).unwrap(); // Reuses idx 2
+        storage.add(800).unwrap(); // idx 5
+        storage.add(900).unwrap(); // idx 6
+
+        // Storage now has: capacity=10, len=7
+        // Valid nodes spread across indices with gaps
+        assert_eq!(storage.capacity(), 10);
+        assert_eq!(storage.len(), 7);
+
+        // Expand to larger capacity - should copy ALL nodes including invalid ones
+        const LARGER_SIZE: usize = 20;
+        let mut larger_memory = [0; LARGER_SIZE * node_size::<usize>()];
+        storage.expand(&mut larger_memory);
+
+        // Verify all 7 nodes are still accessible
+        assert_eq!(storage.len(), 7);
+        assert_eq!(storage.capacity(), 20);
+
+        // Verify we can access all nodes
+        assert!(storage.get(0).is_some());
+        assert!(storage.get(1).is_some());
+        assert!(storage.get(2).is_some());
+        assert!(storage.get(3).is_some());
+        assert!(storage.get(4).is_some());
+        assert!(storage.get(5).is_some());
+        assert!(storage.get(6).is_some());
     }
 }

--- a/core/patina_internal_collections/src/rbt.rs
+++ b/core/patina_internal_collections/src/rbt.rs
@@ -34,7 +34,7 @@ where
     ///
     /// This is useful for creating a tree at compile time and replacing the memory later. Use
     /// [with_capacity](Self::with_capacity) to create a tree with a given slice of memory immediately. Otherwise use
-    /// [resize](Self::resize) to replace the memory later.
+    /// [expand](Self::expand) to replace the memory later.
     pub const fn new() -> Self {
         Rbt { storage: Storage::new(), root: Cell::new(core::ptr::null_mut()) }
     }
@@ -843,11 +843,18 @@ impl<'a, D> Rbt<'a, D>
 where
     D: SliceKey + Copy + 'a,
 {
-    /// Replaces the memory of the tree with a new slice, copying the data from the old slice to the new slice.
-    pub fn resize(&mut self, slice: &'a mut [u8]) {
+    /// Expands the tree's storage capacity to a new, larger buffer.
+    ///
+    /// This function cannot shrink the storage capacity - it only allows expansion.
+    /// All nodes are copied to the new buffer to preserve the tree structure.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the new slice is smaller than the current capacity.
+    pub fn expand(&mut self, slice: &'a mut [u8]) {
         let root = (!self.root.get().is_null()).then(|| self.storage.idx(self.root.get()));
 
-        self.storage.resize(slice);
+        self.storage.expand(slice);
 
         if let Some(idx) = root {
             self.root.set(self.storage.get_mut(idx).expect("Pointer Exists."));
@@ -1773,11 +1780,11 @@ mod tests {
     }
 
     #[test]
-    fn test_simple_resize() {
+    fn test_simple_expand() {
         let mut rbt = Rbt::<usize>::new();
 
         let mut mem = [0; 20 * node_size::<usize>()];
-        rbt.resize(&mut mem);
+        rbt.expand(&mut mem);
 
         for i in 0..10 {
             assert!(rbt.add(i).is_ok());
@@ -1789,7 +1796,7 @@ mod tests {
     }
 
     #[test]
-    fn test_resize_with_existing_data() {
+    fn test_expand_with_existing_data() {
         let mut mem = [0; 10 * node_size::<usize>()];
         let mut rbt = Rbt::<usize>::with_capacity(&mut mem);
 
@@ -1801,7 +1808,7 @@ mod tests {
         }
 
         let mut new_mem = [0; 20 * node_size::<usize>()];
-        rbt.resize(&mut new_mem);
+        rbt.expand(&mut new_mem);
 
         assert_eq!(rbt.len(), 10);
         assert_eq!(rbt.capacity(), 20);

--- a/core/patina_internal_cpu/src/cpu/aarch64/cpu.rs
+++ b/core/patina_internal_cpu/src/cpu/aarch64/cpu.rs
@@ -37,7 +37,7 @@ impl EfiCpuAarch64 {
         loop {
             match _op {
                 CpuFlushType::EfiCpuFlushTypeWriteBack => self.clean_data_entry_by_mva(aligned_addr),
-                CpuFlushType::EFiCpuFlushTypeInvalidate => self.invalidate_data_cache_entry_by_mva(aligned_addr),
+                CpuFlushType::EfiCpuFlushTypeInvalidate => self.invalidate_data_cache_entry_by_mva(aligned_addr),
                 CpuFlushType::EfiCpuFlushTypeWriteBackInvalidate => {
                     self.clean_and_invalidate_data_entry_by_mva(aligned_addr)
                 }
@@ -52,6 +52,7 @@ impl EfiCpuAarch64 {
         #[cfg(all(not(test), target_arch = "aarch64"))]
         {
             // we have a data barrier after all cache lines have had the operation performed on them as an optimization
+            // SAFETY: a data barrier has no impact on safety invariants.
             unsafe {
                 asm!("dsb sy", options(nostack));
             }
@@ -61,6 +62,7 @@ impl EfiCpuAarch64 {
     fn clean_data_entry_by_mva(&self, _mva: efi::PhysicalAddress) {
         #[cfg(all(not(test), target_arch = "aarch64"))]
         {
+            // SAFETY: Cleaning the data cache has no impact on safety invariants.
             unsafe {
                 asm!("dc cvac, {}", in(reg) _mva, options(nostack, preserves_flags));
             }
@@ -70,6 +72,9 @@ impl EfiCpuAarch64 {
     fn invalidate_data_cache_entry_by_mva(&self, _mva: efi::PhysicalAddress) {
         #[cfg(all(not(test), target_arch = "aarch64"))]
         {
+            // SAFETY: Invalidating the data cache does not impact safety checks. It
+            // does have the potential to corrupt memory if used incorrectly, but the caller is
+            // expected to ensure that they are using this function correctly.
             unsafe {
                 asm!("dc ivac, {}", in(reg) _mva, options(nostack, preserves_flags));
             }
@@ -79,6 +84,7 @@ impl EfiCpuAarch64 {
     fn clean_and_invalidate_data_entry_by_mva(&self, _mva: efi::PhysicalAddress) {
         #[cfg(all(not(test), target_arch = "aarch64"))]
         {
+            // SAFETY: Cleaning and invalidating the data cache does not impact safety invariants.
             unsafe {
                 asm!("dc civac, {}", in(reg) _mva, options(nostack, preserves_flags));
             }
@@ -88,6 +94,7 @@ impl EfiCpuAarch64 {
     fn data_cache_line_len(&self) -> u64 {
         cfg_if::cfg_if! {
             if #[cfg(all(not(test), target_arch = "aarch64"))]  {
+                // SAFETY: Reading ctr_el0 has no impact on safety invariants.
                 let ctr_el0 = unsafe {
                     let ctr_el0: u64;
                     asm!("mrs {}, ctr_el0", out(reg) ctr_el0);
@@ -118,11 +125,11 @@ impl EfiCpuAarch64 {
 impl Cpu for EfiCpuAarch64 {
     fn flush_data_cache(
         &self,
-        _start: efi::PhysicalAddress,
-        _length: u64,
+        start: efi::PhysicalAddress,
+        length: u64,
         flush_type: CpuFlushType,
     ) -> Result<(), EfiError> {
-        self.cache_range_operation(_start, _length, flush_type);
+        self.cache_range_operation(start, length, flush_type);
         Ok(())
     }
 
@@ -157,7 +164,7 @@ mod tests {
 
         let start: efi::PhysicalAddress = 0;
         let length: u64 = 0;
-        let flush_type: CpuFlushType = CpuFlushType::EFiCpuFlushTypeInvalidate;
+        let flush_type: CpuFlushType = CpuFlushType::EfiCpuFlushTypeInvalidate;
         assert_eq!(cpu_init.flush_data_cache(start, length, flush_type), Ok(()));
 
         let start: efi::PhysicalAddress = 0;

--- a/core/patina_internal_cpu/src/cpu/x64/cpu.rs
+++ b/core/patina_internal_cpu/src/cpu/x64/cpu.rs
@@ -113,7 +113,7 @@ impl EfiCpuX64 {
 
     fn initialize_fpu(&self) {
         #[cfg(all(not(test), target_arch = "x86_64"))]
-        // Safety: This assembly writes only hard coded values to CR4 register, and MMX and FPU control words. No
+        // SAFETY: This assembly writes only hard coded values to CR4 register, and MMX and FPU control words. No
         // inputs are used that could violate memory safety.
         unsafe {
             // sdm vol. 1, x87 FPU Control Word configuration
@@ -154,7 +154,7 @@ impl Cpu for EfiCpuX64 {
                 self.asm_wbinvd();
                 Ok(())
             }
-            CpuFlushType::EFiCpuFlushTypeInvalidate => {
+            CpuFlushType::EfiCpuFlushTypeInvalidate => {
                 self.asm_invd();
                 Ok(())
             }
@@ -210,7 +210,7 @@ mod tests {
 
         let start: efi::PhysicalAddress = 0;
         let length: u64 = 0;
-        let flush_type: CpuFlushType = CpuFlushType::EFiCpuFlushTypeInvalidate;
+        let flush_type: CpuFlushType = CpuFlushType::EfiCpuFlushTypeInvalidate;
         assert_eq!(x64_cpu_init.flush_data_cache(start, length, flush_type), Ok(()));
 
         let start: efi::PhysicalAddress = 0;

--- a/core/patina_internal_cpu/src/interrupts.rs
+++ b/core/patina_internal_cpu/src/interrupts.rs
@@ -30,6 +30,9 @@ mod stub;
 #[cfg(any(target_arch = "x86_64", test))]
 mod x64;
 
+#[cfg(target_arch = "aarch64")]
+pub use aarch64::gic_manager;
+
 // For std builds, publish the stub version of the interrupt functions.
 cfg_if::cfg_if! {
     if #[cfg(not(target_os = "uefi"))] {
@@ -58,7 +61,6 @@ cfg_if::cfg_if! {
         pub use x64::get_interrupt_state;
     } else if #[cfg(target_arch = "aarch64")] {
         pub type Interrupts = aarch64::InterruptsAarch64;
-        pub use aarch64::gic_manager;
         pub use aarch64::enable_interrupts;
         pub use aarch64::disable_interrupts;
         pub use aarch64::get_interrupt_state;

--- a/core/patina_internal_cpu/src/interrupts/aarch64.rs
+++ b/core/patina_internal_cpu/src/interrupts/aarch64.rs
@@ -11,7 +11,7 @@ use crate::log_registers;
 use patina::{error::EfiError, pi::protocols::cpu_arch::EfiSystemContext};
 use patina_stacktrace::{StackFrame, StackTrace};
 
-#[cfg(not(test))]
+#[cfg(target_arch = "aarch64")]
 pub mod gic_manager;
 mod interrupt_manager;
 #[cfg(not(test))]

--- a/core/patina_internal_cpu/src/interrupts/aarch64/gic_manager.rs
+++ b/core/patina_internal_cpu/src/interrupts/aarch64/gic_manager.rs
@@ -105,7 +105,7 @@ impl AArch64InterruptInitializer {
         }
 
         // Convert raw GIC address pointers to appropriate types.
-        // Safety: function safety requirements guarantee exclusive access to the GICR registers.
+        // SAFETY: function safety requirements guarantee exclusive access to the GICR registers.
         let (gicd, gicr) = unsafe {
             let gicd = UniqueMmioPointer::new(NonNull::new(gicd_base as _).ok_or(EfiError::InvalidParameter)?);
             let gicr = NonNull::new(gicr_base as _).ok_or(EfiError::InvalidParameter)?;
@@ -119,7 +119,7 @@ impl AArch64InterruptInitializer {
         let mpidr = read_sysreg!(MPIDR_EL1) & MPIDR_AFFINITY_MASK;
         log::debug!("Current CPU MPIDR: {:#x}", mpidr);
         // Support for GIC v4 is backward compatible with GIC v3, so always enable it.
-        // Safety: function safety requirements guarantee exclusive access to the GICR registers.
+        // SAFETY: function safety requirements guarantee exclusive access to the GICR registers.
         for (index, redistributor) in unsafe { GicRedistributorIterator::new(gicr, true) }.enumerate() {
             r_count = index + 1;
             if redistributor.typer().core_mpidr() == mpidr {
@@ -153,12 +153,12 @@ impl AArch64InterruptInitializer {
         // Enable gic distributor
         // Enable support for GICv4; this is backward compatible with GICv3, so always enable it.
 
-        // Safety: function safety requirements guarantee exclusive access to the GICR registers.
+        // SAFETY: function safety requirements guarantee exclusive access to the GICR registers.
         let mut gic_v3 = unsafe { GicV3::new(gicd, gicr, r_count, true) };
         gic_v3.setup(cpu_r_idx);
 
         // Set binary point reg to 0x7 (no preemption)
-        // Safety: this is a legal value for BPR1 register.
+        // SAFETY: this is a legal value for BPR1 register.
         // Refer to "Arm Generic Interrupt Controller Architecture Specification GIC
         // architecture version 3 and Version 4" (Arm IHI 0069H.b ID041224)
         // 12.2.5: "ICC_BPR1_EL1, Interrupt Controller Binary Point Register 1"

--- a/core/patina_internal_cpu/src/paging/aarch64.rs
+++ b/core/patina_internal_cpu/src/paging/aarch64.rs
@@ -64,9 +64,7 @@ pub fn create_cpu_aarch64_paging<A: PageAllocator + 'static>(
 
 #[cfg(test)]
 #[coverage(off)]
-#[cfg(target_arch = "x86_64")] // Issue #1071
 mod tests {
-    use std::alloc::{Layout, alloc, dealloc};
 
     use super::*;
     use mockall::mock;
@@ -97,7 +95,7 @@ mod tests {
 
         let mut paging = EfiCpuPagingAArch64 { paging: mock_page_table };
 
-        let result = paging.map_memory_region(0x1000, 0x1000, MemoryAttributes::Uncacheable);
+        let result = paging.map_memory_region(0x1000, 0x1000, MemoryAttributes::Uncached);
         assert!(result.is_ok());
     }
 
@@ -121,7 +119,7 @@ mod tests {
 
         let mut paging = EfiCpuPagingAArch64 { paging: mock_page_table };
 
-        let result = paging.map_memory_region(0x1000, 0x1000, MemoryAttributes::Uncacheable);
+        let result = paging.map_memory_region(0x1000, 0x1000, MemoryAttributes::Uncached);
         assert!(result.is_ok());
     }
 
@@ -131,33 +129,12 @@ mod tests {
 
         mock_page_table
             .expect_query_memory_region()
-            .returning(|_, _| Ok(MemoryAttributes::Writeback | MemoryAttributes::Uncacheable));
+            .returning(|_, _| Ok(MemoryAttributes::Writeback | MemoryAttributes::Uncached));
 
         let paging = EfiCpuPagingAArch64 { paging: mock_page_table };
 
         let result = paging.query_memory_region(0x1000, 0x1000);
         assert!(result.is_ok());
-        assert_eq!(result.unwrap(), MemoryAttributes::Writeback | MemoryAttributes::Uncacheable);
-    }
-
-    #[test]
-    fn test_create_cpu_aarch64_paging() {
-        let mut mock_page_allocator = MockPageAllocator::new();
-
-        // Create a memory layout with the specified size and alignment
-        let layout = Layout::from_size_align(4096, 4096).unwrap();
-        // Allocate the memory
-        let ptr = unsafe { alloc(layout) };
-        let ptr_u64 = ptr as u64;
-
-        mock_page_allocator.expect_allocate_page().returning(move |_, _, _| Ok(ptr_u64));
-
-        let res = create_cpu_aarch64_paging(mock_page_allocator);
-        assert!(res.is_ok());
-
-        // Deallocate the memory when done unsafe
-        unsafe {
-            dealloc(ptr, layout);
-        }
+        assert_eq!(result.unwrap(), MemoryAttributes::Writeback | MemoryAttributes::Uncached);
     }
 }

--- a/core/patina_internal_cpu/src/paging/x64.rs
+++ b/core/patina_internal_cpu/src/paging/x64.rs
@@ -72,7 +72,7 @@ where
         // start by getting the caching attributes as we need to return those even if the page is unmapped in the
         // page table
         let cache_attr = match self.mtrr.get_memory_attribute(address) {
-            MtrrMemoryCacheType::Uncacheable => CacheAttributeValue::Valid(MemoryAttributes::Uncacheable),
+            MtrrMemoryCacheType::Uncacheable => CacheAttributeValue::Valid(MemoryAttributes::Uncached),
             MtrrMemoryCacheType::WriteCombining => CacheAttributeValue::Valid(MemoryAttributes::WriteCombining),
             MtrrMemoryCacheType::WriteThrough => CacheAttributeValue::Valid(MemoryAttributes::WriteThrough),
             MtrrMemoryCacheType::WriteProtected => CacheAttributeValue::Valid(MemoryAttributes::WriteProtect),
@@ -109,7 +109,7 @@ fn apply_caching_attributes<M: Mtrr>(
         }
 
         let cache_type = match cache_attributes {
-            MemoryAttributes::Uncacheable => MtrrMemoryCacheType::Uncacheable,
+            MemoryAttributes::Uncached => MtrrMemoryCacheType::Uncacheable,
             MemoryAttributes::WriteCombining => MtrrMemoryCacheType::WriteCombining,
             MemoryAttributes::WriteThrough => MtrrMemoryCacheType::WriteThrough,
             MemoryAttributes::WriteProtect => MtrrMemoryCacheType::WriteProtected,
@@ -216,7 +216,7 @@ mod tests {
 
         let mut paging = EfiCpuPagingX64 { paging: mock_page_table, mtrr: mock_mtrr };
 
-        let result = paging.map_memory_region(0x1000, 0x1000, MemoryAttributes::Uncacheable);
+        let result = paging.map_memory_region(0x1000, 0x1000, MemoryAttributes::Uncached);
         assert!(result.is_ok());
     }
 
@@ -245,7 +245,7 @@ mod tests {
 
         let mut paging = EfiCpuPagingX64 { paging: mock_page_table, mtrr: mock_mtrr };
 
-        let result = paging.map_memory_region(0x1000, 0x1000, MemoryAttributes::Uncacheable);
+        let result = paging.map_memory_region(0x1000, 0x1000, MemoryAttributes::Uncached);
         assert!(result.is_ok());
     }
 
@@ -261,6 +261,6 @@ mod tests {
 
         let result = paging.query_memory_region(0x1000, 0x1000);
         assert!(result.is_ok());
-        assert_eq!(result.unwrap(), MemoryAttributes::Writeback | MemoryAttributes::Uncacheable);
+        assert_eq!(result.unwrap(), MemoryAttributes::Writeback | MemoryAttributes::Uncached);
     }
 }

--- a/docs/src/background/uefi_memory_safety_case_studies.md
+++ b/docs/src/background/uefi_memory_safety_case_studies.md
@@ -16,17 +16,17 @@ production systems and required security patches.
 
 The are actual CVEs found in UEFI firmware that could have been prevented with the memory safety features in Rust.
 
-| CVE ID | CVSS Score | Vulnerability Type | Potential Rust Prevention Mechanism |
-|--------|------------|-------------------|------------------------------------|
-| [CVE-2023-45230](https://nvd.nist.gov/vuln/detail/CVE-2023-45230) | 8.3 (HIGH) | Buffer Overflow in DHCPv6 | Automatic slice bounds checking |
-| [CVE-2022-36765](https://nvd.nist.gov/vuln/detail/CVE-2022-36765) | 7.0 (HIGH) | Integer Overflow in CreateHob() | Checked arithmetic operations |
-| [CVE-2023-45229](https://nvd.nist.gov/vuln/detail/CVE-2023-45229) | 6.5 (MEDIUM) | Out-of-Bounds Read in DHCPv6 | Slice bounds verification |
-| [CVE-2014-8271](https://nvd.nist.gov/vuln/detail/CVE-2014-8271) | 6.8 (MEDIUM) | Buffer Overflow in Variable Processing | Dynamic Vec sizing eliminates fixed buffers |
-| [CVE-2023-45233](https://nvd.nist.gov/vuln/detail/CVE-2023-45233) | 7.5 (HIGH) | Infinite Loop in IPv6 Parsing | Iterator patterns with explicit termination |
-| [CVE-2021-38575](https://nvd.nist.gov/vuln/detail/CVE-2021-38575) | 8.1 (HIGH) | Remote Buffer Overflow in iSCSI | Slice-based network parsing with bounds checking |
-| [CVE-2019-14563](https://nvd.nist.gov/vuln/detail/CVE-2019-14563) | 7.8 (HIGH) | Integer Truncation | Explicit type conversions with error handling |
-| [CVE-2024-1298](https://nvd.nist.gov/vuln/detail/CVE-2024-1298) | 6.0 (MEDIUM) | Division by Zero from Integer Overflow | Checked arithmetic prevents overflow-induced division by zero |
-| [CVE-2014-4859](https://nvd.nist.gov/vuln/detail/CVE-2014-4859) | Not specified | Integer Overflow in Capsule Update | Safe arithmetic with explicit overflow checking |
+| CVE ID                                                            | CVSS Score    | Vulnerability Type                     | Potential Rust Prevention Mechanism                           |
+| ----------------------------------------------------------------- | ------------- | -------------------------------------- | ------------------------------------------------------------- |
+| [CVE-2023-45230](https://nvd.nist.gov/vuln/detail/CVE-2023-45230) | 8.3 (HIGH)    | Buffer Overflow in DHCPv6              | Automatic slice bounds checking                               |
+| [CVE-2022-36765](https://nvd.nist.gov/vuln/detail/CVE-2022-36765) | 7.0 (HIGH)    | Integer Overflow in CreateHob()        | Checked arithmetic operations                                 |
+| [CVE-2023-45229](https://nvd.nist.gov/vuln/detail/CVE-2023-45229) | 6.5 (MEDIUM)  | Out-of-Bounds Read in DHCPv6           | Slice bounds verification                                     |
+| [CVE-2014-8271](https://nvd.nist.gov/vuln/detail/CVE-2014-8271)   | 6.8 (MEDIUM)  | Buffer Overflow in Variable Processing | Dynamic Vec sizing eliminates fixed buffers                   |
+| [CVE-2023-45233](https://nvd.nist.gov/vuln/detail/CVE-2023-45233) | 7.5 (HIGH)    | Infinite Loop in IPv6 Parsing          | Iterator patterns with explicit termination                   |
+| [CVE-2021-38575](https://nvd.nist.gov/vuln/detail/CVE-2021-38575) | 8.1 (HIGH)    | Remote Buffer Overflow in iSCSI        | Slice-based network parsing with bounds checking              |
+| [CVE-2019-14563](https://nvd.nist.gov/vuln/detail/CVE-2019-14563) | 7.8 (HIGH)    | Integer Truncation                     | Explicit type conversions with error handling                 |
+| [CVE-2024-1298](https://nvd.nist.gov/vuln/detail/CVE-2024-1298)   | 6.0 (MEDIUM)  | Division by Zero from Integer Overflow | Checked arithmetic prevents overflow-induced division by zero |
+| [CVE-2014-4859](https://nvd.nist.gov/vuln/detail/CVE-2014-4859)   | Not specified | Integer Overflow in Capsule Update     | Safe arithmetic with explicit overflow checking               |
 
 ## Vulnerability Classes Eliminated by Rust
 
@@ -342,7 +342,7 @@ fn safe_wrapper(ptr: *const u8) -> Option<u8> {
     }
 
     unsafe {
-        // Safety: We checked for null above
+        // SAFETY: We checked for null above
         Some(*ptr)
     }
 }
@@ -373,7 +373,7 @@ The Rust compiler and tools in the ecosystem enforce that unsafe functions docum
 unsafe fn parse_network_packet(data_ptr: *const u8, len: usize) -> Result<Packet, ParseError> {
     // Implementation that works with raw bytes from network
     let slice = unsafe {
-        // Safety: Caller guarantees ptr and len are valid
+        // SAFETY: Caller guarantees ptr and len are valid
         std::slice::from_raw_parts(data_ptr, len)
     };
 
@@ -423,7 +423,7 @@ impl NetworkBuffer {
 
         // All unsafe operations are contained within this implementation
         unsafe {
-            // Safety: We verified bounds above and self.data is always valid
+            // SAFETY: We verified bounds above and self.data is always valid
             let ptr = self.data.as_ptr().add(offset);
             let remaining = self.len() - offset;
             parse_network_packet(ptr, remaining).map_err(|_| NetworkError::OffsetOutOfBounds())

--- a/docs/src/rfc/text/0022-core-static.md
+++ b/docs/src/rfc/text/0022-core-static.md
@@ -348,7 +348,7 @@ impl <P: Platform> Core<P> {
             return efi::Status::INVALID_PARAMETER;
         }
 
-        // Safety: caller must ensure that file_name is a valid pointer. It is null-checked above.
+        // SAFETY: caller must ensure that file_name is a valid pointer. It is null-checked above.
         let file_name = unsafe { file_name.read_unaligned() };
 
         match Self::instance().uefi_state.dispatcher_context.trust(firmware_volume_handle, &file_name) {

--- a/patina_dxe_core/src/allocator.rs
+++ b/patina_dxe_core/src/allocator.rs
@@ -568,6 +568,8 @@ impl AllocatorMap {
 
     // resets the ALLOCATOR map to empty and resets the static allocators.
     #[cfg(test)]
+    // SAFETY: Caller must ensure that no allocations are active and that no other
+    // contexts can concurrently access the allocator during this call.
     unsafe fn reset(&mut self) {
         self.map.clear();
         let _ = for_each_static_allocator!(alloc => {
@@ -590,7 +592,7 @@ extern "efiapi" fn allocate_pool(pool_type: efi::MemoryType, size: usize, buffer
 
     match core_allocate_pool(pool_type, size) {
         Err(err) => err.into(),
-        // Safety: caller must ensure that buffer is a valid pointer. It is null-checked above.
+        // SAFETY: caller must ensure that buffer is a valid pointer. It is null-checked above.
         Ok(allocation) => unsafe {
             buffer.write_unaligned(allocation);
             efi::Status::SUCCESS
@@ -608,7 +610,7 @@ pub fn core_allocate_pool(pool_type: efi::MemoryType, size: usize) -> Result<*mu
     match ALLOCATORS.lock().get_or_create_allocator(pool_type, handle) {
         Ok(allocator) => {
             let mut buffer: *mut c_void = core::ptr::null_mut();
-
+            // SAFETY: buffer is declared above, we pass the address which guarantees it is a valid pointer.
             unsafe { allocator.allocate_pool(size, core::ptr::addr_of_mut!(buffer)).map(|_| buffer) }
         }
         Err(err) => Err(err),
@@ -627,6 +629,8 @@ pub fn core_free_pool(buffer: *mut c_void) -> Result<(), EfiError> {
         return Err(EfiError::InvalidParameter);
     }
     let allocators = ALLOCATORS.lock();
+    // SAFETY: caller must ensure that buffer is a valid pointer and that it was
+    // originally allocated via allocate_pool(). It is null-checked above.
     unsafe {
         if for_each_static_allocator!(alloc => alloc.free_pool(buffer).is_ok())
             || allocators.iter_dynamic().any(|allocator| allocator.free_pool(buffer).is_ok())
@@ -674,12 +678,12 @@ pub fn core_allocate_pages(
             let result = match allocation_type {
                 efi::ALLOCATE_ANY_PAGES => allocator.allocate_pages(DEFAULT_ALLOCATION_STRATEGY, pages, alignment),
                 efi::ALLOCATE_MAX_ADDRESS => {
-                    // Safety: caller must ensure that "memory" is a valid pointer. It is null-checked above.
+                    // SAFETY: caller must ensure that "memory" is a valid pointer. It is null-checked above.
                     let address = unsafe { memory.read_unaligned() };
                     allocator.allocate_pages(AllocationStrategy::TopDown(Some(address as usize)), pages, alignment)
                 }
                 efi::ALLOCATE_ADDRESS => {
-                    // Safety: caller must ensure that "memory" is a valid pointer. It is null-checked above.
+                    // SAFETY: caller must ensure that "memory" is a valid pointer. It is null-checked above.
                     let address = unsafe { memory.read_unaligned() };
                     allocator.allocate_pages(AllocationStrategy::Address(address as usize), pages, alignment)
                 }
@@ -687,7 +691,7 @@ pub fn core_allocate_pages(
             };
 
             if let Ok(ptr) = result {
-                // Safety: caller must ensure that "memory" is a valid pointer. It is null-checked above.
+                // SAFETY: caller must ensure that "memory" is a valid pointer. It is null-checked above.
                 unsafe { memory.write_unaligned(ptr.expose_provenance().get() as u64) }
                 Ok(())
             } else {
@@ -746,6 +750,8 @@ pub fn core_free_pages(memory: efi::PhysicalAddress, pages: usize) -> Result<(),
 
     let mut memory_type = efi::CONVENTIONAL_MEMORY;
 
+    // SAFETY: caller must ensure that memory is a valid address and that they have
+    // exclusive ownership of this memory. It is validated above.
     let res = unsafe {
         if try_each_static_allocator!(memory_type, alloc => {
             alloc.free_pages(memory as usize, pages)
@@ -779,12 +785,12 @@ pub fn core_free_pages(memory: efi::PhysicalAddress, pages: usize) -> Result<(),
 }
 
 extern "efiapi" fn copy_mem(destination: *mut c_void, source: *mut c_void, length: usize) {
-    // Safety: caller must ensure that the source and destination are valid for length bytes.
+    // SAFETY: caller must ensure that the source and destination are valid for length bytes.
     unsafe { core::ptr::copy(source as *mut u8, destination as *mut u8, length) }
 }
 
 extern "efiapi" fn set_mem(buffer: *mut c_void, size: usize, value: u8) {
-    // Safety: caller must ensure that the buffer is valid for size bytes.
+    // SAFETY: caller must ensure that the buffer is valid for size bytes.
     unsafe {
         let dst_buffer = from_raw_parts_mut(buffer as *mut u8, size);
         dst_buffer.fill(value);
@@ -803,20 +809,21 @@ extern "efiapi" fn get_memory_map(
     }
 
     if !descriptor_size.is_null() {
-        // Safety: caller must ensure that descriptor_size is a valid pointer if it is not null.
+        // SAFETY: caller must ensure that descriptor_size is a valid pointer if it is not null.
         unsafe { descriptor_size.write_unaligned(mem::size_of::<efi::MemoryDescriptor>()) };
     }
 
     if !descriptor_version.is_null() {
-        // Safety: caller must ensure that descriptor_version is a valid pointer if it is not null.
+        // SAFETY: caller must ensure that descriptor_version is a valid pointer if it is not null.
         unsafe { descriptor_version.write_unaligned(efi::MEMORY_DESCRIPTOR_VERSION) };
     }
 
-    // Safety: caller must ensure that memory_map_size is a valid pointer. It is null-checked above.
+    // SAFETY: caller must ensure that memory_map_size is a valid pointer. It is null-checked above.
     let map_size = unsafe { memory_map_size.read_unaligned() };
 
     let required_map_size = GCD.memory_descriptor_count_for_efi_memory_map() * mem::size_of::<efi::MemoryDescriptor>();
     assert_ne!(required_map_size, 0);
+    // SAFETY: caller must ensure that memory_map_size is a valid pointer. It is null-checked above.
     unsafe { memory_map_size.write_unaligned(required_map_size) };
     if map_size < required_map_size {
         return efi::Status::BUFFER_TOO_SMALL;
@@ -828,7 +835,7 @@ extern "efiapi" fn get_memory_map(
 
     let descriptor_count = map_size / mem::size_of::<efi::MemoryDescriptor>();
 
-    // Safety: caller must ensure that memory_map is a valid pointer for at least descriptor_count elements.
+    // SAFETY: caller must ensure that memory_map is a valid pointer for at least descriptor_count elements.
     // It is null-checked above and the size has been validated.
     let buffer = unsafe { slice::from_raw_parts_mut(memory_map, descriptor_count) };
 
@@ -839,10 +846,10 @@ extern "efiapi" fn get_memory_map(
     let actual_map_size = actual_count * mem::size_of::<efi::MemoryDescriptor>();
 
     // Write back the actual map size after merging
-    // Safety: caller must ensure that memory_map_size is a valid pointer. It is null-checked above.
+    // SAFETY: caller must ensure that memory_map_size is a valid pointer. It is null-checked above.
     unsafe { memory_map_size.write_unaligned(actual_map_size) };
 
-    // Safety: caller must ensure that map_key is a valid pointer if it is not null.
+    // SAFETY: caller must ensure that map_key is a valid pointer if it is not null.
     unsafe {
         if !map_key.is_null() {
             let memory_map_as_bytes = slice::from_raw_parts(memory_map as *mut u8, actual_map_size);
@@ -1174,7 +1181,7 @@ pub fn init_memory_support(hob_list: &HobList) {
                 let memory_type_slice_ptr = data.as_ptr() as *const EFiMemoryTypeInformation;
                 let memory_type_slice_len = data.len() / mem::size_of::<EFiMemoryTypeInformation>();
 
-                // Safety: this structure comes from the hob list, so it must be 8-byte aligned (meets alignment
+                // SAFETY: this structure comes from the hob list, so it must be 8-byte aligned (meets alignment
                 // requirement for EfiMemoryTypeInformation), and length is calculated above to fit within the
                 // Guid HOB data. Assert if alignment is not as expected.
                 assert_eq!(memory_type_slice_ptr.align_offset(mem::align_of::<EFiMemoryTypeInformation>()), 0);
@@ -1218,7 +1225,8 @@ pub fn init_memory_support(hob_list: &HobList) {
     }
 }
 
-pub fn install_memory_services(bs: &mut efi::BootServices) {
+pub fn install_memory_services(st: &mut EfiSystemTable) {
+    let mut bs = st.boot_services().get();
     bs.allocate_pages = allocate_pages;
     bs.free_pages = free_pages;
     bs.allocate_pool = allocate_pool;
@@ -1226,17 +1234,22 @@ pub fn install_memory_services(bs: &mut efi::BootServices) {
     bs.copy_mem = copy_mem;
     bs.set_mem = set_mem;
     bs.get_memory_map = get_memory_map;
+    st.boot_services().set(bs);
 }
 
 // Resets the ALLOCATOR map to empty and resets the static allocators for test purposes.
+// SAFETY: caller must ensure that they have exclusive access such that no other context
+// can modify any global state while it's being reset. A global lock is required.
 #[cfg(test)]
 pub(crate) unsafe fn reset_allocators() {
+    // SAFETY: call resets global allocator state. Should only be called when no
+    // allocations are active. A lock is used to ensure exclusive access preventing
+    // use while reset occurs.
     unsafe { ALLOCATORS.lock().reset() };
 }
 
 #[cfg(test)]
 #[coverage(off)]
-#[cfg(target_arch = "x86_64")] // Issue #1071
 mod tests {
 
     use crate::{
@@ -1250,6 +1263,9 @@ mod tests {
 
     fn with_locked_state<F: Fn() + std::panic::RefUnwindSafe>(gcd_size: usize, f: F) {
         test_support::with_global_lock(|| {
+            // SAFETY: multiple functions modify global state. Functions are
+            // called within a global lock to ensure exclusive access during
+            // initialization.
             unsafe {
                 test_support::init_test_logger();
                 test_support::init_test_gcd(Some(gcd_size));
@@ -1264,21 +1280,26 @@ mod tests {
     #[test]
     #[allow(unpredictable_function_pointer_comparisons)]
     fn install_memory_support_should_populate_boot_services_ptrs() {
-        let boot_services = core::mem::MaybeUninit::zeroed();
-        let mut boot_services: efi::BootServices = unsafe { boot_services.assume_init() };
-        install_memory_services(&mut boot_services);
-        assert!(boot_services.allocate_pages == allocate_pages);
-        assert!(boot_services.free_pages == free_pages);
-        assert!(boot_services.allocate_pool == allocate_pool);
-        assert!(boot_services.free_pool == free_pool);
-        assert!(boot_services.copy_mem == copy_mem);
-        assert!(boot_services.get_memory_map == get_memory_map);
+        with_locked_state(0x4000000, || {
+            let mut st = EfiSystemTable::allocate_new_table();
+            install_memory_services(&mut st);
+            let bs = st.boot_services().get();
+            assert!(bs.allocate_pages == allocate_pages);
+            assert!(bs.free_pages == free_pages);
+            assert!(bs.allocate_pool == allocate_pool);
+            assert!(bs.free_pool == free_pool);
+            assert!(bs.copy_mem == copy_mem);
+            assert!(bs.get_memory_map == get_memory_map);
+        })
     }
 
     #[test]
     fn init_memory_support_should_process_memory_bucket_hobs() {
         test_support::with_global_lock(|| {
             let physical_hob_list = build_test_hob_list(0x1000000);
+            // SAFETY: multiple functions modify global state. Functions are
+            // called within a global lock to ensure exclusive access during
+            // initialization.
             unsafe {
                 GCD.reset();
                 gcd::init_gcd(physical_hob_list);
@@ -1303,7 +1324,7 @@ mod tests {
             ));
 
             // Required memory allocation hob for stack
-            let mut stack_base_address = 0xEB000;
+            let mut stack_base_address = 0x18B000;
             stack_base_address = (physical_hob_list as u64).wrapping_add(stack_base_address);
             let stack_hob = Hob::MemoryAllocation(&patina::pi::hob::MemoryAllocation {
                 header: patina::pi::hob::header::Hob {
@@ -1342,6 +1363,9 @@ mod tests {
         // to the GCD. This should cause set_memory_space_attributes to fail with NotFound.
         test_support::with_global_lock(|| {
             let physical_hob_list = build_test_hob_list(0x1000000);
+            // SAFETY: multiple functions modify global state. Functions are
+            // called within a global lock to ensure exclusive access during
+            // initialization.
             unsafe {
                 GCD.reset();
                 gcd::init_gcd(physical_hob_list);
@@ -1352,8 +1376,8 @@ mod tests {
             let mut hob_list = HobList::default();
             hob_list.discover_hobs(physical_hob_list);
 
-            // Create a stack HOB at an address NOT in the GCD (such as 0xEB000)
-            let stack_base_address = 0xEB000;
+            // Create a stack HOB at an address NOT in the GCD (such as 0x18B000)
+            let stack_base_address = 0x18B000;
             let stack_pages = 0x20;
 
             let stack_hob = Hob::MemoryAllocation(&patina::pi::hob::MemoryAllocation {
@@ -1385,6 +1409,9 @@ mod tests {
             // 4 MiB of test memory is required because allocator expansion during initialization
             // may need to handle large allocations for memory buckets and HOBs.
             let physical_hob_list = build_test_hob_list(0x400000);
+            // SAFETY: multiple functions modify global state. Functions are
+            // called within a global lock to ensure exclusive access during
+            // initialization.
             unsafe {
                 GCD.reset();
                 gcd::init_gcd(physical_hob_list);
@@ -1396,7 +1423,7 @@ mod tests {
             hob_list.discover_hobs(physical_hob_list);
 
             // Required memory allocation hob for stack
-            let mut stack_base_address = 0xEB000;
+            let mut stack_base_address = 0x18B000;
             stack_base_address = (physical_hob_list as u64).wrapping_add(stack_base_address);
 
             let stack_hob = Hob::MemoryAllocation(&patina::pi::hob::MemoryAllocation {
@@ -1436,11 +1463,25 @@ mod tests {
             {
                 let allocator = allocators.get_allocator(*memory_type).unwrap();
 
-                if *memory_type == efi::BOOT_SERVICES_DATA {
-                    assert_eq!(allocator.stats().claimed_pages, 3);
-                } else {
-                    assert_eq!(allocator.stats().claimed_pages, 1);
-                }
+                let granularity = match *memory_type {
+                    efi::RESERVED_MEMORY_TYPE
+                    | efi::RUNTIME_SERVICES_CODE
+                    | efi::RUNTIME_SERVICES_DATA
+                    | efi::ACPI_MEMORY_NVS => RUNTIME_PAGE_ALLOCATION_GRANULARITY,
+                    _ => DEFAULT_PAGE_ALLOCATION_GRANULARITY,
+                };
+
+                let expected_pages = match *memory_type {
+                    efi::BOOT_SERVICES_DATA => 3, // Stack + build_test_hob_list allocation
+                    _ => granularity / patina::base::SIZE_4KB,
+                };
+
+                let claimed = allocator.stats().claimed_pages;
+                assert_eq!(
+                    claimed, expected_pages,
+                    "For memory type {:?}: expected {}, got {}",
+                    memory_type, expected_pages, claimed
+                );
             }
 
             // Locate stack hob.
@@ -1493,6 +1534,9 @@ mod tests {
             // 4 MiB of test memory is required because allocator expansion during initialization
             // may need to handle large allocations for memory buckets and HOBs.
             let physical_hob_list = build_test_hob_list(0x400000);
+            // SAFETY: multiple functions modify global state. Functions are
+            // called within a global lock to ensure exclusive access during
+            // initialization.
             unsafe {
                 GCD.reset();
                 gcd::init_gcd(physical_hob_list);
@@ -1515,6 +1559,9 @@ mod tests {
             // 4 MiB of test memory is required because allocator expansion during initialization
             // may need to handle large allocations for memory buckets and HOBs.
             let physical_hob_list = build_test_hob_list(0x400000);
+            // SAFETY: multiple functions modify global state. Functions are
+            // called within a global lock to ensure exclusive access during
+            // initialization.
             unsafe {
                 GCD.reset();
                 gcd::init_gcd(physical_hob_list);
@@ -1707,7 +1754,7 @@ mod tests {
             let allocator = &EFI_BOOT_SERVICES_DATA_ALLOCATOR;
             let mut buffer_ptr = core::ptr::null_mut();
 
-            // Safety: allocator is valid for the duration of the test and these asserts are grouped
+            // SAFETY: allocator is valid for the duration of the test and these asserts are grouped
             // in one block to simplify test structure.
             unsafe {
                 assert!(allocator.allocate_pool(0x1000, core::ptr::addr_of_mut!(buffer_ptr)).is_ok());
@@ -1724,7 +1771,7 @@ mod tests {
             let allocator = &EFI_BOOT_SERVICES_CODE_ALLOCATOR;
             let mut buffer_ptr = core::ptr::null_mut();
 
-            // Safety: allocator is valid for the duration of the test and these asserts are grouped
+            // SAFETY: allocator is valid for the duration of the test and these asserts are grouped
             // in one block to simplify test structure.
             unsafe {
                 assert!(allocator.allocate_pool(0x1000, core::ptr::addr_of_mut!(buffer_ptr)).is_ok());
@@ -1744,7 +1791,7 @@ mod tests {
             let allocator = &EFI_RUNTIME_SERVICES_DATA_ALLOCATOR;
             let mut buffer_ptr = core::ptr::null_mut();
 
-            // Safety: allocator is valid for the duration of the test and these asserts are grouped
+            // SAFETY: allocator is valid for the duration of the test and these asserts are grouped
             // in one block to simplify test structure.
             unsafe {
                 assert!(allocator.allocate_pool(0x1000, core::ptr::addr_of_mut!(buffer_ptr)).is_ok());

--- a/patina_dxe_core/src/allocator/uefi_allocator.rs
+++ b/patina_dxe_core/src/allocator/uefi_allocator.rs
@@ -440,7 +440,7 @@ mod tests {
 
                 let mut buffer: *mut c_void = core::ptr::null_mut();
 
-                // Safety: The allocator has been setup and the buffer pointer is valid for the allocation.
+                // SAFETY: The allocator has been setup and the buffer pointer is valid for the allocation.
                 assert!(unsafe { ua.allocate_pool(0x1000, core::ptr::addr_of_mut!(buffer)) }.is_ok());
 
                 // Corrupt the signature to test validation
@@ -452,7 +452,7 @@ mod tests {
                     .unwrap_or_else(|err| panic!("Allocation layout error: {err:#?}"));
 
                 let allocation_info: *mut AllocationInfo = ((buffer as usize) - offset) as *mut AllocationInfo;
-                // Safety: The allocation_info pointer is valid. It was derived from a buffer pointer above.
+                // SAFETY: The allocation_info pointer is valid. It was derived from a buffer pointer above.
                 unsafe {
                     (*allocation_info).signature = 0x01010101; // Corrupt the signature
                 }

--- a/patina_dxe_core/src/allocator/usage_tests/uefi_memory_map.rs
+++ b/patina_dxe_core/src/allocator/usage_tests/uefi_memory_map.rs
@@ -140,7 +140,6 @@
 //!
 
 #[cfg(test)]
-#[cfg(target_arch = "x86_64")] // Issue #1071
 mod tests {
     use crate::{
         allocator::{get_memory_map, init_memory_support, reset_allocators},
@@ -648,7 +647,7 @@ mod tests {
             .with_memory_allocation(MemoryAllocationConfig {
                 memory_type: efi::RUNTIME_SERVICES_DATA,
                 memory_base_address: SIZE_4MB as u64,
-                memory_length: SIZE_4KB as u64,
+                memory_length: crate::allocator::RUNTIME_PAGE_ALLOCATION_GRANULARITY as u64,
                 name: ZERO,
             })
     }

--- a/patina_dxe_core/src/component_dispatcher.rs
+++ b/patina_dxe_core/src/component_dispatcher.rs
@@ -115,7 +115,7 @@ impl Default for ComponentDispatcher {
     }
 }
 
-/// Safety: The ComponentDispatcher is `Send` as all data stored within this structure is owned by it, and not shared.
+/// SAFETY: The ComponentDispatcher is `Send` as all data stored within this structure is owned by it, and not shared.
 unsafe impl Send for ComponentDispatcher {}
 
 impl ComponentDispatcher {

--- a/patina_dxe_core/src/config_tables.rs
+++ b/patina_dxe_core/src/config_tables.rs
@@ -12,7 +12,7 @@ use alloc::{boxed::Box, vec};
 use core::{
     ffi::c_void,
     ptr::{NonNull, slice_from_raw_parts_mut},
-    slice::from_raw_parts,
+    slice::{from_raw_parts, from_raw_parts_mut},
 };
 use patina::error::EfiError;
 use r_efi::efi;
@@ -28,7 +28,7 @@ extern "efiapi" fn install_configuration_table(table_guid: *mut efi::Guid, table
         return efi::Status::INVALID_PARAMETER;
     }
 
-    // Safety: caller must ensure that table_guid is a valid pointer. It is null-checked above.
+    // SAFETY: caller must ensure that table_guid is a valid pointer. It is null-checked above.
     let table_guid = unsafe { table_guid.read_unaligned() };
 
     let mut st_guard = SYSTEM_TABLE.lock();
@@ -50,81 +50,74 @@ pub fn core_install_configuration_table(
     vendor_table: *mut c_void,
     efi_system_table: &mut EfiSystemTable,
 ) -> Result<Option<NonNull<c_void>>, EfiError> {
-    let system_table = efi_system_table.as_mut();
-    //if a table is already present, reconstruct it from the pointer and length in the st.
-    let old_cfg_table = if system_table.configuration_table.is_null() {
-        assert_eq!(system_table.number_of_table_entries, 0);
-        None
-    } else {
-        let ct_slice_box = unsafe {
-            Box::from_raw_in(
-                slice_from_raw_parts_mut(system_table.configuration_table, system_table.number_of_table_entries),
-                &EFI_RUNTIME_SERVICES_DATA_ALLOCATOR,
-            )
-        };
-        Some(ct_slice_box)
-    };
+    let mut system_table = efi_system_table.get();
 
-    let mut old_vendor_table_ptr = None;
-    // construct the new table contents as a vector.
-    let new_table = match old_cfg_table {
-        Some(cfg_table) => {
-            // a configuration table list is already present.
-            let mut current_table = cfg_table.to_vec();
-            let existing_entry = current_table.iter_mut().find(|x| x.vendor_guid == vendor_guid);
-            if !vendor_table.is_null() {
-                // vendor_table is not null; we are adding or modifying an entry.
-                if let Some(entry) = existing_entry {
-                    //entry exists, modify it.
-                    old_vendor_table_ptr = NonNull::new(entry.vendor_table);
-                    entry.vendor_table = vendor_table;
-                } else {
-                    //entry doesn't exist, add it.
-                    current_table.push(efi::ConfigurationTable { vendor_guid, vendor_table });
-                }
+    let (updated_table, old_vendor_table_ptr) = match system_table.configuration_table {
+        existing_tbl_ptr if existing_tbl_ptr.is_null() => {
+            // existing table is empty.
+            if vendor_table.is_null() {
+                // trying to delete a non-existing table
+                return Err(EfiError::NotFound);
             } else {
-                //vendor_table is none; we are deleting an entry.
+                // adding a new table to an empty configuration table list
+                (vec![efi::ConfigurationTable { vendor_guid, vendor_table }], None)
+            }
+        }
+        existing_table_ptr => {
+            // existing table is present. Make a copy of it as a Vec to process the updates.
+            // SAFETY: existing_table_ptr is non-null, and number_of_table_entries is valid.
+            let mut updated_table =
+                unsafe { from_raw_parts_mut(existing_table_ptr, system_table.number_of_table_entries).to_vec() };
+            let existing_entry = updated_table.iter_mut().find(|x| x.vendor_guid == vendor_guid);
+            if vendor_table.is_null() {
+                // deleting an entry.
                 if let Some(entry) = existing_entry {
                     //entry exists, we can delete it
-                    old_vendor_table_ptr = NonNull::new(entry.vendor_table);
-                    current_table.retain(|x| x.vendor_guid != vendor_guid);
+                    let old_vendor_table_ptr = NonNull::new(entry.vendor_table);
+                    updated_table.retain(|x| x.vendor_guid != vendor_guid);
+                    (updated_table, old_vendor_table_ptr)
                 } else {
-                    //entry does not exist, we can't delete it. We have to put the original box back
-                    //in the config table so it doesn't get dropped though. Pointer should be the same
-                    //so we should not need to recompute CRC.
-                    system_table.configuration_table =
-                        Box::into_raw_with_allocator(cfg_table).0 as *mut efi::ConfigurationTable;
+                    //entry doesn't exist, can't delete it.
                     return Err(EfiError::NotFound);
                 }
-            }
-            current_table
-        }
-        None => {
-            // config table list doesn't exist.
-            if !vendor_table.is_null() {
-                // table is some, meaning we should create the list and add this as the new entry.
-                vec![efi::ConfigurationTable { vendor_guid, vendor_table }]
             } else {
-                // table is null, but can't delete a table entry in a list that doesn't exist.
-                //since the list doesn't exist, we can leave the (null) pointer in the st alone.
-                return Err(EfiError::NotFound);
+                // adding or modifying an entry.
+                if let Some(entry) = existing_entry {
+                    //entry exists, modify it.
+                    let old_vendor_table_ptr = NonNull::new(entry.vendor_table);
+                    entry.vendor_table = vendor_table;
+                    (updated_table, old_vendor_table_ptr)
+                } else {
+                    //entry doesn't exist, add it.
+                    updated_table.push(efi::ConfigurationTable { vendor_guid, vendor_table });
+                    (updated_table, None)
+                }
             }
         }
     };
 
-    if new_table.is_empty() {
-        // if empty, just set config table ptr to null
+    // Updating the table. Reclaim the old table (if present) so it'll get dropped by the runtime allocator.
+    if !system_table.configuration_table.is_null() {
+        unsafe {
+            let _old_boxed_table = Box::from_raw_in(
+                slice_from_raw_parts_mut(system_table.configuration_table, system_table.number_of_table_entries),
+                &EFI_RUNTIME_SERVICES_DATA_ALLOCATOR,
+            );
+        }
+    }
+
+    if updated_table.is_empty() {
         system_table.number_of_table_entries = 0;
         system_table.configuration_table = core::ptr::null_mut();
     } else {
-        //Box up the new table and put it in the system table. The old table (if any) will be dropped
-        //when old_cfg_table goes out of scope at the end of the function.
-        system_table.number_of_table_entries = new_table.len();
-        let new_table = new_table.to_vec_in(&EFI_RUNTIME_SERVICES_DATA_ALLOCATOR).into_boxed_slice();
-        system_table.configuration_table = Box::into_raw_with_allocator(new_table).0 as *mut efi::ConfigurationTable;
+        // Move the updated table into an allocation in the runtime services data allocator.
+        system_table.number_of_table_entries = updated_table.len();
+        let updated_table = updated_table.to_vec_in(&EFI_RUNTIME_SERVICES_DATA_ALLOCATOR).into_boxed_slice();
+        system_table.configuration_table =
+            Box::into_raw_with_allocator(updated_table).0 as *mut efi::ConfigurationTable;
     }
-    //since we modified the system table, re-calculate CRC.
-    efi_system_table.checksum();
+
+    efi_system_table.set(system_table);
 
     //signal the table guid as an event group
     EVENT_DB.signal_group(vendor_guid);
@@ -137,12 +130,12 @@ pub fn get_configuration_table(table_guid: &efi::Guid) -> Option<NonNull<c_void>
     let st_guard = SYSTEM_TABLE.lock();
     let st = st_guard.as_ref()?;
 
-    let system_table = st.as_ref();
+    let system_table = st.get();
     if system_table.configuration_table.is_null() || system_table.number_of_table_entries == 0 {
         return None;
     }
 
-    // Safety: system table exists, and configuration is non-null, and number_of_table_entries is non-zero.
+    // SAFETY: system table exists, and configuration is non-null, and number_of_table_entries is non-zero.
     let ct_slice = unsafe { from_raw_parts(system_table.configuration_table, system_table.number_of_table_entries) };
 
     for entry in ct_slice {
@@ -153,8 +146,10 @@ pub fn get_configuration_table(table_guid: &efi::Guid) -> Option<NonNull<c_void>
     None
 }
 
-pub fn init_config_tables_support(bs: &mut efi::BootServices) {
+pub fn init_config_tables_support(st: &mut EfiSystemTable) {
+    let mut bs = st.boot_services().get();
     bs.install_configuration_table = install_configuration_table;
+    st.boot_services().set(bs);
 }
 
 #[cfg(test)]
@@ -167,6 +162,9 @@ mod tests {
 
     fn with_locked_state<F: Fn() + std::panic::RefUnwindSafe>(f: F) {
         test_support::with_global_lock(|| {
+            // SAFETY: multiple functions modify global state. Functions are
+            // called within a global lock to ensure exclusive access during
+            // initialization.
             unsafe {
                 test_support::init_test_gcd(None);
                 test_support::reset_allocators();

--- a/patina_dxe_core/src/config_tables/memory_attributes_table.rs
+++ b/patina_dxe_core/src/config_tables/memory_attributes_table.rs
@@ -257,7 +257,7 @@ mod tests {
         systemtables::init_system_table,
         test_support,
     };
-    use patina::base::UEFI_PAGE_SIZE;
+    use patina::{base::UEFI_PAGE_SIZE, uefi_size_to_pages};
 
     fn with_locked_state<F: Fn() + std::panic::RefUnwindSafe>(f: F) {
         test_support::with_global_lock(|| {
@@ -283,7 +283,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg(target_arch = "x86_64")] // Issue #1071
     fn test_memory_attributes_table_generation() {
         with_locked_state(|| {
             // Create a vector to store the allocated pages
@@ -305,23 +304,27 @@ mod tests {
                     _ => (efi::BOOT_SERVICES_DATA, efi::MEMORY_XP),
                 };
 
+                // Allocate in granularity chunks. Otherwise the allocation will auto-expand.
+                let page_count =
+                    entry_count * uefi_size_to_pages!(crate::allocator::RUNTIME_PAGE_ALLOCATION_GRANULARITY);
+
                 let mut buffer_ptr: *mut u8 = core::ptr::null_mut();
                 match core_allocate_pages(
                     efi::ALLOCATE_ANY_PAGES,
                     page_type.0,
-                    entry_count + 0x1,
+                    page_count,
                     core::ptr::addr_of_mut!(buffer_ptr) as *mut efi::PhysicalAddress,
                     None,
                 ) {
                     // because we allocate top down, we need to insert at the front of the vector
                     Ok(_) if page_type.0 != efi::BOOT_SERVICES_DATA => {
-                        allocated_pages.insert(0, (buffer_ptr, page_type, entry_count + 1))
+                        allocated_pages.insert(0, (buffer_ptr, page_type, page_count))
                     }
                     Ok(_) => (),
                     _ => panic!("Failed to allocate pages"),
                 }
 
-                let len = (entry_count + 1) * UEFI_PAGE_SIZE;
+                let len = page_count * UEFI_PAGE_SIZE;
                 // ignore failures here, we can't set attributes in the actual page table here, but the GCD will
                 // get updated
                 let _ = core_set_memory_space_capabilities(buffer_ptr as u64, len as u64, u64::MAX);

--- a/patina_dxe_core/src/cpu.rs
+++ b/patina_dxe_core/src/cpu.rs
@@ -142,6 +142,7 @@ mod tests {
         impl CpuInfo for TestPlatform {
             #[cfg(target_arch = "aarch64")]
             fn gic_bases() -> GicBases {
+                // SAFETY: Call is exclusive to the GicBases instance.
                 unsafe { GicBases::new(0, 0) }
             }
         }

--- a/patina_dxe_core/src/cpu/cpu_arch_protocol.rs
+++ b/patina_dxe_core/src/cpu/cpu_arch_protocol.rs
@@ -88,7 +88,7 @@ extern "efiapi" fn get_interrupt_state(this: *const Protocol, state: *mut bool) 
     }
     interrupts::get_interrupt_state()
         .map(|interrupt_state| {
-            // Safety: caller must ensure that state is a valid pointer. It is null-checked above.
+            // SAFETY: caller must ensure that state is a valid pointer. It is null-checked above.
             unsafe {
                 state.write_unaligned(interrupt_state);
             }
@@ -141,7 +141,7 @@ extern "efiapi" fn get_timer_value(
 
     match result {
         Ok((value, period)) => {
-            // Safety: caller must ensure that timer_value and timer_period are valid pointers. They are null-checked above.
+            // SAFETY: caller must ensure that timer_value and timer_period are valid pointers. They are null-checked above.
             unsafe {
                 timer_value.write_unaligned(value);
                 timer_period.write_unaligned(period);

--- a/patina_dxe_core/src/cpu/hw_interrupt_protocol.rs
+++ b/patina_dxe_core/src/cpu/hw_interrupt_protocol.rs
@@ -74,7 +74,7 @@ impl<'a> EfiHardwareInterruptProtocol<'a> {
             return efi::Status::INVALID_PARAMETER;
         }
 
-        // Safety: caller guarantees that *this is valid pointer to EfiHardwareInterruptProtocol.
+        // SAFETY: caller guarantees that *this is valid pointer to EfiHardwareInterruptProtocol.
         let hw_interrupt_protocol = unsafe { &mut *this };
 
         hw_interrupt_protocol.hw_interrupt_handler.register_interrupt_source(interrupt_source as usize, handler)
@@ -88,7 +88,7 @@ impl<'a> EfiHardwareInterruptProtocol<'a> {
             return efi::Status::INVALID_PARAMETER;
         }
 
-        // Safety: caller guarantees that *this is valid pointer to EfiHardwareInterruptProtocol.
+        // SAFETY: caller guarantees that *this is valid pointer to EfiHardwareInterruptProtocol.
         let hw_interrupt_protocol = unsafe { &mut *this };
 
         if let Err(err) =
@@ -108,7 +108,7 @@ impl<'a> EfiHardwareInterruptProtocol<'a> {
             return efi::Status::INVALID_PARAMETER;
         }
 
-        // Safety: caller guarantees that *this is valid pointer to EfiHardwareInterruptProtocol.
+        // SAFETY: caller guarantees that *this is valid pointer to EfiHardwareInterruptProtocol.
         let hw_interrupt_protocol = unsafe { &mut *this };
 
         if let Err(err) =
@@ -129,14 +129,14 @@ impl<'a> EfiHardwareInterruptProtocol<'a> {
             return efi::Status::INVALID_PARAMETER;
         }
 
-        // Safety: caller guarantees that *this is valid pointer to EfiHardwareInterruptProtocol.
+        // SAFETY: caller guarantees that *this is valid pointer to EfiHardwareInterruptProtocol.
         let hw_interrupt_protocol = unsafe { &mut *this };
 
         let enable =
             hw_interrupt_protocol.hw_interrupt_handler.aarch64_int.lock().get_interrupt_source_state(interrupt_source);
         match enable {
             Ok(enable) => {
-                // Safety: caller must ensure that state is a valid pointer. It is null-checked above.
+                // SAFETY: caller must ensure that state is a valid pointer. It is null-checked above.
                 unsafe { state.write_unaligned(enable) }
                 efi::Status::SUCCESS
             }
@@ -152,7 +152,7 @@ impl<'a> EfiHardwareInterruptProtocol<'a> {
             return efi::Status::INVALID_PARAMETER;
         }
 
-        // Safety: caller guarantees that *this is valid pointer to EfiHardwareInterruptProtocol.
+        // SAFETY: caller guarantees that *this is valid pointer to EfiHardwareInterruptProtocol.
         let hw_interrupt_protocol = unsafe { &mut *this };
 
         if let Err(err) =
@@ -225,7 +225,7 @@ impl<'a> EfiHardwareInterruptV2Protocol<'a> {
             return efi::Status::INVALID_PARAMETER;
         }
 
-        // Safety: caller guarantees that *this is valid pointer to EfiHardwareInterruptV2Protocol.
+        // SAFETY: caller guarantees that *this is valid pointer to EfiHardwareInterruptV2Protocol.
         let hw_interrupt2_protocol = unsafe { &mut *this };
         hw_interrupt2_protocol.hw_interrupt_handler.register_interrupt_source(interrupt_source as usize, handler)
     }
@@ -238,7 +238,7 @@ impl<'a> EfiHardwareInterruptV2Protocol<'a> {
             return efi::Status::INVALID_PARAMETER;
         }
 
-        // Safety: caller guarantees that *this is valid pointer to EfiHardwareInterruptV2Protocol.
+        // SAFETY: caller guarantees that *this is valid pointer to EfiHardwareInterruptV2Protocol.
         let hw_interrupt2_protocol = unsafe { &mut *this };
         if let Err(err) =
             hw_interrupt2_protocol.hw_interrupt_handler.aarch64_int.lock().enable_interrupt_source(interrupt_source)
@@ -257,7 +257,7 @@ impl<'a> EfiHardwareInterruptV2Protocol<'a> {
             return efi::Status::INVALID_PARAMETER;
         }
 
-        // Safety: caller guarantees that *this is valid pointer to EfiHardwareInterruptV2Protocol.
+        // SAFETY: caller guarantees that *this is valid pointer to EfiHardwareInterruptV2Protocol.
         let hw_interrupt2_protocol = unsafe { &mut *this };
         if let Err(err) =
             hw_interrupt2_protocol.hw_interrupt_handler.aarch64_int.lock().disable_interrupt_source(interrupt_source)
@@ -277,7 +277,7 @@ impl<'a> EfiHardwareInterruptV2Protocol<'a> {
             return efi::Status::INVALID_PARAMETER;
         }
 
-        // Safety: caller guarantees that *this is valid pointer to EfiHardwareInterruptV2Protocol.
+        // SAFETY: caller guarantees that *this is valid pointer to EfiHardwareInterruptV2Protocol.
         let hw_interrupt2_protocol = unsafe { &mut *this };
         let enable =
             hw_interrupt2_protocol.hw_interrupt_handler.aarch64_int.lock().get_interrupt_source_state(interrupt_source);
@@ -297,7 +297,7 @@ impl<'a> EfiHardwareInterruptV2Protocol<'a> {
         if this.is_null() {
             return efi::Status::INVALID_PARAMETER;
         }
-        // Safety: caller guarantees that *this is valid pointer to EfiHardwareInterruptV2Protocol.
+        // SAFETY: caller guarantees that *this is valid pointer to EfiHardwareInterruptV2Protocol.
         let hw_interrupt2_protocol = unsafe { &mut *this };
         if let Err(err) =
             hw_interrupt2_protocol.hw_interrupt_handler.aarch64_int.lock().end_of_interrupt(interrupt_source)
@@ -317,7 +317,7 @@ impl<'a> EfiHardwareInterruptV2Protocol<'a> {
             return efi::Status::INVALID_PARAMETER;
         }
 
-        // Safety: caller guarantees that *this is valid pointer to EfiHardwareInterruptV2Protocol.
+        // SAFETY: caller guarantees that *this is valid pointer to EfiHardwareInterruptV2Protocol.
         let hw_interrupt2_protocol = unsafe { &mut *this };
         let level = hw_interrupt2_protocol.hw_interrupt_handler.aarch64_int.lock().get_trigger_type(interrupt_source);
         match level {
@@ -338,7 +338,7 @@ impl<'a> EfiHardwareInterruptV2Protocol<'a> {
             return efi::Status::INVALID_PARAMETER;
         }
 
-        // Safety: caller guarantees that *this is valid pointer to EfiHardwareInterruptV2Protocol.
+        // SAFETY: caller guarantees that *this is valid pointer to EfiHardwareInterruptV2Protocol.
         let hw_interrupt2_protocol = unsafe { &mut *this };
         if let Err(err) = hw_interrupt2_protocol
             .hw_interrupt_handler

--- a/patina_dxe_core/src/debugger_reload.rs
+++ b/patina_dxe_core/src/debugger_reload.rs
@@ -277,6 +277,7 @@ fn fixup_hob_list(
         }
 
         let hob_size = hob_header.length as usize;
+        // SAFETY: The hob list should be valid. The physical_hob_list address is validated above.
         next_hob = unsafe { next_hob.byte_add(hob_size) };
     }
     if !fixed_up_core {

--- a/patina_dxe_core/src/driver_services.rs
+++ b/patina_dxe_core/src/driver_services.rs
@@ -25,7 +25,7 @@ use patina_internal_device_path::{concat_device_path_to_boxed_slice, copy_device
 
 use r_efi::efi;
 
-use crate::protocols::PROTOCOL_DB;
+use crate::{protocols::PROTOCOL_DB, systemtables::EfiSystemTable};
 
 fn get_bindings_for_handles(handles: Vec<efi::Handle>) -> Vec<*mut efi::protocols::driver_binding::Protocol> {
     handles
@@ -47,6 +47,7 @@ fn get_platform_driver_override_bindings(
     {
         Err(_) => return Vec::new(),
         Ok(protocol) => unsafe {
+            // SAFETY: locate_protocol guarantees that if `Ok` is returned, a valid pointer is encapsulated in it.
             (protocol as *mut efi::protocols::platform_driver_override::Protocol).as_mut().expect("bad protocol ptr")
         },
     };
@@ -80,6 +81,7 @@ fn get_family_override_bindings() -> Vec<*mut efi::protocols::driver_binding::Pr
     for handle in driver_binding_handles {
         match PROTOCOL_DB.get_interface_for_handle(handle, efi::protocols::driver_family_override::PROTOCOL_GUID) {
             Ok(protocol) => {
+                // SAFETY: get_interface_for_handle guarantees that if `Ok` is returned, a valid pointer is encapsulated in it.
                 let driver_override_protocol = unsafe {
                     (protocol as *mut efi::protocols::driver_family_override::Protocol)
                         .as_mut()
@@ -103,6 +105,7 @@ fn get_bus_specific_override_bindings(
         .get_interface_for_handle(controller_handle, efi::protocols::bus_specific_driver_override::PROTOCOL_GUID)
     {
         Err(_) => return Vec::new(),
+        // SAFETY: get_interface_for_handle guarantees that if `Ok` is returned, a valid pointer is encapsulated in it.
         Ok(protocol) => unsafe {
             (protocol as *mut efi::protocols::bus_specific_driver_override::Protocol)
                 .as_mut()
@@ -133,6 +136,9 @@ fn get_all_driver_bindings() -> Vec<*mut efi::protocols::driver_binding::Protoco
         Ok(handles) => get_bindings_for_handles(handles),
     };
 
+    // SAFETY: driver_bindings must contain valid pointers/handles (a & b as well as *a & *b)
+    // when sort_unstable_by() is called. If .locate_handles() returns 'Ok' and handles is
+    // not empty, we rely on get_bindings_for_handles to return a valid Vec.
     driver_bindings.sort_unstable_by(|a, b| unsafe { (*(*b)).version.cmp(&(*(*a)).version) });
 
     driver_bindings
@@ -162,6 +168,7 @@ fn authenticate_connect(
             };
 
             if let Ok(mut file_path) = file_path {
+                // SAFETY: Pointer is validated using .expect(), will panic if .as_ref() returns a NULL pointer
                 let security2 = unsafe {
                     (security2_ptr as *mut patina::pi::protocols::security2::Protocol)
                         .as_ref()
@@ -222,6 +229,8 @@ fn core_connect_single_controller(
     loop {
         let mut started_drivers = Vec::new();
         for driver_binding_interface in driver_candidates.clone() {
+            // SAFETY: driver_binding_interface is a clone of driver_candidates which is created above.
+            // The pointer should be valid as long as driver_candidates is successfully allocated.
             let driver_binding = unsafe { &mut *(driver_binding_interface) };
             let device_path = remaining_device_path.or(Some(core::ptr::null_mut())).expect("must be some");
 
@@ -280,7 +289,7 @@ fn core_connect_single_controller(
         return Ok(());
     }
 
-    // Safety: caller must ensure that the pointer contained in remaining_device_path is valid if it is Some(_).
+    // SAFETY: caller must ensure that the pointer contained in remaining_device_path is valid if it is Some(_).
     if let Some(device_path) = remaining_device_path
         && unsafe { (device_path.read_unaligned()).r#type == efi::protocols::device_path::TYPE_END }
     {
@@ -323,7 +332,9 @@ pub unsafe fn core_connect_controller(
 
     if recursive {
         for child in PROTOCOL_DB.get_child_handles(handle) {
-            //ignore the return value to match behavior of edk2 reference.
+            // ignore the return value to match behavior of edk2 reference.
+            // SAFETY: We do not remove any of these handles during this call, though it is
+            // possible for a different entity at another TPL to do so.
             _ = unsafe { core_connect_controller(child, Vec::new(), None, true) };
         }
     }
@@ -343,14 +354,14 @@ extern "efiapi" fn connect_controller(
         let mut current_ptr = driver_image_handle;
         let mut handles: Vec<efi::Handle> = Vec::new();
         loop {
-            // Safety: caller must ensure that driver_image_handle is a valid pointer to a null-terminated list of
+            // SAFETY: caller must ensure that driver_image_handle is a valid pointer to a null-terminated list of
             // handles if it is not null.
             let current_val = unsafe { current_ptr.read_unaligned() };
             if current_val.is_null() {
                 break;
             }
             handles.push(current_val);
-            // Safety: caller guarantees a null-terminated list, so safe to advance to the next pointer as the null-terminator
+            // SAFETY: caller guarantees a null-terminated list, so safe to advance to the next pointer as the null-terminator
             // has just been checked above.
             current_ptr = unsafe { current_ptr.add(1) };
         }
@@ -359,7 +370,7 @@ extern "efiapi" fn connect_controller(
     // remaining_device_path is passed in and may not have proper alignment.
     let device_path = if remaining_device_path.is_null() { None } else { Some(remaining_device_path) };
 
-    // Safety: caller must ensure that device_path is a valid pointer to a device path structure if it is not null.
+    // SAFETY: caller must ensure that device_path is a valid pointer to a device path structure if it is not null.
     unsafe {
         match core_connect_controller(handle, driver_handles, device_path, recursive.into()) {
             Err(err) => err.into(),
@@ -491,6 +502,8 @@ pub unsafe fn core_disconnect_controller(
             .get_interface_for_handle(driver_handle, efi::protocols::driver_binding::PROTOCOL_GUID)
             .or(Err(EfiError::InvalidParameter))?;
         let driver_binding_interface = driver_binding_interface as *mut efi::protocols::driver_binding::Protocol;
+        // SAFETY: driver_binding_interface is validated above, would have been caught with the .or and ? above with
+        // the loop being terminated.
         let driver_binding = unsafe { &mut *(driver_binding_interface) };
 
         let mut status = efi::Status::SUCCESS;
@@ -519,8 +532,17 @@ extern "efiapi" fn disconnect_controller(
     driver_image_handle: efi::Handle,
     child_handle: efi::Handle,
 ) -> efi::Status {
+    if controller_handle.is_null() {
+        return efi::Status::INVALID_PARAMETER;
+    }
+
     let driver_image_handle = NonNull::new(driver_image_handle).map(|x| x.as_ptr());
     let child_handle = NonNull::new(child_handle).map(|x| x.as_ptr());
+    // SAFETY: Caller must ensure controller_handle is valid for the duration of the call.
+    // driver_image_handle and child_handle are both created above using NonNull which should
+    // guarantee they are non-null pointers. controller_handle is validated above. We do not
+    // remove any of these handles during this call, though it is possible for a different
+    // entity at another TPL to do so.
     unsafe {
         match core_disconnect_controller(controller_handle, driver_image_handle, child_handle) {
             Err(err) => err.into(),
@@ -529,9 +551,11 @@ extern "efiapi" fn disconnect_controller(
     }
 }
 
-pub fn init_driver_services(bs: &mut efi::BootServices) {
+pub fn init_driver_services(st: &mut EfiSystemTable) {
+    let mut bs = st.boot_services().get();
     bs.connect_controller = connect_controller;
     bs.disconnect_controller = disconnect_controller;
+    st.boot_services().set(bs);
 }
 
 #[cfg(test)]
@@ -539,7 +563,7 @@ pub fn init_driver_services(bs: &mut efi::BootServices) {
 mod tests {
     use super::*;
     use crate::{protocol_db::DXE_CORE_HANDLE, test_support};
-    use core::{ffi::c_void, ptr};
+    use core::ffi::c_void;
     use std::{
         str::FromStr,
         sync::atomic::{AtomicUsize, Ordering},
@@ -554,6 +578,8 @@ mod tests {
     fn with_locked_state<F: Fn() + std::panic::RefUnwindSafe>(f: F) {
         test_support::with_global_lock(|| {
             test_support::init_test_logger();
+            // SAFETY: init_test_protocol_db modifies global state. It is being called within a
+            // lock to have exclusive mutable access to the protocol database.
             unsafe {
                 test_support::init_test_protocol_db();
             }
@@ -761,6 +787,8 @@ mod tests {
             assert_eq!(bindings.len(), 2);
 
             // Verify the binding versions
+            // SAFETY: The length of bindings is being verified above. This should guarantee
+            // bindings contains at least two valid elements which are checked below.
             unsafe {
                 assert_eq!((*bindings[0]).version, 10);
                 assert_eq!((*bindings[1]).version, 20);
@@ -972,6 +1000,8 @@ mod tests {
 
             // First binding should be from handle2 (version 200)
             // Second binding should be from handle1 (version 100)
+            // SAFETY: The length of bindings is being verified above. This should guarantee
+            // bindings contains at least two valid elements which are checked below.
             unsafe {
                 assert_eq!((*bindings[0]).version, 20); // handle2's binding version
                 assert_eq!((*bindings[1]).version, 10); // handle1's binding version
@@ -1019,6 +1049,8 @@ mod tests {
             assert_eq!(bindings.len(), 3);
 
             // Verify the correct order by version (descending)
+            // SAFETY: The length of bindings is being verified above. This should guarantee
+            // bindings contains at least three valid elements which are checked below.
             unsafe {
                 assert_eq!((*bindings[0]).version, 30); // handle2's binding - highest version
                 assert_eq!((*bindings[1]).version, 20); // handle3's binding - middle version
@@ -1225,6 +1257,9 @@ mod tests {
             START_CALL_COUNT.store(0, Ordering::SeqCst);
 
             // Test 1: Basic connection (non-recursive)
+            // SAFETY: Both controller_handle and driver_handle are required to be valid. Both are
+            // set via an .unwrap() call from an .install_protocol_interface() call. These calls
+            // would panic if an error was returned.
             unsafe {
                 let result = core_connect_controller(
                     controller_handle,
@@ -1263,6 +1298,9 @@ mod tests {
                 .unwrap();
 
             // Test recursive connection
+            // SAFETY: Both controller_handle and driver_handle are required to be valid. Both are
+            // set via an .unwrap() call from an .install_protocol_interface() call. These calls
+            // would panic if an error was returned.
             unsafe {
                 let result = core_connect_controller(
                     controller_handle,
@@ -1285,6 +1323,10 @@ mod tests {
             SUPPORTED_CALL_COUNT.store(0, Ordering::SeqCst);
             START_CALL_COUNT.store(0, Ordering::SeqCst);
 
+            // SAFETY: controller_handle, driver_handle and end_path_ptr are required to be valid.
+            // controller_handle and driver_handle are set via an .unwrap() call from an
+            // .install_protocol_interface() call. These calls would panic if an error was returned.
+            // end_path_ptr was set via Box::into_raw which is guaranteed to return a non-null pointer.
             unsafe {
                 let result = core_connect_controller(
                     controller_handle,
@@ -1432,6 +1474,8 @@ mod tests {
                     .unwrap();
 
                 // Test disconnect without specifying driver or child
+                // SAFETY: controller_handle is required to be valid. It was set via an .unwrap() call
+                // from an .install_protocol_interface() call. This call would panic if an error was returned.
                 unsafe {
                     let result = core_disconnect_controller(controller_handle, None, None);
                     assert!(result.is_ok(), "Should successfully disconnect all drivers");
@@ -1538,6 +1582,8 @@ mod tests {
             LAST_CHILD_COUNT.store(999, Ordering::SeqCst); // Set to invalid value to detect changes
 
             // Test disconnect - should call stop function
+            // SAFETY: controller_handle is required to be valid. It was set via an .unwrap() call
+            // from an .install_protocol_interface() call. This call would panic if an error was returned.
             unsafe {
                 let result = core_disconnect_controller(controller_handle, None, None);
                 assert!(result.is_ok(), "disconnect should succeed");
@@ -1657,6 +1703,9 @@ mod tests {
             // Test disconnect with specific child handle (which is the ONLY child)
             // This should trigger: is_only_child = total_children == child_handles.len() = true
             // Because: total_children = 1, child_handles.retain() keeps 1 child, so 1 == 1
+            // SAFETY: Both controller_handle and child_handle are required to be valid. Both were set
+            // via an .unwrap() call from an .install_protocol_interface() call. These calls would panic
+            // if an error was returned.
             unsafe {
                 let result = core_disconnect_controller(controller_handle, None, Some(child_handle));
                 assert!(result.is_ok(), "disconnect should succeed");
@@ -1690,6 +1739,10 @@ mod tests {
             let invalid_driver_handle = 0x9999 as efi::Handle;
 
             // Test disconnect with invalid driver handle
+            // SAFETY: Both controller_handle and invalid_driver_handle are required to be valid.
+            // controller_handle is set via an .unwrap() call from an .install_protocol_interface()
+            // call. This call would panic if an error was returned. invalid_driver_handle is
+            // statically set to 0x9999 which guarantees it is non-null.
             unsafe {
                 let result = core_disconnect_controller(
                     controller_handle,
@@ -1726,6 +1779,10 @@ mod tests {
             let invalid_child_handle = 0x8888 as efi::Handle;
 
             // Test disconnect with invalid child handle
+            // SAFETY: Both controller_handle and invalid_child_handle are required to be valid.
+            // controller_handle is set via an .unwrap() call from an .install_protocol_interface()
+            // call. This call would panic if an error was returned. invalid_child_handle is
+            // statically set to 0x8888 which guarantees it is non-null.
             unsafe {
                 let result = core_disconnect_controller(
                     controller_handle,
@@ -1778,322 +1835,14 @@ mod tests {
 
     #[test]
     fn test_init_driver_services() {
-        // Create dummy function pointers to use for initialization
-        extern "efiapi" fn dummy_raise_tpl(_new_tpl: efi::Tpl) -> efi::Tpl {
-            0
-        }
-        extern "efiapi" fn dummy_restore_tpl(_old_tpl: efi::Tpl) {}
-        extern "efiapi" fn dummy_allocate_pages(
-            _allocation_type: u32,
-            _memory_type: u32,
-            _pages: usize,
-            _memory: *mut u64,
-        ) -> efi::Status {
-            efi::Status::SUCCESS
-        }
-        extern "efiapi" fn dummy_free_pages(_memory: u64, _pages: usize) -> efi::Status {
-            efi::Status::SUCCESS
-        }
-        extern "efiapi" fn dummy_get_memory_map(
-            _memory_map_size: *mut usize,
-            _memory_map: *mut efi::MemoryDescriptor,
-            _map_key: *mut usize,
-            _descriptor_size: *mut usize,
-            _descriptor_version: *mut u32,
-        ) -> efi::Status {
-            efi::Status::SUCCESS
-        }
-        extern "efiapi" fn dummy_allocate_pool(
-            _pool_type: u32,
-            _size: usize,
-            _buffer: *mut *mut c_void,
-        ) -> efi::Status {
-            efi::Status::SUCCESS
-        }
-        extern "efiapi" fn dummy_free_pool(_buffer: *mut c_void) -> efi::Status {
-            efi::Status::SUCCESS
-        }
-        extern "efiapi" fn dummy_create_event(
-            _event_type: u32,
-            _notify_tpl: efi::Tpl,
-            _notify_function: Option<efi::EventNotify>,
-            _notify_context: *mut c_void,
-            _event: *mut efi::Event,
-        ) -> efi::Status {
-            efi::Status::SUCCESS
-        }
-        extern "efiapi" fn dummy_set_timer(_event: efi::Event, _type: u32, _trigger_time: u64) -> efi::Status {
-            efi::Status::SUCCESS
-        }
-        extern "efiapi" fn dummy_wait_for_event(
-            _number_of_events: usize,
-            _event: *mut efi::Event,
-            _index: *mut usize,
-        ) -> efi::Status {
-            efi::Status::SUCCESS
-        }
-        extern "efiapi" fn dummy_signal_event(_event: efi::Event) -> efi::Status {
-            efi::Status::SUCCESS
-        }
-        extern "efiapi" fn dummy_close_event(_event: efi::Event) -> efi::Status {
-            efi::Status::SUCCESS
-        }
-        extern "efiapi" fn dummy_check_event(_event: efi::Event) -> efi::Status {
-            efi::Status::SUCCESS
-        }
-        extern "efiapi" fn dummy_install_protocol_interface(
-            _handle: *mut efi::Handle,
-            _protocol: *mut efi::Guid,
-            _interface_type: u32,
-            _interface: *mut c_void,
-        ) -> efi::Status {
-            efi::Status::SUCCESS
-        }
-        extern "efiapi" fn dummy_reinstall_protocol_interface(
-            _handle: efi::Handle,
-            _protocol: *mut efi::Guid,
-            _old_interface: *mut c_void,
-            _new_interface: *mut c_void,
-        ) -> efi::Status {
-            efi::Status::SUCCESS
-        }
-        extern "efiapi" fn dummy_uninstall_protocol_interface(
-            _handle: efi::Handle,
-            _protocol: *mut efi::Guid,
-            _interface: *mut c_void,
-        ) -> efi::Status {
-            efi::Status::SUCCESS
-        }
-        extern "efiapi" fn dummy_handle_protocol(
-            _handle: efi::Handle,
-            _protocol: *mut efi::Guid,
-            _interface: *mut *mut c_void,
-        ) -> efi::Status {
-            efi::Status::SUCCESS
-        }
-        extern "efiapi" fn dummy_register_protocol_notify(
-            _protocol: *mut efi::Guid,
-            _event: efi::Event,
-            _registration: *mut *mut c_void,
-        ) -> efi::Status {
-            efi::Status::SUCCESS
-        }
-        extern "efiapi" fn dummy_locate_handle(
-            _search_type: u32,
-            _protocol: *mut efi::Guid,
-            _search_key: *mut c_void,
-            _buffer_size: *mut usize,
-            _buffer: *mut efi::Handle,
-        ) -> efi::Status {
-            efi::Status::SUCCESS
-        }
-        extern "efiapi" fn dummy_locate_device_path(
-            _protocol: *mut efi::Guid,
-            _device_path: *mut *mut r_efi::protocols::device_path::Protocol,
-            _device: *mut efi::Handle,
-        ) -> efi::Status {
-            efi::Status::SUCCESS
-        }
-        extern "efiapi" fn dummy_install_configuration_table(
-            _guid: *mut efi::Guid,
-            _table: *mut c_void,
-        ) -> efi::Status {
-            efi::Status::SUCCESS
-        }
-        extern "efiapi" fn dummy_load_image(
-            _boot_policy: efi::Boolean,
-            _parent_image_handle: efi::Handle,
-            _device_path: *mut r_efi::protocols::device_path::Protocol,
-            _source_buffer: *mut c_void,
-            _source_size: usize,
-            _image_handle: *mut efi::Handle,
-        ) -> efi::Status {
-            efi::Status::SUCCESS
-        }
-        extern "efiapi" fn dummy_start_image(
-            _image_handle: efi::Handle,
-            _exit_data_size: *mut usize,
-            _exit_data: *mut *mut u16,
-        ) -> efi::Status {
-            efi::Status::SUCCESS
-        }
-        extern "efiapi" fn dummy_exit(
-            _image_handle: efi::Handle,
-            _exit_status: efi::Status,
-            _exit_data_size: usize,
-            _exit_data: *mut u16,
-        ) -> efi::Status {
-            efi::Status::SUCCESS
-        }
-        extern "efiapi" fn dummy_unload_image(_image_handle: efi::Handle) -> efi::Status {
-            efi::Status::SUCCESS
-        }
-        extern "efiapi" fn dummy_exit_boot_services(_image_handle: efi::Handle, _map_key: usize) -> efi::Status {
-            efi::Status::SUCCESS
-        }
-        extern "efiapi" fn dummy_get_next_monotonic_count(_count: *mut u64) -> efi::Status {
-            efi::Status::SUCCESS
-        }
-        extern "efiapi" fn dummy_stall(_microseconds: usize) -> efi::Status {
-            efi::Status::SUCCESS
-        }
-        extern "efiapi" fn dummy_set_watchdog_timer(
-            _timeout: usize,
-            _watchdog_code: u64,
-            _data_size: usize,
-            _watchdog_data: *mut u16,
-        ) -> efi::Status {
-            efi::Status::SUCCESS
-        }
-        extern "efiapi" fn dummy_connect_controller(
-            _controller_handle: efi::Handle,
-            _driver_image_handle: *mut efi::Handle,
-            _remaining_device_path: *mut r_efi::protocols::device_path::Protocol,
-            _recursive: efi::Boolean,
-        ) -> efi::Status {
-            efi::Status::SUCCESS
-        }
-        extern "efiapi" fn dummy_disconnect_controller(
-            _controller_handle: efi::Handle,
-            _driver_image_handle: efi::Handle,
-            _child_handle: efi::Handle,
-        ) -> efi::Status {
-            efi::Status::SUCCESS
-        }
-        extern "efiapi" fn dummy_open_protocol(
-            _handle: efi::Handle,
-            _protocol: *mut efi::Guid,
-            _interface: *mut *mut c_void,
-            _agent_handle: efi::Handle,
-            _controller_handle: efi::Handle,
-            _attributes: u32,
-        ) -> efi::Status {
-            efi::Status::SUCCESS
-        }
-        extern "efiapi" fn dummy_close_protocol(
-            _handle: efi::Handle,
-            _protocol: *mut efi::Guid,
-            _agent_handle: efi::Handle,
-            _controller_handle: efi::Handle,
-        ) -> efi::Status {
-            efi::Status::SUCCESS
-        }
-        extern "efiapi" fn dummy_open_protocol_information(
-            _handle: efi::Handle,
-            _protocol: *mut efi::Guid,
-            _entry_buffer: *mut *mut efi::OpenProtocolInformationEntry,
-            _entry_count: *mut usize,
-        ) -> efi::Status {
-            efi::Status::SUCCESS
-        }
-        extern "efiapi" fn dummy_protocols_per_handle(
-            _handle: efi::Handle,
-            _protocol_buffer: *mut *mut *mut efi::Guid,
-            _protocol_buffer_count: *mut usize,
-        ) -> efi::Status {
-            efi::Status::SUCCESS
-        }
-        extern "efiapi" fn dummy_locate_handle_buffer(
-            _search_type: u32,
-            _protocol: *mut efi::Guid,
-            _search_key: *mut c_void,
-            _no_handles: *mut usize,
-            _buffer: *mut *mut efi::Handle,
-        ) -> efi::Status {
-            efi::Status::SUCCESS
-        }
-        extern "efiapi" fn dummy_locate_protocol(
-            _protocol: *mut efi::Guid,
-            _registration: *mut c_void,
-            _interface: *mut *mut c_void,
-        ) -> efi::Status {
-            efi::Status::SUCCESS
-        }
-        extern "efiapi" fn dummy_install_multiple_protocol_interfaces(
-            _handle: *mut efi::Handle,
-            _args: *mut c_void,
-            _more_args: *mut c_void,
-        ) -> efi::Status {
-            efi::Status::SUCCESS
-        }
-        extern "efiapi" fn dummy_uninstall_multiple_protocol_interfaces(
-            _handle: efi::Handle,
-            _args: *mut c_void,
-            _more_args: *mut c_void,
-        ) -> efi::Status {
-            efi::Status::SUCCESS
-        }
-        extern "efiapi" fn dummy_calculate_crc32(
-            _data: *mut c_void,
-            _data_size: usize,
-            _crc32: *mut u32,
-        ) -> efi::Status {
-            efi::Status::SUCCESS
-        }
-        extern "efiapi" fn dummy_copy_mem(_destination: *mut c_void, _source: *mut c_void, _length: usize) {}
-        extern "efiapi" fn dummy_set_mem(_buffer: *mut c_void, _size: usize, _value: u8) {}
-        extern "efiapi" fn dummy_create_event_ex(
-            _event_type: u32,
-            _notify_tpl: efi::Tpl,
-            _notify_function: Option<efi::EventNotify>,
-            _notify_context: *const c_void,
-            _event_group: *const efi::Guid,
-            _event: *mut efi::Event,
-        ) -> efi::Status {
-            efi::Status::SUCCESS
-        }
+        with_locked_state(|| {
+            let mut st = EfiSystemTable::allocate_new_table();
+            init_driver_services(&mut st);
 
-        let mut boot_services = efi::BootServices {
-            hdr: efi::TableHeader { signature: 0, revision: 0, header_size: 0, crc32: 0, reserved: 0 },
-            // Fill with dummy function pointers
-            raise_tpl: dummy_raise_tpl,
-            restore_tpl: dummy_restore_tpl,
-            allocate_pages: dummy_allocate_pages,
-            free_pages: dummy_free_pages,
-            get_memory_map: dummy_get_memory_map,
-            allocate_pool: dummy_allocate_pool,
-            free_pool: dummy_free_pool,
-            create_event: dummy_create_event,
-            set_timer: dummy_set_timer,
-            wait_for_event: dummy_wait_for_event,
-            signal_event: dummy_signal_event,
-            close_event: dummy_close_event,
-            check_event: dummy_check_event,
-            install_protocol_interface: dummy_install_protocol_interface,
-            reinstall_protocol_interface: dummy_reinstall_protocol_interface,
-            uninstall_protocol_interface: dummy_uninstall_protocol_interface,
-            handle_protocol: dummy_handle_protocol,
-            reserved: ptr::null_mut(),
-            register_protocol_notify: dummy_register_protocol_notify,
-            locate_handle: dummy_locate_handle,
-            locate_device_path: dummy_locate_device_path,
-            install_configuration_table: dummy_install_configuration_table,
-            load_image: dummy_load_image,
-            start_image: dummy_start_image,
-            exit: dummy_exit,
-            unload_image: dummy_unload_image,
-            exit_boot_services: dummy_exit_boot_services,
-            get_next_monotonic_count: dummy_get_next_monotonic_count,
-            stall: dummy_stall,
-            set_watchdog_timer: dummy_set_watchdog_timer,
-            connect_controller: dummy_connect_controller,
-            disconnect_controller: dummy_disconnect_controller,
-            open_protocol: dummy_open_protocol,
-            close_protocol: dummy_close_protocol,
-            open_protocol_information: dummy_open_protocol_information,
-            protocols_per_handle: dummy_protocols_per_handle,
-            locate_handle_buffer: dummy_locate_handle_buffer,
-            locate_protocol: dummy_locate_protocol,
-            install_multiple_protocol_interfaces: dummy_install_multiple_protocol_interfaces,
-            uninstall_multiple_protocol_interfaces: dummy_uninstall_multiple_protocol_interfaces,
-            calculate_crc32: dummy_calculate_crc32,
-            copy_mem: dummy_copy_mem,
-            set_mem: dummy_set_mem,
-            create_event_ex: dummy_create_event_ex,
-        };
-        init_driver_services(&mut boot_services);
+            let boot_services = st.boot_services().get();
 
-        assert!(boot_services.connect_controller as usize == connect_controller as *const () as usize);
-        assert!(boot_services.disconnect_controller as usize == disconnect_controller as *const () as usize);
+            assert!(boot_services.connect_controller as usize == connect_controller as *const () as usize);
+            assert!(boot_services.disconnect_controller as usize == disconnect_controller as *const () as usize);
+        })
     }
 }

--- a/patina_dxe_core/src/dxe_services.rs
+++ b/patina_dxe_core/src/dxe_services.rs
@@ -49,19 +49,19 @@ extern "efiapi" fn allocate_memory_space(
 
     let allocate_type = match gcd_allocate_type {
         dxe_services::GcdAllocateType::Address => {
-            // Safety: caller must ensure that base_address is a valid pointer. It is null-checked above.
+            // SAFETY: caller must ensure that base_address is a valid pointer. It is null-checked above.
             let desired_address = unsafe { base_address.read_unaligned() };
             gcd::AllocateType::Address(desired_address as usize)
         }
         dxe_services::GcdAllocateType::AnySearchBottomUp => gcd::AllocateType::BottomUp(None),
         dxe_services::GcdAllocateType::AnySearchTopDown => gcd::AllocateType::TopDown(None),
         dxe_services::GcdAllocateType::MaxAddressSearchBottomUp => {
-            // Safety: caller must ensure that base_address is a valid pointer. It is null-checked above.
+            // SAFETY: caller must ensure that base_address is a valid pointer. It is null-checked above.
             let limit = unsafe { base_address.read_unaligned() };
             gcd::AllocateType::BottomUp(Some(limit as usize))
         }
         dxe_services::GcdAllocateType::MaxAddressSearchTopDown => {
-            // Safety: caller must ensure that base_address is a valid pointer. It is null-checked above.
+            // SAFETY: caller must ensure that base_address is a valid pointer. It is null-checked above.
             let limit = unsafe { base_address.read_unaligned() };
             gcd::AllocateType::TopDown(Some(limit as usize))
         }
@@ -79,7 +79,7 @@ extern "efiapi" fn allocate_memory_space(
 
     match result {
         Ok(allocated_addr) => {
-            // Safety: caller must ensure that base_address is a valid pointer. It is null-checked above.
+            // SAFETY: caller must ensure that base_address is a valid pointer. It is null-checked above.
             unsafe { base_address.write_unaligned(allocated_addr as u64) };
             efi::Status::SUCCESS
         }
@@ -115,7 +115,7 @@ extern "efiapi" fn get_memory_space_descriptor(
     match core_get_memory_space_descriptor(base_address) {
         Err(err) => return err.into(),
         Ok(target_descriptor) =>
-        // Safety: caller must ensure that descriptor is a valid pointer. It is null-checked above.
+        // SAFETY: caller must ensure that descriptor is a valid pointer. It is null-checked above.
         unsafe {
             descriptor.write_unaligned(target_descriptor);
         },
@@ -204,7 +204,7 @@ extern "efiapi" fn get_memory_space_map(
     match core_allocate_pool(efi::BOOT_SERVICES_DATA, buffer_size) {
         Err(err) => err.into(),
         Ok(allocation) =>
-        // Safety: caller must ensure that number_of_descriptors and memory_space_map are valid pointers. They are
+        // SAFETY: caller must ensure that number_of_descriptors and memory_space_map are valid pointers. They are
         // null-checked above.
         unsafe {
             memory_space_map.write_unaligned(allocation as *mut dxe_services::MemorySpaceDescriptor);
@@ -243,19 +243,19 @@ extern "efiapi" fn allocate_io_space(
 
     let allocate_type = match gcd_allocate_type {
         dxe_services::GcdAllocateType::Address => {
-            // Safety: caller must ensure that base_address is a valid pointer. It is null-checked above.
+            // SAFETY: caller must ensure that base_address is a valid pointer. It is null-checked above.
             let desired_address = unsafe { base_address.read_unaligned() };
             gcd::AllocateType::Address(desired_address as usize)
         }
         dxe_services::GcdAllocateType::AnySearchBottomUp => gcd::AllocateType::BottomUp(None),
         dxe_services::GcdAllocateType::AnySearchTopDown => gcd::AllocateType::TopDown(None),
         dxe_services::GcdAllocateType::MaxAddressSearchBottomUp => {
-            // Safety: caller must ensure that base_address is a valid pointer. It is null-checked above.
+            // SAFETY: caller must ensure that base_address is a valid pointer. It is null-checked above.
             let limit = unsafe { base_address.read_unaligned() };
             gcd::AllocateType::BottomUp(Some(limit as usize))
         }
         dxe_services::GcdAllocateType::MaxAddressSearchTopDown => {
-            // Safety: caller must ensure that base_address is a valid pointer. It is null-checked above.
+            // SAFETY: caller must ensure that base_address is a valid pointer. It is null-checked above.
             let limit = unsafe { base_address.read_unaligned() };
             gcd::AllocateType::TopDown(Some(limit as usize))
         }
@@ -273,7 +273,7 @@ extern "efiapi" fn allocate_io_space(
 
     match result {
         Ok(allocated_addr) => {
-            // Safety: caller must ensure that base_address is a valid pointer. It is null-checked above.
+            // SAFETY: caller must ensure that base_address is a valid pointer. It is null-checked above.
             unsafe { base_address.write_unaligned(allocated_addr as u64) };
             efi::Status::SUCCESS
         }
@@ -322,7 +322,7 @@ extern "efiapi" fn get_io_space_descriptor(
         descriptors.iter().find(|x| (x.base_address <= base_address) && (base_address < (x.base_address + x.length)));
 
     if let Some(target_descriptor) = target_descriptor {
-        // Safety: caller must ensure that descriptor is a valid pointer. It is null-checked above.
+        // SAFETY: caller must ensure that descriptor is a valid pointer. It is null-checked above.
         unsafe { descriptor.write_unaligned(*target_descriptor) };
         efi::Status::SUCCESS
     } else {
@@ -352,7 +352,7 @@ extern "efiapi" fn get_io_space_map(
     match core_allocate_pool(efi::BOOT_SERVICES_DATA, buffer_size) {
         Err(err) => err.into(),
         Ok(allocation) =>
-        // Safety: caller must ensure that number_of_descriptors and io_space_map are valid pointers. They are null-checked above.
+        // SAFETY: caller must ensure that number_of_descriptors and io_space_map are valid pointers. They are null-checked above.
         unsafe {
             io_space_map.write_unaligned(allocation as *mut dxe_services::IoSpaceDescriptor);
             number_of_descriptors.write_unaligned(descriptors.len());
@@ -420,12 +420,12 @@ impl<P: PlatformInfo> Core<P> {
         }
 
         // construct a FirmwareVolume to verify sanity
-        // Safety: caller must ensure that firmware_volume_header is a valid pointer. It is null-checked above.
+        // SAFETY: caller must ensure that firmware_volume_header is a valid pointer. It is null-checked above.
         let fv_slice = unsafe { slice::from_raw_parts(firmware_volume_header as *const u8, size) };
         if let Err(err) = VolumeRef::new(fv_slice) {
             return err.into();
         }
-        // Safety: caller must ensure that firmware_volume_header is a valid firmware volume that will not be freed
+        // SAFETY: caller must ensure that firmware_volume_header is a valid firmware volume that will not be freed
         // or moved after being sent to the core for processing.
         let res =
             unsafe { Self::instance().pi_dispatcher.install_firmware_volume(firmware_volume_header as u64, None) };
@@ -434,7 +434,7 @@ impl<P: PlatformInfo> Core<P> {
             Err(err) => return err.into(),
         };
 
-        // Safety: caller must ensure that firmware_volume_handle is a valid pointer. It is null-checked above.
+        // SAFETY: caller must ensure that firmware_volume_handle is a valid pointer. It is null-checked above.
         unsafe {
             firmware_volume_handle.write_unaligned(handle);
         }
@@ -457,7 +457,7 @@ impl<P: PlatformInfo> Core<P> {
         if file_name.is_null() {
             return efi::Status::INVALID_PARAMETER;
         }
-        // Safety: caller must ensure that file_name is a valid pointer. It is null-checked above.
+        // SAFETY: caller must ensure that file_name is a valid pointer. It is null-checked above.
         let file_name = unsafe { file_name.read_unaligned() };
 
         match Self::instance().pi_dispatcher.schedule(firmware_volume_handle, &file_name) {
@@ -470,7 +470,7 @@ impl<P: PlatformInfo> Core<P> {
         if file_name.is_null() {
             return efi::Status::INVALID_PARAMETER;
         }
-        // Safety: caller must ensure that file_name is a valid pointer. It is null-checked above.
+        // SAFETY: caller must ensure that file_name is a valid pointer. It is null-checked above.
         let file_name = unsafe { file_name.read_unaligned() };
 
         match Self::instance().pi_dispatcher.trust(firmware_volume_handle, &file_name) {
@@ -2249,18 +2249,18 @@ mod tests {
             let st = st_guard.as_mut().expect("System Table not initialized");
 
             // Before: no configuration tables are expected on a fresh init
-            assert_eq!(st.system_table().number_of_table_entries, 0);
+            assert_eq!(st.get().number_of_table_entries, 0);
 
             // Act: install the DXE Services table
             CORE.install_dxe_services_table(st);
 
             // After: one entry should exist and match DXE_SERVICES_TABLE_GUID
-            let st_ref = st.system_table();
-            assert_eq!(st_ref.number_of_table_entries, 1);
-            assert!(!st_ref.configuration_table.is_null());
+            let st_raw = st.get();
+            assert_eq!(st_raw.number_of_table_entries, 1);
+            assert!(!st_raw.configuration_table.is_null());
 
             let entries =
-                unsafe { core::slice::from_raw_parts(st_ref.configuration_table, st_ref.number_of_table_entries) };
+                unsafe { core::slice::from_raw_parts(st_raw.configuration_table, st_raw.number_of_table_entries) };
 
             let entry = entries
                 .iter()

--- a/patina_dxe_core/src/events.rs
+++ b/patina_dxe_core/src/events.rs
@@ -21,6 +21,7 @@ use crate::{
     event_db::{SpinLockedEventDb, TimerDelay},
     gcd,
     protocols::PROTOCOL_DB,
+    systemtables::EfiSystemTable,
 };
 
 pub static EVENT_DB: SpinLockedEventDb = SpinLockedEventDb::new();
@@ -51,7 +52,7 @@ extern "efiapi" fn create_event(
 
     match EVENT_DB.create_event(event_type, notify_tpl, notify_function, notify_context, event_group) {
         Ok(new_event) => {
-            // Safety: caller must ensure that event is a valid pointer. It is null-checked above.
+            // SAFETY: caller must ensure that event is a valid pointer. It is null-checked above.
             unsafe { event.write_unaligned(new_event) };
             efi::Status::SUCCESS
         }
@@ -80,12 +81,12 @@ extern "efiapi" fn create_event_ex(
         _ => (),
     }
 
-    // Safety: caller must ensure that event_group is a valid pointer if not null.
+    // SAFETY: caller must ensure that event_group is a valid pointer if not null.
     let event_group = if !event_group.is_null() { Some(unsafe { event_group.read_unaligned() }) } else { None };
 
     match EVENT_DB.create_event(event_type, notify_tpl, notify_function, notify_context, event_group) {
         Ok(new_event) => {
-            // Safety: caller must ensure that event is a valid pointer. It is null-checked above.
+            // SAFETY: caller must ensure that event is a valid pointer. It is null-checked above.
             unsafe { event.write_unaligned(new_event) };
             efi::Status::SUCCESS
         }
@@ -127,12 +128,12 @@ extern "efiapi" fn wait_for_event(
     loop {
         let mut event_ptr = event_array;
         for index in 0..number_of_events {
-            // Safety: caller must ensure that event_array is a valid pointer and number_of_events is correct. event_array is null-checked above.
+            // SAFETY: caller must ensure that event_array is a valid pointer and number_of_events is correct. event_array is null-checked above.
             let event = unsafe { event_ptr.read_unaligned() };
             match check_event(event) {
                 efi::Status::NOT_READY => (),
                 status => {
-                    // Safety: caller must ensure that out_index is a valid pointer if it is not null.
+                    // SAFETY: caller must ensure that out_index is a valid pointer if it is not null.
                     if !out_index.is_null() {
                         unsafe {
                             out_index.write_unaligned(index);
@@ -141,7 +142,7 @@ extern "efiapi" fn wait_for_event(
                     return status;
                 }
             }
-            // Safety: caller must ensure that event_array is a valid pointer and number_of_events is correct. event_array is null-checked above.
+            // SAFETY: caller must ensure that event_array is a valid pointer and number_of_events is correct. event_array is null-checked above.
             event_ptr = unsafe { event_ptr.add(1) };
         }
 
@@ -325,7 +326,8 @@ pub fn gcd_map_change(map_change_type: gcd::MapChangeType) {
     }
 }
 
-pub fn init_events_support(bs: &mut efi::BootServices) {
+pub fn init_events_support(st: &mut EfiSystemTable) {
+    let mut bs = st.boot_services().get();
     bs.create_event = create_event;
     bs.create_event_ex = create_event_ex;
     bs.close_event = close_event;
@@ -335,6 +337,7 @@ pub fn init_events_support(bs: &mut efi::BootServices) {
     bs.set_timer = set_timer;
     bs.raise_tpl = raise_tpl;
     bs.restore_tpl = restore_tpl;
+    st.boot_services().set(bs);
 
     //set up call back for timer arch protocol installation.
     let event = EVENT_DB
@@ -759,7 +762,7 @@ mod tests {
             assert_eq!(result, efi::Status::SUCCESS);
 
             //raise TPL to callback than event
-            let _old_tpl = raise_tpl(efi::TPL_CALLBACK);
+            let old_tpl = raise_tpl(efi::TPL_CALLBACK);
 
             // Signal the event
             let result = signal_event(event);
@@ -781,6 +784,7 @@ mod tests {
             // Clean up
             let _ = close_event(event);
             let _ = close_event(event2);
+            restore_tpl(old_tpl);
         });
     }
 
@@ -1056,334 +1060,22 @@ mod tests {
     #[test]
     fn test_init_events_support() {
         with_locked_state(|| {
-            // Create dummy function pointers to use for initialization
-            extern "efiapi" fn dummy_raise_tpl(_new_tpl: efi::Tpl) -> efi::Tpl {
-                0
-            }
-            extern "efiapi" fn dummy_restore_tpl(_old_tpl: efi::Tpl) {}
-            extern "efiapi" fn dummy_allocate_pages(
-                _allocation_type: u32,
-                _memory_type: u32,
-                _pages: usize,
-                _memory: *mut u64,
-            ) -> efi::Status {
-                efi::Status::SUCCESS
-            }
-            extern "efiapi" fn dummy_free_pages(_memory: u64, _pages: usize) -> efi::Status {
-                efi::Status::SUCCESS
-            }
-            extern "efiapi" fn dummy_get_memory_map(
-                _memory_map_size: *mut usize,
-                _memory_map: *mut efi::MemoryDescriptor,
-                _map_key: *mut usize,
-                _descriptor_size: *mut usize,
-                _descriptor_version: *mut u32,
-            ) -> efi::Status {
-                efi::Status::SUCCESS
-            }
-            extern "efiapi" fn dummy_allocate_pool(
-                _pool_type: u32,
-                _size: usize,
-                _buffer: *mut *mut c_void,
-            ) -> efi::Status {
-                efi::Status::SUCCESS
-            }
-            extern "efiapi" fn dummy_free_pool(_buffer: *mut c_void) -> efi::Status {
-                efi::Status::SUCCESS
-            }
-            extern "efiapi" fn dummy_create_event(
-                _event_type: u32,
-                _notify_tpl: efi::Tpl,
-                _notify_function: Option<efi::EventNotify>,
-                _notify_context: *mut c_void,
-                _event: *mut efi::Event,
-            ) -> efi::Status {
-                efi::Status::SUCCESS
-            }
-            extern "efiapi" fn dummy_set_timer(_event: efi::Event, _type: u32, _trigger_time: u64) -> efi::Status {
-                efi::Status::SUCCESS
-            }
-            extern "efiapi" fn dummy_wait_for_event(
-                _number_of_events: usize,
-                _event: *mut efi::Event,
-                _index: *mut usize,
-            ) -> efi::Status {
-                efi::Status::SUCCESS
-            }
-            extern "efiapi" fn dummy_signal_event(_event: efi::Event) -> efi::Status {
-                efi::Status::SUCCESS
-            }
-            extern "efiapi" fn dummy_close_event(_event: efi::Event) -> efi::Status {
-                efi::Status::SUCCESS
-            }
-            extern "efiapi" fn dummy_check_event(_event: efi::Event) -> efi::Status {
-                efi::Status::SUCCESS
-            }
-            extern "efiapi" fn dummy_install_protocol_interface(
-                _handle: *mut efi::Handle,
-                _protocol: *mut efi::Guid,
-                _interface_type: u32,
-                _interface: *mut c_void,
-            ) -> efi::Status {
-                efi::Status::SUCCESS
-            }
-            extern "efiapi" fn dummy_reinstall_protocol_interface(
-                _handle: efi::Handle,
-                _protocol: *mut efi::Guid,
-                _old_interface: *mut c_void,
-                _new_interface: *mut c_void,
-            ) -> efi::Status {
-                efi::Status::SUCCESS
-            }
-            extern "efiapi" fn dummy_uninstall_protocol_interface(
-                _handle: efi::Handle,
-                _protocol: *mut efi::Guid,
-                _interface: *mut c_void,
-            ) -> efi::Status {
-                efi::Status::SUCCESS
-            }
-            extern "efiapi" fn dummy_handle_protocol(
-                _handle: efi::Handle,
-                _protocol: *mut efi::Guid,
-                _interface: *mut *mut c_void,
-            ) -> efi::Status {
-                efi::Status::SUCCESS
-            }
-            extern "efiapi" fn dummy_register_protocol_notify(
-                _protocol: *mut efi::Guid,
-                _event: efi::Event,
-                _registration: *mut *mut c_void,
-            ) -> efi::Status {
-                efi::Status::SUCCESS
-            }
-            extern "efiapi" fn dummy_locate_handle(
-                _search_type: u32,
-                _protocol: *mut efi::Guid,
-                _search_key: *mut c_void,
-                _buffer_size: *mut usize,
-                _buffer: *mut efi::Handle,
-            ) -> efi::Status {
-                efi::Status::SUCCESS
-            }
-            extern "efiapi" fn dummy_locate_device_path(
-                _protocol: *mut efi::Guid,
-                _device_path: *mut *mut r_efi::protocols::device_path::Protocol,
-                _device: *mut efi::Handle,
-            ) -> efi::Status {
-                efi::Status::SUCCESS
-            }
-            extern "efiapi" fn dummy_install_configuration_table(
-                _guid: *mut efi::Guid,
-                _table: *mut c_void,
-            ) -> efi::Status {
-                efi::Status::SUCCESS
-            }
-            extern "efiapi" fn dummy_load_image(
-                _boot_policy: efi::Boolean,
-                _parent_image_handle: efi::Handle,
-                _device_path: *mut r_efi::protocols::device_path::Protocol,
-                _source_buffer: *mut c_void,
-                _source_size: usize,
-                _image_handle: *mut efi::Handle,
-            ) -> efi::Status {
-                efi::Status::SUCCESS
-            }
-            extern "efiapi" fn dummy_start_image(
-                _image_handle: efi::Handle,
-                _exit_data_size: *mut usize,
-                _exit_data: *mut *mut u16,
-            ) -> efi::Status {
-                efi::Status::SUCCESS
-            }
-            extern "efiapi" fn dummy_exit(
-                _image_handle: efi::Handle,
-                _exit_status: efi::Status,
-                _exit_data_size: usize,
-                _exit_data: *mut u16,
-            ) -> efi::Status {
-                efi::Status::SUCCESS
-            }
-            extern "efiapi" fn dummy_unload_image(_image_handle: efi::Handle) -> efi::Status {
-                efi::Status::SUCCESS
-            }
-            extern "efiapi" fn dummy_exit_boot_services(_image_handle: efi::Handle, _map_key: usize) -> efi::Status {
-                efi::Status::SUCCESS
-            }
-            extern "efiapi" fn dummy_get_next_monotonic_count(_count: *mut u64) -> efi::Status {
-                efi::Status::SUCCESS
-            }
-            extern "efiapi" fn dummy_stall(_microseconds: usize) -> efi::Status {
-                efi::Status::SUCCESS
-            }
-            extern "efiapi" fn dummy_set_watchdog_timer(
-                _timeout: usize,
-                _watchdog_code: u64,
-                _data_size: usize,
-                _watchdog_data: *mut u16,
-            ) -> efi::Status {
-                efi::Status::SUCCESS
-            }
-            extern "efiapi" fn dummy_connect_controller(
-                _controller_handle: efi::Handle,
-                _driver_image_handle: *mut efi::Handle,
-                _remaining_device_path: *mut r_efi::protocols::device_path::Protocol,
-                _recursive: efi::Boolean,
-            ) -> efi::Status {
-                efi::Status::SUCCESS
-            }
-            extern "efiapi" fn dummy_disconnect_controller(
-                _controller_handle: efi::Handle,
-                _driver_image_handle: efi::Handle,
-                _child_handle: efi::Handle,
-            ) -> efi::Status {
-                efi::Status::SUCCESS
-            }
-            extern "efiapi" fn dummy_open_protocol(
-                _handle: efi::Handle,
-                _protocol: *mut efi::Guid,
-                _interface: *mut *mut c_void,
-                _agent_handle: efi::Handle,
-                _controller_handle: efi::Handle,
-                _attributes: u32,
-            ) -> efi::Status {
-                efi::Status::SUCCESS
-            }
-            extern "efiapi" fn dummy_close_protocol(
-                _handle: efi::Handle,
-                _protocol: *mut efi::Guid,
-                _agent_handle: efi::Handle,
-                _controller_handle: efi::Handle,
-            ) -> efi::Status {
-                efi::Status::SUCCESS
-            }
-            extern "efiapi" fn dummy_open_protocol_information(
-                _handle: efi::Handle,
-                _protocol: *mut efi::Guid,
-                _entry_buffer: *mut *mut efi::OpenProtocolInformationEntry,
-                _entry_count: *mut usize,
-            ) -> efi::Status {
-                efi::Status::SUCCESS
-            }
-            extern "efiapi" fn dummy_protocols_per_handle(
-                _handle: efi::Handle,
-                _protocol_buffer: *mut *mut *mut efi::Guid,
-                _protocol_buffer_count: *mut usize,
-            ) -> efi::Status {
-                efi::Status::SUCCESS
-            }
-            extern "efiapi" fn dummy_locate_handle_buffer(
-                _search_type: u32,
-                _protocol: *mut efi::Guid,
-                _search_key: *mut c_void,
-                _no_handles: *mut usize,
-                _buffer: *mut *mut efi::Handle,
-            ) -> efi::Status {
-                efi::Status::SUCCESS
-            }
-            extern "efiapi" fn dummy_locate_protocol(
-                _protocol: *mut efi::Guid,
-                _registration: *mut c_void,
-                _interface: *mut *mut c_void,
-            ) -> efi::Status {
-                efi::Status::SUCCESS
-            }
-            extern "efiapi" fn dummy_install_multiple_protocol_interfaces(
-                _handle: *mut efi::Handle,
-                _args: *mut c_void,
-                _more_args: *mut c_void,
-            ) -> efi::Status {
-                efi::Status::SUCCESS
-            }
-            extern "efiapi" fn dummy_uninstall_multiple_protocol_interfaces(
-                _handle: efi::Handle,
-                _args: *mut c_void,
-                _more_args: *mut c_void,
-            ) -> efi::Status {
-                efi::Status::SUCCESS
-            }
-            extern "efiapi" fn dummy_calculate_crc32(
-                _data: *mut c_void,
-                _data_size: usize,
-                _crc32: *mut u32,
-            ) -> efi::Status {
-                efi::Status::SUCCESS
-            }
-            extern "efiapi" fn dummy_copy_mem(_destination: *mut c_void, _source: *mut c_void, _length: usize) {}
-            extern "efiapi" fn dummy_set_mem(_buffer: *mut c_void, _size: usize, _value: u8) {}
-            extern "efiapi" fn dummy_create_event_ex(
-                _event_type: u32,
-                _notify_tpl: efi::Tpl,
-                _notify_function: Option<efi::EventNotify>,
-                _notify_context: *const c_void,
-                _event_group: *const efi::Guid,
-                _event: *mut efi::Event,
-            ) -> efi::Status {
-                efi::Status::SUCCESS
-            }
-
-            // Create a mutable BootServices to pass to init_events_support
-            let mut boot_services = efi::BootServices {
-                hdr: efi::TableHeader { signature: 0, revision: 0, header_size: 0, crc32: 0, reserved: 0 },
-                // Fill with dummy function pointers
-                raise_tpl: dummy_raise_tpl,
-                restore_tpl: dummy_restore_tpl,
-                allocate_pages: dummy_allocate_pages,
-                free_pages: dummy_free_pages,
-                get_memory_map: dummy_get_memory_map,
-                allocate_pool: dummy_allocate_pool,
-                free_pool: dummy_free_pool,
-                create_event: dummy_create_event,
-                set_timer: dummy_set_timer,
-                wait_for_event: dummy_wait_for_event,
-                signal_event: dummy_signal_event,
-                close_event: dummy_close_event,
-                check_event: dummy_check_event,
-                install_protocol_interface: dummy_install_protocol_interface,
-                reinstall_protocol_interface: dummy_reinstall_protocol_interface,
-                uninstall_protocol_interface: dummy_uninstall_protocol_interface,
-                handle_protocol: dummy_handle_protocol,
-                reserved: ptr::null_mut(),
-                register_protocol_notify: dummy_register_protocol_notify,
-                locate_handle: dummy_locate_handle,
-                locate_device_path: dummy_locate_device_path,
-                install_configuration_table: dummy_install_configuration_table,
-                load_image: dummy_load_image,
-                start_image: dummy_start_image,
-                exit: dummy_exit,
-                unload_image: dummy_unload_image,
-                exit_boot_services: dummy_exit_boot_services,
-                get_next_monotonic_count: dummy_get_next_monotonic_count,
-                stall: dummy_stall,
-                set_watchdog_timer: dummy_set_watchdog_timer,
-                connect_controller: dummy_connect_controller,
-                disconnect_controller: dummy_disconnect_controller,
-                open_protocol: dummy_open_protocol,
-                close_protocol: dummy_close_protocol,
-                open_protocol_information: dummy_open_protocol_information,
-                protocols_per_handle: dummy_protocols_per_handle,
-                locate_handle_buffer: dummy_locate_handle_buffer,
-                locate_protocol: dummy_locate_protocol,
-                install_multiple_protocol_interfaces: dummy_install_multiple_protocol_interfaces,
-                uninstall_multiple_protocol_interfaces: dummy_uninstall_multiple_protocol_interfaces,
-                calculate_crc32: dummy_calculate_crc32,
-                copy_mem: dummy_copy_mem,
-                set_mem: dummy_set_mem,
-                create_event_ex: dummy_create_event_ex,
-            };
+            let mut st = EfiSystemTable::allocate_new_table();
 
             // Initialize events support
-            init_events_support(&mut boot_services);
+            init_events_support(&mut st);
 
             // Verify function pointers are updated
-            assert!(boot_services.create_event as usize != dummy_create_event as *const () as usize);
-            assert!(boot_services.create_event_ex as usize != dummy_create_event_ex as *const () as usize);
-            assert!(boot_services.close_event as usize != dummy_close_event as *const () as usize);
-            assert!(boot_services.signal_event as usize != dummy_signal_event as *const () as usize);
-            assert!(boot_services.wait_for_event as usize != dummy_wait_for_event as *const () as usize);
-            assert!(boot_services.check_event as usize != dummy_check_event as *const () as usize);
-            assert!(boot_services.set_timer as usize != dummy_set_timer as *const () as usize);
-            assert!(boot_services.raise_tpl as usize != dummy_raise_tpl as *const () as usize);
-            assert!(boot_services.restore_tpl as usize != dummy_restore_tpl as *const () as usize);
+            let boot_services = st.boot_services().get();
+            assert_eq!(boot_services.create_event as usize, create_event as *const () as usize);
+            assert_eq!(boot_services.create_event_ex as usize, create_event_ex as *const () as usize);
+            assert_eq!(boot_services.close_event as usize, close_event as *const () as usize);
+            assert_eq!(boot_services.signal_event as usize, signal_event as *const () as usize);
+            assert_eq!(boot_services.wait_for_event as usize, wait_for_event as *const () as usize);
+            assert_eq!(boot_services.check_event as usize, check_event as *const () as usize);
+            assert_eq!(boot_services.set_timer as usize, set_timer as *const () as usize);
+            assert_eq!(boot_services.raise_tpl as usize, raise_tpl as *const () as usize);
+            assert_eq!(boot_services.restore_tpl as usize, restore_tpl as *const () as usize);
         });
     }
 }

--- a/patina_dxe_core/src/gcd.rs
+++ b/patina_dxe_core/src/gcd.rs
@@ -756,7 +756,7 @@ mod tests {
             .unwrap();
         descriptors
             .iter()
-            .find(|x| x.base_address == mem_base + 0xF0000 && x.memory_type == GcdMemoryType::Reserved)
+            .find(|x| x.base_address == mem_base + 0x190000 && x.memory_type == GcdMemoryType::Reserved)
             .unwrap();
         //Note: resource descriptors 3 & are merged into a single contiguous region in GCD, so no separate entry exists.
         //So verify the length of the entry encompasses both.

--- a/patina_dxe_core/src/gcd/spin_locked_gcd.rs
+++ b/patina_dxe_core/src/gcd/spin_locked_gcd.rs
@@ -386,7 +386,7 @@ impl GCD {
         });
 
         self.memory_blocks
-            .resize(unsafe { slice::from_raw_parts_mut::<'static>(base_address as *mut u8, MEMORY_BLOCK_SLICE_SIZE) });
+            .expand(unsafe { slice::from_raw_parts_mut::<'static>(base_address as *mut u8, MEMORY_BLOCK_SLICE_SIZE) });
 
         self.memory_blocks.add(unallocated_memory_space).map_err(|_| EfiError::OutOfResources)?;
         let idx = unsafe { self.add_memory_space(memory_type, base_address, len, capabilities) }?;
@@ -1402,7 +1402,7 @@ impl IoGCD {
     fn init_io_blocks(&mut self) -> Result<(), EfiError> {
         ensure!(self.maximum_address != 0, EfiError::NotReady);
 
-        self.io_blocks.resize(unsafe {
+        self.io_blocks.expand(unsafe {
             Box::into_raw(vec![0_u8; IO_BLOCK_SLICE_SIZE].into_boxed_slice())
                 .as_mut()
                 .expect("RBT given null pointer in initialization.")
@@ -2942,7 +2942,6 @@ impl<'a> Iterator for DescRangeIterator<'a> {
 
 #[cfg(test)]
 #[coverage(off)]
-#[cfg(target_arch = "x86_64")] // Issue #1071
 mod tests {
     //! GCD (Global Coherency Domain) test module.
     //!
@@ -5142,7 +5141,7 @@ mod tests {
             let length = 0x1000;
 
             // Test Uncacheable
-            let result = GCD.set_paging_attributes(base_address, length, MemoryAttributes::Uncacheable.bits());
+            let result = GCD.set_paging_attributes(base_address, length, MemoryAttributes::Uncached.bits());
             assert!(result.is_ok());
 
             // Test WriteThrough - should overwrite the previous mapping
@@ -5163,7 +5162,7 @@ mod tests {
 
             // Should have 3 map operations recorded
             assert_eq!(mapped.len(), 3);
-            assert_eq!(mapped[0], (base_address as u64, length as u64, MemoryAttributes::Uncacheable));
+            assert_eq!(mapped[0], (base_address as u64, length as u64, MemoryAttributes::Uncached));
             assert_eq!(mapped[1], (base_address as u64, length as u64, MemoryAttributes::WriteThrough));
             assert_eq!(mapped[2], (base_address as u64, length as u64, MemoryAttributes::WriteCombining));
 
@@ -5294,7 +5293,7 @@ mod tests {
             // Map multiple non-overlapping regions
             let regions = [
                 (0x1000, 0x1000, MemoryAttributes::Writeback),
-                (0x3000, 0x2000, MemoryAttributes::Uncacheable),
+                (0x3000, 0x2000, MemoryAttributes::Uncached),
                 (0x6000, 0x1000, MemoryAttributes::WriteCombining),
             ];
 
@@ -5314,13 +5313,13 @@ mod tests {
             // Should have 3 map operations recorded
             assert_eq!(mapped.len(), 3);
             assert_eq!(mapped[0], (0x1000, 0x1000, MemoryAttributes::Writeback));
-            assert_eq!(mapped[1], (0x3000, 0x2000, MemoryAttributes::Uncacheable));
+            assert_eq!(mapped[1], (0x3000, 0x2000, MemoryAttributes::Uncached));
             assert_eq!(mapped[2], (0x6000, 0x1000, MemoryAttributes::WriteCombining));
 
             // Current mappings should show all 3 regions (no overlaps)
             assert_eq!(current_mappings.len(), 3);
             assert!(current_mappings.contains(&(0x1000, 0x1000, MemoryAttributes::Writeback)));
-            assert!(current_mappings.contains(&(0x3000, 0x2000, MemoryAttributes::Uncacheable)));
+            assert!(current_mappings.contains(&(0x3000, 0x2000, MemoryAttributes::Uncached)));
             assert!(current_mappings.contains(&(0x6000, 0x1000, MemoryAttributes::WriteCombining)));
         });
     }
@@ -5347,7 +5346,7 @@ mod tests {
             let overlapping_base = 0x1800;
             let overlapping_length = 0x1000;
             let result =
-                GCD.set_paging_attributes(overlapping_base, overlapping_length, MemoryAttributes::Uncacheable.bits());
+                GCD.set_paging_attributes(overlapping_base, overlapping_length, MemoryAttributes::Uncached.bits());
             assert!(result.is_ok());
 
             // Manually drop the page table to release the reference
@@ -5361,14 +5360,14 @@ mod tests {
             // Should have 2 map operations recorded
             assert_eq!(mapped.len(), 2);
             assert_eq!(mapped[0], (base_address as u64, length as u64, MemoryAttributes::Writeback));
-            assert_eq!(mapped[1], (overlapping_base as u64, overlapping_length as u64, MemoryAttributes::Uncacheable));
+            assert_eq!(mapped[1], (overlapping_base as u64, overlapping_length as u64, MemoryAttributes::Uncached));
 
             // Current mappings should show the overlapping region replaced the original
             // (MockPageTable removes overlapping regions when adding new ones)
             assert_eq!(current_mappings.len(), 1);
             assert_eq!(
                 current_mappings[0],
-                (overlapping_base as u64, overlapping_length as u64, MemoryAttributes::Uncacheable)
+                (overlapping_base as u64, overlapping_length as u64, MemoryAttributes::Uncached)
             );
         });
     }

--- a/patina_dxe_core/src/lib.rs
+++ b/patina_dxe_core/src/lib.rs
@@ -511,16 +511,16 @@ impl<P: PlatformInfo> Core<P> {
         let mut st = systemtables::SYSTEM_TABLE.lock();
         let st = st.as_mut().expect("System Table not initialized!");
 
-        allocator::install_memory_services(st.boot_services_mut());
+        allocator::install_memory_services(st);
         gcd::init_paging(self.hob_list());
-        events::init_events_support(st.boot_services_mut());
-        protocols::init_protocol_support(st.boot_services_mut());
-        misc_boot_services::init_misc_boot_services_support(st.boot_services_mut());
-        config_tables::init_config_tables_support(st.boot_services_mut());
-        runtime::init_runtime_support(st.runtime_services_mut());
+        events::init_events_support(st);
+        protocols::init_protocol_support(st);
+        misc_boot_services::init_misc_boot_services_support(st);
+        config_tables::init_config_tables_support(st);
+        runtime::init_runtime_support();
         self.pi_dispatcher.init(self.hob_list(), st);
         self.install_dxe_services_table(st);
-        driver_services::init_driver_services(st.boot_services_mut());
+        driver_services::init_driver_services(st);
 
         memory_attributes_protocol::install_memory_attributes_protocol();
 
@@ -539,8 +539,10 @@ impl<P: PlatformInfo> Core<P> {
 
         memory_attributes_table::init_memory_attributes_table_support();
 
-        self.component_dispatcher.lock().set_boot_services(StandardBootServices::new(st.boot_services()));
-        self.component_dispatcher.lock().set_runtime_services(StandardRuntimeServices::new(st.runtime_services()));
+        self.component_dispatcher.lock().set_boot_services(StandardBootServices::new(st.boot_services().as_mut_ptr()));
+        self.component_dispatcher
+            .lock()
+            .set_runtime_services(StandardRuntimeServices::new(st.runtime_services().as_mut_ptr()));
 
         Ok(())
     }

--- a/patina_dxe_core/src/memory_attributes_protocol.rs
+++ b/patina_dxe_core/src/memory_attributes_protocol.rs
@@ -75,7 +75,7 @@ extern "efiapi" fn get_memory_attributes(
     }
 
     if let Some(attrs) = found_attrs {
-        // Safety: caller must provide a valid pointer to receive the attributes. It is null-checked above.
+        // SAFETY: caller must provide a valid pointer to receive the attributes. It is null-checked above.
         unsafe { attributes.write_unaligned(attrs) };
         efi::Status::SUCCESS
     } else {

--- a/patina_dxe_core/src/misc_boot_services.rs
+++ b/patina_dxe_core/src/misc_boot_services.rs
@@ -16,7 +16,11 @@ use r_efi::efi;
 use spin::Once;
 
 use crate::{
-    GCD, allocator::terminate_memory_map, events::EVENT_DB, protocols::PROTOCOL_DB, systemtables::SYSTEM_TABLE,
+    GCD,
+    allocator::terminate_memory_map,
+    events::EVENT_DB,
+    protocols::PROTOCOL_DB,
+    systemtables::{EfiSystemTable, SYSTEM_TABLE},
 };
 
 struct ArchProtocolPtr<T>(Once<*mut T>);
@@ -30,14 +34,14 @@ impl<T> ArchProtocolPtr<T> {
         self.0.get().copied()
     }
 
-    // Safety: ptr must be a valid pointer to T and init must only be called once.
+    // SAFETY: ptr must be a valid pointer to T and init must only be called once.
     unsafe fn init(&self, ptr: *mut c_void) {
         assert!(!self.0.is_completed(), "Attempted to set ArchProtocolPtr more than once.");
         let _ = self.0.call_once(|| ptr as *mut T);
     }
 }
 
-// Safety: ArchProtocolPtr is Send/Sync because the pointer it wraps is initialized in a thread-safe manner (using
+// SAFETY: ArchProtocolPtr is Send/Sync because the pointer it wraps is initialized in a thread-safe manner (using
 // `Once`), and the pointer itself is never used to mutate data.
 unsafe impl<T> Send for ArchProtocolPtr<T> {}
 unsafe impl<T> Sync for ArchProtocolPtr<T> {}
@@ -60,7 +64,7 @@ extern "efiapi" fn calculate_crc32(data: *mut c_void, data_size: usize, crc_32: 
     if data.is_null() || data_size == 0 || crc_32.is_null() {
         return efi::Status::INVALID_PARAMETER;
     }
-    // Safety: caller must ensure that data and crc_32 are valid pointers. They are null-checked above.
+    // SAFETY: caller must ensure that data and crc_32 are valid pointers. They are null-checked above.
     unsafe {
         let buffer = from_raw_parts(data as *mut u8, data_size);
         crc_32.write_unaligned(crc32fast::hash(buffer));
@@ -73,7 +77,7 @@ extern "efiapi" fn calculate_crc32(data: *mut c_void, data_size: usize, crc_32: 
 // Execution of the processor is not yielded for the duration of the stall.
 extern "efiapi" fn stall(microseconds: usize) -> efi::Status {
     if let Some(metronome_ptr) = METRONOME_ARCH_PTR.get() {
-        // Safety: metronome_ptr is guaranteed to be a valid pointer to the metronome protocol if it is Some.
+        // SAFETY: metronome_ptr is guaranteed to be a valid pointer to the metronome protocol if it is Some.
         let metronome = unsafe { metronome_ptr.as_mut().unwrap() };
         let ticks_100ns: u128 = (microseconds as u128) * 10;
         let mut ticks = ticks_100ns / metronome.tick_period as u128;
@@ -113,7 +117,7 @@ extern "efiapi" fn set_watchdog_timer(
 ) -> efi::Status {
     const WATCHDOG_TIMER_CALIBRATE_PER_SECOND: u64 = 10000000;
     if let Some(watchdog_ptr) = WATCHDOG_ARCH_PTR.get() {
-        // Safety: watchdog_ptr is guaranteed to be a valid pointer to the watchdog protocol if it is Some.
+        // SAFETY: watchdog_ptr is guaranteed to be a valid pointer to the watchdog protocol if it is Some.
         let watchdog = unsafe { watchdog_ptr.as_mut().unwrap() };
         let timeout = (timeout as u64).saturating_mul(WATCHDOG_TIMER_CALIBRATE_PER_SECOND);
         let status = (watchdog.set_timer_period)(watchdog_ptr, timeout);
@@ -132,7 +136,7 @@ extern "efiapi" fn set_watchdog_timer(
 extern "efiapi" fn metronome_arch_available(event: efi::Event, _context: *mut c_void) {
     match PROTOCOL_DB.locate_protocol(protocols::metronome::PROTOCOL_GUID) {
         Ok(metronome_arch_ptr) => {
-            // Safety: metronome_arch_ptr is expected to be a valid pointer to the metronome protocol since it is
+            // SAFETY: metronome_arch_ptr is expected to be a valid pointer to the metronome protocol since it is
             // associated with the metronome arch guid.
             assert!(!metronome_arch_ptr.is_null(), "Located metronome protocol pointer is null.");
             unsafe { METRONOME_ARCH_PTR.init(metronome_arch_ptr) };
@@ -150,7 +154,7 @@ extern "efiapi" fn metronome_arch_available(event: efi::Event, _context: *mut c_
 extern "efiapi" fn watchdog_arch_available(event: efi::Event, _context: *mut c_void) {
     match PROTOCOL_DB.locate_protocol(protocols::watchdog::PROTOCOL_GUID) {
         Ok(watchdog_arch_ptr) => {
-            // Safety: watchdog_arch_ptr is expected to be a valid pointer to the watchdog protocol since it is
+            // SAFETY: watchdog_arch_ptr is expected to be a valid pointer to the watchdog protocol since it is
             // associated with the watchdog arch guid.
             assert!(!watchdog_arch_ptr.is_null(), "Located watchdog protocol pointer is null.");
             unsafe { WATCHDOG_ARCH_PTR.init(watchdog_arch_ptr) };
@@ -224,12 +228,15 @@ pub extern "efiapi" fn exit_boot_services(_handle: efi::Handle, map_key: usize) 
     interrupts::disable_interrupts();
 
     // Clear non-runtime services from the EFI System Table
-    SYSTEM_TABLE
-        .lock()
-        .as_mut()
-        .expect("The System Table pointer is null. This is invalid.")
-        .clear_boot_time_services();
-
+    // SAFETY: the required invariant is that this must only be after the exit_boot_services handler is invoked.
+    // This is the exit_boot_services handler, so the invariant is upheld.
+    unsafe {
+        SYSTEM_TABLE
+            .lock()
+            .as_mut()
+            .expect("The System Table pointer is null. This is invalid.")
+            .clear_boot_time_services();
+    }
     match PROTOCOL_DB.locate_protocol(protocols::runtime::PROTOCOL_GUID) {
         Ok(rt_arch_ptr) => {
             let rt_arch_ptr = rt_arch_ptr as *mut protocols::runtime::Protocol;
@@ -245,11 +252,13 @@ pub extern "efiapi" fn exit_boot_services(_handle: efi::Handle, map_key: usize) 
     efi::Status::SUCCESS
 }
 
-pub fn init_misc_boot_services_support(bs: &mut efi::BootServices) {
+pub fn init_misc_boot_services_support(st: &mut EfiSystemTable) {
+    let mut bs = st.boot_services().get();
     bs.calculate_crc32 = calculate_crc32;
     bs.exit_boot_services = exit_boot_services;
     bs.stall = stall;
     bs.set_watchdog_timer = set_watchdog_timer;
+    st.boot_services().set(bs);
 
     //set up call back for metronome arch protocol installation.
     let event = EVENT_DB
@@ -281,34 +290,6 @@ mod tests {
     use core::{ffi::c_void, ptr};
     use patina::pi::protocols::watchdog;
     use r_efi::efi;
-    use std::cell::UnsafeCell;
-
-    // Define a global static variable to store the Boot Services pointer
-    struct BootServicesWrapper {
-        boot_services: UnsafeCell<Option<&'static mut efi::BootServices>>,
-    }
-
-    // SAFETY: Access is serialized through test_support::with_global_lock to prevent
-    // concurrent mutations.
-    unsafe impl Sync for BootServicesWrapper {}
-
-    static BOOT_SERVICES: BootServicesWrapper = BootServicesWrapper { boot_services: UnsafeCell::new(None) };
-
-    // Function to initialize the global Boot Services pointer
-    pub fn initialize_boot_services(bs: &'static mut efi::BootServices) {
-        // SAFETY: Test code only - UnsafeCell mutation is serialized through the test
-        // lock in with_global_lock.
-        unsafe {
-            *BOOT_SERVICES.boot_services.get() = Some(bs);
-        }
-    }
-
-    // Helper function to get a static reference from the system table
-    unsafe fn get_static_boot_services(bs: &mut efi::BootServices) -> &'static mut efi::BootServices {
-        // SAFETY: The SYSTEM_TABLE is a static global that lives for the entire program duration
-        // The boot services within it have the same lifetime as the system table itself
-        unsafe { core::mem::transmute(bs) }
-    }
 
     fn with_locked_state<F>(f: F)
     where
@@ -334,26 +315,20 @@ mod tests {
     #[test]
     fn test_init_misc_boot_services_support() {
         with_locked_state(|st| {
-            // SAFETY: Test code - transmuting mutable reference to static lifetime is considered safe
-            // because the system table has a static lifetime that outlives this test scope.
-            initialize_boot_services(unsafe { get_static_boot_services(st.boot_services_mut()) });
-            init_misc_boot_services_support(st.boot_services_mut());
+            init_misc_boot_services_support(st);
         });
     }
 
     #[test]
     fn test_misc_calc_crc32() {
         with_locked_state(|st| {
-            // SAFETY: Test code - transmuting mutable reference to static lifetime is considered safe
-            // because the system table has a static lifetime that outlives this test scope.
-            initialize_boot_services(unsafe { get_static_boot_services(st.boot_services_mut()) });
-            init_misc_boot_services_support(st.boot_services_mut());
+            init_misc_boot_services_support(st);
 
             static BUFFER: [u8; 16] = [0; 16];
             let mut data_crc: u32 = 0;
 
             // Test case 1: Valid parameters - successful CRC32 calculation
-            let status = (st.boot_services_mut().calculate_crc32)(
+            let status = (st.boot_services().get().calculate_crc32)(
                 BUFFER.as_ptr() as *mut c_void,
                 BUFFER.len(),
                 &mut data_crc as *mut u32,
@@ -371,8 +346,11 @@ mod tests {
             }
 
             // Test case 2: Zero data size - should return INVALID_PARAMETER
-            let status =
-                (st.boot_services_mut().calculate_crc32)(BUFFER.as_ptr() as *mut c_void, 0, &mut data_crc as *mut u32);
+            let status = (st.boot_services().get().calculate_crc32)(
+                BUFFER.as_ptr() as *mut c_void,
+                0,
+                &mut data_crc as *mut u32,
+            );
             if status == efi::Status::INVALID_PARAMETER {
                 log::debug!("Zero data size correctly returned INVALID_PARAMETER");
             } else {
@@ -380,7 +358,7 @@ mod tests {
             }
 
             // Test case 3: Null data pointer - should return INVALID_PARAMETER
-            let status = (st.boot_services_mut().calculate_crc32)(
+            let status = (st.boot_services().get().calculate_crc32)(
                 core::ptr::null_mut(),
                 BUFFER.len(),
                 &mut data_crc as *mut u32,
@@ -392,7 +370,7 @@ mod tests {
             }
 
             // Test case 4: Null output pointer - should return INVALID_PARAMETER
-            let status = (st.boot_services_mut().calculate_crc32)(
+            let status = (st.boot_services().get().calculate_crc32)(
                 BUFFER.as_ptr() as *mut c_void,
                 BUFFER.len(),
                 core::ptr::null_mut(),
@@ -407,13 +385,10 @@ mod tests {
     #[test]
     fn test_misc_watchdog_timer() {
         with_locked_state(|st| {
-            // SAFETY: Test code - transmuting mutable reference to static lifetime is considered safe
-            // because the system table has a static lifetime that outlives this test scope.
-            initialize_boot_services(unsafe { get_static_boot_services(st.boot_services_mut()) });
-            init_misc_boot_services_support(st.boot_services_mut());
+            init_misc_boot_services_support(st);
 
             // Test case 1: Set watchdog timer with null data - should return NOT_READY (no watchdog available in test)
-            let status = (st.boot_services_mut().set_watchdog_timer)(300, 0, 0, ptr::null_mut());
+            let status = (st.boot_services().get().set_watchdog_timer)(300, 0, 0, ptr::null_mut());
             if status == efi::Status::NOT_READY {
                 log::debug!("Set watchdog timer correctly returned NOT_READY (no watchdog protocol)");
             } else {
@@ -421,7 +396,7 @@ mod tests {
             }
 
             // Test case 2: Disable watchdog timer with null data - should return NOT_READY
-            let status = (st.boot_services_mut().set_watchdog_timer)(0, 0, 0, ptr::null_mut());
+            let status = (st.boot_services().get().set_watchdog_timer)(0, 0, 0, ptr::null_mut());
             if status == efi::Status::NOT_READY {
                 log::debug!("Disable watchdog timer correctly returned NOT_READY");
             } else {
@@ -432,7 +407,7 @@ mod tests {
             let data_ptr = data.as_ptr() as *mut efi::Char16;
 
             // Test case 3: Set the watchdog timer with non-null data - should return NOT_READY
-            let status = (st.boot_services_mut().set_watchdog_timer)(300, 0, data.len(), data_ptr);
+            let status = (st.boot_services().get().set_watchdog_timer)(300, 0, data.len(), data_ptr);
             if status == efi::Status::NOT_READY {
                 log::debug!("Set watchdog timer with data correctly returned NOT_READY");
             } else {
@@ -440,7 +415,7 @@ mod tests {
             }
 
             // Test case 4: Disable the watchdog timer with non-null data - should return NOT_READY
-            let status = (st.boot_services_mut().set_watchdog_timer)(0, 0, data.len(), data_ptr);
+            let status = (st.boot_services().get().set_watchdog_timer)(0, 0, data.len(), data_ptr);
             if status == efi::Status::NOT_READY {
                 log::debug!("Disable watchdog timer with data correctly returned NOT_READY");
             } else {
@@ -475,7 +450,7 @@ mod tests {
                 WATCHDOG_ARCH_PTR.init(&watchdog as *const _ as *mut c_void);
             };
             // Test case 5: Set watchdog timer with null data - should return SUCCESS (watchdog protocol available)
-            let status = (st.boot_services_mut().set_watchdog_timer)(300, 0, 0, ptr::null_mut());
+            let status = (st.boot_services().get().set_watchdog_timer)(300, 0, 0, ptr::null_mut());
             if status == efi::Status::SUCCESS {
                 log::debug!("Set watchdog timer correctly returned SUCCESS (watchdog protocol available)");
                 assert!(SET_PERIOD_CALLED.is_completed(), "set_timer_period was not called during set_watchdog_timer.");
@@ -487,13 +462,10 @@ mod tests {
     #[test]
     fn test_misc_stall() {
         with_locked_state(|st| {
-            // SAFETY: Test code - transmuting mutable reference to static lifetime is considered safe
-            // because the system table has a static lifetime that outlives this test scope.
-            initialize_boot_services(unsafe { get_static_boot_services(st.boot_services_mut()) });
-            init_misc_boot_services_support(st.boot_services_mut());
+            init_misc_boot_services_support(st);
 
             // Test case 1: Normal stall duration - should return NOT_READY (no metronome available in test)
-            let status = (st.boot_services_mut().stall)(10000);
+            let status = (st.boot_services().get().stall)(10000);
             if status == efi::Status::NOT_READY {
                 log::debug!("Stall function correctly returned NOT_READY (no metronome protocol)");
             } else {
@@ -501,7 +473,7 @@ mod tests {
             }
 
             // Test case 2: Zero microseconds stall - should return NOT_READY
-            let status = (st.boot_services_mut().stall)(0);
+            let status = (st.boot_services().get().stall)(0);
             if status == efi::Status::NOT_READY {
                 log::debug!("Zero stall correctly returned NOT_READY");
             } else {
@@ -509,7 +481,7 @@ mod tests {
             }
 
             // Test case 3: Maximum stall duration - should return NOT_READY
-            let status = (st.boot_services_mut().stall)(usize::MAX);
+            let status = (st.boot_services().get().stall)(usize::MAX);
             if status == efi::Status::NOT_READY {
                 log::debug!("Maximum stall correctly returned NOT_READY");
             } else {
@@ -538,7 +510,7 @@ mod tests {
             }
 
             // Test case 4: Normal stall duration - should return SUCCESS (metronome protocol available)
-            let status = (st.boot_services_mut().stall)(10000);
+            let status = (st.boot_services().get().stall)(10000);
             if status == efi::Status::SUCCESS {
                 log::debug!("Stall function correctly returned SUCCESS (metronome protocol available)");
                 assert!(WAIT_FOR_TICK_CALLED.is_completed(), "wait_for_tick was not called during stall.");
@@ -552,10 +524,10 @@ mod tests {
     fn test_misc_exit_boot_services() {
         with_locked_state(|st| {
             let valid_map_key: usize = 0x2000;
-            init_misc_boot_services_support(st.boot_services_mut());
+            init_misc_boot_services_support(st);
             // Call exit_boot_services with a valid map_key
             let handle: efi::Handle = 0x1000 as efi::Handle; // Example handle
-            let _status = (st.boot_services_mut().exit_boot_services)(handle, valid_map_key);
+            let _status = (st.boot_services().get().exit_boot_services)(handle, valid_map_key);
         });
     }
 }

--- a/patina_dxe_core/src/pi_dispatcher.rs
+++ b/patina_dxe_core/src/pi_dispatcher.rs
@@ -119,13 +119,15 @@ impl<P: PlatformInfo> PiDispatcher<P> {
     pub fn init(&self, hob_list: &HobList<'static>, system_table: &mut EfiSystemTable) {
         const ALIGNMENT_SHIFT_4MB: usize = 22;
 
-        self.image_data.lock().set_system_table(system_table.as_ptr() as *mut _);
+        self.image_data.lock().set_system_table(system_table.as_mut_ptr() as *mut _);
         self.image_data.lock().install_dxe_core_image(hob_list, system_table, &mut self.debug_image_data.write());
 
-        system_table.boot_services_mut().load_image = Self::load_image_efiapi;
-        system_table.boot_services_mut().start_image = Self::start_image_efiapi;
-        system_table.boot_services_mut().unload_image = Self::unload_image_efiapi;
-        system_table.boot_services_mut().exit = Self::exit_efiapi;
+        let mut bs = system_table.boot_services().get();
+        bs.load_image = Self::load_image_efiapi;
+        bs.start_image = Self::start_image_efiapi;
+        bs.unload_image = Self::unload_image_efiapi;
+        bs.exit = Self::exit_efiapi;
+        system_table.boot_services().set(bs);
 
         // set up exit boot services callback
         let _ = EVENT_DB
@@ -166,7 +168,7 @@ impl<P: PlatformInfo> PiDispatcher<P> {
         }
 
         // Now create the EFI_SYSTEM_TABLE_POINTER structure
-        let system_table_pointer = system_table.system_table() as *const _ as u64;
+        let system_table_pointer = system_table.as_mut_ptr() as *const _ as u64;
 
         // we need to align the the pointer to 4MB and near the top of memory
         let Ok(address) = crate::GCD.allocate_memory_space(
@@ -332,7 +334,7 @@ impl<P: PlatformInfo> PiDispatcher<P> {
 
                         // Check if this FV is already installed (using the FV name GUID)
                         let fv_name_guid = {
-                            // Safety: fv_data is a valid FV section allocated above
+                            // SAFETY: fv_data is a valid FV section allocated above
                             let volume = match unsafe { VolumeRef::new_from_address(fv_data.as_ptr() as u64) } {
                                 Ok(vol) => vol,
                                 Err(e) => {
@@ -363,7 +365,7 @@ impl<P: PlatformInfo> PiDispatcher<P> {
                             dispatcher.fv_section_data.last().expect("freshly pushed fv section data must be valid");
 
                         let volume_address: u64 = data_ptr.as_ptr() as u64;
-                        // Safety: FV section data is stored in the dispatcher and is valid until end of UEFI (nothing drops it).
+                        // SAFETY: FV section data is stored in the dispatcher and is valid until end of UEFI (nothing drops it).
                         let res = unsafe {
                             self.fv_data
                                 .lock()
@@ -432,7 +434,7 @@ impl<P: PlatformInfo> PiDispatcher<P> {
             };
             let fvb_ptr = ptr as *mut firmware_volume_block::Protocol;
 
-            // Safety: fvb_ptr is obtained from a valid handle that has a FVB protocol instance
+            // SAFETY: fvb_ptr is obtained from a valid handle that has a FVB protocol instance
             // and the as_ref() call checks for null
             let Some(fvb) = (unsafe { fvb_ptr.as_ref() }) else {
                 continue;
@@ -444,7 +446,7 @@ impl<P: PlatformInfo> PiDispatcher<P> {
                 continue;
             }
 
-            // Safety: fv_address is checked for being non-zero above
+            // SAFETY: fv_address is checked for being non-zero above
             let Ok(volume) = (unsafe { VolumeRef::new_from_address(fv_address) }) else {
                 continue;
             };
@@ -630,7 +632,7 @@ impl DispatcherContext {
                 let fv_device_path =
                     fv_device_path.unwrap_or(core::ptr::null_mut()) as *mut efi::protocols::device_path::Protocol;
 
-                // Safety: this code assumes that the fv_address from FVB protocol yields a pointer to a real FV,
+                // SAFETY: this code assumes that the fv_address from FVB protocol yields a pointer to a real FV,
                 // and that the memory backing the FVB is essentially permanent while the dispatcher is running (i.e.
                 // that no one uninstalls the FVB protocol and frees the memory).
                 let fv = match unsafe { VolumeRef::new_from_address(fv_address) } {
@@ -926,7 +928,7 @@ mod tests {
         with_locked_state(|| {
             static CORE: MockCore = MockCore::new(NullSectionExtractor::new());
             CORE.override_instance();
-            // Safety: fv is leaked to ensure it is not freed and remains valid for the duration of the program.
+            // SAFETY: fv is leaked to ensure it is not freed and remains valid for the duration of the program.
             let handle = unsafe {
                 CORE.pi_dispatcher
                     .fv_data
@@ -973,7 +975,7 @@ mod tests {
             static CORE: MockCore = MockCore::new(NullSectionExtractor::new());
             CORE.override_instance();
 
-            // Safety: fv is leaked to ensure it is not freed and remains valid for the duration of the program.
+            // SAFETY: fv is leaked to ensure it is not freed and remains valid for the duration of the program.
             let handle = unsafe {
                 CORE.pi_dispatcher
                     .fv_data
@@ -1009,7 +1011,7 @@ mod tests {
             static CORE: MockCore = MockCore::new(NullSectionExtractor::new());
             CORE.override_instance();
 
-            // Safety: fv is leaked to ensure it is not freed and remains valid for the duration of the program.
+            // SAFETY: fv is leaked to ensure it is not freed and remains valid for the duration of the program.
             let handle = unsafe {
                 CORE.pi_dispatcher
                     .fv_data
@@ -1045,7 +1047,7 @@ mod tests {
             static CORE: MockCore = MockCore::new(NullSectionExtractor::new());
             CORE.override_instance();
 
-            // Safety: fv is leaked to ensure it is not freed and remains valid for the duration of the program.
+            // SAFETY: fv is leaked to ensure it is not freed and remains valid for the duration of the program.
             let fv_phys_addr = fv_raw.expose_provenance() as u64;
             let handle =
                 unsafe { CORE.pi_dispatcher.fv_data.lock().install_firmware_volume(fv_phys_addr, None).unwrap() };
@@ -1080,7 +1082,7 @@ mod tests {
             static CORE: MockCore = MockCore::new(NullSectionExtractor::new());
             CORE.override_instance();
 
-            // Safety: fv is leaked to ensure it is not freed and remains valid for the duration of the program.
+            // SAFETY: fv is leaked to ensure it is not freed and remains valid for the duration of the program.
             let handle = unsafe {
                 CORE.pi_dispatcher
                     .fv_data
@@ -1109,7 +1111,7 @@ mod tests {
             static CORE: MockCore = MockCore::new(NullSectionExtractor::new());
             CORE.override_instance();
 
-            // Safety: fv is leaked to ensure it is not freed and remains valid for the duration of the program.
+            // SAFETY: fv is leaked to ensure it is not freed and remains valid for the duration of the program.
             let handle = unsafe {
                 CORE.pi_dispatcher
                     .fv_data
@@ -1139,7 +1141,7 @@ mod tests {
             static CORE: MockCore = MockCore::new(NullSectionExtractor::new());
             CORE.override_instance();
 
-            // Safety: fv is leaked to ensure it is not freed and remains valid for the duration of the program.
+            // SAFETY: fv is leaked to ensure it is not freed and remains valid for the duration of the program.
             let _ = unsafe {
                 CORE.pi_dispatcher
                     .fv_data
@@ -1197,7 +1199,7 @@ mod tests {
             static CORE: MockCore = MockCore::new(NullSectionExtractor::new());
             CORE.override_instance();
 
-            // Safety: fv is leaked to ensure it is not freed and remains valid for the duration of the program.
+            // SAFETY: fv is leaked to ensure it is not freed and remains valid for the duration of the program.
             let handle = unsafe {
                 CORE.pi_dispatcher
                     .fv_data
@@ -1228,7 +1230,7 @@ mod tests {
         with_locked_state(|| {
             static CORE: MockCore = MockCore::new(NullSectionExtractor::new());
             CORE.override_instance();
-            // Safety: fv is leaked to ensure it is not freed and remains valid for the duration of the program.
+            // SAFETY: fv is leaked to ensure it is not freed and remains valid for the duration of the program.
             let handle = unsafe {
                 CORE.pi_dispatcher
                     .fv_data
@@ -1308,7 +1310,7 @@ mod tests {
                     &security_protocol as *const _ as *mut _,
                 )
                 .unwrap();
-            // Safety: fv is leaked to ensure it is not freed and remains valid for the duration of the program.
+            // SAFETY: fv is leaked to ensure it is not freed and remains valid for the duration of the program.
             let handle =
                 unsafe { CORE.pi_dispatcher.fv_data.lock().install_firmware_volume(fv.as_ptr() as u64, None).unwrap() };
 

--- a/patina_dxe_core/src/pi_dispatcher/fv.rs
+++ b/patina_dxe_core/src/pi_dispatcher/fv.rs
@@ -119,7 +119,7 @@ impl<P: PlatformInfo> FvProtocolData<P> {
     ) -> Result<fvb::attributes::EfiFvbAttributes2, EfiError> {
         let physical_address = self.get_fvb_address(protocol).ok_or(EfiError::NotFound)?;
 
-        // Safety: physical_address must point to a valid FV (i.e. private_data is correctly constructed and
+        // SAFETY: physical_address must point to a valid FV (i.e. private_data is correctly constructed and
         // its invariants - like not removing fv once installed - are upheld).
         let fv = unsafe { VolumeRef::new_from_address(physical_address)? };
         Ok(fv.attributes())
@@ -143,7 +143,7 @@ impl<P: PlatformInfo> FvProtocolData<P> {
     ) -> Result<(usize, usize), EfiError> {
         let physical_address = self.get_fvb_address(protocol).ok_or(EfiError::NotFound)?;
 
-        // Safety: physical_address must point to a valid FV (i.e. private_data is correctly constructed and
+        // SAFETY: physical_address must point to a valid FV (i.e. private_data is correctly constructed and
         // its invariants - like not removing fv once installed - are upheld).
         let fv = unsafe { VolumeRef::new_from_address(physical_address)? };
 
@@ -164,7 +164,7 @@ impl<P: PlatformInfo> FvProtocolData<P> {
     ) -> Result<&'static [u8], EfiError> {
         let physical_address = self.get_fvb_address(protocol).ok_or(EfiError::NotFound)?;
 
-        // Safety: physical_address must point to a valid FV (i.e. private_data is correctly constructed and
+        // SAFETY: physical_address must point to a valid FV (i.e. private_data is correctly constructed and
         // its invariants - like not removing fv once installed - are upheld).
         let fv = unsafe { VolumeRef::new_from_address(physical_address) }?;
         let Ok(lba) = lba.try_into() else {
@@ -180,7 +180,7 @@ impl<P: PlatformInfo> FvProtocolData<P> {
         }
 
         let lba_start = (physical_address as usize).saturating_add(lba_base_addr).saturating_add(offset) as *mut u8;
-        // Safety: lba_start is calculated from the base address of a valid FV, plus an offset and offset+num_bytes.
+        // SAFETY: lba_start is calculated from the base address of a valid FV, plus an offset and offset+num_bytes.
         // consistency of this data is guaranteed by checks on instantiation of the VolumeRef.
         // The FV data is expected to be 'static (i.e. permanently mapped) for the lifetime of the system.
         unsafe { Ok(slice::from_raw_parts(lba_start, bytes_to_read)) }
@@ -193,7 +193,7 @@ impl<P: PlatformInfo> FvProtocolData<P> {
     ) -> Result<fv::attributes::EfiFvAttributes, EfiError> {
         let physical_address = self.get_fv_address(protocol).ok_or(EfiError::NotFound)?;
 
-        // Safety: physical_address must point to a valid FV (i.e. private_data is correctly constructed and
+        // SAFETY: physical_address must point to a valid FV (i.e. private_data is correctly constructed and
         // its invariants - like not removing fv once installed - are upheld).
         let fv = unsafe { VolumeRef::new_from_address(physical_address)? };
 
@@ -208,7 +208,7 @@ impl<P: PlatformInfo> FvProtocolData<P> {
     ) -> Result<FileRef<'_>, EfiError> {
         let physical_address = self.get_fv_address(protocol).ok_or(EfiError::NotFound)?;
 
-        // Safety: physical_address must point to a valid FV (i.e. private_data is correctly constructed and
+        // SAFETY: physical_address must point to a valid FV (i.e. private_data is correctly constructed and
         // its invariants - like not removing fv once installed - are upheld).
         let fv = unsafe { VolumeRef::new_from_address(physical_address) }?;
 
@@ -254,7 +254,7 @@ impl<P: PlatformInfo> FvProtocolData<P> {
     ) -> Result<(efi::Guid, fv::file::EfiFvFileAttributes, usize, fv::EfiFvFileType), EfiError> {
         let physical_address = self.get_fv_address(protocol).ok_or(EfiError::NotFound)?;
 
-        // Safety: physical_address must point to a valid FV (i.e. private_data is correctly constructed and
+        // SAFETY: physical_address must point to a valid FV (i.e. private_data is correctly constructed and
         // its invariants - like not removing fv once installed - are upheld).
         let fv = unsafe { VolumeRef::new_from_address(physical_address) }?;
 
@@ -372,7 +372,7 @@ impl<P: PlatformInfo> FvProtocolData<P> {
         base_address: u64,
         parent_handle: Option<efi::Handle>,
     ) -> Result<efi::Handle, EfiError> {
-        // Safety: Caller must meet the safety requirements of this function.
+        // SAFETY: Caller must meet the safety requirements of this function.
         let handle = unsafe { self.install_fv_device_path_protocol(None, base_address)? };
         self.install_fvb_protocol(Some(handle), parent_handle, base_address)?;
         self.install_fv_protocol(Some(handle), parent_handle, base_address)?;
@@ -386,10 +386,10 @@ impl<P: PlatformInfo> FvProtocolData<P> {
 
         for fv in fv_hobs {
             // construct a FirmwareVolume struct to verify sanity.
-            // Safety: base addresses of FirmwareVolume HOBs are assumed to be valid and accessible.
+            // SAFETY: base addresses of FirmwareVolume HOBs are assumed to be valid and accessible.
             let fv_slice = unsafe { slice::from_raw_parts(fv.base_address as *const u8, fv.length as usize) };
             VolumeRef::new(fv_slice)?;
-            // Safety: base addresses of FirmwareVolume HOBs are assumed to be valid and accessible.
+            // SAFETY: base addresses of FirmwareVolume HOBs are assumed to be valid and accessible.
             unsafe { self.install_firmware_volume(fv.base_address, None) }?;
         }
         Ok(())
@@ -405,7 +405,7 @@ impl<P: PlatformInfo> FvProtocolData<P> {
         handle: Option<efi::Handle>,
         base_address: u64,
     ) -> Result<efi::Handle, EfiError> {
-        // Safety: caller must ensure that base_address is valid.
+        // SAFETY: caller must ensure that base_address is valid.
         let fv = unsafe { VolumeRef::new_from_address(base_address) }?;
 
         let device_path_ptr = match fv.fv_name() {
@@ -468,7 +468,7 @@ impl<P: PlatformInfo> FvProtocolData<P> {
 
         match Self::instance().fvb_get_attributes(protocol) {
             Err(err) => return err.into(),
-            // Safety: caller must provide a valid pointer to receive the attributes. It is null-checked above.
+            // SAFETY: caller must provide a valid pointer to receive the attributes. It is null-checked above.
             Ok(fvb_attributes) => unsafe { attributes.write_unaligned(fvb_attributes) },
         };
 
@@ -498,7 +498,7 @@ impl<P: PlatformInfo> FvProtocolData<P> {
 
         match Self::instance().fvb_get_physical_address(protocol) {
             Err(err) => return err.into(),
-            // Safety: caller must provide a valid pointer to receive the address. It is null-checked above.
+            // SAFETY: caller must provide a valid pointer to receive the address. It is null-checked above.
             Ok(physical_address) => unsafe { address.write_unaligned(physical_address) },
         };
 
@@ -525,7 +525,7 @@ impl<P: PlatformInfo> FvProtocolData<P> {
             Ok((size, remaining_blocks)) => (size, remaining_blocks),
         };
 
-        // Safety: caller must provide valid pointers to receive the block size and number of blocks. They are null-checked above.
+        // SAFETY: caller must provide valid pointers to receive the block size and number of blocks. They are null-checked above.
         unsafe {
             block_size.write_unaligned(size);
             number_of_blocks.write_unaligned(remaining_blocks);
@@ -550,7 +550,7 @@ impl<P: PlatformInfo> FvProtocolData<P> {
             return efi::Status::INVALID_PARAMETER;
         };
 
-        // Safety: caller must provide valid pointers for num_bytes and buffer. They are null-checked above.
+        // SAFETY: caller must provide valid pointers for num_bytes and buffer. They are null-checked above.
         let bytes_to_read = unsafe { *num_bytes };
 
         let data = match Self::instance().fvb_read(protocol, lba, offset, bytes_to_read) {
@@ -559,13 +559,13 @@ impl<P: PlatformInfo> FvProtocolData<P> {
         };
 
         if data.len() > bytes_to_read {
-            // Safety: caller must provide a valid pointer for num_bytes. It is null-checked above.
+            // SAFETY: caller must provide a valid pointer for num_bytes. It is null-checked above.
             unsafe { num_bytes.write_unaligned(data.len()) };
             return efi::Status::BUFFER_TOO_SMALL;
         }
 
         // copy from memory into the destination buffer to do the read.
-        // Safety: buffer must be valid for writes of at least bytes_to_read length. It is null-checked above, and
+        // SAFETY: buffer must be valid for writes of at least bytes_to_read length. It is null-checked above, and
         // the caller must ensure that the buffer is large enough to hold the data being read.
         unsafe {
             let dest_buffer = slice::from_raw_parts_mut(buffer as *mut u8, data.len());
@@ -613,7 +613,7 @@ impl<P: PlatformInfo> FvProtocolData<P> {
             Ok(attrs) => attrs,
         };
 
-        // Safety: caller must provide a valid pointer to receive the attributes. It is null-checked above.
+        // SAFETY: caller must provide a valid pointer to receive the attributes. It is null-checked above.
         unsafe { fv_attributes.write_unaligned(fv_attributes_data) };
 
         efi::Status::SUCCESS
@@ -650,9 +650,9 @@ impl<P: PlatformInfo> FvProtocolData<P> {
             return efi::Status::INVALID_PARAMETER;
         };
 
-        // Safety: caller must provide valid pointers for buffer_size and name_guid. They are null-checked above.
+        // SAFETY: caller must provide valid pointers for buffer_size and name_guid. They are null-checked above.
         let local_buffer_size = unsafe { buffer_size.read_unaligned() };
-        // Safety: caller must provide valid pointers for buffer_size and name_guid. They are null-checked above.
+        // SAFETY: caller must provide valid pointers for buffer_size and name_guid. They are null-checked above.
         let name = unsafe { name_guid.read_unaligned() };
 
         let this = Self::instance();
@@ -662,7 +662,7 @@ impl<P: PlatformInfo> FvProtocolData<P> {
         };
 
         // update file metadata output pointers (buffer_size is written later).
-        // Safety: caller must provide valid pointers for found_type and file_attributes. They are null-checked above.
+        // SAFETY: caller must provide valid pointers for found_type and file_attributes. They are null-checked above.
         unsafe {
             found_type.write_unaligned(file.file_type_raw());
             file_attributes.write_unaligned(file.fv_attributes());
@@ -672,14 +672,14 @@ impl<P: PlatformInfo> FvProtocolData<P> {
 
         if buffer.is_null() {
             // The caller just wants file meta data, no need to read file data.
-            // Safety: The caller must provide a valid pointer for buffer_size. It is null-checked above.
+            // SAFETY: The caller must provide a valid pointer for buffer_size. It is null-checked above.
             unsafe {
                 buffer_size.write_unaligned(file.content().len());
             }
             return efi::Status::SUCCESS;
         }
 
-        // Safety: caller must provide a valid pointer for buffer. It is null-checked above.
+        // SAFETY: caller must provide a valid pointer for buffer. It is null-checked above.
         let mut local_buffer_ptr = unsafe { buffer.read_unaligned() };
 
         // Determine the size to copy and the return status. For compatibility with existing callers to this function,
@@ -700,7 +700,7 @@ impl<P: PlatformInfo> FvProtocolData<P> {
             //allocate it via allocate_pool.
             match core_allocate_pool(efi::BOOT_SERVICES_DATA, file.content().len()) {
                 Err(err) => return err.into(),
-                // Safety: caller must provide a valid pointer for buffer. It is null-checked above.
+                // SAFETY: caller must provide a valid pointer for buffer. It is null-checked above.
                 Ok(allocation) => unsafe {
                     local_buffer_ptr = allocation;
                     buffer.write_unaligned(local_buffer_ptr);
@@ -714,13 +714,13 @@ impl<P: PlatformInfo> FvProtocolData<P> {
             (file.content().len(), efi::Status::SUCCESS)
         };
 
-        // Safety: The caller must provide a valid pointer for buffer_size. It is null-checked above.
+        // SAFETY: The caller must provide a valid pointer for buffer_size. It is null-checked above.
         unsafe {
             buffer_size.write_unaligned(copy_size);
         }
 
         // convert pointer+size into a slice and copy the file data (truncated if necessary).
-        // Safety: local_buffer_ptr is either provided by the caller (and null-checked above), or allocated via allocate pool
+        // SAFETY: local_buffer_ptr is either provided by the caller (and null-checked above), or allocated via allocate pool
         // and is of sufficient size to contain the data.
         let out_buffer = unsafe { slice::from_raw_parts_mut(local_buffer_ptr as *mut u8, copy_size) };
         out_buffer.copy_from_slice(&file.content()[..copy_size]);
@@ -746,7 +746,7 @@ impl<P: PlatformInfo> FvProtocolData<P> {
             return efi::Status::INVALID_PARAMETER;
         };
 
-        // Safety: caller must provide valid pointer for name_guid. It is null-checked above.
+        // SAFETY: caller must provide valid pointer for name_guid. It is null-checked above.
         let name = unsafe { name_guid.read_unaligned() };
 
         let extractor = &Core::<P>::instance().pi_dispatcher.section_extractor;
@@ -762,7 +762,7 @@ impl<P: PlatformInfo> FvProtocolData<P> {
         };
 
         // get the buffer_size and buffer parameters from caller.
-        // Safety: null-checks are at the start of the routine, but caller is required to guarantee that buffer_size and
+        // SAFETY: null-checks are at the start of the routine, but caller is required to guarantee that buffer_size and
         // buffer are valid.
         let mut local_buffer_size = unsafe { buffer_size.read_unaligned() };
         let mut local_buffer_ptr = unsafe { buffer.read_unaligned() };
@@ -774,7 +774,7 @@ impl<P: PlatformInfo> FvProtocolData<P> {
             //allocate it via allocate_pool.
             match core_allocate_pool(efi::BOOT_SERVICES_DATA, section_data.len()) {
                 Err(err) => return err.into(),
-                // Safety: caller is required to guarantee that buffer_size and buffer are valid.
+                // SAFETY: caller is required to guarantee that buffer_size and buffer are valid.
                 Ok(allocation) => unsafe {
                     local_buffer_size = section_data.len();
                     local_buffer_ptr = allocation;
@@ -784,7 +784,7 @@ impl<P: PlatformInfo> FvProtocolData<P> {
             }
         } else {
             // update buffer size output for the caller
-            // Safety: null-checked at the start of the routine, but caller is required to guarantee buffer_size is valid.
+            // SAFETY: null-checked at the start of the routine, but caller is required to guarantee buffer_size is valid.
             unsafe {
                 buffer_size.write_unaligned(section_data.len());
             }
@@ -798,7 +798,7 @@ impl<P: PlatformInfo> FvProtocolData<P> {
         // larger than the section_data, we could inadvertently copy beyond the section_data slice.
         let copy_size = core::cmp::min(section_data.len(), local_buffer_size);
 
-        // Safety: local_buffer_ptr is either provided by the caller (and null-checked above), or allocated via allocate pool and
+        // SAFETY: local_buffer_ptr is either provided by the caller (and null-checked above), or allocated via allocate pool and
         // is of sufficient size to contain the data. We copy the minimum of section_data.len() and local_buffer_size to ensure we do not
         // copy beyond the bounds of either buffer.
         let dest_buffer = unsafe { slice::from_raw_parts_mut(local_buffer_ptr as *mut u8, copy_size) };
@@ -836,9 +836,9 @@ impl<P: PlatformInfo> FvProtocolData<P> {
             return efi::Status::INVALID_PARAMETER;
         };
 
-        // Safety: caller must provide valid pointers for key and file_type. They are null-checked above.
+        // SAFETY: caller must provide valid pointers for key and file_type. They are null-checked above.
         let local_key = unsafe { (key as *mut usize).read_unaligned() };
-        // Safety: caller must provide valid pointers for key and file_type. They are null-checked above.
+        // SAFETY: caller must provide valid pointers for key and file_type. They are null-checked above.
         let local_file_type = unsafe { file_type.read_unaligned() };
 
         if local_file_type >= ffs::file::raw::r#type::FFS_MIN {
@@ -851,7 +851,7 @@ impl<P: PlatformInfo> FvProtocolData<P> {
                 Ok((name, attrs, size, file_type)) => (name, attrs, size, file_type),
             };
 
-        // Safety: caller must provide valid pointers for key, file_type, name_guid, attributes, and size. They are null-checked above.
+        // SAFETY: caller must provide valid pointers for key, file_type, name_guid, attributes, and size. They are null-checked above.
         unsafe {
             (key as *mut usize).write_unaligned(local_key.saturating_add(1));
             name_guid.write_unaligned(file_name);
@@ -1003,7 +1003,7 @@ mod tests {
     #[test]
     fn test_fv_init_core() {
         test_support::with_global_lock(|| {
-            // Safety: global lock ensures exclusive access to the private data.
+            // SAFETY: global lock ensures exclusive access to the private data.
             fn gen_firmware_volume2() -> hob::FirmwareVolume2 {
                 let header =
                     hob::header::Hob { r#type: hob::FV, length: size_of::<hob::FirmwareVolume2>() as u16, reserved: 0 };
@@ -1093,7 +1093,7 @@ mod tests {
 
             static CORE: MockCore = MockCore::new(CompositeSectionExtractor::new());
             CORE.override_instance();
-            // Safety: fv was leaked above to ensure that the buffer is valid and immutable for the rest of the test.
+            // SAFETY: fv was leaked above to ensure that the buffer is valid and immutable for the rest of the test.
             let _handle =
                 unsafe { CORE.pi_dispatcher.fv_data.lock().install_fv_device_path_protocol(None, base_address) };
 
@@ -1101,7 +1101,7 @@ mod tests {
              * for test_fv_functionality.
              * In case other functions/modules are written, clear the private global data again.
              */
-            // Safety: global lock ensures exclusive access to the private data.
+            // SAFETY: global lock ensures exclusive access to the private data.
             CORE.pi_dispatcher.fv_data.lock().fv_metadata.clear();
             assert!(CORE.pi_dispatcher.fv_data.lock().fv_metadata.is_empty());
 
@@ -1173,7 +1173,7 @@ mod tests {
             });
             let fvb_intf_data_n_mut = fvb_intf_data_n.as_mut() as *mut pi::protocols::firmware_volume_block::Protocol;
 
-            // Safety: the following test code must uphold the safety expectations of the unsafe
+            // SAFETY: the following test code must uphold the safety expectations of the unsafe
             // functions it calls. It uses direct memory allocations to create buffers for testing FFI
             // functions.
             unsafe {
@@ -1674,7 +1674,7 @@ mod tests {
              * for test_fv_functionality.
              * In case other functions/modules are written, clear the private global data again.
              */
-            // Safety: global lock ensures exclusive access to the private data.
+            // SAFETY: global lock ensures exclusive access to the private data.
             static CORE: MockCore = MockCore::new(CompositeSectionExtractor::new());
             CORE.override_instance();
 
@@ -1687,7 +1687,7 @@ mod tests {
             CORE.pi_dispatcher.fv_data.lock().fv_metadata.insert(fv_ptr.addr(), private_data);
             let fv_ptr1: *const pi::protocols::firmware_volume::Protocol = fv_ptr.as_ptr();
 
-            // Safety: the following test code must uphold the safety expectations of the unsafe
+            // SAFETY: the following test code must uphold the safety expectations of the unsafe
             // functions it calls. It uses direct memory management to test fv FFI primitives.
             unsafe {
                 let layout = Layout::from_size_align(1000, 8).unwrap();
@@ -1763,7 +1763,7 @@ mod tests {
 
             let fv_ptr1: *const pi::protocols::firmware_volume::Protocol = fv_ptr.as_ptr();
 
-            // Safety: the following test code must uphold the safety expectations of the unsafe
+            // SAFETY: the following test code must uphold the safety expectations of the unsafe
             // functions it calls. This unsafe section encompasses all of the logic for the remaining
             // test since this is test code.
             unsafe {
@@ -1892,7 +1892,7 @@ mod tests {
 
             let fv_ptr1 = fv_ptr.as_ptr();
 
-            // Safety: the following test code must uphold the safety expectations of the unsafe
+            // SAFETY: the following test code must uphold the safety expectations of the unsafe
             // functions it calls. This unsafe section encompasses all of the logic for the remaining
             // test since this is test code.
             unsafe {

--- a/patina_dxe_core/src/pi_dispatcher/image.rs
+++ b/patina_dxe_core/src/pi_dispatcher/image.rs
@@ -809,7 +809,7 @@ impl<P: super::PlatformInfo> super::PiDispatcher<P> {
                 Err(ImageStatus::LoadError(err)) => return err.into(),
             };
 
-        // Safety: Caller must ensure that image_handle is a valid pointer. It is null-checked above.
+        // SAFETY: Caller must ensure that image_handle is a valid pointer. It is null-checked above.
         unsafe { image_handle.write_unaligned(handle) };
         status
     }
@@ -926,7 +926,7 @@ impl<P: super::PlatformInfo> super::PiDispatcher<P> {
                 && !exit_data_size.is_null()
                 && !exit_data.is_null()
             {
-                // Safety: Caller must ensure that exit_data_size and exit_data are valid pointers if they are non-null.
+                // SAFETY: Caller must ensure that exit_data_size and exit_data are valid pointers if they are non-null.
                 unsafe {
                     exit_data_size.write_unaligned(image_exit_data.0);
                     exit_data.write_unaligned(image_exit_data.1);
@@ -1224,9 +1224,10 @@ fn core_load_pe_image(
 
     private_info.load_resource_section(image)?;
 
-    // If we are not NX compatible and a runtime driver, we need to attempt to activate compatibility mode.
+    // If we are not NX compatible and a EFI Application, we need to attempt to activate compatibility mode.
+    // Compatability mode may or may not actually activate depending on how we are configured.
     // Otherwise apply the memory protections.
-    if private_info.pe_info.image_type == EFI_IMAGE_SUBSYSTEM_EFI_RUNTIME_DRIVER && !private_info.pe_info.nx_compat {
+    if private_info.pe_info.image_type == EFI_IMAGE_SUBSYSTEM_EFI_APPLICATION && !private_info.pe_info.nx_compat {
         private_info.activate_compatibility_mode()?;
     } else {
         // finally, update the GCD attributes for this image so that code sections have RO set and data sections

--- a/patina_dxe_core/src/protocol_db.rs
+++ b/patina_dxe_core/src/protocol_db.rs
@@ -513,9 +513,17 @@ impl ProtocolDb {
     }
 
     fn register_protocol_notify(&mut self, protocol: efi::Guid, event: efi::Event) -> Result<*mut c_void, EfiError> {
+        // Modeling EDK2 behavior, enumerate handles *already* installed, not only future installs
+        let mut fresh_handles = BTreeSet::new();
+        for (key, handle_data) in self.handles.iter() {
+            if handle_data.contains_key(&OrdGuid(protocol)) {
+                fresh_handles.insert(*key as efi::Handle);
+            }
+        }
+
         let registration = self.next_registration as *mut c_void;
         self.next_registration += 1;
-        let protocol_notify = ProtocolNotify { event, registration, fresh_handles: BTreeSet::new() };
+        let protocol_notify = ProtocolNotify { event, registration, fresh_handles };
 
         if let Some(existing_key) = self.notifications.get_mut(&OrdGuid(protocol)) {
             existing_key.push(protocol_notify);
@@ -2014,6 +2022,33 @@ mod tests {
             assert_eq!(notify_list[1].fresh_handles.len(), 1);
             assert!(notify_list[1].fresh_handles.contains(&result.0));
             assert_eq!(notify_list[1].registration, reg2);
+        });
+    }
+
+    #[test]
+    fn register_protocol_notify_should_seed_existing_handles() {
+        with_locked_state(|| {
+            static SPIN_LOCKED_PROTOCOL_DB: SpinLockedProtocolDb = SpinLockedProtocolDb::new();
+
+            let uuid1 = Uuid::from_str("0e896c7a-57dc-4987-bc22-abc3a8263210").unwrap();
+            let guid1 = efi::Guid::from_bytes(uuid1.as_bytes());
+            let interface1: *mut c_void = 0x1234 as *mut c_void;
+
+            // Create existing protocol
+            let existing_handle =
+                SPIN_LOCKED_PROTOCOL_DB.install_protocol_interface(None, guid1, interface1).unwrap().0;
+
+            // Register for notification
+            let event = 0x8765 as *mut c_void;
+            let reg = SPIN_LOCKED_PROTOCOL_DB.register_protocol_notify(guid1, event).unwrap();
+
+            // First call after register should return handle to existing protocol
+            let next = SPIN_LOCKED_PROTOCOL_DB.next_handle_for_registration(reg);
+            assert_eq!(next, Some(existing_handle));
+
+            // Second call should return no more protocols
+            let next = SPIN_LOCKED_PROTOCOL_DB.next_handle_for_registration(reg);
+            assert_eq!(next, None);
         });
     }
 

--- a/patina_dxe_core/src/protocols.rs
+++ b/patina_dxe_core/src/protocols.rs
@@ -20,6 +20,7 @@ use crate::{
     driver_services::{core_connect_controller, core_disconnect_controller},
     events::{EVENT_DB, signal_event},
     protocol_db::{DXE_CORE_HANDLE, SpinLockedProtocolDb},
+    systemtables::EfiSystemTable,
     tpl_mutex,
 };
 
@@ -56,7 +57,7 @@ extern "efiapi" fn install_protocol_interface(
     if handle.is_null() || protocol.is_null() || interface_type != efi::NATIVE_INTERFACE {
         return efi::Status::INVALID_PARAMETER;
     }
-    // Safety: Caller must ensure that handle and protocol are valid pointers. They are null-checked above.
+    // SAFETY: Caller must ensure that handle and protocol are valid pointers. They are null-checked above.
     let caller_handle = unsafe { handle.read_unaligned() };
     let caller_protocol = unsafe { protocol.read_unaligned() };
 
@@ -168,7 +169,7 @@ extern "efiapi" fn uninstall_protocol_interface(
         return efi::Status::INVALID_PARAMETER;
     }
 
-    // Safety: Caller must ensure that protocol is a valid pointer. It is null-checked above.
+    // SAFETY: Caller must ensure that protocol is a valid pointer. It is null-checked above.
     let caller_protocol = unsafe { protocol.read_unaligned() };
 
     core_uninstall_protocol_interface(handle, caller_protocol, interface)
@@ -219,7 +220,7 @@ extern "efiapi" fn reinstall_protocol_interface(
         }
     }
 
-    // Safety: Caller must ensure that protocol is a valid pointer. It is null-checked above.
+    // SAFETY: Caller must ensure that protocol is a valid pointer. It is null-checked above.
     let protocol = unsafe { protocol.read_unaligned() };
 
     // Call install to install the new interface and trigger any notifies
@@ -250,7 +251,7 @@ extern "efiapi" fn register_protocol_notify(
     if protocol.is_null() || registration.is_null() || !EVENT_DB.is_valid(event) {
         return efi::Status::INVALID_PARAMETER;
     }
-    // Safety: Caller must ensure that protocol is a valid pointer. It is null-checked above.
+    // SAFETY: Caller must ensure that protocol is a valid pointer. It is null-checked above.
     match PROTOCOL_DB.register_protocol_notify(unsafe { protocol.read_unaligned() }, event) {
         Err(err) => err.into(),
         Ok(new_registration) => {
@@ -283,7 +284,7 @@ extern "efiapi" fn locate_handle(
             if protocol.is_null() {
                 return efi::Status::INVALID_PARAMETER;
             }
-            // Safety: Caller must ensure that protocol is a valid pointer. It is null-checked above.
+            // SAFETY: Caller must ensure that protocol is a valid pointer. It is null-checked above.
             PROTOCOL_DB.locate_handles(Some(unsafe { protocol.read_unaligned() }))
         }
         _ => return efi::Status::INVALID_PARAMETER,
@@ -300,9 +301,9 @@ extern "efiapi" fn locate_handle(
             }
 
             list.shrink_to_fit();
-            // Safety: Caller must ensure that buffer_size is a valid pointer. It is null-checked above.
+            // SAFETY: Caller must ensure that buffer_size is a valid pointer. It is null-checked above.
             let input_size = unsafe { buffer_size.read_unaligned() };
-            // Safety: Caller must ensure that buffer_size is a valid pointer. It is null-checked above.
+            // SAFETY: Caller must ensure that buffer_size is a valid pointer. It is null-checked above.
             unsafe {
                 buffer_size.write_unaligned(list.len() * size_of::<efi::Handle>());
             }
@@ -354,7 +355,7 @@ extern "efiapi" fn open_protocol(
         return efi::Status::INVALID_PARAMETER;
     }
 
-    // Safety: Caller must ensure that protocol is a valid pointer. It is null-checked above.
+    // SAFETY: Caller must ensure that protocol is a valid pointer. It is null-checked above.
     let protocol = unsafe { protocol.read_unaligned() };
 
     if interface.is_null() && attributes != efi::OPEN_PROTOCOL_TEST_PROTOCOL {
@@ -379,7 +380,7 @@ extern "efiapi" fn open_protocol(
                 && (x.attributes & efi::OPEN_PROTOCOL_EXCLUSIVE) == 0
                 && x.agent_handle != agent_handle
         }) {
-            // Safety: handles are validated above.
+            // SAFETY: handles are validated above.
             unsafe {
                 if core_disconnect_controller(handle, usage.agent_handle, None).is_err() {
                     return efi::Status::ACCESS_DENIED;
@@ -391,7 +392,7 @@ extern "efiapi" fn open_protocol(
     match PROTOCOL_DB.add_protocol_usage(handle, protocol, agent_handle, controller_handle, attributes) {
         Err(EfiError::Unsupported) => {
             if !interface.is_null() {
-                // Safety: Caller must ensure that interface is a valid pointer if it is non-null.
+                // SAFETY: Caller must ensure that interface is a valid pointer if it is non-null.
                 unsafe { interface.write_unaligned(core::ptr::null_mut()) };
             }
             return efi::Status::UNSUPPORTED;
@@ -402,7 +403,7 @@ extern "efiapi" fn open_protocol(
                 .get_interface_for_handle(handle, protocol)
                 .expect("Already Started can't happen if protocol doesn't exist.");
             if !interface.is_null() {
-                // Safety: Caller must ensure that interface is a valid pointer if it is non-null.
+                // SAFETY: Caller must ensure that interface is a valid pointer if it is non-null.
                 unsafe { interface.write_unaligned(desired_interface) };
             }
             return efi::Status::ALREADY_STARTED;
@@ -418,7 +419,7 @@ extern "efiapi" fn open_protocol(
     };
 
     if attributes != efi::OPEN_PROTOCOL_TEST_PROTOCOL {
-        // Safety: Caller must ensure that interface is a valid pointer if it is non-null.
+        // SAFETY: Caller must ensure that interface is a valid pointer if it is non-null.
         unsafe { interface.write_unaligned(desired_interface) };
     }
     efi::Status::SUCCESS
@@ -450,7 +451,7 @@ extern "efiapi" fn close_protocol(
 
     match PROTOCOL_DB.remove_protocol_usage(
         handle,
-        // Safety: Caller must ensure that protocol is a valid pointer. It is null-checked above.
+        // SAFETY: Caller must ensure that protocol is a valid pointer. It is null-checked above.
         unsafe { protocol.read_unaligned() },
         Some(agent_handle),
         controller_handle,
@@ -472,7 +473,7 @@ extern "efiapi" fn open_protocol_information(
     }
 
     let mut open_info: Vec<efi::OpenProtocolInformationEntry> =
-        // Safety: Caller must ensure that protocol is a valid pointer. It is null-checked above.
+        // SAFETY: Caller must ensure that protocol is a valid pointer. It is null-checked above.
         match PROTOCOL_DB.get_open_protocol_information_by_protocol(handle, unsafe { protocol.read_unaligned() }) {
             Err(err) => return err.into(),
             Ok(info) => info.into_iter().map(efi::OpenProtocolInformationEntry::from).collect(),
@@ -485,7 +486,7 @@ extern "efiapi" fn open_protocol_information(
     match core_allocate_pool(efi::BOOT_SERVICES_DATA, buffer_size) {
         Err(err) => err.into(),
         Ok(allocation) =>
-        // Safety: Caller must ensure that entry_buffer and entry_count are valid pointers. They are null-checked above.
+        // SAFETY: Caller must ensure that entry_buffer and entry_count are valid pointers. They are null-checked above.
         unsafe {
             entry_buffer.write_unaligned(allocation as *mut efi::OpenProtocolInformationEntry);
             entry_count.write_unaligned(open_info.len());
@@ -614,7 +615,7 @@ extern "efiapi" fn protocols_per_handle(
     //caller is supposed to free the entry buffer using free pool, so we need to allocate it using allocate pool.
     match core_allocate_pool(efi::BOOT_SERVICES_DATA, ptr_buffer_size + guid_buffer_size) {
         Err(err) => err.into(),
-        // Safety: Caller must ensure that protocol_buffer and protocol_buffer_count are valid pointers. They are null-checked above.
+        // SAFETY: Caller must ensure that protocol_buffer and protocol_buffer_count are valid pointers. They are null-checked above.
         Ok(allocation) => unsafe {
             protocol_buffer.write_unaligned(allocation as *mut *mut efi::Guid);
             protocol_buffer_count.write_unaligned(protocol_list.len());
@@ -644,7 +645,7 @@ extern "efiapi" fn locate_handle_buffer(
 
     //EDK2 C reference code unconditionally sets no_handles and buffer to default values regardless of success or failure
     //of the function, and some callers expect this behavior (and don't check return status before using no_handles).
-    // Safety: Caller must ensure that no_handles and buffer are valid pointers. They are null-checked above.
+    // SAFETY: Caller must ensure that no_handles and buffer are valid pointers. They are null-checked above.
     unsafe {
         no_handles.write_unaligned(0);
         buffer.write_unaligned(core::ptr::null_mut());
@@ -666,7 +667,7 @@ extern "efiapi" fn locate_handle_buffer(
             if protocol.is_null() {
                 return efi::Status::INVALID_PARAMETER;
             }
-            // Safety: Caller must ensure that protocol is a valid pointer. It is null-checked above.
+            // SAFETY: Caller must ensure that protocol is a valid pointer. It is null-checked above.
             unsafe { PROTOCOL_DB.locate_handles(Some(protocol.read_unaligned())) }
         }
         _ => return efi::Status::INVALID_PARAMETER,
@@ -683,7 +684,7 @@ extern "efiapi" fn locate_handle_buffer(
         let buffer_size = handles.len() * size_of::<efi::Handle>();
         match core_allocate_pool(efi::BOOT_SERVICES_DATA, buffer_size) {
             Err(err) => err.into(),
-            // Safety: Caller must ensure that no_handles and buffer are valid pointers. They are null-checked above.
+            // SAFETY: Caller must ensure that no_handles and buffer are valid pointers. They are null-checked above.
             Ok(allocation) => unsafe {
                 buffer.write_unaligned(allocation as *mut efi::Handle);
                 no_handles.write_unaligned(handles.len());
@@ -705,7 +706,7 @@ extern "efiapi" fn locate_protocol(
 
     if !registration.is_null() {
         if let Some(handle) = PROTOCOL_DB.next_handle_for_registration(registration) {
-            // Safety: Caller must ensure that protocol and interface are valid pointers. They are null-checked above.
+            // SAFETY: Caller must ensure that protocol and interface are valid pointers. They are null-checked above.
             let i_face = PROTOCOL_DB
                 .get_interface_for_handle(handle, unsafe { protocol.read_unaligned() })
                 .expect("Protocol should exist on handle if it is returned for registration key.");
@@ -716,11 +717,11 @@ extern "efiapi" fn locate_protocol(
     } else {
         match PROTOCOL_DB.locate_protocol(unsafe { protocol.read_unaligned() }) {
             Err(err) => {
-                // Safety: Caller must ensure that interface is a valid pointer. It is null-checked above.
+                // SAFETY: Caller must ensure that interface is a valid pointer. It is null-checked above.
                 unsafe { interface.write_unaligned(core::ptr::null_mut()) };
                 return err.into();
             }
-            // Safety: Caller must ensure that interface is a valid pointer. It is null-checked above.
+            // SAFETY: Caller must ensure that interface is a valid pointer. It is null-checked above.
             Ok(i_face) => unsafe { interface.write_unaligned(i_face) },
         }
     }
@@ -774,13 +775,13 @@ extern "efiapi" fn locate_device_path(
     device_path: *mut *mut r_efi::protocols::device_path::Protocol,
     device: *mut efi::Handle,
 ) -> efi::Status {
-    // Safety: Caller must ensure that protocol, device_path, and device are valid pointers. They are null-checked below.
+    // SAFETY: Caller must ensure that protocol, device_path, and device are valid pointers. They are null-checked below.
     if protocol.is_null() || device_path.is_null() || unsafe { device_path.read_unaligned() }.is_null() {
         return efi::Status::INVALID_PARAMETER;
     }
 
     let (best_remaining_path, best_device) =
-        // Safety: Caller must ensure that protocol and device_path are valid pointers. They are null-checked above.
+        // SAFETY: Caller must ensure that protocol and device_path are valid pointers. They are null-checked above.
         match core_locate_device_path(unsafe { protocol.read_unaligned() }, unsafe { device_path.read_unaligned() }) {
             Err(err) => return err.into(),
             Ok((path, device)) => (path, device),
@@ -788,7 +789,7 @@ extern "efiapi" fn locate_device_path(
     if device.is_null() {
         return efi::Status::INVALID_PARAMETER;
     }
-    // Safety: Caller must ensure that device_path and device are valid pointers. They are null-checked above.
+    // SAFETY: Caller must ensure that device_path and device are valid pointers. They are null-checked above.
     unsafe {
         device.write_unaligned(best_device);
         device_path.write_unaligned(best_remaining_path);
@@ -797,13 +798,14 @@ extern "efiapi" fn locate_device_path(
     efi::Status::SUCCESS
 }
 
-pub fn init_protocol_support(bs: &mut efi::BootServices) {
+pub fn init_protocol_support(st: &mut EfiSystemTable) {
+    let mut bs = st.boot_services().get();
+
     //This bit of trickery is needed because r_efi definition of (Un)InstallMultipleProtocolInterfaces
     //is not variadic, due to rust only supporting variadic for "unsafe extern C" and not "efiapi"
-    //until very recently. For x86_64 "efiapi" and "extern C" match, so we can get away with a
-    //transmute here. Fixing it for other architectures more generally would require an upstream
-    //change in r_efi to pick up. There is also a bug in r_efi definition for
-    //uninstall_multiple_program_interfaces - per spec, the first argument is a handle, but
+    //until rust 1.91. For our purposes "efiapi" and "extern C" match, so we can get away with a
+    //transmute here. Fixing it properly would require an upstream change in r_efi to pick up. There is also a bug in
+    //the r_efi definition for uninstall_multiple_protocol_interfaces - per spec, the first argument is a handle, but
     //r_efi has it as *mut handle.
     bs.install_multiple_protocol_interfaces = unsafe {
         let ptr = install_multiple_protocol_interfaces as *const ();
@@ -829,4 +831,6 @@ pub fn init_protocol_support(bs: &mut efi::BootServices) {
     bs.locate_handle_buffer = locate_handle_buffer;
     bs.locate_protocol = locate_protocol;
     bs.locate_device_path = locate_device_path;
+
+    st.boot_services().set(bs);
 }

--- a/patina_dxe_core/src/runtime.rs
+++ b/patina_dxe_core/src/runtime.rs
@@ -68,7 +68,7 @@ impl RuntimeData {
     }
 }
 
-pub fn init_runtime_support(_rt: &mut efi::RuntimeServices) {
+pub fn init_runtime_support() {
     // Setup a event callback for the runtime protocol.
     let event = EVENT_DB
         .create_event(efi::EVT_NOTIFY_SIGNAL, efi::TPL_CALLBACK, Some(runtime_protocol_notify), None, None)

--- a/patina_dxe_core/src/systemtables.rs
+++ b/patina_dxe_core/src/systemtables.rs
@@ -10,7 +10,7 @@
 //!
 use core::{ffi::c_void, mem::size_of, slice::from_raw_parts};
 
-use alloc::{alloc::Allocator, boxed::Box};
+use alloc::boxed::Box;
 use patina::{boot_services::BootServices, component::component, pi::error_codes::EFI_NOT_AVAILABLE_YET};
 use r_efi::efi;
 
@@ -20,576 +20,830 @@ pub static SYSTEM_TABLE: tpl_mutex::TplMutex<Option<EfiSystemTable>> =
     tpl_mutex::TplMutex::new(efi::TPL_NOTIFY, None, "StLock");
 
 pub struct EfiRuntimeServicesTable {
-    runtime_services: Box<efi::RuntimeServices, &'static dyn Allocator>,
+    runtime_services: *mut efi::RuntimeServices,
 }
 
 impl EfiRuntimeServicesTable {
-    //private unimplemented stub functions used to initialize the table.
-    #[coverage(off)]
-    extern "efiapi" fn get_time_unimplemented(_: *mut efi::Time, _: *mut efi::TimeCapabilities) -> efi::Status {
-        efi::Status::from_usize(EFI_NOT_AVAILABLE_YET)
-    }
-
-    #[coverage(off)]
-    extern "efiapi" fn set_time_unimplemented(_: *mut efi::Time) -> efi::Status {
-        efi::Status::from_usize(EFI_NOT_AVAILABLE_YET)
-    }
-
-    #[coverage(off)]
-    extern "efiapi" fn get_wakeup_time_unimplemented(
-        _: *mut efi::Boolean,
-        _: *mut efi::Boolean,
-        _: *mut efi::Time,
-    ) -> efi::Status {
-        efi::Status::from_usize(EFI_NOT_AVAILABLE_YET)
-    }
-
-    #[coverage(off)]
-    extern "efiapi" fn set_wakeup_time_unimplemented(_: efi::Boolean, _: *mut efi::Time) -> efi::Status {
-        efi::Status::from_usize(EFI_NOT_AVAILABLE_YET)
-    }
-
-    #[coverage(off)]
-    extern "efiapi" fn set_virtual_address_map_unimplemented(
-        _: usize,
-        _: usize,
-        _: u32,
-        _: *mut efi::MemoryDescriptor,
-    ) -> efi::Status {
-        efi::Status::from_usize(EFI_NOT_AVAILABLE_YET)
-    }
-
-    #[coverage(off)]
-    extern "efiapi" fn convert_pointer_unimplemented(_: usize, _: *mut *mut c_void) -> efi::Status {
-        efi::Status::from_usize(EFI_NOT_AVAILABLE_YET)
-    }
-
-    #[coverage(off)]
-    extern "efiapi" fn get_variable_unimplemented(
-        _: *mut efi::Char16,
-        _: *mut efi::Guid,
-        _: *mut u32,
-        _: *mut usize,
-        _: *mut c_void,
-    ) -> efi::Status {
-        efi::Status::from_usize(EFI_NOT_AVAILABLE_YET)
-    }
-
-    #[coverage(off)]
-    extern "efiapi" fn get_next_variable_name_unimplemented(
-        _: *mut usize,
-        _: *mut efi::Char16,
-        _: *mut efi::Guid,
-    ) -> efi::Status {
-        efi::Status::from_usize(EFI_NOT_AVAILABLE_YET)
-    }
-
-    #[coverage(off)]
-    extern "efiapi" fn set_variable_unimplemented(
-        _: *mut efi::Char16,
-        _: *mut efi::Guid,
-        _: u32,
-        _: usize,
-        _: *mut c_void,
-    ) -> efi::Status {
-        efi::Status::from_usize(EFI_NOT_AVAILABLE_YET)
-    }
-
-    #[coverage(off)]
-    extern "efiapi" fn get_next_high_mono_count_unimplemented(_: *mut u32) -> efi::Status {
-        efi::Status::from_usize(EFI_NOT_AVAILABLE_YET)
-    }
-
-    #[coverage(off)]
-    extern "efiapi" fn reset_system_unimplemented(_: efi::ResetType, _: efi::Status, _: usize, _: *mut c_void) {}
-
-    #[coverage(off)]
-    extern "efiapi" fn update_capsule_unimplemented(
-        _: *mut *mut efi::CapsuleHeader,
-        _: usize,
-        _: efi::PhysicalAddress,
-    ) -> efi::Status {
-        efi::Status::from_usize(EFI_NOT_AVAILABLE_YET)
-    }
-
-    #[coverage(off)]
-    extern "efiapi" fn query_capsule_capabilities_unimplemented(
-        _: *mut *mut efi::CapsuleHeader,
-        _: usize,
-        _: *mut u64,
-        _: *mut efi::ResetType,
-    ) -> efi::Status {
-        efi::Status::from_usize(EFI_NOT_AVAILABLE_YET)
-    }
-
-    #[coverage(off)]
-    extern "efiapi" fn query_variable_info_unimplemented(_: u32, _: *mut u64, _: *mut u64, _: *mut u64) -> efi::Status {
-        efi::Status::from_usize(EFI_NOT_AVAILABLE_YET)
-    }
-
-    pub fn init() -> EfiRuntimeServicesTable {
-        let mut rt = efi::RuntimeServices {
-            hdr: efi::TableHeader {
-                signature: efi::RUNTIME_SERVICES_SIGNATURE,
-                revision: efi::RUNTIME_SERVICES_REVISION,
-                header_size: 0,
-                crc32: 0,
-                reserved: 0,
-            },
-            get_time: Self::get_time_unimplemented,
-            set_time: Self::set_time_unimplemented,
-            get_wakeup_time: Self::get_wakeup_time_unimplemented,
-            set_wakeup_time: Self::set_wakeup_time_unimplemented,
-            set_virtual_address_map: Self::set_virtual_address_map_unimplemented,
-            convert_pointer: Self::convert_pointer_unimplemented,
-            get_variable: Self::get_variable_unimplemented,
-            get_next_variable_name: Self::get_next_variable_name_unimplemented,
-            set_variable: Self::set_variable_unimplemented,
-            get_next_high_mono_count: Self::get_next_high_mono_count_unimplemented,
-            reset_system: Self::reset_system_unimplemented,
-            update_capsule: Self::update_capsule_unimplemented,
-            query_capsule_capabilities: Self::query_capsule_capabilities_unimplemented,
-            query_variable_info: Self::query_variable_info_unimplemented,
-        };
-
-        rt.hdr.header_size = size_of::<efi::RuntimeServices>() as u32;
-
-        let mut table =
-            EfiRuntimeServicesTable { runtime_services: Box::new_in(rt, &EFI_RUNTIME_SERVICES_DATA_ALLOCATOR) };
+    /// Allocates a new Runtime Services table initialized to default stub functions in the Runtime Services Data allocator.
+    pub fn allocate_new_table() -> Self {
+        let rt = Self::default_runtime_services_table();
+        let (runtime_services, _alloc) =
+            Box::into_raw_with_allocator(Box::new_in(rt, &EFI_RUNTIME_SERVICES_DATA_ALLOCATOR));
+        let mut table = Self { runtime_services };
         table.checksum();
         table
     }
 
-    pub fn checksum(&mut self) {
-        self.runtime_services.hdr.crc32 = 0;
-        let rs_ptr = self.runtime_services.as_ref() as *const efi::RuntimeServices as *const u8;
-        let rs_slice = unsafe { from_raw_parts(rs_ptr, size_of::<efi::RuntimeServices>()) };
-        self.runtime_services.hdr.crc32 = crc32fast::hash(rs_slice);
+    /// Creates a new Runtime Services Table instance from the given raw pointer.
+    /// # Safety
+    /// The pointer must be valid and point to a properly initialized efi::RuntimeServices structure.
+    pub unsafe fn from_raw_pointer(ptr: *mut efi::RuntimeServices) -> Self {
+        Self { runtime_services: ptr }
+    }
+
+    // Checksums the Runtime Services table.
+    fn checksum(&mut self) {
+        // SAFETY: structure construction ensures pointer is valid.
+        let mut table_copy = unsafe { self.runtime_services.read() };
+        table_copy.hdr.crc32 = 0;
+
+        let tbl_slice =
+            unsafe { from_raw_parts(&table_copy as *const _ as *const u8, size_of::<efi::RuntimeServices>()) };
+        table_copy.hdr.crc32 = crc32fast::hash(tbl_slice);
+
+        // SAFETY: structure construction ensures pointer is valid.
+        unsafe { self.runtime_services.write(table_copy) }
+    }
+
+    // Used in tests and included for API completness; may be used in future.
+    #[allow(dead_code)]
+    /// Returns a copy of the Runtime Services table.
+    pub fn get(&self) -> efi::RuntimeServices {
+        // SAFETY: structure construction ensures pointer is valid.
+        // To be truly paranoid here the TPL should be raised to TPL_HIGH to kill interrupts to prevent any possibility
+        // of external concurrent modification while the table is read out. The current anticipated usage patterns
+        // for boot services (externally) don't require this level of paranoia, but noting this for future reference.
+        unsafe { self.runtime_services.read() }
+    }
+
+    // Used in tests and included for API completness; may be used in future.
+    #[allow(dead_code)]
+    /// Writes the given Runtime Services table into the stored pointer and updates the checksum.
+    pub fn set(&mut self, new_table: efi::RuntimeServices) {
+        // SAFETY: structure construction ensures pointer is valid.
+        // To be truly paranoid here the TPL should be raised to TPL_HIGH to kill interrupts to prevent any possibility
+        // of external concurrent modification while the table is written. The current anticipated usage patterns
+        // for runtime services (externally) don't require this level of paranoia, but noting this for future reference.
+        unsafe {
+            self.runtime_services.write(new_table);
+        }
+        self.checksum();
+    }
+
+    /// Returns the raw pointer to the Runtime Services table.
+    pub fn as_mut_ptr(&self) -> *mut efi::RuntimeServices {
+        self.runtime_services
+    }
+
+    // Create a default table populated with stub functions that return `EFI_NOT_AVAILABLE_YET` and which is not
+    // checksummed.
+    fn default_runtime_services_table() -> efi::RuntimeServices {
+        //private unimplemented stub functions used to initialize the table.
+        #[coverage(off)]
+        extern "efiapi" fn get_time_unimplemented(_: *mut efi::Time, _: *mut efi::TimeCapabilities) -> efi::Status {
+            efi::Status::from_usize(EFI_NOT_AVAILABLE_YET)
+        }
+
+        #[coverage(off)]
+        extern "efiapi" fn set_time_unimplemented(_: *mut efi::Time) -> efi::Status {
+            efi::Status::from_usize(EFI_NOT_AVAILABLE_YET)
+        }
+
+        #[coverage(off)]
+        extern "efiapi" fn get_wakeup_time_unimplemented(
+            _: *mut efi::Boolean,
+            _: *mut efi::Boolean,
+            _: *mut efi::Time,
+        ) -> efi::Status {
+            efi::Status::from_usize(EFI_NOT_AVAILABLE_YET)
+        }
+
+        #[coverage(off)]
+        extern "efiapi" fn set_wakeup_time_unimplemented(_: efi::Boolean, _: *mut efi::Time) -> efi::Status {
+            efi::Status::from_usize(EFI_NOT_AVAILABLE_YET)
+        }
+
+        #[coverage(off)]
+        extern "efiapi" fn set_virtual_address_map_unimplemented(
+            _: usize,
+            _: usize,
+            _: u32,
+            _: *mut efi::MemoryDescriptor,
+        ) -> efi::Status {
+            efi::Status::from_usize(EFI_NOT_AVAILABLE_YET)
+        }
+
+        #[coverage(off)]
+        extern "efiapi" fn convert_pointer_unimplemented(_: usize, _: *mut *mut c_void) -> efi::Status {
+            efi::Status::from_usize(EFI_NOT_AVAILABLE_YET)
+        }
+
+        #[coverage(off)]
+        extern "efiapi" fn get_variable_unimplemented(
+            _: *mut efi::Char16,
+            _: *mut efi::Guid,
+            _: *mut u32,
+            _: *mut usize,
+            _: *mut c_void,
+        ) -> efi::Status {
+            efi::Status::from_usize(EFI_NOT_AVAILABLE_YET)
+        }
+
+        #[coverage(off)]
+        extern "efiapi" fn get_next_variable_name_unimplemented(
+            _: *mut usize,
+            _: *mut efi::Char16,
+            _: *mut efi::Guid,
+        ) -> efi::Status {
+            efi::Status::from_usize(EFI_NOT_AVAILABLE_YET)
+        }
+
+        #[coverage(off)]
+        extern "efiapi" fn set_variable_unimplemented(
+            _: *mut efi::Char16,
+            _: *mut efi::Guid,
+            _: u32,
+            _: usize,
+            _: *mut c_void,
+        ) -> efi::Status {
+            efi::Status::from_usize(EFI_NOT_AVAILABLE_YET)
+        }
+
+        #[coverage(off)]
+        extern "efiapi" fn get_next_high_mono_count_unimplemented(_: *mut u32) -> efi::Status {
+            efi::Status::from_usize(EFI_NOT_AVAILABLE_YET)
+        }
+
+        #[coverage(off)]
+        extern "efiapi" fn reset_system_unimplemented(_: efi::ResetType, _: efi::Status, _: usize, _: *mut c_void) {}
+
+        #[coverage(off)]
+        extern "efiapi" fn update_capsule_unimplemented(
+            _: *mut *mut efi::CapsuleHeader,
+            _: usize,
+            _: efi::PhysicalAddress,
+        ) -> efi::Status {
+            efi::Status::from_usize(EFI_NOT_AVAILABLE_YET)
+        }
+
+        #[coverage(off)]
+        extern "efiapi" fn query_capsule_capabilities_unimplemented(
+            _: *mut *mut efi::CapsuleHeader,
+            _: usize,
+            _: *mut u64,
+            _: *mut efi::ResetType,
+        ) -> efi::Status {
+            efi::Status::from_usize(EFI_NOT_AVAILABLE_YET)
+        }
+
+        #[coverage(off)]
+        extern "efiapi" fn query_variable_info_unimplemented(
+            _: u32,
+            _: *mut u64,
+            _: *mut u64,
+            _: *mut u64,
+        ) -> efi::Status {
+            efi::Status::from_usize(EFI_NOT_AVAILABLE_YET)
+        }
+        efi::RuntimeServices {
+            hdr: efi::TableHeader {
+                signature: efi::RUNTIME_SERVICES_SIGNATURE,
+                revision: efi::RUNTIME_SERVICES_REVISION,
+                header_size: size_of::<efi::RuntimeServices>() as u32,
+                crc32: 0,
+                reserved: 0,
+            },
+            get_time: get_time_unimplemented,
+            set_time: set_time_unimplemented,
+            get_wakeup_time: get_wakeup_time_unimplemented,
+            set_wakeup_time: set_wakeup_time_unimplemented,
+            set_virtual_address_map: set_virtual_address_map_unimplemented,
+            convert_pointer: convert_pointer_unimplemented,
+            get_variable: get_variable_unimplemented,
+            get_next_variable_name: get_next_variable_name_unimplemented,
+            set_variable: set_variable_unimplemented,
+            get_next_high_mono_count: get_next_high_mono_count_unimplemented,
+            reset_system: reset_system_unimplemented,
+            update_capsule: update_capsule_unimplemented,
+            query_capsule_capabilities: query_capsule_capabilities_unimplemented,
+            query_variable_info: query_variable_info_unimplemented,
+        }
     }
 }
 
 pub struct EfiBootServicesTable {
-    boot_services: Box<efi::BootServices>, //Use the global allocator (EfiBootServicesData)
+    boot_services: *mut efi::BootServices,
 }
 
 impl EfiBootServicesTable {
-    //private unimplemented stub functions used to initialize the table.
-    #[coverage(off)]
-    extern "efiapi" fn raise_tpl_unimplemented(_: efi::Tpl) -> efi::Tpl {
-        efi::TPL_APPLICATION
-    }
-
-    #[coverage(off)]
-    extern "efiapi" fn restore_tpl_unimplemented(_: efi::Tpl) {}
-
-    #[coverage(off)]
-    extern "efiapi" fn allocate_pages_unimplemented(
-        _: efi::AllocateType,
-        _: efi::MemoryType,
-        _: usize,
-        _: *mut efi::PhysicalAddress,
-    ) -> efi::Status {
-        efi::Status::from_usize(EFI_NOT_AVAILABLE_YET)
-    }
-
-    #[coverage(off)]
-    extern "efiapi" fn free_pages_unimplemented(_: efi::PhysicalAddress, _: usize) -> efi::Status {
-        efi::Status::from_usize(EFI_NOT_AVAILABLE_YET)
-    }
-
-    #[coverage(off)]
-    extern "efiapi" fn get_memory_map_unimplemented(
-        _: *mut usize,
-        _: *mut efi::MemoryDescriptor,
-        _: *mut usize,
-        _: *mut usize,
-        _: *mut u32,
-    ) -> efi::Status {
-        efi::Status::from_usize(EFI_NOT_AVAILABLE_YET)
-    }
-
-    #[coverage(off)]
-    extern "efiapi" fn allocate_pool_unimplemented(_: efi::MemoryType, _: usize, _: *mut *mut c_void) -> efi::Status {
-        efi::Status::from_usize(EFI_NOT_AVAILABLE_YET)
-    }
-
-    #[coverage(off)]
-    extern "efiapi" fn free_pool_unimplemented(_: *mut c_void) -> efi::Status {
-        efi::Status::from_usize(EFI_NOT_AVAILABLE_YET)
-    }
-
-    #[coverage(off)]
-    extern "efiapi" fn create_event_unimplemented(
-        _: u32,
-        _: efi::Tpl,
-        _: Option<efi::EventNotify>,
-        _: *mut c_void,
-        _: *mut efi::Event,
-    ) -> efi::Status {
-        efi::Status::from_usize(EFI_NOT_AVAILABLE_YET)
-    }
-
-    #[coverage(off)]
-    extern "efiapi" fn set_timer_unimplemented(_: efi::Event, _: efi::TimerDelay, _: u64) -> efi::Status {
-        efi::Status::from_usize(EFI_NOT_AVAILABLE_YET)
-    }
-
-    #[coverage(off)]
-    extern "efiapi" fn wait_for_event_unimplemented(_: usize, _: *mut efi::Event, _: *mut usize) -> efi::Status {
-        efi::Status::from_usize(EFI_NOT_AVAILABLE_YET)
-    }
-
-    #[coverage(off)]
-    extern "efiapi" fn signal_event_unimplemented(_: efi::Event) -> efi::Status {
-        efi::Status::from_usize(EFI_NOT_AVAILABLE_YET)
-    }
-
-    #[coverage(off)]
-    extern "efiapi" fn close_event_unimplemented(_: efi::Event) -> efi::Status {
-        efi::Status::from_usize(EFI_NOT_AVAILABLE_YET)
-    }
-
-    #[coverage(off)]
-    extern "efiapi" fn check_event_unimplemented(_: efi::Event) -> efi::Status {
-        efi::Status::from_usize(EFI_NOT_AVAILABLE_YET)
-    }
-
-    #[coverage(off)]
-    extern "efiapi" fn install_protocol_interface_unimplemented(
-        _: *mut efi::Handle,
-        _: *mut efi::Guid,
-        _: efi::InterfaceType,
-        _: *mut c_void,
-    ) -> efi::Status {
-        efi::Status::from_usize(EFI_NOT_AVAILABLE_YET)
-    }
-
-    #[coverage(off)]
-    extern "efiapi" fn reinstall_protocol_interface_unimplemented(
-        _: efi::Handle,
-        _: *mut efi::Guid,
-        _: *mut c_void,
-        _: *mut c_void,
-    ) -> efi::Status {
-        efi::Status::from_usize(EFI_NOT_AVAILABLE_YET)
-    }
-
-    #[coverage(off)]
-    extern "efiapi" fn uninstall_protocol_interface_unimplemented(
-        _: efi::Handle,
-        _: *mut efi::Guid,
-        _: *mut c_void,
-    ) -> efi::Status {
-        efi::Status::from_usize(EFI_NOT_AVAILABLE_YET)
-    }
-
-    #[coverage(off)]
-    extern "efiapi" fn handle_protocol_unimplemented(
-        _: efi::Handle,
-        _: *mut efi::Guid,
-        _: *mut *mut c_void,
-    ) -> efi::Status {
-        efi::Status::from_usize(EFI_NOT_AVAILABLE_YET)
-    }
-
-    #[coverage(off)]
-    extern "efiapi" fn register_protocol_notify_unimplemented(
-        _: *mut efi::Guid,
-        _: efi::Event,
-        _: *mut *mut c_void,
-    ) -> efi::Status {
-        efi::Status::from_usize(EFI_NOT_AVAILABLE_YET)
-    }
-
-    #[coverage(off)]
-    extern "efiapi" fn locate_handle_unimplemented(
-        _: efi::LocateSearchType,
-        _: *mut efi::Guid,
-        _: *mut c_void,
-        _: *mut usize,
-        _: *mut efi::Handle,
-    ) -> efi::Status {
-        efi::Status::from_usize(EFI_NOT_AVAILABLE_YET)
-    }
-
-    #[coverage(off)]
-    extern "efiapi" fn locate_device_path_unimplemented(
-        _: *mut efi::Guid,
-        _: *mut *mut efi::protocols::device_path::Protocol,
-        _: *mut efi::Handle,
-    ) -> efi::Status {
-        efi::Status::from_usize(EFI_NOT_AVAILABLE_YET)
-    }
-
-    #[coverage(off)]
-    extern "efiapi" fn install_configuration_table_unimplemented(_: *mut efi::Guid, _: *mut c_void) -> efi::Status {
-        efi::Status::from_usize(EFI_NOT_AVAILABLE_YET)
-    }
-
-    #[coverage(off)]
-    extern "efiapi" fn load_image_unimplemented(
-        _: efi::Boolean,
-        _: efi::Handle,
-        _: *mut efi::protocols::device_path::Protocol,
-        _: *mut c_void,
-        _: usize,
-        _: *mut efi::Handle,
-    ) -> efi::Status {
-        efi::Status::from_usize(EFI_NOT_AVAILABLE_YET)
-    }
-
-    #[coverage(off)]
-    extern "efiapi" fn start_image_unimplemented(
-        _: efi::Handle,
-        _: *mut usize,
-        _: *mut *mut efi::Char16,
-    ) -> efi::Status {
-        efi::Status::from_usize(EFI_NOT_AVAILABLE_YET)
-    }
-
-    #[coverage(off)]
-    extern "efiapi" fn exit_unimplemented(
-        _: efi::Handle,
-        _: efi::Status,
-        _: usize,
-        _: *mut efi::Char16,
-    ) -> efi::Status {
-        efi::Status::from_usize(EFI_NOT_AVAILABLE_YET)
-    }
-
-    #[coverage(off)]
-    extern "efiapi" fn unload_image_unimplemented(_: efi::Handle) -> efi::Status {
-        efi::Status::from_usize(EFI_NOT_AVAILABLE_YET)
-    }
-
-    #[coverage(off)]
-    extern "efiapi" fn exit_boot_services_unimplemented(_: efi::Handle, _: usize) -> efi::Status {
-        efi::Status::from_usize(EFI_NOT_AVAILABLE_YET)
-    }
-
-    #[coverage(off)]
-    extern "efiapi" fn get_next_monotonic_count_unimplemented(_: *mut u64) -> efi::Status {
-        efi::Status::from_usize(EFI_NOT_AVAILABLE_YET)
-    }
-
-    #[coverage(off)]
-    extern "efiapi" fn stall_unimplemented(_: usize) -> efi::Status {
-        efi::Status::from_usize(EFI_NOT_AVAILABLE_YET)
-    }
-
-    #[coverage(off)]
-    extern "efiapi" fn set_watchdog_timer_unimplemented(
-        _: usize,
-        _: u64,
-        _: usize,
-        _: *mut efi::Char16,
-    ) -> efi::Status {
-        efi::Status::from_usize(EFI_NOT_AVAILABLE_YET)
-    }
-
-    #[coverage(off)]
-    extern "efiapi" fn connect_controller_unimplemented(
-        _: efi::Handle,
-        _: *mut efi::Handle,
-        _: *mut efi::protocols::device_path::Protocol,
-        _: efi::Boolean,
-    ) -> efi::Status {
-        efi::Status::from_usize(EFI_NOT_AVAILABLE_YET)
-    }
-
-    #[coverage(off)]
-    extern "efiapi" fn disconnect_controller_unimplemented(
-        _: efi::Handle,
-        _: efi::Handle,
-        _: efi::Handle,
-    ) -> efi::Status {
-        efi::Status::from_usize(EFI_NOT_AVAILABLE_YET)
-    }
-
-    #[coverage(off)]
-    extern "efiapi" fn open_protocol_unimplemented(
-        _: efi::Handle,
-        _: *mut efi::Guid,
-        _: *mut *mut c_void,
-        _: efi::Handle,
-        _: efi::Handle,
-        _: u32,
-    ) -> efi::Status {
-        efi::Status::from_usize(EFI_NOT_AVAILABLE_YET)
-    }
-
-    #[coverage(off)]
-    extern "efiapi" fn close_protocol_unimplemented(
-        _: efi::Handle,
-        _: *mut efi::Guid,
-        _: efi::Handle,
-        _: efi::Handle,
-    ) -> efi::Status {
-        efi::Status::from_usize(EFI_NOT_AVAILABLE_YET)
-    }
-
-    #[coverage(off)]
-    extern "efiapi" fn open_protocol_information_unimplemented(
-        _: efi::Handle,
-        _: *mut efi::Guid,
-        _: *mut *mut efi::OpenProtocolInformationEntry,
-        _: *mut usize,
-    ) -> efi::Status {
-        efi::Status::from_usize(EFI_NOT_AVAILABLE_YET)
-    }
-
-    #[coverage(off)]
-    extern "efiapi" fn protocols_per_handle_unimplemented(
-        _: efi::Handle,
-        _: *mut *mut *mut efi::Guid,
-        _: *mut usize,
-    ) -> efi::Status {
-        efi::Status::from_usize(EFI_NOT_AVAILABLE_YET)
-    }
-
-    #[coverage(off)]
-    extern "efiapi" fn locate_handle_buffer_unimplemented(
-        _: efi::LocateSearchType,
-        _: *mut efi::Guid,
-        _: *mut c_void,
-        _: *mut usize,
-        _: *mut *mut efi::Handle,
-    ) -> efi::Status {
-        efi::Status::from_usize(EFI_NOT_AVAILABLE_YET)
-    }
-
-    #[coverage(off)]
-    extern "efiapi" fn locate_protocol_unimplemented(
-        _: *mut efi::Guid,
-        _: *mut c_void,
-        _: *mut *mut c_void,
-    ) -> efi::Status {
-        efi::Status::from_usize(EFI_NOT_AVAILABLE_YET)
-    }
-
-    #[coverage(off)]
-    extern "efiapi" fn install_multiple_protocol_interfaces_unimplemented(
-        _: *mut efi::Handle,
-        _: *mut c_void,
-        _: *mut c_void,
-    ) -> efi::Status {
-        efi::Status::from_usize(EFI_NOT_AVAILABLE_YET)
-    }
-
-    #[coverage(off)]
-    extern "efiapi" fn uninstall_multiple_protocol_interfaces_unimplemented(
-        _: efi::Handle,
-        _: *mut c_void,
-        _: *mut c_void,
-    ) -> efi::Status {
-        efi::Status::from_usize(EFI_NOT_AVAILABLE_YET)
-    }
-
-    #[coverage(off)]
-    extern "efiapi" fn calculate_crc32_unimplemented(_: *mut c_void, _: usize, _: *mut u32) -> efi::Status {
-        efi::Status::from_usize(EFI_NOT_AVAILABLE_YET)
-    }
-
-    #[coverage(off)]
-    extern "efiapi" fn copy_mem_unimplemented(_: *mut c_void, _: *mut c_void, _: usize) {}
-
-    #[coverage(off)]
-    extern "efiapi" fn set_mem_unimplemented(_: *mut c_void, _: usize, _: u8) {}
-
-    #[coverage(off)]
-    extern "efiapi" fn create_event_ex_unimplemented(
-        _: u32,
-        _: efi::Tpl,
-        _: Option<efi::EventNotify>,
-        _: *const c_void,
-        _: *const efi::Guid,
-        _: *mut efi::Event,
-    ) -> efi::Status {
-        efi::Status::from_usize(EFI_NOT_AVAILABLE_YET)
-    }
-
-    pub fn init() -> EfiBootServicesTable {
-        let mut bs = efi::BootServices {
-            hdr: efi::TableHeader {
-                signature: efi::BOOT_SERVICES_SIGNATURE,
-                revision: efi::BOOT_SERVICES_REVISION,
-                header_size: 0,
-                crc32: 0,
-                reserved: 0,
-            },
-            raise_tpl: Self::raise_tpl_unimplemented,
-            restore_tpl: Self::restore_tpl_unimplemented,
-            allocate_pages: Self::allocate_pages_unimplemented,
-            free_pages: Self::free_pages_unimplemented,
-            get_memory_map: Self::get_memory_map_unimplemented,
-            allocate_pool: Self::allocate_pool_unimplemented,
-            free_pool: Self::free_pool_unimplemented,
-            create_event: Self::create_event_unimplemented,
-            set_timer: Self::set_timer_unimplemented,
-            wait_for_event: Self::wait_for_event_unimplemented,
-            signal_event: Self::signal_event_unimplemented,
-            close_event: Self::close_event_unimplemented,
-            check_event: Self::check_event_unimplemented,
-            install_protocol_interface: Self::install_protocol_interface_unimplemented,
-            reinstall_protocol_interface: Self::reinstall_protocol_interface_unimplemented,
-            uninstall_protocol_interface: Self::uninstall_protocol_interface_unimplemented,
-            handle_protocol: Self::handle_protocol_unimplemented,
-            reserved: core::ptr::null_mut(),
-            register_protocol_notify: Self::register_protocol_notify_unimplemented,
-            locate_handle: Self::locate_handle_unimplemented,
-            locate_device_path: Self::locate_device_path_unimplemented,
-            install_configuration_table: Self::install_configuration_table_unimplemented,
-            load_image: Self::load_image_unimplemented,
-            start_image: Self::start_image_unimplemented,
-            exit: Self::exit_unimplemented,
-            unload_image: Self::unload_image_unimplemented,
-            exit_boot_services: Self::exit_boot_services_unimplemented,
-            get_next_monotonic_count: Self::get_next_monotonic_count_unimplemented,
-            stall: Self::stall_unimplemented,
-            set_watchdog_timer: Self::set_watchdog_timer_unimplemented,
-            connect_controller: Self::connect_controller_unimplemented,
-            disconnect_controller: Self::disconnect_controller_unimplemented,
-            open_protocol: Self::open_protocol_unimplemented,
-            close_protocol: Self::close_protocol_unimplemented,
-            open_protocol_information: Self::open_protocol_information_unimplemented,
-            protocols_per_handle: Self::protocols_per_handle_unimplemented,
-            locate_handle_buffer: Self::locate_handle_buffer_unimplemented,
-            locate_protocol: Self::locate_protocol_unimplemented,
-            install_multiple_protocol_interfaces: Self::install_multiple_protocol_interfaces_unimplemented,
-            uninstall_multiple_protocol_interfaces: Self::uninstall_multiple_protocol_interfaces_unimplemented,
-            calculate_crc32: Self::calculate_crc32_unimplemented,
-            copy_mem: Self::copy_mem_unimplemented,
-            set_mem: Self::set_mem_unimplemented,
-            create_event_ex: Self::create_event_ex_unimplemented,
-        };
-
-        bs.hdr.header_size = size_of::<efi::BootServices>() as u32;
-        let mut table = EfiBootServicesTable { boot_services: Box::new(bs) };
+    /// Allocates a new Boot Services table initialized to default stub functions in the Boot Services Data allocator.
+    pub fn allocate_new_table() -> Self {
+        let bs = Self::default_boot_services_table();
+        let boot_services = Box::into_raw(Box::new(bs));
+        let mut table = Self { boot_services };
         table.checksum();
         table
     }
 
-    pub fn checksum(&mut self) {
-        self.boot_services.hdr.crc32 = 0;
-        let bs_ptr = self.boot_services.as_ref() as *const efi::BootServices as *const u8;
-        let bs_slice = unsafe { from_raw_parts(bs_ptr, size_of::<efi::BootServices>()) };
-        self.boot_services.hdr.crc32 = crc32fast::hash(bs_slice);
+    /// Creates a new Boot Services Table instance from the given raw pointer.
+    /// # Safety
+    /// The pointer must be valid and point to a properly initialized efi::BootServices structure.
+    pub unsafe fn from_raw_pointer(ptr: *mut efi::BootServices) -> Self {
+        Self { boot_services: ptr }
+    }
+
+    fn checksum(&mut self) {
+        // SAFETY: structure construction ensures pointer is valid.
+        let mut table_copy = unsafe { self.boot_services.read() };
+        table_copy.hdr.crc32 = 0;
+
+        let tbl_slice = unsafe { from_raw_parts(&table_copy as *const _ as *const u8, size_of::<efi::BootServices>()) };
+        table_copy.hdr.crc32 = crc32fast::hash(tbl_slice);
+
+        // SAFETY: structure construction ensures pointer is valid.
+        unsafe { self.boot_services.write(table_copy) }
+    }
+
+    /// Returns a copy of the Boot Services table
+    pub fn get(&self) -> efi::BootServices {
+        // SAFETY: structure construction ensures pointer is valid.
+        // To be truly paranoid here the TPL should be raised to TPL_HIGH to kill interrupts to prevent any possibility
+        // of external concurrent modification while the table is read out. The current anticipated usage patterns
+        // for boot services (externally) don't require this level of paranoia, but noting this for future reference.
+        unsafe { self.boot_services.read() }
+    }
+
+    /// Sets the Boot Services table to a new value and updates the checksum.
+    pub fn set(&mut self, new_table: efi::BootServices) {
+        // SAFETY: structure construction ensures pointer is valid.
+        // To be truly paranoid here the TPL should be raised to TPL_HIGH to kill interrupts to prevent any possibility
+        // of external concurrent modification while the table is written. The current anticipated usage patterns
+        // for runtime services (externally) don't require this level of paranoia, but noting this for future reference.
+        unsafe {
+            self.boot_services.write(new_table);
+        }
+        self.checksum();
+    }
+
+    /// Returns the raw pointer to the Boot Services table.
+    pub fn as_mut_ptr(&self) -> *mut efi::BootServices {
+        self.boot_services
+    }
+
+    // Create a default table populated with stub functions that return `EFI_NOT_AVAILABLE_YET` and which is not
+    // checksummed.
+    fn default_boot_services_table() -> efi::BootServices {
+        //private unimplemented stub functions used to initialize the table.
+        #[coverage(off)]
+        extern "efiapi" fn raise_tpl_unimplemented(_: efi::Tpl) -> efi::Tpl {
+            efi::TPL_APPLICATION
+        }
+
+        #[coverage(off)]
+        extern "efiapi" fn restore_tpl_unimplemented(_: efi::Tpl) {}
+
+        #[coverage(off)]
+        extern "efiapi" fn allocate_pages_unimplemented(
+            _: efi::AllocateType,
+            _: efi::MemoryType,
+            _: usize,
+            _: *mut efi::PhysicalAddress,
+        ) -> efi::Status {
+            efi::Status::from_usize(EFI_NOT_AVAILABLE_YET)
+        }
+
+        #[coverage(off)]
+        extern "efiapi" fn free_pages_unimplemented(_: efi::PhysicalAddress, _: usize) -> efi::Status {
+            efi::Status::from_usize(EFI_NOT_AVAILABLE_YET)
+        }
+
+        #[coverage(off)]
+        extern "efiapi" fn get_memory_map_unimplemented(
+            _: *mut usize,
+            _: *mut efi::MemoryDescriptor,
+            _: *mut usize,
+            _: *mut usize,
+            _: *mut u32,
+        ) -> efi::Status {
+            efi::Status::from_usize(EFI_NOT_AVAILABLE_YET)
+        }
+
+        #[coverage(off)]
+        extern "efiapi" fn allocate_pool_unimplemented(
+            _: efi::MemoryType,
+            _: usize,
+            _: *mut *mut c_void,
+        ) -> efi::Status {
+            efi::Status::from_usize(EFI_NOT_AVAILABLE_YET)
+        }
+
+        #[coverage(off)]
+        extern "efiapi" fn free_pool_unimplemented(_: *mut c_void) -> efi::Status {
+            efi::Status::from_usize(EFI_NOT_AVAILABLE_YET)
+        }
+
+        #[coverage(off)]
+        extern "efiapi" fn create_event_unimplemented(
+            _: u32,
+            _: efi::Tpl,
+            _: Option<efi::EventNotify>,
+            _: *mut c_void,
+            _: *mut efi::Event,
+        ) -> efi::Status {
+            efi::Status::from_usize(EFI_NOT_AVAILABLE_YET)
+        }
+
+        #[coverage(off)]
+        extern "efiapi" fn set_timer_unimplemented(_: efi::Event, _: efi::TimerDelay, _: u64) -> efi::Status {
+            efi::Status::from_usize(EFI_NOT_AVAILABLE_YET)
+        }
+
+        #[coverage(off)]
+        extern "efiapi" fn wait_for_event_unimplemented(_: usize, _: *mut efi::Event, _: *mut usize) -> efi::Status {
+            efi::Status::from_usize(EFI_NOT_AVAILABLE_YET)
+        }
+
+        #[coverage(off)]
+        extern "efiapi" fn signal_event_unimplemented(_: efi::Event) -> efi::Status {
+            efi::Status::from_usize(EFI_NOT_AVAILABLE_YET)
+        }
+
+        #[coverage(off)]
+        extern "efiapi" fn close_event_unimplemented(_: efi::Event) -> efi::Status {
+            efi::Status::from_usize(EFI_NOT_AVAILABLE_YET)
+        }
+
+        #[coverage(off)]
+        extern "efiapi" fn check_event_unimplemented(_: efi::Event) -> efi::Status {
+            efi::Status::from_usize(EFI_NOT_AVAILABLE_YET)
+        }
+
+        #[coverage(off)]
+        extern "efiapi" fn install_protocol_interface_unimplemented(
+            _: *mut efi::Handle,
+            _: *mut efi::Guid,
+            _: efi::InterfaceType,
+            _: *mut c_void,
+        ) -> efi::Status {
+            efi::Status::from_usize(EFI_NOT_AVAILABLE_YET)
+        }
+
+        #[coverage(off)]
+        extern "efiapi" fn reinstall_protocol_interface_unimplemented(
+            _: efi::Handle,
+            _: *mut efi::Guid,
+            _: *mut c_void,
+            _: *mut c_void,
+        ) -> efi::Status {
+            efi::Status::from_usize(EFI_NOT_AVAILABLE_YET)
+        }
+
+        #[coverage(off)]
+        extern "efiapi" fn uninstall_protocol_interface_unimplemented(
+            _: efi::Handle,
+            _: *mut efi::Guid,
+            _: *mut c_void,
+        ) -> efi::Status {
+            efi::Status::from_usize(EFI_NOT_AVAILABLE_YET)
+        }
+
+        #[coverage(off)]
+        extern "efiapi" fn handle_protocol_unimplemented(
+            _: efi::Handle,
+            _: *mut efi::Guid,
+            _: *mut *mut c_void,
+        ) -> efi::Status {
+            efi::Status::from_usize(EFI_NOT_AVAILABLE_YET)
+        }
+
+        #[coverage(off)]
+        extern "efiapi" fn register_protocol_notify_unimplemented(
+            _: *mut efi::Guid,
+            _: efi::Event,
+            _: *mut *mut c_void,
+        ) -> efi::Status {
+            efi::Status::from_usize(EFI_NOT_AVAILABLE_YET)
+        }
+
+        #[coverage(off)]
+        extern "efiapi" fn locate_handle_unimplemented(
+            _: efi::LocateSearchType,
+            _: *mut efi::Guid,
+            _: *mut c_void,
+            _: *mut usize,
+            _: *mut efi::Handle,
+        ) -> efi::Status {
+            efi::Status::from_usize(EFI_NOT_AVAILABLE_YET)
+        }
+
+        #[coverage(off)]
+        extern "efiapi" fn locate_device_path_unimplemented(
+            _: *mut efi::Guid,
+            _: *mut *mut efi::protocols::device_path::Protocol,
+            _: *mut efi::Handle,
+        ) -> efi::Status {
+            efi::Status::from_usize(EFI_NOT_AVAILABLE_YET)
+        }
+
+        #[coverage(off)]
+        extern "efiapi" fn install_configuration_table_unimplemented(_: *mut efi::Guid, _: *mut c_void) -> efi::Status {
+            efi::Status::from_usize(EFI_NOT_AVAILABLE_YET)
+        }
+
+        #[coverage(off)]
+        extern "efiapi" fn load_image_unimplemented(
+            _: efi::Boolean,
+            _: efi::Handle,
+            _: *mut efi::protocols::device_path::Protocol,
+            _: *mut c_void,
+            _: usize,
+            _: *mut efi::Handle,
+        ) -> efi::Status {
+            efi::Status::from_usize(EFI_NOT_AVAILABLE_YET)
+        }
+
+        #[coverage(off)]
+        extern "efiapi" fn start_image_unimplemented(
+            _: efi::Handle,
+            _: *mut usize,
+            _: *mut *mut efi::Char16,
+        ) -> efi::Status {
+            efi::Status::from_usize(EFI_NOT_AVAILABLE_YET)
+        }
+
+        #[coverage(off)]
+        extern "efiapi" fn exit_unimplemented(
+            _: efi::Handle,
+            _: efi::Status,
+            _: usize,
+            _: *mut efi::Char16,
+        ) -> efi::Status {
+            efi::Status::from_usize(EFI_NOT_AVAILABLE_YET)
+        }
+
+        #[coverage(off)]
+        extern "efiapi" fn unload_image_unimplemented(_: efi::Handle) -> efi::Status {
+            efi::Status::from_usize(EFI_NOT_AVAILABLE_YET)
+        }
+
+        #[coverage(off)]
+        extern "efiapi" fn exit_boot_services_unimplemented(_: efi::Handle, _: usize) -> efi::Status {
+            efi::Status::from_usize(EFI_NOT_AVAILABLE_YET)
+        }
+
+        #[coverage(off)]
+        extern "efiapi" fn get_next_monotonic_count_unimplemented(_: *mut u64) -> efi::Status {
+            efi::Status::from_usize(EFI_NOT_AVAILABLE_YET)
+        }
+
+        #[coverage(off)]
+        extern "efiapi" fn stall_unimplemented(_: usize) -> efi::Status {
+            efi::Status::from_usize(EFI_NOT_AVAILABLE_YET)
+        }
+
+        #[coverage(off)]
+        extern "efiapi" fn set_watchdog_timer_unimplemented(
+            _: usize,
+            _: u64,
+            _: usize,
+            _: *mut efi::Char16,
+        ) -> efi::Status {
+            efi::Status::from_usize(EFI_NOT_AVAILABLE_YET)
+        }
+
+        #[coverage(off)]
+        extern "efiapi" fn connect_controller_unimplemented(
+            _: efi::Handle,
+            _: *mut efi::Handle,
+            _: *mut efi::protocols::device_path::Protocol,
+            _: efi::Boolean,
+        ) -> efi::Status {
+            efi::Status::from_usize(EFI_NOT_AVAILABLE_YET)
+        }
+
+        #[coverage(off)]
+        extern "efiapi" fn disconnect_controller_unimplemented(
+            _: efi::Handle,
+            _: efi::Handle,
+            _: efi::Handle,
+        ) -> efi::Status {
+            efi::Status::from_usize(EFI_NOT_AVAILABLE_YET)
+        }
+
+        #[coverage(off)]
+        extern "efiapi" fn open_protocol_unimplemented(
+            _: efi::Handle,
+            _: *mut efi::Guid,
+            _: *mut *mut c_void,
+            _: efi::Handle,
+            _: efi::Handle,
+            _: u32,
+        ) -> efi::Status {
+            efi::Status::from_usize(EFI_NOT_AVAILABLE_YET)
+        }
+
+        #[coverage(off)]
+        extern "efiapi" fn close_protocol_unimplemented(
+            _: efi::Handle,
+            _: *mut efi::Guid,
+            _: efi::Handle,
+            _: efi::Handle,
+        ) -> efi::Status {
+            efi::Status::from_usize(EFI_NOT_AVAILABLE_YET)
+        }
+
+        #[coverage(off)]
+        extern "efiapi" fn open_protocol_information_unimplemented(
+            _: efi::Handle,
+            _: *mut efi::Guid,
+            _: *mut *mut efi::OpenProtocolInformationEntry,
+            _: *mut usize,
+        ) -> efi::Status {
+            efi::Status::from_usize(EFI_NOT_AVAILABLE_YET)
+        }
+
+        #[coverage(off)]
+        extern "efiapi" fn protocols_per_handle_unimplemented(
+            _: efi::Handle,
+            _: *mut *mut *mut efi::Guid,
+            _: *mut usize,
+        ) -> efi::Status {
+            efi::Status::from_usize(EFI_NOT_AVAILABLE_YET)
+        }
+
+        #[coverage(off)]
+        extern "efiapi" fn locate_handle_buffer_unimplemented(
+            _: efi::LocateSearchType,
+            _: *mut efi::Guid,
+            _: *mut c_void,
+            _: *mut usize,
+            _: *mut *mut efi::Handle,
+        ) -> efi::Status {
+            efi::Status::from_usize(EFI_NOT_AVAILABLE_YET)
+        }
+
+        #[coverage(off)]
+        extern "efiapi" fn locate_protocol_unimplemented(
+            _: *mut efi::Guid,
+            _: *mut c_void,
+            _: *mut *mut c_void,
+        ) -> efi::Status {
+            efi::Status::from_usize(EFI_NOT_AVAILABLE_YET)
+        }
+
+        #[coverage(off)]
+        extern "efiapi" fn install_multiple_protocol_interfaces_unimplemented(
+            _: *mut efi::Handle,
+            _: *mut c_void,
+            _: *mut c_void,
+        ) -> efi::Status {
+            efi::Status::from_usize(EFI_NOT_AVAILABLE_YET)
+        }
+
+        #[coverage(off)]
+        extern "efiapi" fn uninstall_multiple_protocol_interfaces_unimplemented(
+            _: efi::Handle,
+            _: *mut c_void,
+            _: *mut c_void,
+        ) -> efi::Status {
+            efi::Status::from_usize(EFI_NOT_AVAILABLE_YET)
+        }
+
+        #[coverage(off)]
+        extern "efiapi" fn calculate_crc32_unimplemented(_: *mut c_void, _: usize, _: *mut u32) -> efi::Status {
+            efi::Status::from_usize(EFI_NOT_AVAILABLE_YET)
+        }
+
+        #[coverage(off)]
+        extern "efiapi" fn copy_mem_unimplemented(_: *mut c_void, _: *mut c_void, _: usize) {}
+
+        #[coverage(off)]
+        extern "efiapi" fn set_mem_unimplemented(_: *mut c_void, _: usize, _: u8) {}
+
+        #[coverage(off)]
+        extern "efiapi" fn create_event_ex_unimplemented(
+            _: u32,
+            _: efi::Tpl,
+            _: Option<efi::EventNotify>,
+            _: *const c_void,
+            _: *const efi::Guid,
+            _: *mut efi::Event,
+        ) -> efi::Status {
+            efi::Status::from_usize(EFI_NOT_AVAILABLE_YET)
+        }
+        efi::BootServices {
+            hdr: efi::TableHeader {
+                signature: efi::BOOT_SERVICES_SIGNATURE,
+                revision: efi::BOOT_SERVICES_REVISION,
+                header_size: size_of::<efi::BootServices>() as u32,
+                crc32: 0,
+                reserved: 0,
+            },
+            raise_tpl: raise_tpl_unimplemented,
+            restore_tpl: restore_tpl_unimplemented,
+            allocate_pages: allocate_pages_unimplemented,
+            free_pages: free_pages_unimplemented,
+            get_memory_map: get_memory_map_unimplemented,
+            allocate_pool: allocate_pool_unimplemented,
+            free_pool: free_pool_unimplemented,
+            create_event: create_event_unimplemented,
+            set_timer: set_timer_unimplemented,
+            wait_for_event: wait_for_event_unimplemented,
+            signal_event: signal_event_unimplemented,
+            close_event: close_event_unimplemented,
+            check_event: check_event_unimplemented,
+            install_protocol_interface: install_protocol_interface_unimplemented,
+            reinstall_protocol_interface: reinstall_protocol_interface_unimplemented,
+            uninstall_protocol_interface: uninstall_protocol_interface_unimplemented,
+            handle_protocol: handle_protocol_unimplemented,
+            reserved: core::ptr::null_mut(),
+            register_protocol_notify: register_protocol_notify_unimplemented,
+            locate_handle: locate_handle_unimplemented,
+            locate_device_path: locate_device_path_unimplemented,
+            install_configuration_table: install_configuration_table_unimplemented,
+            load_image: load_image_unimplemented,
+            start_image: start_image_unimplemented,
+            exit: exit_unimplemented,
+            unload_image: unload_image_unimplemented,
+            exit_boot_services: exit_boot_services_unimplemented,
+            get_next_monotonic_count: get_next_monotonic_count_unimplemented,
+            stall: stall_unimplemented,
+            set_watchdog_timer: set_watchdog_timer_unimplemented,
+            connect_controller: connect_controller_unimplemented,
+            disconnect_controller: disconnect_controller_unimplemented,
+            open_protocol: open_protocol_unimplemented,
+            close_protocol: close_protocol_unimplemented,
+            open_protocol_information: open_protocol_information_unimplemented,
+            protocols_per_handle: protocols_per_handle_unimplemented,
+            locate_handle_buffer: locate_handle_buffer_unimplemented,
+            locate_protocol: locate_protocol_unimplemented,
+            install_multiple_protocol_interfaces: install_multiple_protocol_interfaces_unimplemented,
+            uninstall_multiple_protocol_interfaces: uninstall_multiple_protocol_interfaces_unimplemented,
+            calculate_crc32: calculate_crc32_unimplemented,
+            copy_mem: copy_mem_unimplemented,
+            set_mem: set_mem_unimplemented,
+            create_event_ex: create_event_ex_unimplemented,
+        }
     }
 }
 
 pub struct EfiSystemTable {
-    system_table: Box<efi::SystemTable, &'static dyn Allocator>,
-    boot_service: EfiBootServicesTable, // These fields ensure the efi::BootServices and efi::RuntimeServices structure pointers (in
-    runtime_service: EfiRuntimeServicesTable, // the system_table) have the same lifetime as the EfiSystemTable.
+    system_table: *mut efi::SystemTable,
 }
 
+// SAFETY: EfiSystemTable implementation below takes care to ensure that the underlying raw pointer is used in a
+// copy/modify/write manner that strives for consistency in the face of external mutation. This implementation assumes
+// that external code may modify the underlying structure outside of the Patina context. Some assumptions are made on
+// the behavior of external code: in particular,  that the system table structures are modified by external drivers in
+// event callbacks that might interrupt core use of the table (i.e. between a get and a set).
+//
+// Within Patina, access to the system table is synchronized via SYSTEM_TABLE TplMutex to prevent data races.
+unsafe impl Send for EfiSystemTable {}
+
 impl EfiSystemTable {
-    fn init() -> EfiSystemTable {
-        let mut st = efi::SystemTable {
+    /// Allocates a new EFI System Table with default contents in the Runtime Services Data allocator. Includes creation
+    /// of default Runtime and Boot services tables in the Runtime Services Data allocator and Boot Services Data
+    /// allocator respectively.
+    pub fn allocate_new_table() -> Self {
+        let mut st = Self::default_system_table();
+
+        st.runtime_services = EfiRuntimeServicesTable::allocate_new_table().as_mut_ptr();
+        st.boot_services = EfiBootServicesTable::allocate_new_table().as_mut_ptr();
+
+        let (system_table, _alloc) =
+            Box::into_raw_with_allocator(Box::new_in(st, &EFI_RUNTIME_SERVICES_DATA_ALLOCATOR));
+        let mut table = Self { system_table };
+
+        table.checksum();
+        table
+    }
+
+    // Included for API completness; may be used in future.
+    #[allow(dead_code)]
+    /// Creates a new EFI System Table instance from the given raw pointer.
+    /// # Safety
+    /// The pointer must be valid and point to a properly initialized efi::SystemTable structure.
+    pub unsafe fn from_raw_pointer(ptr: *mut efi::SystemTable) -> Self {
+        unsafe {
+            assert!(!ptr.is_null(), "Attempted to create EfiSystemTable with null System Table pointer");
+            assert!(
+                !(*ptr).boot_services.is_null(),
+                "Attempted to create EfiSystemTable with null Boot Services pointer"
+            );
+            assert!(
+                !(*ptr).runtime_services.is_null(),
+                "Attempted to create EfiSystemTable with null Runtime Services pointer"
+            );
+        }
+        Self { system_table: ptr }
+    }
+
+    // Checksums the System Table
+    fn checksum(&mut self) {
+        // SAFETY: structure construction ensures pointer is valid.
+        let mut table_copy = unsafe { self.system_table.read() };
+        table_copy.hdr.crc32 = 0;
+
+        let st_slice = unsafe { from_raw_parts(&table_copy as *const _ as *const u8, size_of::<efi::SystemTable>()) };
+        table_copy.hdr.crc32 = crc32fast::hash(st_slice);
+
+        // SAFETY: structure construction ensures pointer is valid.
+        unsafe { self.system_table.write(table_copy) }
+    }
+
+    /// Returns a copy of the System Table
+    pub fn get(&self) -> efi::SystemTable {
+        // SAFETY: structure construction ensures pointer is valid.
+        unsafe { self.system_table.read() }
+    }
+
+    /// Writes the given System Table into the stored pointer and updates the checksum.
+    pub fn set(&mut self, new_table: efi::SystemTable) {
+        assert!(!new_table.boot_services.is_null(), "Attempted to set System Table with null Boot Services pointer");
+        assert!(
+            !new_table.runtime_services.is_null(),
+            "Attempted to set System Table with null Runtime Services pointer"
+        );
+        // SAFETY: structure construction ensures pointer is valid.
+        unsafe {
+            self.system_table.write(new_table);
+        }
+        self.checksum();
+    }
+
+    /// Writes the given System Table into the stored pointer without validation and updates the checksum.
+    ///
+    /// # Safety
+    ///
+    /// The caller must ensure that the new table is has valid pointers for runtime_services and boot_services.
+    /// Boot services pointer may be null if the table is being updated for use after ExitBootServices.
+    pub unsafe fn set_unchecked(&mut self, new_table: efi::SystemTable) {
+        // SAFETY: caller must ensure that the new_table is valid.
+        unsafe {
+            self.system_table.write(new_table);
+        }
+        self.checksum();
+    }
+
+    /// Returns the raw pointer to the System Table.
+    pub fn as_mut_ptr(&self) -> *mut efi::SystemTable {
+        self.system_table
+    }
+
+    /// Returns the Runtime Services table from the system table.
+    pub fn runtime_services(&self) -> EfiRuntimeServicesTable {
+        // SAFETY: structure construction ensures System Table pointer is valid.
+        // Self::set ensures runtime_services pointer is not null.
+        unsafe {
+            let st = self.system_table.read();
+            assert!(!st.runtime_services.is_null(), "RuntimeServices pointer is null");
+            EfiRuntimeServicesTable::from_raw_pointer(st.runtime_services)
+        }
+    }
+
+    /// Returns the Boot Services table from the system table.
+    pub fn boot_services(&self) -> EfiBootServicesTable {
+        // SAFETY: structure construction ensures System Table pointer is valid.
+        // Self::set ensures boot_services pointer is not null.
+        unsafe {
+            let st = self.system_table.read();
+            assert!(!st.boot_services.is_null(), "BootServices pointer is null");
+            EfiBootServicesTable::from_raw_pointer(st.boot_services)
+        }
+    }
+
+    /// Clears the Boot Services and console pointers from the System Table.
+    ///
+    /// # Safety
+    ///
+    /// This should only be called after ExitBootServices has been invoked.
+    pub unsafe fn clear_boot_time_services(&mut self) {
+        let mut st = self.get();
+
+        st.boot_services = core::ptr::null_mut();
+        st.con_in = core::ptr::null_mut();
+        st.console_in_handle = core::ptr::null_mut();
+        st.con_out = core::ptr::null_mut();
+        st.console_out_handle = core::ptr::null_mut();
+        st.std_err = core::ptr::null_mut();
+        st.standard_error_handle = core::ptr::null_mut();
+
+        // SAFETY: set unchecked is used here because the table being set violates the normal invariant that the
+        // boot_services pointer is non-null. The caller must ensure that this is only called after ExitBootServices
+        // which is the case here.
+        unsafe {
+            self.set_unchecked(st);
+        }
+    }
+
+    /// Updates the checksum of the System Table, Runtime Services Table, and Boot Services Table.
+    pub fn checksum_all(&mut self) {
+        let mut rt = self.runtime_services();
+        rt.checksum();
+
+        let mut bs = self.boot_services();
+        bs.checksum();
+
+        self.checksum();
+    }
+
+    // Create a default System Table populated with null Runtime and Boot Services pointers and which is not checksummed.
+    fn default_system_table() -> efi::SystemTable {
+        efi::SystemTable {
             hdr: efi::TableHeader {
                 signature: efi::SYSTEM_TABLE_SIGNATURE,
                 revision: efi::SYSTEM_TABLE_REVISION,
-                header_size: 0,
+                header_size: size_of::<efi::SystemTable>() as u32,
                 crc32: 0,
                 reserved: 0,
             },
@@ -605,123 +859,12 @@ impl EfiSystemTable {
             boot_services: core::ptr::null_mut(),
             number_of_table_entries: 0,
             configuration_table: core::ptr::null_mut(),
-        };
-        let mut bs = EfiBootServicesTable::init();
-        let mut rt = EfiRuntimeServicesTable::init();
-        st.boot_services = bs.boot_services.as_mut();
-        st.runtime_services = rt.runtime_services.as_mut();
-
-        st.hdr.header_size = size_of::<efi::SystemTable>() as u32;
-
-        EfiSystemTable {
-            system_table: Box::new_in(st, &EFI_RUNTIME_SERVICES_DATA_ALLOCATOR),
-            boot_service: bs,
-            runtime_service: rt,
         }
     }
-
-    pub fn as_ptr(&self) -> *const efi::SystemTable {
-        self.system_table.as_ref() as *const efi::SystemTable
-    }
-
-    #[allow(dead_code)]
-    pub fn system_table(&self) -> &efi::SystemTable {
-        self.system_table.as_ref()
-    }
-
-    #[allow(dead_code)]
-    pub fn system_table_mut(&mut self) -> &mut efi::SystemTable {
-        self.system_table.as_mut()
-    }
-
-    #[allow(dead_code)]
-    pub fn boot_services(&self) -> &'static efi::BootServices {
-        // SAFETY: boot_services pointer in the system table is valid once system table is constructed.
-        // Note: some function pointers within the boot_services table may point to stub functions until
-        // architectural drivers outside the core install the corresponding architectural interfaces; but
-        // the pointers will be valid pointers to stub functions.
-        unsafe { self.system_table.boot_services.as_ref().expect("BootServices uninitialized") }
-    }
-
-    #[allow(dead_code)]
-    pub fn boot_services_mut(&mut self) -> &mut efi::BootServices {
-        // SAFETY: boot_services pointer in the system table is valid once system table is constructed.
-        // Note: this creates a mutable reference to the boot services pointer. The function should be marked unsafe
-        // since the caller needs to ensure that no other references to boot services exist when this is called.
-        // Issue: #1200
-        unsafe { self.system_table.boot_services.as_mut().expect("BootServices uninitialized") }
-    }
-
-    #[allow(dead_code)]
-    pub fn runtime_services(&self) -> &'static efi::RuntimeServices {
-        // SAFETY: runtime_services pointer in the system table is valid once system table is constructed.
-        // Note: some function pointers within the runtime_services table may point to stub functions until
-        // architectural drivers outside the core install the corresponding architectural interfaces; but
-        // the pointers will be valid pointers to stub functions.
-        unsafe { self.system_table.runtime_services.as_ref().expect("RuntimeServices uninitialized") }
-    }
-
-    pub fn runtime_services_mut(&mut self) -> &mut efi::RuntimeServices {
-        // SAFETY: runtime_services pointer in the system table is valid once system table is constructed.
-        // Note: this creates a mutable reference to the runtime services pointer. The function should be marked unsafe
-        // since the caller needs to ensure that no other references to runtime services exist when this is called.
-        // Issue: #1200
-        unsafe { self.system_table.runtime_services.as_mut().expect("RuntimeServices uninitialized") }
-    }
-
-    pub fn checksum(&mut self) {
-        self.system_table.hdr.crc32 = 0;
-        let st_ptr = self.system_table.as_ref() as *const efi::SystemTable as *const u8;
-        let st_slice = unsafe { from_raw_parts(st_ptr, size_of::<efi::SystemTable>()) };
-        self.system_table.hdr.crc32 = crc32fast::hash(st_slice);
-    }
-
-    pub fn checksum_runtime_services(&mut self) {
-        self.runtime_service.checksum();
-    }
-
-    pub fn checksum_boot_services(&mut self) {
-        self.boot_service.checksum();
-    }
-
-    pub fn checksum_all(&mut self) {
-        self.checksum_boot_services();
-        self.checksum_runtime_services();
-        self.checksum();
-    }
-
-    pub fn clear_boot_time_services(&mut self) {
-        self.system_table.boot_services = core::ptr::null_mut();
-        self.system_table.con_in = core::ptr::null_mut();
-        self.system_table.console_in_handle = core::ptr::null_mut();
-        self.system_table.con_out = core::ptr::null_mut();
-        self.system_table.console_out_handle = core::ptr::null_mut();
-        self.system_table.std_err = core::ptr::null_mut();
-        self.system_table.standard_error_handle = core::ptr::null_mut();
-        self.checksum();
-    }
 }
-
-impl AsMut<efi::SystemTable> for EfiSystemTable {
-    fn as_mut(&mut self) -> &mut efi::SystemTable {
-        self.system_table.as_mut()
-    }
-}
-
-impl AsRef<efi::SystemTable> for EfiSystemTable {
-    fn as_ref(&self) -> &efi::SystemTable {
-        self.system_table.as_ref()
-    }
-}
-
-//access to global system table is only through mutex guard, so safe to mark sync/send.
-unsafe impl Sync for EfiSystemTable {}
-unsafe impl Send for EfiSystemTable {}
 
 pub fn init_system_table() {
-    let mut table = EfiSystemTable::init();
-    table.checksum();
-    _ = SYSTEM_TABLE.lock().insert(table);
+    *SYSTEM_TABLE.lock() = Some(EfiSystemTable::allocate_new_table());
 }
 
 /// A component to register a callback that recalculates the CRC32 checksum of the system table
@@ -790,18 +933,20 @@ mod tests {
     #[test]
     fn test_checksum_changes_on_edit() {
         with_locked_state(|| {
-            let mut table = EfiSystemTable::init();
+            let mut table = EfiSystemTable::allocate_new_table();
             table.checksum();
 
-            let system_table_crc32 = table.as_ref().hdr.crc32;
-            let boot_services_crc32 = table.boot_services_mut().hdr.crc32;
-            let runtime_services_crc32 = table.runtime_services_mut().hdr.crc32;
+            let system_table_crc32 = table.get().hdr.crc32;
+            let boot_services_crc32 = table.boot_services().get().hdr.crc32;
+            let runtime_services_crc32 = table.runtime_services().get().hdr.crc32;
 
             // Update a boot_services function
             extern "efiapi" fn raise_tpl(_: efi::Tpl) -> efi::Tpl {
                 efi::TPL_APPLICATION
             }
-            table.boot_services_mut().raise_tpl = raise_tpl;
+            let mut bs = table.boot_services().get();
+            bs.raise_tpl = raise_tpl;
+            table.boot_services().set(bs);
 
             // Update a runtime_services function
             extern "efiapi" fn get_variable(
@@ -813,21 +958,30 @@ mod tests {
             ) -> efi::Status {
                 efi::Status::SUCCESS
             }
-            table.runtime_services_mut().get_variable = get_variable;
+            let mut rt = table.runtime_services().get();
+            rt.get_variable = get_variable;
+            table.runtime_services().set(rt);
 
             // Update a system_table field
-            table.as_mut().hdr.revision = 0x100;
+            let mut st = table.get();
+            st.hdr.revision = 0x100;
+            table.set(st);
 
-            // Checksums should be different
-            table.checksum_all();
-            assert_ne!(system_table_crc32, table.system_table_mut().hdr.crc32);
-            assert_ne!(boot_services_crc32, table.boot_services_mut().hdr.crc32);
-            assert_ne!(runtime_services_crc32, table.runtime_services_mut().hdr.crc32);
+            // Checksums should be different.
+            let new_system_table_crc32 = table.get().hdr.crc32;
+            let new_boot_services_crc32 = table.boot_services().get().hdr.crc32;
+            let new_runtime_services_crc32 = table.runtime_services().get().hdr.crc32;
+
+            assert_ne!(system_table_crc32, new_system_table_crc32);
+            assert_ne!(boot_services_crc32, new_boot_services_crc32);
+            assert_ne!(runtime_services_crc32, new_runtime_services_crc32);
 
             // Check that clearing boot time services changes the checksum
-            table.system_table_mut().hdr.revision = efi::RUNTIME_SERVICES_REVISION;
-            table.clear_boot_time_services();
-            assert_eq!(table.system_table_mut().boot_services, core::ptr::null_mut());
+            // SAFETY: this is test code modeling exit boot services behavior.
+            unsafe {
+                table.clear_boot_time_services();
+                assert_eq!((*table.system_table).boot_services, core::ptr::null_mut());
+            };
         })
     }
 }

--- a/patina_dxe_core/src/test_support.rs
+++ b/patina_dxe_core/src/test_support.rs
@@ -8,7 +8,7 @@
 //!
 //! SPDX-License-Identifier: Apache-2.0
 //!
-use crate::{GCD, protocols::PROTOCOL_DB};
+use crate::{GCD, allocator::DEFAULT_PAGE_ALLOCATION_GRANULARITY, protocols::PROTOCOL_DB};
 use core::ffi::c_void;
 use patina::{
     guids::ZERO,
@@ -211,13 +211,16 @@ pub(crate) fn with_global_lock<F: Fn() + std::panic::RefUnwindSafe>(f: F) -> Res
 
 /// Allocates a chunk of memory of the specified size from the system allocator.
 ///
+/// The memory allocated will be 64Kb aligned to simplify alignment requirements such
+/// as AArch64 runtime memory.
+///
 /// ## Safety
 /// This function is intended for test code only. The caller must ensure that the size is valid
 /// for allocation.
 pub(crate) unsafe fn get_memory(size: usize) -> &'static mut [u8] {
     // SAFETY: Test code - allocates memory from the system allocator with UEFI page alignment.
     // The returned slice is intentionally leaked for test simplicity and valid for 'static lifetime.
-    let addr = unsafe { alloc::alloc::alloc(alloc::alloc::Layout::from_size_align(size, 0x1000).unwrap()) };
+    let addr = unsafe { alloc::alloc::alloc(alloc::alloc::Layout::from_size_align(size, 0x10000).unwrap()) };
     // SAFETY: The allocated pointer is valid for `size` bytes and properly aligned.
     unsafe { core::slice::from_raw_parts_mut(addr, size) }
 }
@@ -285,16 +288,17 @@ pub(crate) fn build_test_hob_list(mem_size: u64) -> *const c_void {
     // SAFETY: Test code - allocates memory for the test HOB list.
     let mem = unsafe { get_memory(mem_size as usize) };
     let mem_base = mem.as_mut_ptr() as u64;
+    assert!(mem_size >= 0x1B0000);
 
     // Build a test HOB list that describes memory layout as follows:
     //
     // Base:         offset 0                   ************
     // HobList:      offset base+0              HOBS
     // Empty:        offset base+HobListSize    N/A
-    // SystemMemory  offset base+0xE0000        SystemMemory (resource_descriptor1)
-    // Reserved      offset base+0xF0000        Untested SystemMemory (resource_descriptor2)
-    // FreeMemory    offset base+0x100000       FreeMemory (phit)
-    // End           offset base+0x200000       ************
+    // SystemMemory  offset base+0x0E0000       SystemMemory (resource_descriptor1)
+    // Reserved      offset base+0x190000       Untested SystemMemory (resource_descriptor2)
+    // FreeMemory    offset base+0x1A0000       FreeMemory (phit)
+    // End           offset base+mem_size       ************
     //
     // The test HOB list will also include resource descriptor hobs that describe MMIO/IO as follows:
     // MMIO at 0x10000000 size 0x1000000 (resource_descriptor3)
@@ -304,9 +308,15 @@ pub(crate) fn build_test_hob_list(mem_size: u64) -> *const c_void {
     // Reserved Legacy I/O at 0x0000 size 0x1000 (resource_descriptor7)
     //
     // The test HOB list will also include resource allocation hobs that describe allocations as follows:
-    // A Memory Allocation Hob for each memory type. This will be placed in the SystemMemory region at base+0xE0000 as
-    // 4K allocations. There is also a Memory Allocation Hob for MMIO space at 0x10000000 for 0x2000 bytes.
-    // A Firmware Volume HOB located in the FirmwareDevice region at 0x10000000
+    // A Memory Allocation Hob for each memory type. This will be placed in the SystemMemory region at base+0xE0000 with
+    // appropriate granularity for each type (64KB for runtime types on aarch64, 4KB otherwise). There is also a Memory
+    // Allocation Hob for MMIO space at 0x10000000 for 0x2000 bytes. A Firmware Volume HOB located in the FirmwareDevice
+    // region at 0x10000000
+    //
+    // The system memory is of length 0xB0000 bytes. This includes 0xA0000 for the regular allocations plus 0x10000 for
+    // potential stack allocations. 0xA0000 bytes allows for each memory type to be aligned up to 64kb. Really, only
+    // 0x70000 bytes is needed for that in the current layout of allocation hobs, but leaving room provides flexibility
+    // for future changes.
     //
     let phit = hob::PhaseHandoffInformationTable {
         header: header::Hob {
@@ -319,11 +329,13 @@ pub(crate) fn build_test_hob_list(mem_size: u64) -> *const c_void {
         memory_top: mem_base + mem_size,
         memory_bottom: mem_base,
         free_memory_top: mem_base + mem_size,
-        free_memory_bottom: mem_base + 0x100000,
+        free_memory_bottom: mem_base + 0x1A0000,
         end_of_hob_list: mem_base
             + core::mem::size_of::<hob::PhaseHandoffInformationTable>() as u64
             + core::mem::size_of::<hob::Cpu>() as u64
             + (core::mem::size_of::<ResourceDescriptorV2>() as u64) * 7
+            + (core::mem::size_of::<hob::MemoryAllocation>() as u64) * 11  // 10 memory type allocations + 1 MMIO
+            + core::mem::size_of::<hob::FirmwareVolume>() as u64
             + core::mem::size_of::<header::Hob>() as u64,
     };
 
@@ -345,7 +357,7 @@ pub(crate) fn build_test_hob_list(mem_size: u64) -> *const c_void {
             resource_type: hob::EFI_RESOURCE_SYSTEM_MEMORY,
             resource_attribute: hob::TESTED_MEMORY_ATTRIBUTES | hob::EFI_RESOURCE_ATTRIBUTE_WRITE_BACK_CACHEABLE,
             physical_start: mem_base + 0xE0000,
-            resource_length: 0x10000,
+            resource_length: 0xB0000,
         },
         attributes: efi::MEMORY_WB,
     };
@@ -360,7 +372,7 @@ pub(crate) fn build_test_hob_list(mem_size: u64) -> *const c_void {
             owner: efi::Guid::from_fields(0, 0, 0, 0, 0, &[0u8; 6]),
             resource_type: hob::EFI_RESOURCE_SYSTEM_MEMORY,
             resource_attribute: hob::INITIALIZED_MEMORY_ATTRIBUTES | hob::EFI_RESOURCE_ATTRIBUTE_WRITE_BACK_CACHEABLE,
-            physical_start: mem_base + 0xF0000,
+            physical_start: mem_base + 0x190000,
             resource_length: 0x10000,
         },
         attributes: efi::MEMORY_WB,
@@ -516,7 +528,8 @@ pub(crate) fn build_test_hob_list(mem_size: u64) -> *const c_void {
         cursor = cursor.offset(resource_descriptor7.v1.header.length as isize);
 
         //memory allocation HOBs.
-        for (idx, memory_type) in [
+        let mut address: u64 = resource_descriptor1.v1.physical_start;
+        for memory_type in [
             efi::RESERVED_MEMORY_TYPE,
             efi::LOADER_CODE,
             efi::LOADER_DATA,
@@ -529,15 +542,28 @@ pub(crate) fn build_test_hob_list(mem_size: u64) -> *const c_void {
             efi::PAL_CODE,
         ]
         .iter()
-        .enumerate()
         {
-            allocation_hob_template.alloc_descriptor.memory_base_address =
-                resource_descriptor1.v1.physical_start + idx as u64 * 0x1000;
+            let granularity = match *memory_type {
+                efi::RESERVED_MEMORY_TYPE
+                | efi::RUNTIME_SERVICES_CODE
+                | efi::RUNTIME_SERVICES_DATA
+                | efi::ACPI_MEMORY_NVS => crate::allocator::RUNTIME_PAGE_ALLOCATION_GRANULARITY,
+                _ => DEFAULT_PAGE_ALLOCATION_GRANULARITY,
+            } as u64;
+
+            // Make sure the memory region is aligned as needed.
+            address = patina::base::align_up(address, granularity).unwrap();
+            allocation_hob_template.alloc_descriptor.memory_base_address = address;
             allocation_hob_template.alloc_descriptor.memory_type = *memory_type;
+            allocation_hob_template.alloc_descriptor.memory_length = granularity;
 
             core::ptr::copy(&allocation_hob_template, cursor as *mut hob::MemoryAllocation, 1);
             cursor = cursor.offset(allocation_hob_template.header.length as isize);
+            address += granularity;
         }
+
+        // Double check this never over-runs the memory region.
+        assert!(address <= resource_descriptor1.v1.physical_start + resource_descriptor1.v1.resource_length);
 
         // memory allocation HOB for MMIO space
         allocation_hob_template.alloc_descriptor.memory_base_address = resource_descriptor3.v1.physical_start;

--- a/patina_dxe_core/src/tpl_mutex.rs
+++ b/patina_dxe_core/src/tpl_mutex.rs
@@ -111,7 +111,7 @@ impl<T: ?Sized + fmt::Display> fmt::Display for TplGuard<'_, T> {
 impl<'a, T: ?Sized> Deref for TplGuard<'a, T> {
     type Target = T;
     fn deref(&self) -> &'a T {
-        // Safety: data is only accessible through the guard, which guarantees mutual exclusion since no higher TPL can
+        // SAFETY: data is only accessible through the guard, which guarantees mutual exclusion since no higher TPL can
         // obtain the lock without panic, and no code at equal or lower TPL can interrupt while the lock is held.
         unsafe { self.mutex.data.get().as_ref().expect("TplMutex data pointer should not be null") }
     }
@@ -119,7 +119,7 @@ impl<'a, T: ?Sized> Deref for TplGuard<'a, T> {
 
 impl<'a, T: ?Sized> DerefMut for TplGuard<'a, T> {
     fn deref_mut(&mut self) -> &'a mut T {
-        // Safety: data is only accessible through the guard, which guarantees mutual exclusion since no higher TPL can
+        // SAFETY: data is only accessible through the guard, which guarantees mutual exclusion since no higher TPL can
         // obtain the lock without panic, and no code at equal or lower TPL can interrupt while the lock is held.
         unsafe { self.mutex.data.get().as_mut().expect("TplMutex data pointer should not be null") }
     }

--- a/sdk/patina/benches/bench_component.rs
+++ b/sdk/patina/benches/bench_component.rs
@@ -88,12 +88,12 @@ fn add_component_abstracted(b: &mut Bencher<'_>, count: &usize) {
 }
 
 fn run_component_abstracted(b: &mut Bencher<'_>, count: &usize) {
-    let mock_bs = core::mem::MaybeUninit::<r_efi::efi::BootServices>::zeroed();
+    let mut mock_bs = core::mem::MaybeUninit::<r_efi::efi::BootServices>::zeroed();
 
-    let init = |count: usize| -> Scheduler {
+    let mut init = |count: usize| -> Scheduler {
         let mut core = Scheduler::new();
         // SAFETY: Benchmark code - using zeroed BootServices for performance testing.
-        core.storage.set_boot_services(StandardBootServices::new(unsafe { &*mock_bs.as_ptr() }));
+        core.storage.set_boot_services(StandardBootServices::new(mock_bs.as_mut_ptr()));
         for _ in 0..count {
             core = core.with_component(TestComponent);
         }
@@ -110,12 +110,12 @@ fn run_component_abstracted(b: &mut Bencher<'_>, count: &usize) {
 }
 
 fn add_and_run_component_abstracted(b: &mut Bencher<'_>, count: &usize) {
-    let mock_bs = core::mem::MaybeUninit::<r_efi::efi::BootServices>::zeroed();
+    let mut mock_bs = core::mem::MaybeUninit::<r_efi::efi::BootServices>::zeroed();
 
     let init = || -> Scheduler {
         let mut core = Scheduler::new();
         // SAFETY: Benchmark code - using zeroed BootServices for performance testing.
-        core.storage.set_boot_services(StandardBootServices::new(unsafe { &*mock_bs.as_ptr() }));
+        core.storage.set_boot_services(StandardBootServices::new(mock_bs.as_mut_ptr()));
         core
     };
 

--- a/sdk/patina/src/boot_services.rs
+++ b/sdk/patina/src/boot_services.rs
@@ -45,19 +45,19 @@ use tpl::{Tpl, TplGuard};
 
 /// This is the boot services used in the UEFI.
 pub struct StandardBootServices {
-    efi_boot_services: Once<&'static efi::BootServices>,
+    efi_boot_services: Once<*mut efi::BootServices>,
 }
 
 // Safety: efi::BootServices is not Sync/Send automatically due to the use of *mut c_void as part of function signatures
-// within the struct. Those pointers are only used by spec-defined APIs. With respect to the efi_boot_services reference
-// itself, that is protected by the Once wrapper.
+// within the struct. Those pointers are only used by spec-defined APIs. With respect to the efi_boot_services pointer
+// itself, that is protected by the Once wrapper, and is not expected to change once initialized.
 unsafe impl Sync for StandardBootServices {}
 // Safety: See Sync impl above.
 unsafe impl Send for StandardBootServices {}
 
 impl StandardBootServices {
     /// Create a new StandardBootServices with the provided [efi::BootServices].
-    pub fn new(efi_boot_services: &'static efi::BootServices) -> Self {
+    pub fn new(efi_boot_services: *mut efi::BootServices) -> Self {
         let this = Self::new_uninit();
         this.init(efi_boot_services);
         this
@@ -69,7 +69,7 @@ impl StandardBootServices {
     }
 
     /// Initialize the StandardBootServices.
-    pub fn init(&self, efi_boot_services: &'static efi::BootServices) {
+    pub fn init(&self, efi_boot_services: *mut efi::BootServices) {
         // This struct never mutate the efi_boot_services.
         self.efi_boot_services.call_once(|| efi_boot_services);
     }
@@ -79,8 +79,9 @@ impl StandardBootServices {
         self.efi_boot_services.is_completed()
     }
 
-    fn efi_boot_services(&self) -> &efi::BootServices {
-        self.efi_boot_services.get().expect("Standard Boot Services is not initialized!")
+    // Returns the boot services pointer if initialized, panics otherwise.
+    fn as_mut_ptr(&self) -> *mut efi::BootServices {
+        *self.efi_boot_services.get().expect("Standard Boot Services is not initialized!")
     }
 }
 
@@ -93,7 +94,7 @@ impl AsRef<StandardBootServices> for StandardBootServices {
 impl Clone for StandardBootServices {
     fn clone(&self) -> Self {
         if let Some(efi_boot_services) = self.efi_boot_services.get() {
-            StandardBootServices::new(efi_boot_services)
+            StandardBootServices::new(*efi_boot_services)
         } else {
             StandardBootServices::new_uninit()
         }
@@ -106,56 +107,54 @@ impl Debug for StandardBootServices {
             return f.debug_struct("StandardBootServices").field("efi_boot_services", &"Not Initialized").finish();
         }
 
+        // SAFETY: assume that boot services struct is not being externally modified while static reference is in use
+        // In this case, if the struct is being modified, the debug print may be inaccurate, but it won't cause
+        // undefined behavior beyond that.
+        let bs = unsafe { &*self.as_mut_ptr() };
         f.debug_struct("StandardBootServices")
-            .field("create_event", &(self.efi_boot_services().create_event))
-            .field("create_event_ex", &(self.efi_boot_services().create_event_ex))
-            .field("close_event", &(self.efi_boot_services().close_event))
-            .field("signal_event", &(self.efi_boot_services().signal_event))
-            .field("wait_for_event", &(self.efi_boot_services().wait_for_event))
-            .field("check_event", &(self.efi_boot_services().check_event))
-            .field("set_timer", &(self.efi_boot_services().set_timer))
-            .field("raise_tpl", &(self.efi_boot_services().raise_tpl))
-            .field("restore_tpl", &(self.efi_boot_services().restore_tpl))
-            .field("allocate_page", &(self.efi_boot_services().allocate_pages))
-            .field("free_pages", &(self.efi_boot_services().free_pages))
-            .field("get_memory_map", &(self.efi_boot_services().get_memory_map))
-            .field("allocate_pool", &(self.efi_boot_services().allocate_pool))
-            .field("free_pool", &(self.efi_boot_services().free_pool))
-            .field("install_protocol_interface", &(self.efi_boot_services().install_protocol_interface))
-            .field("uninstall_protocol_interface", &(self.efi_boot_services().uninstall_protocol_interface))
-            .field("reinstall_protocol_interface", &(self.efi_boot_services().reinstall_protocol_interface))
-            .field("register_protocol_notify", &(self.efi_boot_services().register_protocol_notify))
-            .field("locate_handle", &(self.efi_boot_services().locate_handle))
-            .field("handle_protocol", &(self.efi_boot_services().handle_protocol))
-            .field("locate_device_path", &(self.efi_boot_services().locate_device_path))
-            .field("open_protocol", &(self.efi_boot_services().open_protocol))
-            .field("close_protocol", &(self.efi_boot_services().close_protocol))
-            .field("open_protocol_information", &(self.efi_boot_services().open_protocol_information))
-            .field("connect_controller", &(self.efi_boot_services().connect_controller))
-            .field("disconnect_controller", &(self.efi_boot_services().disconnect_controller))
-            .field("protocols_per_handle", &(self.efi_boot_services().protocols_per_handle))
-            .field("locate_handle_buffer", &(self.efi_boot_services().locate_handle_buffer))
-            .field("locate_protocol", &(self.efi_boot_services().locate_protocol))
-            .field(
-                "install_multiple_protocol_interfaces",
-                &(self.efi_boot_services().install_multiple_protocol_interfaces),
-            )
-            .field(
-                "uninstall_multiple_protocol_interfaces",
-                &(self.efi_boot_services().uninstall_multiple_protocol_interfaces),
-            )
-            .field("load_image", &(self.efi_boot_services().load_image))
-            .field("start_image", &(self.efi_boot_services().start_image))
-            .field("unload_image", &(self.efi_boot_services().unload_image))
-            .field("exit", &(self.efi_boot_services().exit))
-            .field("exit_boot_services", &(self.efi_boot_services().exit_boot_services))
-            .field("set_watchdog_timer", &(self.efi_boot_services().set_watchdog_timer))
-            .field("stall", &(self.efi_boot_services().stall))
-            .field("copy_mem", &(self.efi_boot_services().copy_mem))
-            .field("set_mem", &(self.efi_boot_services().set_mem))
-            .field("get_next_monotonic_count", &(self.efi_boot_services().get_next_monotonic_count))
-            .field("install_configuration_table", &(self.efi_boot_services().install_configuration_table))
-            .field("calculate_crc32", &(self.efi_boot_services().calculate_crc32))
+            .field("create_event", &bs.create_event)
+            .field("create_event_ex", &bs.create_event_ex)
+            .field("close_event", &bs.close_event)
+            .field("signal_event", &bs.signal_event)
+            .field("wait_for_event", &bs.wait_for_event)
+            .field("check_event", &bs.check_event)
+            .field("set_timer", &bs.set_timer)
+            .field("raise_tpl", &bs.raise_tpl)
+            .field("restore_tpl", &bs.restore_tpl)
+            .field("allocate_page", &bs.allocate_pages)
+            .field("free_pages", &bs.free_pages)
+            .field("get_memory_map", &bs.get_memory_map)
+            .field("allocate_pool", &bs.allocate_pool)
+            .field("free_pool", &bs.free_pool)
+            .field("install_protocol_interface", &bs.install_protocol_interface)
+            .field("uninstall_protocol_interface", &bs.uninstall_protocol_interface)
+            .field("reinstall_protocol_interface", &bs.reinstall_protocol_interface)
+            .field("register_protocol_notify", &bs.register_protocol_notify)
+            .field("locate_handle", &bs.locate_handle)
+            .field("handle_protocol", &bs.handle_protocol)
+            .field("locate_device_path", &bs.locate_device_path)
+            .field("open_protocol", &bs.open_protocol)
+            .field("close_protocol", &bs.close_protocol)
+            .field("open_protocol_information", &bs.open_protocol_information)
+            .field("connect_controller", &bs.connect_controller)
+            .field("disconnect_controller", &bs.disconnect_controller)
+            .field("protocols_per_handle", &bs.protocols_per_handle)
+            .field("locate_handle_buffer", &bs.locate_handle_buffer)
+            .field("locate_protocol", &bs.locate_protocol)
+            .field("install_multiple_protocol_interfaces", &bs.install_multiple_protocol_interfaces)
+            .field("uninstall_multiple_protocol_interfaces", &bs.uninstall_multiple_protocol_interfaces)
+            .field("load_image", &bs.load_image)
+            .field("start_image", &bs.start_image)
+            .field("unload_image", &bs.unload_image)
+            .field("exit", &bs.exit)
+            .field("exit_boot_services", &bs.exit_boot_services)
+            .field("set_watchdog_timer", &bs.set_watchdog_timer)
+            .field("stall", &bs.stall)
+            .field("copy_mem", &bs.copy_mem)
+            .field("set_mem", &bs.set_mem)
+            .field("get_next_monotonic_count", &bs.get_next_monotonic_count)
+            .field("install_configuration_table", &bs.install_configuration_table)
+            .field("calculate_crc32", &bs.calculate_crc32)
             .finish()
     }
 }
@@ -994,7 +993,18 @@ impl BootServices for StandardBootServices {
         notify_context: *mut T,
     ) -> Result<efi::Event, efi::Status> {
         let mut event = MaybeUninit::zeroed();
-        let status = efi_boot_services_fn!(self.efi_boot_services(), create_event)(
+        // SAFETY: If this function pointer is modified in an event callback/interrupt while the read is in progress
+        // or if this function is invoked in a callback/interrupt that interrupts an external agent that is modifying
+        // the boot services struct, then an incorrect function pointer might be returned that is composed of parts
+        // of the pointer from before and after the interrupt. Function pointer read/write operations could consist of
+        // several instructions - not necessarily a single atomic operation. The safety of this code therefore relies on
+        // the assumption that the boot services struct is not being modified in such a manner, which is true for all
+        // known external modifiers of the struct in EDK2. If this code requires stronger guarantees in the future, then
+        // synchronization with external modifications may be needed, or the table could be copied to local storage and
+        // verified (via CRC) before use with an error returned on mismatch. Present use cases for external modification
+        // of boot services don't merit such complexity at this time.
+        let create_event = unsafe { efi_boot_services_fn!(*self.as_mut_ptr(), create_event) };
+        let status = create_event(
             event_type.into(),
             notify_tpl.into(),
             // Safety: Transmuting function pointer types with matching ABIs and compatible signatures.
@@ -1022,7 +1032,9 @@ impl BootServices for StandardBootServices {
         event_group: &'static efi::Guid,
     ) -> Result<efi::Event, efi::Status> {
         let mut event = MaybeUninit::zeroed();
-        let status = efi_boot_services_fn!(self.efi_boot_services(), create_event_ex)(
+        // SAFETY: See safety comment in create_event_unchecked for details on corner cases around external modifications.
+        let create_event_ex = unsafe { efi_boot_services_fn!(*self.as_mut_ptr(), create_event_ex) };
+        let status = create_event_ex(
             event_type.into(),
             notify_tpl.into(),
             // Safety: Transmuting function pointer types with matching ABIs and compatible signatures.
@@ -1043,14 +1055,18 @@ impl BootServices for StandardBootServices {
     }
 
     fn close_event(&self, event: efi::Event) -> Result<(), efi::Status> {
-        match efi_boot_services_fn!(self.efi_boot_services(), close_event)(event) {
+        // SAFETY: See safety comment in create_event_unchecked for details on corner cases around external modifications.
+        let close_event = unsafe { efi_boot_services_fn!(*self.as_mut_ptr(), close_event) };
+        match close_event(event) {
             s if s.is_error() => Err(s),
             _ => Ok(()),
         }
     }
 
     fn signal_event(&self, event: efi::Event) -> Result<(), efi::Status> {
-        match efi_boot_services_fn!(self.efi_boot_services(), signal_event)(event) {
+        // SAFETY: See safety comment in create_event_unchecked for details on corner cases around external modifications.
+        let signal_event = unsafe { efi_boot_services_fn!(*self.as_mut_ptr(), signal_event) };
+        match signal_event(event) {
             s if s.is_error() => Err(s),
             _ => Ok(()),
         }
@@ -1058,35 +1074,41 @@ impl BootServices for StandardBootServices {
 
     fn wait_for_event(&self, events: &mut [efi::Event]) -> Result<usize, efi::Status> {
         let mut index = MaybeUninit::zeroed();
-        let status = efi_boot_services_fn!(self.efi_boot_services(), wait_for_event)(
-            events.len(),
-            events.as_mut_ptr(),
-            index.as_mut_ptr(),
-        );
+        // SAFETY: See safety comment in create_event_unchecked for details on corner cases around external modifications.
+        let wait_for_event = unsafe { efi_boot_services_fn!(*self.as_mut_ptr(), wait_for_event) };
+        let status = wait_for_event(events.len(), events.as_mut_ptr(), index.as_mut_ptr());
         // SAFETY: If the call succeeded, index has been initialized with the event index.
         if status.is_error() { Err(status) } else { Ok(unsafe { index.assume_init() }) }
     }
 
     fn check_event(&self, event: efi::Event) -> Result<(), efi::Status> {
-        match efi_boot_services_fn!(self.efi_boot_services(), check_event)(event) {
+        // SAFETY: See safety comment in create_event_unchecked for details on corner cases around external modifications.
+        let check_event = unsafe { efi_boot_services_fn!(*self.as_mut_ptr(), check_event) };
+        match check_event(event) {
             s if s.is_error() => Err(s),
             _ => Ok(()),
         }
     }
 
     fn set_timer(&self, event: efi::Event, timer_type: EventTimerType, trigger_time: u64) -> Result<(), efi::Status> {
-        match efi_boot_services_fn!(self.efi_boot_services(), set_timer)(event, timer_type.into(), trigger_time) {
+        // SAFETY: See safety comment in create_event_unchecked for details on corner cases around external modifications.
+        let set_timer = unsafe { efi_boot_services_fn!(*self.as_mut_ptr(), set_timer) };
+        match set_timer(event, timer_type.into(), trigger_time) {
             s if s.is_error() => Err(s),
             _ => Ok(()),
         }
     }
 
     fn raise_tpl(&self, new_tpl: Tpl) -> Tpl {
-        efi_boot_services_fn!(self.efi_boot_services(), raise_tpl)(new_tpl.into()).into()
+        // SAFETY: See safety comment in create_event_unchecked for details on corner cases around external modifications.
+        let raise_tpl = unsafe { efi_boot_services_fn!(*self.as_mut_ptr(), raise_tpl) };
+        raise_tpl(new_tpl.into()).into()
     }
 
     fn restore_tpl(&self, old_tpl: Tpl) {
-        efi_boot_services_fn!(self.efi_boot_services(), restore_tpl)(old_tpl.into())
+        // SAFETY: See safety comment in create_event_unchecked for details on corner cases around external modifications.
+        let restore_tpl = unsafe { efi_boot_services_fn!(*self.as_mut_ptr(), restore_tpl) };
+        restore_tpl(old_tpl.into())
     }
 
     fn allocate_pages(
@@ -1100,7 +1122,9 @@ impl BootServices for StandardBootServices {
             AllocType::MaxAddress(address) => address,
             _ => 0,
         };
-        match efi_boot_services_fn!(self.efi_boot_services(), allocate_pages)(
+        // SAFETY: See safety comment in create_event_unchecked for details on corner cases around external modifications.
+        let allocate_pages = unsafe { efi_boot_services_fn!(*self.as_mut_ptr(), allocate_pages) };
+        match allocate_pages(
             alloc_type.into(),
             memory_type.into(),
             nb_pages,
@@ -1112,14 +1136,17 @@ impl BootServices for StandardBootServices {
     }
 
     fn free_pages(&self, address: usize, nb_pages: usize) -> Result<(), efi::Status> {
-        match efi_boot_services_fn!(self.efi_boot_services(), free_pages)(address as u64, nb_pages) {
+        // SAFETY: See safety comment in create_event_unchecked for details on corner cases around external modifications.
+        let free_pages = unsafe { efi_boot_services_fn!(*self.as_mut_ptr(), free_pages) };
+        match free_pages(address as u64, nb_pages) {
             s if s.is_error() => Err(s),
             _ => Ok(()),
         }
     }
 
     fn get_memory_map(&self) -> Result<MemoryMap<'_, Self>, (efi::Status, usize)> {
-        let get_memory_map = efi_boot_services_fn!(self.efi_boot_services(), get_memory_map);
+        // SAFETY: See safety comment in create_event_unchecked for details on corner cases around external modifications.
+        let get_memory_map = unsafe { efi_boot_services_fn!(*self.as_mut_ptr(), get_memory_map) };
 
         let mut memory_map_size = 0;
         let mut map_key = 0;
@@ -1161,18 +1188,18 @@ impl BootServices for StandardBootServices {
 
     fn allocate_pool(&self, memory_type: EfiMemoryType, size: usize) -> Result<*mut u8, efi::Status> {
         let mut buffer = ptr::null_mut();
-        match efi_boot_services_fn!(self.efi_boot_services(), allocate_pool)(
-            memory_type.into(),
-            size,
-            ptr::addr_of_mut!(buffer),
-        ) {
+        // SAFETY: See safety comment in create_event_unchecked for details on corner cases around external modifications.
+        let allocate_pool = unsafe { efi_boot_services_fn!(*self.as_mut_ptr(), allocate_pool) };
+        match allocate_pool(memory_type.into(), size, ptr::addr_of_mut!(buffer)) {
             s if s.is_error() => Err(s),
             _ => Ok(buffer as *mut u8),
         }
     }
 
     fn free_pool(&self, buffer: *mut u8) -> Result<(), efi::Status> {
-        match efi_boot_services_fn!(self.efi_boot_services(), free_pool)(buffer as *mut c_void) {
+        // SAFETY: See safety comment in create_event_unchecked for details on corner cases around external modifications.
+        let free_pool = unsafe { efi_boot_services_fn!(*self.as_mut_ptr(), free_pool) };
+        match free_pool(buffer as *mut c_void) {
             s if s.is_error() => Err(s),
             _ => Ok(()),
         }
@@ -1185,7 +1212,10 @@ impl BootServices for StandardBootServices {
         interface: *mut c_void,
     ) -> Result<efi::Handle, efi::Status> {
         let mut handle = handle.unwrap_or(ptr::null_mut());
-        match efi_boot_services_fn!(self.efi_boot_services(), install_protocol_interface)(
+        // SAFETY: See safety comment in create_event_unchecked for details on corner cases around external modifications.
+        let install_protocol_interface =
+            unsafe { efi_boot_services_fn!(*self.as_mut_ptr(), install_protocol_interface) };
+        match install_protocol_interface(
             ptr::addr_of_mut!(handle),
             protocol as *const _ as *mut _,
             efi::NATIVE_INTERFACE,
@@ -1202,11 +1232,10 @@ impl BootServices for StandardBootServices {
         protocol: &'static efi::Guid,
         interface: *mut c_void,
     ) -> Result<(), efi::Status> {
-        match efi_boot_services_fn!(self.efi_boot_services(), uninstall_protocol_interface)(
-            handle,
-            protocol as *const _ as *mut _,
-            interface,
-        ) {
+        // SAFETY: See safety comment in create_event_unchecked for details on corner cases around external modifications.
+        let uninstall_protocol_interface =
+            unsafe { efi_boot_services_fn!(*self.as_mut_ptr(), uninstall_protocol_interface) };
+        match uninstall_protocol_interface(handle, protocol as *const _ as *mut _, interface) {
             s if s.is_error() => Err(s),
             _ => Ok(()),
         }
@@ -1219,7 +1248,10 @@ impl BootServices for StandardBootServices {
         old_protocol_interface: *mut c_void,
         new_protocol_interface: *mut c_void,
     ) -> Result<(), efi::Status> {
-        match efi_boot_services_fn!(self.efi_boot_services(), reinstall_protocol_interface)(
+        // SAFETY: See safety comment in create_event_unchecked for details on corner cases around external modifications.
+        let reinstall_protocol_interface =
+            unsafe { efi_boot_services_fn!(*self.as_mut_ptr(), reinstall_protocol_interface) };
+        match reinstall_protocol_interface(
             handle,
             protocol as *const _ as *mut _,
             old_protocol_interface,
@@ -1232,11 +1264,9 @@ impl BootServices for StandardBootServices {
 
     fn register_protocol_notify(&self, protocol: &efi::Guid, event: efi::Event) -> Result<Registration, efi::Status> {
         let mut registration = MaybeUninit::uninit();
-        match efi_boot_services_fn!(self.efi_boot_services(), register_protocol_notify)(
-            protocol as *const _ as *mut _,
-            event,
-            registration.as_mut_ptr() as *mut _,
-        ) {
+        // SAFETY: See safety comment in create_event_unchecked for details on corner cases around external modifications.
+        let register_protocol_notify = unsafe { efi_boot_services_fn!(*self.as_mut_ptr(), register_protocol_notify) };
+        match register_protocol_notify(protocol as *const _ as *mut _, event, registration.as_mut_ptr() as *mut _) {
             s if s.is_error() => Err(s),
             // SAFETY: If the call succeeded, registration has been initialized.
             _ => Ok(unsafe { registration.assume_init() }),
@@ -1247,7 +1277,8 @@ impl BootServices for StandardBootServices {
         &self,
         search_type: HandleSearchType,
     ) -> Result<BootServicesBox<'_, [efi::Handle], Self>, efi::Status> {
-        let locate_handle = efi_boot_services_fn!(self.efi_boot_services(), locate_handle);
+        // SAFETY: See safety comment in create_event_unchecked for details on corner cases around external modifications.
+        let locate_handle = unsafe { efi_boot_services_fn!(*self.as_mut_ptr(), locate_handle) };
 
         let protocol = match search_type {
             HandleSearchType::ByProtocol(p) => p as *const _ as *mut _,
@@ -1258,9 +1289,13 @@ impl BootServices for StandardBootServices {
             _ => ptr::null_mut(),
         };
 
-        // Use to get the buffer_size
+        // Expect locate_handle to return BUFFER_TOO_SMALL along with the proper buffer_size
         let mut buffer_size = 0;
-        locate_handle(search_type.into(), protocol, search_key, ptr::addr_of_mut!(buffer_size), ptr::null_mut());
+        match locate_handle(search_type.into(), protocol, search_key, ptr::addr_of_mut!(buffer_size), ptr::null_mut()) {
+            s if s == efi::Status::BUFFER_TOO_SMALL => (),
+            s if s.is_error() => return Err(s),
+            _ => (),
+        }
 
         let buffer = self.allocate_pool(EfiMemoryType::BootServicesData, buffer_size)?;
 
@@ -1286,11 +1321,9 @@ impl BootServices for StandardBootServices {
         protocol: &efi::Guid,
     ) -> Result<*mut c_void, efi::Status> {
         let mut interface = ptr::null_mut();
-        match efi_boot_services_fn!(self.efi_boot_services(), handle_protocol)(
-            handle,
-            protocol as *const _ as *mut _,
-            ptr::addr_of_mut!(interface),
-        ) {
+        // SAFETY: See safety comment in create_event_unchecked for details on corner cases around external modifications.
+        let handle_protocol = unsafe { efi_boot_services_fn!(*self.as_mut_ptr(), handle_protocol) };
+        match handle_protocol(handle, protocol as *const _ as *mut _, ptr::addr_of_mut!(interface)) {
             s if s.is_error() => Err(s),
             _ => Ok(interface),
         }
@@ -1302,11 +1335,9 @@ impl BootServices for StandardBootServices {
         device_path: *mut *mut efi::protocols::device_path::Protocol,
     ) -> Result<efi::Handle, efi::Status> {
         let mut device = ptr::null_mut();
-        match efi_boot_services_fn!(self.efi_boot_services(), locate_device_path)(
-            protocol as *const _ as *mut _,
-            device_path,
-            ptr::addr_of_mut!(device),
-        ) {
+        // SAFETY: See safety comment in create_event_unchecked for details on corner cases around external modifications.
+        let locate_device_path = unsafe { efi_boot_services_fn!(*self.as_mut_ptr(), locate_device_path) };
+        match locate_device_path(protocol as *const _ as *mut _, device_path, ptr::addr_of_mut!(device)) {
             s if s.is_error() => Err(s),
             _ => Ok(device),
         }
@@ -1321,7 +1352,9 @@ impl BootServices for StandardBootServices {
         attribute: u32,
     ) -> Result<*mut c_void, efi::Status> {
         let mut interface = ptr::null_mut();
-        match efi_boot_services_fn!(self.efi_boot_services(), open_protocol)(
+        // SAFETY: See safety comment in create_event_unchecked for details on corner cases around external modifications.
+        let open_protocol = unsafe { efi_boot_services_fn!(*self.as_mut_ptr(), open_protocol) };
+        match open_protocol(
             handle,
             protocol as *const _ as *mut _,
             ptr::addr_of_mut!(interface),
@@ -1341,12 +1374,9 @@ impl BootServices for StandardBootServices {
         agent_handle: efi::Handle,
         controller_handle: efi::Handle,
     ) -> Result<(), efi::Status> {
-        match efi_boot_services_fn!(self.efi_boot_services(), close_protocol)(
-            handle,
-            protocol as *const _ as *mut _,
-            agent_handle,
-            controller_handle,
-        ) {
+        // SAFETY: See safety comment in create_event_unchecked for details on corner cases around external modifications.
+        let close_protocol = unsafe { efi_boot_services_fn!(*self.as_mut_ptr(), close_protocol) };
+        match close_protocol(handle, protocol as *const _ as *mut _, agent_handle, controller_handle) {
             s if s.is_error() => Err(s),
             _ => Ok(()),
         }
@@ -1362,7 +1392,9 @@ impl BootServices for StandardBootServices {
     {
         let mut entry_buffer = ptr::null_mut();
         let mut entry_count = 0;
-        match efi_boot_services_fn!(self.efi_boot_services(), open_protocol_information)(
+        // SAFETY: See safety comment in create_event_unchecked for details on corner cases around external modifications.
+        let open_protocol_information = unsafe { efi_boot_services_fn!(*self.as_mut_ptr(), open_protocol_information) };
+        match open_protocol_information(
             handle,
             protocol as *const _ as *mut _,
             ptr::addr_of_mut!(entry_buffer),
@@ -1388,12 +1420,9 @@ impl BootServices for StandardBootServices {
             driver_image_handles.push(ptr::null_mut());
             driver_image_handles.as_mut_ptr()
         };
-        match efi_boot_services_fn!(self.efi_boot_services(), connect_controller)(
-            controller_handle,
-            driver_image_handles,
-            remaining_device_path,
-            recursive.into(),
-        ) {
+        // SAFETY: See safety comment in create_event_unchecked for details on corner cases around external modifications.
+        let connect_controller = unsafe { efi_boot_services_fn!(*self.as_mut_ptr(), connect_controller) };
+        match connect_controller(controller_handle, driver_image_handles, remaining_device_path, recursive.into()) {
             s if s.is_error() => Err(s),
             _ => Ok(()),
         }
@@ -1405,7 +1434,9 @@ impl BootServices for StandardBootServices {
         driver_image_handle: Option<efi::Handle>,
         child_handle: Option<efi::Handle>,
     ) -> Result<(), efi::Status> {
-        match efi_boot_services_fn!(self.efi_boot_services(), disconnect_controller)(
+        // SAFETY: See safety comment in create_event_unchecked for details on corner cases around external modifications.
+        let disconnect_controller = unsafe { efi_boot_services_fn!(*self.as_mut_ptr(), disconnect_controller) };
+        match disconnect_controller(
             controller_handle,
             driver_image_handle.unwrap_or(ptr::null_mut()),
             child_handle.unwrap_or(ptr::null_mut()),
@@ -1421,11 +1452,10 @@ impl BootServices for StandardBootServices {
     ) -> Result<BootServicesBox<'_, [&'static efi::Guid], Self>, efi::Status> {
         let mut protocol_buffer = ptr::null_mut();
         let mut protocol_buffer_count = 0;
-        match efi_boot_services_fn!(self.efi_boot_services(), protocols_per_handle)(
-            handle,
-            ptr::addr_of_mut!(protocol_buffer),
-            ptr::addr_of_mut!(protocol_buffer_count),
-        ) {
+        // SAFETY: See safety comment in create_event_unchecked for details on corner cases around external modifications.
+        let protocols_per_handle = unsafe { efi_boot_services_fn!(*self.as_mut_ptr(), protocols_per_handle) };
+        match protocols_per_handle(handle, ptr::addr_of_mut!(protocol_buffer), ptr::addr_of_mut!(protocol_buffer_count))
+        {
             s if s.is_error() => Err(s),
             // SAFETY: The firmware allocates protocol_buffer and sets protocol_buffer_count.
             // from_raw_parts_mut creates a slice with the proper length as specified.
@@ -1452,7 +1482,9 @@ impl BootServices for StandardBootServices {
             HandleSearchType::ByRegisterNotify(r) => r.as_ptr(),
             _ => ptr::null_mut(),
         };
-        match efi_boot_services_fn!(self.efi_boot_services(), locate_handle_buffer)(
+        // SAFETY: See safety comment in create_event_unchecked for details on corner cases around external modifications.
+        let locate_handle_buffer = unsafe { efi_boot_services_fn!(*self.as_mut_ptr(), locate_handle_buffer) };
+        match locate_handle_buffer(
             search_type.into(),
             protocol,
             search_key,
@@ -1474,11 +1506,9 @@ impl BootServices for StandardBootServices {
         registration: *mut c_void,
     ) -> Result<*mut c_void, efi::Status> {
         let mut interface = ptr::null_mut();
-        match efi_boot_services_fn!(self.efi_boot_services(), locate_protocol)(
-            protocol as *const _ as *mut _,
-            registration,
-            ptr::addr_of_mut!(interface),
-        ) {
+        // SAFETY: See safety comment in create_event_unchecked for details on corner cases around external modifications.
+        let locate_protocol = unsafe { efi_boot_services_fn!(*self.as_mut_ptr(), locate_protocol) };
+        match locate_protocol(protocol as *const _ as *mut _, registration, ptr::addr_of_mut!(interface)) {
             s if s.is_error() => Err(s),
             _ => Ok(interface),
         }
@@ -1495,7 +1525,9 @@ impl BootServices for StandardBootServices {
             source_buffer.map_or(ptr::null_mut(), |buffer| buffer.as_ptr() as *const _ as *mut c_void);
         let source_buffer_size = source_buffer.map_or(0, |buffer| buffer.len());
         let mut image_handle = MaybeUninit::uninit();
-        match efi_boot_services_fn!(self.efi_boot_services(), load_image)(
+        // SAFETY: See safety comment in create_event_unchecked for details on corner cases around external modifications.
+        let load_image = unsafe { efi_boot_services_fn!(*self.as_mut_ptr(), load_image) };
+        match load_image(
             boot_policy.into(),
             parent_image_handle,
             device_path,
@@ -1515,11 +1547,9 @@ impl BootServices for StandardBootServices {
     ) -> Result<(), (efi::Status, Option<BootServicesBox<'_, [u8], Self>>)> {
         let mut exit_data_size = MaybeUninit::uninit();
         let mut exit_data = MaybeUninit::uninit();
-        match efi_boot_services_fn!(self.efi_boot_services(), start_image)(
-            image_handle,
-            exit_data_size.as_mut_ptr(),
-            exit_data.as_mut_ptr(),
-        ) {
+        // SAFETY: See safety comment in create_event_unchecked for details on corner cases around external modifications.
+        let start_image = unsafe { efi_boot_services_fn!(*self.as_mut_ptr(), start_image) };
+        match start_image(image_handle, exit_data_size.as_mut_ptr(), exit_data.as_mut_ptr()) {
             s if s.is_error() => {
                 // SAFETY: If exit_data pointer is not null, it points to valid memory.
                 // exit_data_size contains the size of the allocated data. from_raw_parts_mut creates a proper slice.
@@ -1537,7 +1567,9 @@ impl BootServices for StandardBootServices {
     }
 
     fn unload_image(&self, image_handle: efi::Handle) -> Result<(), efi::Status> {
-        match efi_boot_services_fn!(self.efi_boot_services(), unload_image)(image_handle) {
+        // SAFETY: See safety comment in create_event_unchecked for details on corner cases around external modifications.
+        let unload_image = unsafe { efi_boot_services_fn!(*self.as_mut_ptr(), unload_image) };
+        match unload_image(image_handle) {
             s if s.is_error() => Err(s),
             _ => Ok(()),
         }
@@ -1551,53 +1583,58 @@ impl BootServices for StandardBootServices {
     ) -> Result<(), efi::Status> {
         let exit_data_ptr = exit_data.as_ref().map_or(ptr::null_mut(), |data| data.as_ptr() as *mut u16);
         let exit_data_size = exit_data.as_ref().map_or(0, |data| data.len());
-        match efi_boot_services_fn!(self.efi_boot_services(), exit)(
-            image_handle,
-            exit_status,
-            exit_data_size,
-            exit_data_ptr,
-        ) {
+        // SAFETY: See safety comment in create_event_unchecked for details on corner cases around external modifications.
+        let exit = unsafe { efi_boot_services_fn!(*self.as_mut_ptr(), exit) };
+        match exit(image_handle, exit_status, exit_data_size, exit_data_ptr) {
             s if s.is_error() => Err(s),
             _ => Ok(()),
         }
     }
 
     fn exit_boot_services(&self, image_handle: efi::Handle, map_key: usize) -> Result<(), efi::Status> {
-        match efi_boot_services_fn!(self.efi_boot_services(), exit_boot_services)(image_handle, map_key) {
+        // SAFETY: See safety comment in create_event_unchecked for details on corner cases around external modifications.
+        let exit_boot_services = unsafe { efi_boot_services_fn!(*self.as_mut_ptr(), exit_boot_services) };
+        match exit_boot_services(image_handle, map_key) {
             s if s.is_error() => Err(s),
             _ => Ok(()),
         }
     }
 
     fn set_watchdog_timer(&self, timeout: usize) -> Result<(), efi::Status> {
-        match efi_boot_services_fn!(self.efi_boot_services(), set_watchdog_timer)(timeout, 0, 0, ptr::null_mut()) {
+        // SAFETY: See safety comment in create_event_unchecked for details on corner cases around external modifications.
+        let set_watchdog_timer = unsafe { efi_boot_services_fn!(*self.as_mut_ptr(), set_watchdog_timer) };
+        match set_watchdog_timer(timeout, 0, 0, ptr::null_mut()) {
             s if s.is_error() => Err(s),
             _ => Ok(()),
         }
     }
 
     fn stall(&self, microseconds: usize) -> Result<(), efi::Status> {
-        match efi_boot_services_fn!(self.efi_boot_services(), stall)(microseconds) {
+        // SAFETY: See safety comment in create_event_unchecked for details on corner cases around external modifications.
+        let stall = unsafe { efi_boot_services_fn!(*self.as_mut_ptr(), stall) };
+        match stall(microseconds) {
             s if s.is_error() => Err(s),
             _ => Ok(()),
         }
     }
 
     unsafe fn copy_mem_unchecked(&self, dest: *mut c_void, src: *const c_void, length: usize) {
-        efi_boot_services_fn!(self.efi_boot_services(), copy_mem)(dest, src as *mut _, length);
+        // SAFETY: See safety comment in create_event_unchecked for details on corner cases around external modifications.
+        let copy_mem = unsafe { efi_boot_services_fn!(*self.as_mut_ptr(), copy_mem) };
+        copy_mem(dest, src as *mut _, length);
     }
 
     fn set_mem(&self, buffer: &mut [u8], value: u8) {
-        efi_boot_services_fn!(self.efi_boot_services(), set_mem)(
-            buffer.as_mut_ptr() as *mut c_void,
-            buffer.len(),
-            value,
-        );
+        // SAFETY: See safety comment in create_event_unchecked for details on corner cases around external modifications.
+        let set_mem = unsafe { efi_boot_services_fn!(*self.as_mut_ptr(), set_mem) };
+        set_mem(buffer.as_mut_ptr() as *mut c_void, buffer.len(), value);
     }
 
     fn get_next_monotonic_count(&self) -> Result<u64, efi::Status> {
         let mut count = MaybeUninit::uninit();
-        match efi_boot_services_fn!(self.efi_boot_services(), get_next_monotonic_count)(count.as_mut_ptr()) {
+        // SAFETY: See safety comment in create_event_unchecked for details on corner cases around external modifications.
+        let get_next_monotonic_count = unsafe { efi_boot_services_fn!(*self.as_mut_ptr(), get_next_monotonic_count) };
+        match get_next_monotonic_count(count.as_mut_ptr()) {
             s if s.is_error() => Err(s),
             // SAFETY: If the UEFI call succeeded, count has been initialized.
             _ => Ok(unsafe { count.assume_init() }),
@@ -1609,10 +1646,10 @@ impl BootServices for StandardBootServices {
         guid: &efi::Guid,
         table: *mut c_void,
     ) -> Result<(), efi::Status> {
-        match efi_boot_services_fn!(self.efi_boot_services(), install_configuration_table)(
-            guid as *const _ as *mut _,
-            table,
-        ) {
+        // SAFETY: See safety comment in create_event_unchecked for details on corner cases around external modifications.
+        let install_configuration_table =
+            unsafe { efi_boot_services_fn!(*self.as_mut_ptr(), install_configuration_table) };
+        match install_configuration_table(guid as *const _ as *mut _, table) {
             s if s.is_error() => Err(s),
             _ => Ok(()),
         }
@@ -1620,11 +1657,9 @@ impl BootServices for StandardBootServices {
 
     unsafe fn calculate_crc_32_unchecked(&self, data: *const c_void, data_size: usize) -> Result<u32, efi::Status> {
         let mut crc32 = MaybeUninit::uninit();
-        match efi_boot_services_fn!(self.efi_boot_services(), calculate_crc32)(
-            data as *mut _,
-            data_size,
-            crc32.as_mut_ptr(),
-        ) {
+        // SAFETY: See safety comment in create_event_unchecked for details on corner cases around external modifications.
+        let calculate_crc32 = unsafe { efi_boot_services_fn!(*self.as_mut_ptr(), calculate_crc32) };
+        match calculate_crc32(data as *mut _, data_size, crc32.as_mut_ptr()) {
             s if s.is_error() => Err(s),
             // SAFETY: If the call succeeded, crc32 has been initialized.
             _ => Ok(unsafe { crc32.assume_init() }),
@@ -1714,7 +1749,8 @@ mod tests {
     #[should_panic(expected = "Standard Boot Services is not initialized!")]
     fn test_that_accessing_uninit_boot_services_should_panic() {
         let bs = StandardBootServices::new_uninit();
-        bs.efi_boot_services();
+        // SAFETY: test code - accessing uninitialized boot services should panic.
+        bs.as_mut_ptr();
     }
 
     #[test]
@@ -3402,5 +3438,13 @@ mod tests {
 
         let crc = boot_services.calculate_crc_32(&BUFFER).unwrap();
         assert_eq!(10, crc);
+    }
+
+    #[test]
+    fn test_debug_output_should_not_crash() {
+        let boot_services = boot_services!();
+        let debug_str = format!("{:?}", boot_services);
+        assert!(!debug_str.is_empty());
+        assert!(debug_str.contains("StandardBootServices"));
     }
 }

--- a/sdk/patina/src/component/params.rs
+++ b/sdk/patina/src/component/params.rs
@@ -677,7 +677,7 @@ unsafe impl Param for StandardBootServices {
     }
 
     fn validate(_state: &Self::State, storage: UnsafeStorageCell) -> bool {
-        // Safety: Storage access is valid - UnsafeStorageCell ensures proper synchronization.
+        // SAFETY: Storage access is valid - UnsafeStorageCell ensures proper synchronization.
         unsafe { storage.storage() }.boot_services().is_init()
     }
 
@@ -702,7 +702,7 @@ unsafe impl Param for StandardRuntimeServices {
     }
 
     fn validate(_state: &Self::State, storage: UnsafeStorageCell) -> bool {
-        // Safety: Storage access is valid - UnsafeStorageCell ensures proper synchronization.
+        // SAFETY: Storage access is valid - UnsafeStorageCell ensures proper synchronization.
         unsafe { storage.storage() }.runtime_services().is_init()
     }
 
@@ -897,6 +897,7 @@ mod tests {
         let mut storage = Storage::new();
         let mut mock_metadata = MetaData::new::<i32>();
 
+        // Config::init_state adds config which is locked by default
         let id = Config::<i32>::init_state(&mut storage, &mut mock_metadata).unwrap();
 
         // Config<T> requires configs to be locked
@@ -929,10 +930,8 @@ mod tests {
         let mut storage = Storage::new();
         let mut mock_metadata = MetaData::new::<i32>();
 
+        // Config::init_state adds config which is locked by default, so ConfigMut cannot access it
         let id = Config::<i32>::init_state(&mut storage, &mut mock_metadata).unwrap();
-
-        // Lock configs so ConfigMut cannot access
-        storage.lock_configs();
 
         assert!(
             ConfigMut::<i32>::try_validate(&id, (&storage).into())
@@ -1015,16 +1014,8 @@ mod tests {
         let mut storage = Storage::default();
         let mut mock_metadata = MetaData::new::<i32>();
 
-        // OOF, this is bad. But I don't wan't to write dummy functions for all the boot service functions. So we do this
-        // instead, so that the pointer to the boot services table is not null.
-        #[allow(invalid_value)]
-        let efi_bs = core::mem::MaybeUninit::<r_efi::efi::BootServices>::zeroed();
-
-        // SAFETY: Test code - Creating StandardBootServices from a zeroed BootServices struct for testing.
-        // This is acceptable in test code as we're only checking parameter validation logic.
-        let bs = unsafe { StandardBootServices::new(&*efi_bs.as_ptr()) };
-
-        storage.set_boot_services(bs);
+        let mut mock_bs = core::mem::MaybeUninit::<r_efi::efi::BootServices>::zeroed();
+        storage.set_boot_services(StandardBootServices::new(mock_bs.as_mut_ptr()));
 
         <StandardBootServices as Param>::init_state(&mut storage, &mut mock_metadata).unwrap();
         assert!(<StandardBootServices as Param>::try_validate(&(), (&storage).into()).is_ok());
@@ -1052,16 +1043,8 @@ mod tests {
         let mut storage = Storage::default();
         let mut mock_metadata = MetaData::new::<i32>();
 
-        // OOF, this is bad. But I don't wan't to write dummy functions for all the boot service functions. So we do this
-        // instead, so that the pointer to the boot services table is not null.
-        #[allow(invalid_value)]
-        let efi_rt = core::mem::MaybeUninit::<r_efi::efi::RuntimeServices>::zeroed();
-
-        // SAFETY: Test code - Creating StandardRuntimeServices from a zeroed RuntimeServices struct for testing.
-        // This is acceptable in test code as we're only checking parameter validation logic.
-        let rt = unsafe { StandardRuntimeServices::new(&*efi_rt.as_ptr()) };
-
-        storage.set_runtime_services(rt);
+        let mut mock_rt = core::mem::MaybeUninit::<r_efi::efi::RuntimeServices>::zeroed();
+        storage.set_runtime_services(StandardRuntimeServices::new(mock_rt.as_mut_ptr()));
 
         <StandardRuntimeServices as Param>::init_state(&mut storage, &mut mock_metadata).unwrap();
         assert!(<StandardRuntimeServices as Param>::try_validate(&(), (&storage).into()).is_ok());

--- a/sdk/patina/src/component/storage.rs
+++ b/sdk/patina/src/component/storage.rs
@@ -300,24 +300,18 @@ impl Storage {
     }
 
     /// Adds a default valued config datum to the storage if it does not exist.
-    ///
-    /// Default configs are created unlocked so that `ConfigMut<T>` can modify them.
     pub(crate) fn add_config_default_if_not_present<C: Default + 'static>(&mut self) -> usize {
         let idx = self.register_config::<C>();
         if !self.configs.contains(idx) {
-            self.configs.insert(idx, RefCell::new(ConfigRaw::new(false, Box::<C>::default())));
+            self.configs.insert(idx, RefCell::new(ConfigRaw::new(true, Box::<C>::default())));
         }
         idx
     }
 
     /// Adds a config datum to the storage, overwriting an existing value if it exists.
-    ///
-    /// Configs are created unlocked so that components with `ConfigMut<T>` can modify them
-    /// during the first dispatch phase. Call `lock_configs()` to lock all configs before
-    /// dispatching components that require `Config<T>` (immutable access).
     pub fn add_config<C: Default + 'static>(&mut self, config: C) {
         let id = self.register_config::<C>();
-        self.configs.insert(id, RefCell::new(ConfigRaw::new(false, Box::new(config))));
+        self.configs.insert(id, RefCell::new(ConfigRaw::new(true, Box::new(config))));
     }
 
     /// Attempts to retrieve a config datum from the storage.
@@ -454,12 +448,12 @@ impl Storage {
 #[derive(Copy, Clone)]
 pub struct UnsafeStorageCell<'s>(*mut Storage, PhantomData<(&'s Storage, &'s UnsafeCell<Storage>)>);
 
-// Safety: UnsafeStorageCell wraps a raw pointer but does not own the data. The lifetime specifier ensures the pointer
+// SAFETY: UnsafeStorageCell wraps a raw pointer but does not own the data. The lifetime specifier ensures the pointer
 // remains valid. Send is safe because the wrapper doesn't allow unsynchronized access. All access goes through
 // unsafe methods that require the caller to ensure proper synchronization. The PhantomData ties the lifetime
 // to the storage reference, preventing the cell from outliving the storage.
 unsafe impl Send for UnsafeStorageCell<'_> {}
-// Safety: Sync is safe because UnsafeStorageCell provides controlled access to storage through unsafe methods
+// SAFETY: Sync is safe because UnsafeStorageCell provides controlled access to storage through unsafe methods
 // that place the synchronization burden on the caller. The wrapper itself contains no mutable state - just a
 // raw pointer and phantom data. Multiple threads can hold UnsafeStorageCell instances safely as long as they
 // follow the access rules documented on storage() and storage_mut().
@@ -509,7 +503,7 @@ impl<'s> UnsafeStorageCell<'s> {
     ///     mutable borrow is active.
     #[inline]
     pub unsafe fn storage_mut(self) -> &'s mut Storage {
-        // Safety:
+        // SAFETY:
         // - caller ensures the created `&mut Storage` is the only borrow of the storage.
         unsafe { &mut *self.0 }
     }
@@ -525,7 +519,7 @@ impl<'s> UnsafeStorageCell<'s> {
     /// - there must be no live exclusive borrow of storage
     #[inline]
     pub unsafe fn storage(self) -> &'s Storage {
-        // Safety:
+        // SAFETY:
         // - caller ensures there is no `&mut Storage`
         // - caller ensures there is no mutable borrows of storage data. This means the caller
         //   cannot misuse the returned `&World`.
@@ -533,7 +527,7 @@ impl<'s> UnsafeStorageCell<'s> {
     }
 }
 
-// Safety: &mut Storage parameter provides exclusive access to the entire storage. The Param implementation
+// SAFETY: &mut Storage parameter provides exclusive access to the entire storage. The Param implementation
 // ensures exclusive access by tracking config reads/writes in MetaData. init_state() asserts no conflicting
 // config access exists and marks all configs as exclusively written. get_param() uses storage_mut() which
 // requires the UnsafeStorageCell was created from mutable storage access.
@@ -541,14 +535,14 @@ unsafe impl Param for &mut Storage {
     type State = ();
     type Item<'storage, 'state> = &'storage mut Storage;
 
-    // Safety: UnsafeStorageCell was created from &mut Storage (validated by init_state). storage_mut()
+    // SAFETY: UnsafeStorageCell was created from &mut Storage (validated by init_state). storage_mut()
     // returns the underlying mutable reference. The Param trait ensures this is the only active borrow
     // of storage data.
     unsafe fn get_param<'storage, 'state>(
         _state: &'state Self::State,
         storage: UnsafeStorageCell<'storage>,
     ) -> Self::Item<'storage, 'state> {
-        // Safety: UnsafeStorageCell was created with exclusive access. init_state ensured no conflicting
+        // SAFETY: UnsafeStorageCell was created with exclusive access. init_state ensured no conflicting
         // config access. storage_mut() safety requirements are met by the Param trait.
         unsafe { storage.storage_mut() }
     }
@@ -583,21 +577,21 @@ unsafe impl Param for &mut Storage {
     }
 }
 
-// Safety: &Storage parameter provides shared immutable access to the entire storage. The Param implementation
+// SAFETY: &Storage parameter provides shared immutable access to the entire storage. The Param implementation
 // ensures no conflicting mutable access exists by checking that no ConfigMut<T> parameters have been registered
 // (which would require mutable config access). get_param() uses storage() which only requires immutable access.
 unsafe impl Param for &Storage {
     type State = ();
     type Item<'storage, 'state> = &'storage Storage;
 
-    // Safety: UnsafeStorageCell provides access to storage. storage() returns an immutable reference.
+    // SAFETY: UnsafeStorageCell provides access to storage. storage() returns an immutable reference.
     // init_state() ensured no conflicting mutable config access exists. The Param protocol ensures this
     // shared access is safe.
     unsafe fn get_param<'storage, 'state>(
         _state: &'state Self::State,
         storage: UnsafeStorageCell<'storage>,
     ) -> Self::Item<'storage, 'state> {
-        // Safety: storage() requires no exclusive borrows of storage data. init_state verified no
+        // SAFETY: storage() requires no exclusive borrows of storage data. init_state verified no
         // ConfigMut<T> access exists that would create conflicting mutable access.
         unsafe { storage.storage() }
     }

--- a/sdk/patina/src/pi/hob.rs
+++ b/sdk/patina/src/pi/hob.rs
@@ -1105,38 +1105,38 @@ impl<'a> HobList<'a> {
         let mut hob_header: *const header::Hob = hob_list as *const header::Hob;
 
         loop {
-            // Safety: hob_header points to valid HOB data provided by firmware. Each HOB has a valid header.
+            // SAFETY: hob_header points to valid HOB data provided by firmware. Each HOB has a valid header.
             let current_header = unsafe { hob_header.cast::<header::Hob>().as_ref().expect(NOT_NULL) };
             match current_header.r#type {
                 HANDOFF => {
                     assert_hob_size::<PhaseHandoffInformationTable>(current_header);
-                    // Safety: HOB type is HANDOFF and size was validated. Cast to specific HOB type is valid.
+                    // SAFETY: HOB type is HANDOFF and size was validated. Cast to specific HOB type is valid.
                     let phit_hob =
                         unsafe { hob_header.cast::<PhaseHandoffInformationTable>().as_ref().expect(NOT_NULL) };
                     self.0.push(Hob::Handoff(phit_hob));
                 }
                 MEMORY_ALLOCATION => {
                     if current_header.length == mem::size_of::<MemoryAllocationModule>() as u16 {
-                        // Safety: HOB type is MEMORY_ALLOCATION with correct size for Module variant.
+                        // SAFETY: HOB type is MEMORY_ALLOCATION with correct size for Module variant.
                         let mem_alloc_hob =
                             unsafe { hob_header.cast::<MemoryAllocationModule>().as_ref().expect(NOT_NULL) };
                         self.0.push(Hob::MemoryAllocationModule(mem_alloc_hob));
                     } else {
                         assert_hob_size::<MemoryAllocation>(current_header);
-                        // Safety: HOB type is MEMORY_ALLOCATION and size was validated.
+                        // SAFETY: HOB type is MEMORY_ALLOCATION and size was validated.
                         let mem_alloc_hob = unsafe { hob_header.cast::<MemoryAllocation>().as_ref().expect(NOT_NULL) };
                         self.0.push(Hob::MemoryAllocation(mem_alloc_hob));
                     }
                 }
                 RESOURCE_DESCRIPTOR => {
                     assert_hob_size::<ResourceDescriptor>(current_header);
-                    // Safety: HOB type is RESOURCE_DESCRIPTOR and size was validated.
+                    // SAFETY: HOB type is RESOURCE_DESCRIPTOR and size was validated.
                     let resource_desc_hob =
                         unsafe { hob_header.cast::<ResourceDescriptor>().as_ref().expect(NOT_NULL) };
                     self.0.push(Hob::ResourceDescriptor(resource_desc_hob));
                 }
                 GUID_EXTENSION => {
-                    // Safety: HOB type is GUID_EXTENSION. GuidHob header is valid, and data follows immediately after.
+                    // SAFETY: HOB type is GUID_EXTENSION. GuidHob header is valid, and data follows immediately after.
                     // Data length is calculated from HOB length minus header size. Pointer arithmetic is within HOB bounds.
                     let (guid_hob, data) = unsafe {
                         let hob = hob_header.cast::<GuidHob>().as_ref().expect(NOT_NULL);
@@ -1148,37 +1148,37 @@ impl<'a> HobList<'a> {
                 }
                 FV => {
                     assert_hob_size::<FirmwareVolume>(current_header);
-                    // Safety: HOB type is FV and size was validated.
+                    // SAFETY: HOB type is FV and size was validated.
                     let fv_hob = unsafe { hob_header.cast::<FirmwareVolume>().as_ref().expect(NOT_NULL) };
                     self.0.push(Hob::FirmwareVolume(fv_hob));
                 }
                 FV2 => {
                     assert_hob_size::<FirmwareVolume2>(current_header);
-                    // Safety: HOB type is FV2 and size was validated.
+                    // SAFETY: HOB type is FV2 and size was validated.
                     let fv2_hob = unsafe { hob_header.cast::<FirmwareVolume2>().as_ref().expect(NOT_NULL) };
                     self.0.push(Hob::FirmwareVolume2(fv2_hob));
                 }
                 FV3 => {
                     assert_hob_size::<FirmwareVolume3>(current_header);
-                    // Safety: HOB type is FV3 and size was validated.
+                    // SAFETY: HOB type is FV3 and size was validated.
                     let fv3_hob = unsafe { hob_header.cast::<FirmwareVolume3>().as_ref().expect(NOT_NULL) };
                     self.0.push(Hob::FirmwareVolume3(fv3_hob));
                 }
                 CPU => {
                     assert_hob_size::<Cpu>(current_header);
-                    // Safety: HOB type is CPU and size was validated.
+                    // SAFETY: HOB type is CPU and size was validated.
                     let cpu_hob = unsafe { hob_header.cast::<Cpu>().as_ref().expect(NOT_NULL) };
                     self.0.push(Hob::Cpu(cpu_hob));
                 }
                 UEFI_CAPSULE => {
                     assert_hob_size::<Capsule>(current_header);
-                    // Safety: HOB type is UEFI_CAPSULE and size was validated.
+                    // SAFETY: HOB type is UEFI_CAPSULE and size was validated.
                     let capsule_hob = unsafe { hob_header.cast::<Capsule>().as_ref().expect(NOT_NULL) };
                     self.0.push(Hob::Capsule(capsule_hob));
                 }
                 RESOURCE_DESCRIPTOR2 => {
                     assert_hob_size::<ResourceDescriptorV2>(current_header);
-                    // Safety: HOB type is RESOURCE_DESCRIPTOR2 and size was validated.
+                    // SAFETY: HOB type is RESOURCE_DESCRIPTOR2 and size was validated.
                     let resource_desc_hob =
                         unsafe { hob_header.cast::<ResourceDescriptorV2>().as_ref().expect(NOT_NULL) };
                     self.0.push(Hob::ResourceDescriptorV2(resource_desc_hob));
@@ -1454,9 +1454,9 @@ impl<'a> Iterator for HobIter<'a> {
 
     fn next(&mut self) -> Option<Self::Item> {
         const NOT_NULL: &str = "Ptr should not be NULL";
-        // Safety: hob_ptr points to valid HOB data. The iterator maintains the pointer through the HOB chain.
+        // SAFETY: hob_ptr points to valid HOB data. The iterator maintains the pointer through the HOB chain.
         let hob_header = unsafe { *(self.hob_ptr) };
-        // Safety: HOB type determines the specific HOB structure. Each cast is to the appropriate type based
+        // SAFETY: HOB type determines the specific HOB structure. Each cast is to the appropriate type based
         // on the HOB header type field. as_ref() converts to a reference with the iterator's lifetime.
         let hob = unsafe {
             match hob_header.r#type {

--- a/sdk/patina/src/pi/protocols/cpu_arch.rs
+++ b/sdk/patina/src/pi/protocols/cpu_arch.rs
@@ -28,7 +28,7 @@ pub enum CpuFlushType {
     /// Write-back cache only.
     EfiCpuFlushTypeWriteBack,
     /// Invalidate cache only.
-    EFiCpuFlushTypeInvalidate,
+    EfiCpuFlushTypeInvalidate,
 }
 
 /// Flushes a range of the processor's data cache. If the processor does not contain a data cache or the data cache is

--- a/sdk/patina/src/pi/protocols/firmware_volume.rs
+++ b/sdk/patina/src/pi/protocols/firmware_volume.rs
@@ -150,9 +150,9 @@ pub struct Protocol {
     pub set_info: SetInfo,
 }
 
-// Safety: The only non-send type in this structure is `Handle` which itself is actually `Send` as it is an opaque
+// SAFETY: The only non-send type in this structure is `Handle` which itself is actually `Send` as it is an opaque
 // pointer used purely as a token for identification purposes.
 unsafe impl Send for Protocol {}
-// Safety: The only non-sync type in this structure is `Handle` which itself is actually `Send` as it is an opaque
+// SAFETY: The only non-sync type in this structure is `Handle` which itself is actually `Send` as it is an opaque
 // pointer used purely as a token for identification purposes.
 unsafe impl Sync for Protocol {}

--- a/sdk/patina/src/pi/protocols/firmware_volume_block.rs
+++ b/sdk/patina/src/pi/protocols/firmware_volume_block.rs
@@ -100,9 +100,9 @@ pub struct Protocol {
     pub parent_handle: Handle,
 }
 
-// Safety: The only non-send type in this structure is `Handle` which itself is actually `Send` as it is an opaque
+// SAFETY: The only non-send type in this structure is `Handle` which itself is actually `Send` as it is an opaque
 // pointer used purely as a token for identification purposes.
 unsafe impl Send for Protocol {}
-// Safety: The only non-sync type in this structure is `Handle` which itself is actually `Send` as it is an opaque
+// SAFETY: The only non-sync type in this structure is `Handle` which itself is actually `Send` as it is an opaque
 // pointer used purely as a token for identification purposes.
 unsafe impl Sync for Protocol {}

--- a/sdk/patina/src/runtime_services.rs
+++ b/sdk/patina/src/runtime_services.rs
@@ -30,19 +30,19 @@ use variable_services::{GetVariableStatus, VariableInfo};
 ///
 /// UEFI Spec Documentation: [8. Services - RuntimeServices](https://uefi.org/specs/UEFI/2.10/08_Services_Runtime_Services.html)
 pub struct StandardRuntimeServices {
-    efi_runtime_services: Once<&'static efi::RuntimeServices>,
+    efi_runtime_services: Once<*mut efi::RuntimeServices>,
 }
 
-// Safety: efi::BootServices is not Sync/Send automatically due to the use of *mut c_void as part of function signatures
-// within the struct. Those pointers are only used by spec-defined APIs. With respect to the efi_boot_services reference
-// itself, that is protected by the Once wrapper.
+// SAFETY: efi::RuntimeServices is not Sync/Send automatically due to the use of *mut c_void as part of function signatures
+// within the struct. Those pointers are only used by spec-defined APIs. With respect to the efi_runtime_services pointer
+// itself, that is protected by the Once wrapper and is not expected to change once initialized.
 unsafe impl Sync for StandardRuntimeServices {}
-// Safety: See Sync impl above.
+// SAFETY: See Sync impl above.
 unsafe impl Send for StandardRuntimeServices {}
 
 impl StandardRuntimeServices {
     /// Create a new StandardRuntimeServices with the provided [efi::RuntimeServices].
-    pub fn new(efi_runtime_services: &'static efi::RuntimeServices) -> Self {
+    pub fn new(efi_runtime_services: *mut efi::RuntimeServices) -> Self {
         let this = StandardRuntimeServices::new_uninit();
         this.init(efi_runtime_services);
         this
@@ -54,7 +54,8 @@ impl StandardRuntimeServices {
     }
 
     /// Initialized the StandardRuntimeServices.
-    pub fn init(&self, efi_runtime_services: &'static efi::RuntimeServices) {
+    pub fn init(&self, efi_runtime_services: *mut efi::RuntimeServices) {
+        assert!(!efi_runtime_services.is_null(), "Cannot initialize StandardRuntimeServices with null pointer!");
         self.efi_runtime_services.call_once(|| efi_runtime_services);
     }
 
@@ -63,9 +64,10 @@ impl StandardRuntimeServices {
         self.efi_runtime_services.is_completed()
     }
 
-    fn efi_runtime_services(&self) -> &efi::RuntimeServices {
-        // SAFETY: Runtime services lifetime is expected to live long enough.
-        self.efi_runtime_services.get().expect("Standard Runtime Services is not initialized!")
+    /// Returns the Runtime Services pointer. Panics if uninitialized.
+    pub fn as_mut_ptr(&self) -> *mut efi::RuntimeServices {
+        // constructors guarantee that if initialized, the pointer is not null.
+        *self.efi_runtime_services.get().expect("Standard Runtime Services is not initialized!")
     }
 }
 
@@ -78,7 +80,7 @@ impl AsRef<StandardRuntimeServices> for StandardRuntimeServices {
 impl Clone for StandardRuntimeServices {
     fn clone(&self) -> Self {
         if let Some(efi_runtime_services) = self.efi_runtime_services.get() {
-            Self::new(efi_runtime_services)
+            Self::new(*efi_runtime_services)
         } else {
             Self::new_uninit()
         }
@@ -93,21 +95,24 @@ impl Debug for StandardRuntimeServices {
                 .field("efi_runtime_services", &"Not Initialized")
                 .finish();
         }
-
+        // SAFETY: assume that runtime services struct is not being externally modified while static reference is in use
+        // In this case, if the struct is being modified, the debug print may be inaccurate, but it won't cause
+        // undefined behavior beyond that.
+        let rt = unsafe { &*self.as_mut_ptr() };
         f.debug_struct("StandardRuntimeServices")
-            .field("get_variable", &(self.efi_runtime_services().get_variable))
-            .field("get_next_variable_name", &(self.efi_runtime_services().get_next_variable_name))
-            .field("set_variable", &(self.efi_runtime_services().set_variable))
-            .field("query_variable_info", &(self.efi_runtime_services().query_variable_info))
-            .field("get_time", &(self.efi_runtime_services().get_time))
-            .field("set_time", &(self.efi_runtime_services().set_time))
-            .field("get_wakeup_time", &(self.efi_runtime_services().get_wakeup_time))
-            .field("set_wakeup_time", &(self.efi_runtime_services().set_wakeup_time))
-            .field("set_virtual_address_map", &(self.efi_runtime_services().set_virtual_address_map))
-            .field("convert_pointer", &(self.efi_runtime_services().convert_pointer))
-            .field("reset_system", &(self.efi_runtime_services().reset_system))
-            .field("get_next_high_mono_count", &(self.efi_runtime_services().get_next_high_mono_count))
-            .field("update_capsule", &(self.efi_runtime_services().update_capsule))
+            .field("get_variable", &rt.get_variable)
+            .field("get_next_variable_name", &rt.get_next_variable_name)
+            .field("set_variable", &rt.set_variable)
+            .field("query_variable_info", &rt.query_variable_info)
+            .field("get_time", &rt.get_time)
+            .field("set_time", &rt.set_time)
+            .field("get_wakeup_time", &rt.get_wakeup_time)
+            .field("set_wakeup_time", &rt.set_wakeup_time)
+            .field("set_virtual_address_map", &rt.set_virtual_address_map)
+            .field("convert_pointer", &rt.convert_pointer)
+            .field("reset_system", &rt.reset_system)
+            .field("get_next_high_mono_count", &rt.get_next_high_mono_count)
+            .field("update_capsule", &rt.update_capsule)
             .finish()
     }
 }
@@ -319,7 +324,17 @@ impl RuntimeServices for StandardRuntimeServices {
         attributes: u32,
         data: &[u8],
     ) -> Result<(), efi::Status> {
-        let set_variable = self.efi_runtime_services().set_variable;
+        // SAFETY: If this function pointer is modified in an event callback/interrupt while the read is in progress
+        // or if this function is invoked in a callback/interrupt that interrupts an external agent that is modifying
+        // the runtime services struct, then an incorrect function pointer might be returned that is composed of parts
+        // of the pointer from before and after the interrupt. Function pointer read/write operations could consist of
+        // several instructions - not necessarily a single atomic operation. The safety of this code therefore relies on
+        // the assumption that the runtime services struct is not being modified in such a manner, which is true for all
+        // known external modifiers of the struct in EDK2. If this code requires stronger guarantees in the future, then
+        // synchronization with external modifications may be needed, or the table could be copied to local storage and
+        // verified (via CRC) before use with an error returned on mismatch. Present use cases for external modification
+        // of runtime services don't merit such complexity at this time.
+        let set_variable = unsafe { (*self.as_mut_ptr()).set_variable };
         if set_variable as usize == 0 {
             debug_assert!(false, "SetVariable has not initialized in the Runtime Services Table.");
             return Err(efi::Status::NOT_FOUND);
@@ -342,7 +357,8 @@ impl RuntimeServices for StandardRuntimeServices {
         namespace: &efi::Guid,
         data: Option<&mut [u8]>,
     ) -> GetVariableStatus {
-        let get_variable = self.efi_runtime_services().get_variable;
+        // SAFETY: See safety comment in set_variable_unchecked for details on corner cases around external modifications.
+        let get_variable = unsafe { (*self.as_mut_ptr()).get_variable };
         if get_variable as usize == 0 {
             debug_assert!(false, "GetVariable has not initialized in the Runtime Services Table.");
             return GetVariableStatus::Error(efi::Status::NOT_FOUND);
@@ -381,7 +397,8 @@ impl RuntimeServices for StandardRuntimeServices {
         next_name: &mut Vec<u16>,
         next_namespace: &mut efi::Guid,
     ) -> Result<(), efi::Status> {
-        let get_next_variable_name = self.efi_runtime_services().get_next_variable_name;
+        // SAFETY: See safety comment in set_variable_unchecked for details on corner cases around external modifications.
+        let get_next_variable_name = unsafe { (*self.as_mut_ptr()).get_next_variable_name };
         if get_next_variable_name as usize == 0 {
             debug_assert!(false, "GetNextVariableName has not initialized in the Runtime Services Table.");
             return Err(efi::Status::NOT_FOUND);
@@ -427,7 +444,8 @@ impl RuntimeServices for StandardRuntimeServices {
     }
 
     fn query_variable_info(&self, attributes: u32) -> Result<VariableInfo, efi::Status> {
-        let query_variable_info = self.efi_runtime_services().query_variable_info;
+        // SAFETY: See safety comment in set_variable_unchecked for details on corner cases around external modifications.
+        let query_variable_info = unsafe { (*self.as_mut_ptr()).query_variable_info };
         if query_variable_info as usize == 0 {
             debug_assert!(false, "QueryVariableInfo has not initialized in the Runtime Services Table.");
             return Err(efi::Status::NOT_FOUND);
@@ -458,7 +476,7 @@ pub(crate) mod test {
 
     macro_rules! runtime_services {
         ($($efi_services:ident = $efi_service_fn:ident),*) => {{
-            // SAFETY: This is only used in tests. A zero sized RuntimeServices struct is created
+            // SAFETY: This is only used in tests. A zero-initialized RuntimeServices struct is created
             // and only the specified function pointers are initialized with valid function
             // implementations. The RuntimeServices wrapper will handle uninitialized fields.
             let efi_runtime_services = Box::leak(Box::new(unsafe {
@@ -710,7 +728,7 @@ pub(crate) mod test {
     #[should_panic(expected = "Standard Runtime Services is not initialized!")]
     fn test_that_accessing_uninit_runtime_services_should_panic() {
         let rs = StandardRuntimeServices::new_uninit();
-        rs.efi_runtime_services();
+        rs.as_mut_ptr();
     }
 
     #[test]
@@ -893,5 +911,13 @@ pub(crate) mod test {
 
         assert!(status.is_err());
         assert_eq!(status.unwrap_err(), efi::Status::INVALID_PARAMETER);
+    }
+
+    #[test]
+    fn test_debug_output_should_not_crash() {
+        let runtime_services = runtime_services!();
+        let debug_str = format!("{:?}", runtime_services);
+        assert!(!debug_str.is_empty());
+        assert!(debug_str.contains("StandardRuntimeServices"));
     }
 }

--- a/sdk/patina/src/runtime_services/variable_services.rs
+++ b/sdk/patina/src/runtime_services/variable_services.rs
@@ -121,7 +121,7 @@ impl<R: RuntimeServices> FallibleStreamingIterator for VariableNameIterator<'_, 
     type Error = efi::Status;
 
     fn advance(&mut self) -> Result<(), Self::Error> {
-        // Safety: get_next_variable_name_unchecked is called with valid variable name and namespace references.
+        // SAFETY: get_next_variable_name_unchecked is called with valid variable name and namespace references.
         // The iterator manages the state and ensures proper sequencing through the variable list.
         unsafe {
             // Don't do anything if we've reached the end already

--- a/sdk/patina/src/test.rs
+++ b/sdk/patina/src/test.rs
@@ -90,7 +90,7 @@ use r_efi::efi::EVENT_GROUP_READY_TO_BOOT;
 use crate as patina;
 use crate::{
     boot_services::{
-        BootServices,
+        BootServices, StandardBootServices,
         event::{EventTimerType, EventType},
         tpl::Tpl,
     },
@@ -436,6 +436,17 @@ impl TestRunner {
                             NonNull::from_ref(Box::leak(Box::new(test.clone()))),
                         )?;
 
+                        // We need to disable the timer at ReadyToBoot so it does not continue firing while a
+                        // bootloader is running.
+                        let _ = storage.boot_services().create_event_ex(
+                            EventType::NOTIFY_SIGNAL,
+                            Tpl::CALLBACK,
+                            Some(Self::disable_timer),
+                            NonNull::from_ref(Box::leak(Box::new((event, storage.boot_services().clone())))).as_ptr()
+                                as *mut core::ffi::c_void,
+                            &EVENT_GROUP_READY_TO_BOOT,
+                        )?;
+
                         storage.boot_services().set_timer(event, EventTimerType::Periodic, *interval)?;
                     }
                 }
@@ -443,6 +454,15 @@ impl TestRunner {
         }
 
         Ok(())
+    }
+
+    #[coverage(off)]
+    /// An EFIAPI compatible event callback to disable a timer event at ReadyToBoot
+    extern "efiapi" fn disable_timer(rtb_event: r_efi::efi::Event, context: *mut core::ffi::c_void) {
+        // SAFETY: We set up the context pointer in `run_tests` to point to a valid tuple of (Event, &mut Storage).
+        let (timer_event, boot_services) = unsafe { &mut *(context as *mut (r_efi::efi::Event, StandardBootServices)) };
+        let _ = boot_services.set_timer(*timer_event, EventTimerType::Cancel, 0);
+        let _ = boot_services.close_event(rtb_event);
     }
 
     /// An EFIAPI compatible event callback to run the patina-test

--- a/sdk/patina/src/test/__private_api.rs
+++ b/sdk/patina/src/test/__private_api.rs
@@ -122,7 +122,7 @@ where
     pub fn run(&mut self, storage: UnsafeStorageCell) -> Result<bool, &'static str> {
         let mut metadata = MetaData::default();
 
-        // Safety: init_state requires mutable access to storage. UnsafeStorageCell provides controlled access.
+        // SAFETY: init_state requires mutable access to storage. UnsafeStorageCell provides controlled access.
         // This is the initialization phase before parameter validation.
         let param_state = match Func::Param::init_state(unsafe { storage.storage_mut() }, &mut metadata) {
             Ok(param_state) => param_state,
@@ -137,7 +137,7 @@ where
             return Ok(false);
         }
 
-        // Safety: Parameter was successfully validated by try_validate. get_param extracts the validated parameter
+        // SAFETY: Parameter was successfully validated by try_validate. get_param extracts the validated parameter
         // from storage using the param_state that was initialized above.
         let param_value = unsafe { Func::Param::get_param(&param_state, storage) };
 

--- a/sdk/patina/src/tpl_mutex.rs
+++ b/sdk/patina/src/tpl_mutex.rs
@@ -117,15 +117,15 @@ impl<T: ?Sized + fmt::Display, B: BootServices> fmt::Display for TplMutexGuard<'
     }
 }
 
-// Safety: TplMutex is Sync because it ensures exclusive access to T through TPL-based locking.
+// SAFETY: TplMutex is Sync because it ensures exclusive access to T through TPL-based locking.
 // The lock/unlock operations at TPL_HIGH_LEVEL prevent concurrent access. T must be Send to
 // allow transfer between threads, and the mutex ensures only one thread accesses T at a time.
 unsafe impl<T: ?Sized + Send, B: BootServices + Send> Sync for TplMutex<T, B> {}
-// Safety: TplMutex is Send because it owns T (which is Send) and uses TPL locking to ensure
+// SAFETY: TplMutex is Send because it owns T (which is Send) and uses TPL locking to ensure
 // thread-safe access. The mutex can be safely transferred between threads.
 unsafe impl<T: ?Sized + Send, B: BootServices + Send> Send for TplMutex<T, B> {}
 
-// Safety: TplMutexGuard is Sync when T is Sync because the guard represents exclusive access
+// SAFETY: TplMutexGuard is Sync when T is Sync because the guard represents exclusive access
 // to T through the TPL mutex. The guard can be shared across threads safely.
 unsafe impl<T: ?Sized + Sync, B: BootServices> Sync for TplMutexGuard<'_, T, B> {}
 

--- a/sdk/patina/src/uefi_protocol.rs
+++ b/sdk/patina/src/uefi_protocol.rs
@@ -30,7 +30,7 @@ pub unsafe trait ProtocolInterface {
 
 macro_rules! impl_r_efi_protocol {
     ($protocol:ident) => {
-        // Safety: This macro implements ProtocolInterface for r_efi protocol types. The PROTOCOL_GUID constant
+        // SAFETY: This macro implements ProtocolInterface for r_efi protocol types. The PROTOCOL_GUID constant
         // from r_efi matches the protocol interface layout by design - r_efi provides the canonical UEFI
         // protocol definitions and GUIDs from the UEFI specification. The Protocol struct layout matches
         // the UEFI protocol interface requirements.

--- a/sdk/patina/src/uefi_protocol/decompress.rs
+++ b/sdk/patina/src/uefi_protocol/decompress.rs
@@ -92,10 +92,10 @@ impl EfiDecompressProtocol {
         assert!(!source_buffer.is_null());
         assert!(!destination_buffer.is_null());
 
-        // Safety: source_buffer and destination_buffer pointers are validated as non-null.
+        // SAFETY: source_buffer and destination_buffer pointers are validated as non-null.
         // Sizes are provided by caller and trusted to match the buffer allocations.
         let src = unsafe { core::slice::from_raw_parts(source_buffer as *const u8, source_size as usize) };
-        // Safety: destination_buffer is validated as non-null and mutable access is exclusive.
+        // SAFETY: destination_buffer is validated as non-null and mutable access is exclusive.
         let dst = unsafe { core::slice::from_raw_parts_mut(destination_buffer as *mut u8, destination_size as usize) };
 
         match decompress_into_with_algo(src, dst, DecompressionAlgorithm::UefiDecompress) {
@@ -111,7 +111,7 @@ impl Default for EfiDecompressProtocol {
     }
 }
 
-// Safety: EfiDecompressProtocol implements the UEFI Decompress protocol interface.
+// SAFETY: EfiDecompressProtocol implements the UEFI Decompress protocol interface.
 // The PROTOCOL_GUID matches the UEFI specification for the Decompress protocol.
 // The protocol structure layout matches the UEFI protocol requirements.
 unsafe impl ProtocolInterface for EfiDecompressProtocol {

--- a/sdk/patina/src/uefi_protocol/device_path/nodes.rs
+++ b/sdk/patina/src/uefi_protocol/device_path/nodes.rs
@@ -456,7 +456,6 @@ pub struct Sata {
     pub lun: u16,
 }
 
-#[coverage(off)]
 impl Sata {
     /// The on-wire size of Sata data (without header): 2 + 2 + 2 = 6 bytes.
     const DATA_SIZE: usize = 6;
@@ -472,7 +471,6 @@ impl Sata {
     }
 }
 
-#[coverage(off)]
 impl super::device_path_node::DevicePathNode for Sata {
     fn header(&self) -> super::device_path_node::Header {
         super::device_path_node::Header {
@@ -497,7 +495,6 @@ impl super::device_path_node::DevicePathNode for Sata {
     }
 }
 
-#[coverage(off)]
 impl core::fmt::Debug for Sata {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         f.debug_struct("Sata")
@@ -508,14 +505,12 @@ impl core::fmt::Debug for Sata {
     }
 }
 
-#[coverage(off)]
 impl Display for Sata {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         f.debug_tuple("Sata").field(&self.hba_port).field(&self.port_multiplier_port).field(&self.lun).finish()
     }
 }
 
-#[coverage(off)]
 impl TryIntoCtx<scroll::Endian> for Sata {
     type Error = scroll::Error;
 
@@ -528,7 +523,6 @@ impl TryIntoCtx<scroll::Endian> for Sata {
     }
 }
 
-#[coverage(off)]
 impl TryFromCtx<'_, scroll::Endian> for Sata {
     type Error = scroll::Error;
 
@@ -552,7 +546,6 @@ pub struct NvmExpress {
     pub eui64: u64,
 }
 
-#[coverage(off)]
 impl NvmExpress {
     /// The on-wire size of NvmExpress data (without header): 4 bytes NSID + 8 bytes EUI64.
     const DATA_SIZE: usize = 4 + 8;
@@ -567,7 +560,6 @@ impl NvmExpress {
     }
 }
 
-#[coverage(off)]
 impl super::device_path_node::DevicePathNode for NvmExpress {
     fn header(&self) -> super::device_path_node::Header {
         super::device_path_node::Header {
@@ -591,21 +583,18 @@ impl super::device_path_node::DevicePathNode for NvmExpress {
     }
 }
 
-#[coverage(off)]
 impl core::fmt::Debug for NvmExpress {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         f.debug_struct("NvmExpress").field("namespace_id", &self.namespace_id).field("eui64", &self.eui64).finish()
     }
 }
 
-#[coverage(off)]
 impl Display for NvmExpress {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         f.debug_tuple("NvmExpress").field(&self.namespace_id).field(&self.eui64).finish()
     }
 }
 
-#[coverage(off)]
 impl TryIntoCtx<scroll::Endian> for NvmExpress {
     type Error = scroll::Error;
 
@@ -617,7 +606,6 @@ impl TryIntoCtx<scroll::Endian> for NvmExpress {
     }
 }
 
-#[coverage(off)]
 impl TryFromCtx<'_, scroll::Endian> for NvmExpress {
     type Error = scroll::Error;
 
@@ -649,7 +637,6 @@ pub struct HardDrive {
     pub signature_type: u8,
 }
 
-#[coverage(off)]
 impl HardDrive {
     /// The on-wire size of HardDrive data (without header).
     const DATA_SIZE: usize = 4 + 8 + 8 + 16 + 1 + 1; // 38 bytes
@@ -683,7 +670,6 @@ impl HardDrive {
     }
 }
 
-#[coverage(off)]
 impl super::device_path_node::DevicePathNode for HardDrive {
     fn header(&self) -> super::device_path_node::Header {
         super::device_path_node::Header {
@@ -713,7 +699,6 @@ impl super::device_path_node::DevicePathNode for HardDrive {
     }
 }
 
-#[coverage(off)]
 impl core::fmt::Debug for HardDrive {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         f.debug_struct("HardDrive")
@@ -726,14 +711,12 @@ impl core::fmt::Debug for HardDrive {
     }
 }
 
-#[coverage(off)]
 impl Display for HardDrive {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         write!(f, "HD({}, GPT, ...)", self.partition_number)
     }
 }
 
-#[coverage(off)]
 impl TryIntoCtx<scroll::Endian> for HardDrive {
     type Error = scroll::Error;
 
@@ -751,7 +734,6 @@ impl TryIntoCtx<scroll::Endian> for HardDrive {
     }
 }
 
-#[coverage(off)]
 impl TryFromCtx<'_, scroll::Endian> for HardDrive {
     type Error = scroll::Error;
 
@@ -790,7 +772,6 @@ pub struct FilePath {
     pub path: String,
 }
 
-#[coverage(off)]
 impl FilePath {
     /// Create a new FilePath device path node from a path string.
     pub fn new(path: impl Into<String>) -> Self {
@@ -805,7 +786,6 @@ impl FilePath {
     }
 }
 
-#[coverage(off)]
 impl super::device_path_node::DevicePathNode for FilePath {
     fn header(&self) -> super::device_path_node::Header {
         super::device_path_node::Header {
@@ -834,21 +814,18 @@ impl super::device_path_node::DevicePathNode for FilePath {
     }
 }
 
-#[coverage(off)]
 impl core::fmt::Debug for FilePath {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         f.debug_struct("FilePath").field("path", &self.path).finish()
     }
 }
 
-#[coverage(off)]
 impl Display for FilePath {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         write!(f, "{}", self.path)
     }
 }
 
-#[coverage(off)]
 impl TryIntoCtx<scroll::Endian> for FilePath {
     type Error = scroll::Error;
 
@@ -865,7 +842,6 @@ impl TryIntoCtx<scroll::Endian> for FilePath {
     }
 }
 
-#[coverage(off)]
 impl TryFromCtx<'_, scroll::Endian> for FilePath {
     type Error = scroll::Error;
 
@@ -889,5 +865,144 @@ impl TryFromCtx<'_, scroll::Endian> for FilePath {
         }
 
         Ok((Self { path }, offset))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    extern crate std;
+
+    use super::*;
+    use scroll::{Pread, Pwrite};
+
+    #[test]
+    fn test_sata_new() {
+        let sata = Sata::new(1, 0xFFFF, 0);
+        assert_eq!(sata.hba_port, 1);
+        assert_eq!(sata.port_multiplier_port, 0xFFFF);
+        assert_eq!(sata.lun, 0);
+    }
+
+    #[test]
+    fn test_sata_serialization_roundtrip() {
+        let sata = Sata::new(2, 0, 1);
+        let mut buf = [0u8; 6];
+        let written = buf.pwrite_with(sata.clone(), 0, scroll::LE).unwrap();
+        assert_eq!(written, 6);
+
+        let parsed: Sata = buf.pread_with(0, scroll::LE).unwrap();
+        assert_eq!(parsed.hba_port, 2);
+        assert_eq!(parsed.port_multiplier_port, 0);
+        assert_eq!(parsed.lun, 1);
+    }
+
+    #[test]
+    fn test_sata_display() {
+        let sata = Sata::new(1, 0xFFFF, 0);
+        let display = std::format!("{}", sata);
+        assert!(display.contains("Sata"));
+    }
+
+    #[test]
+    fn test_nvme_new() {
+        let nvme = NvmExpress::new(1, 0x123456789ABCDEF0);
+        assert_eq!(nvme.namespace_id, 1);
+        assert_eq!(nvme.eui64, 0x123456789ABCDEF0);
+    }
+
+    #[test]
+    fn test_nvme_serialization_roundtrip() {
+        let nvme = NvmExpress::new(1, 0xDEADBEEF12345678);
+        let mut buf = [0u8; 12];
+        let written = buf.pwrite_with(nvme.clone(), 0, scroll::LE).unwrap();
+        assert_eq!(written, 12);
+
+        let parsed: NvmExpress = buf.pread_with(0, scroll::LE).unwrap();
+        assert_eq!(parsed.namespace_id, 1);
+        assert_eq!(parsed.eui64, 0xDEADBEEF12345678);
+    }
+
+    #[test]
+    fn test_nvme_display() {
+        let nvme = NvmExpress::new(1, 0);
+        let display = std::format!("{}", nvme);
+        assert!(display.contains("NvmExpress"));
+    }
+
+    #[test]
+    fn test_hard_drive_new_gpt() {
+        let guid = [0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F, 0x10];
+        let hd = HardDrive::new_gpt(1, 2048, 1000000, guid);
+        assert_eq!(hd.partition_number, 1);
+        assert_eq!(hd.partition_start, 2048);
+        assert_eq!(hd.partition_size, 1000000);
+        assert_eq!(hd.partition_signature, guid);
+        assert_eq!(hd.partition_format, HardDrive::FORMAT_GPT);
+        assert_eq!(hd.signature_type, HardDrive::SIGNATURE_TYPE_GUID);
+    }
+
+    #[test]
+    fn test_hard_drive_serialization_roundtrip() {
+        let guid = [0xAA; 16];
+        let hd = HardDrive::new_gpt(2, 4096, 500000, guid);
+        // DATA_SIZE = 4 + 8 + 8 + 16 + 1 + 1 = 38 bytes (no header in TryIntoCtx)
+        let mut buf = [0u8; 38];
+        let written = buf.pwrite_with(hd.clone(), 0, scroll::LE).unwrap();
+        assert_eq!(written, 38);
+
+        let parsed: HardDrive = buf.pread_with(0, scroll::LE).unwrap();
+        assert_eq!(parsed.partition_number, 2);
+        assert_eq!(parsed.partition_start, 4096);
+        assert_eq!(parsed.partition_size, 500000);
+        assert_eq!(parsed.partition_signature, guid);
+        assert_eq!(parsed.partition_format, HardDrive::FORMAT_GPT);
+        assert_eq!(parsed.signature_type, HardDrive::SIGNATURE_TYPE_GUID);
+    }
+
+    #[test]
+    fn test_hard_drive_display() {
+        let hd = HardDrive::new_gpt(1, 0, 0, [0; 16]);
+        let display = std::format!("{}", hd);
+        assert!(display.contains("HD"));
+    }
+
+    #[test]
+    fn test_file_path_new() {
+        let fp = FilePath::new("\\EFI\\BOOT\\BOOTX64.EFI");
+        assert_eq!(fp.path, "\\EFI\\BOOT\\BOOTX64.EFI");
+    }
+
+    #[test]
+    fn test_file_path_serialization_roundtrip() {
+        let fp = FilePath::new("\\test.efi");
+        // UTF-16: 9 chars (\test.efi) + null = 10 * 2 = 20 bytes
+        let mut buf = [0u8; 20];
+        let written = buf.pwrite_with(fp.clone(), 0, scroll::LE).unwrap();
+        assert_eq!(written, 20);
+
+        let parsed: FilePath = buf.pread_with(0, scroll::LE).unwrap();
+        assert_eq!(parsed.path, "\\test.efi");
+    }
+
+    #[test]
+    fn test_file_path_display() {
+        let fp = FilePath::new("\\EFI\\BOOT\\BOOTX64.EFI");
+        let display = std::format!("{}", fp);
+        assert_eq!(display, "\\EFI\\BOOT\\BOOTX64.EFI");
+    }
+
+    #[test]
+    fn test_file_path_utf16_encoding() {
+        let fp = FilePath::new("A");
+        // 'A' (0x0041) + null (0x0000) = 4 bytes
+        let mut buf = [0u8; 4];
+        let written = buf.pwrite_with(fp, 0, scroll::LE).unwrap();
+        assert_eq!(written, 4);
+        // UTF-16LE: 'A' = 0x41, 0x00
+        assert_eq!(buf[0], 0x41);
+        assert_eq!(buf[1], 0x00);
+        // Null terminator
+        assert_eq!(buf[2], 0x00);
+        assert_eq!(buf[3], 0x00);
     }
 }

--- a/sdk/patina/src/uefi_protocol/performance_measurement.rs
+++ b/sdk/patina/src/uefi_protocol/performance_measurement.rs
@@ -67,7 +67,7 @@ pub struct EdkiiPerformanceMeasurement {
     pub create_performance_measurement: CreateMeasurementUefi,
 }
 
-// Safety: EdkiiPerformanceMeasurement implements the EDK II Performance Measurement protocol interface.
+// SAFETY: EdkiiPerformanceMeasurement implements the EDK II Performance Measurement protocol interface.
 // The PROTOCOL_GUID matches the EDK II defined value. The protocol structure layout matches the protocol
 // interface requirements.
 unsafe impl ProtocolInterface for EdkiiPerformanceMeasurement {

--- a/sdk/patina/src/uefi_protocol/status_code.rs
+++ b/sdk/patina/src/uefi_protocol/status_code.rs
@@ -31,7 +31,7 @@ pub struct StatusCodeRuntimeProtocol {
     protocol: status_code::Protocol,
 }
 
-// Safety: StatusCodeRuntimeProtocol implements the UEFI Status Code Runtime protocol interface.
+// SAFETY: StatusCodeRuntimeProtocol implements the UEFI Status Code Runtime protocol interface.
 // The PROTOCOL_GUID matches the PI specification. The repr(transparent) ensures that the
 // structure layout matches the underlying r_efi protocol definition.
 unsafe impl ProtocolInterface for StatusCodeRuntimeProtocol {

--- a/sdk/patina_ffs/src/section.rs
+++ b/sdk/patina_ffs/src/section.rs
@@ -278,7 +278,7 @@ impl Section {
             Err(FirmwareFileSystemError::InvalidHeader)?;
         }
 
-        // Safety: buffer is large enough to contain the header.
+        // SAFETY: buffer is large enough to contain the header.
         let section_header = unsafe { ptr::read_unaligned(buffer.as_ptr() as *const section::Header) };
 
         // Determine section size and start of section content
@@ -289,7 +289,7 @@ impl Section {
                 if buffer.len() < ext_header_size {
                     Err(FirmwareFileSystemError::InvalidHeader)?;
                 }
-                // Safety: buffer is large enough to contain extended header.
+                // SAFETY: buffer is large enough to contain extended header.
                 let ext_header = unsafe {
                     ptr::read_unaligned(buffer.as_ptr() as *const section::header::CommonSectionHeaderExtended)
                 };
@@ -316,7 +316,7 @@ impl Section {
                 if buffer.len() < section_data_offset + compression_header_size {
                     Err(FirmwareFileSystemError::InvalidHeader)?;
                 }
-                // Safety: buffer is large enough to hold the compression header.
+                // SAFETY: buffer is large enough to hold the compression header.
                 let compression_header = unsafe {
                     ptr::read_unaligned(buffer[section_data_offset..].as_ptr() as *const section::header::Compression)
                 };
@@ -334,7 +334,7 @@ impl Section {
                 if buffer.len() < section_data_offset + guid_header_size {
                     Err(FirmwareFileSystemError::InvalidHeader)?;
                 }
-                // Safety: buffer is large enough to hold the GuidDefined header.
+                // SAFETY: buffer is large enough to hold the GuidDefined header.
                 let guid_defined_header = unsafe {
                     ptr::read_unaligned(buffer[section_data_offset..].as_ptr() as *const section::header::GuidDefined)
                 };
@@ -356,7 +356,7 @@ impl Section {
                 if buffer.len() < section_data_offset + version_header_size {
                     Err(FirmwareFileSystemError::InvalidHeader)?;
                 }
-                // Safety: buffer is large enough to hold the version header.
+                // SAFETY: buffer is large enough to hold the version header.
                 let version_header = unsafe {
                     ptr::read_unaligned(buffer[section_data_offset..].as_ptr() as *const section::header::Version)
                 };
@@ -371,7 +371,7 @@ impl Section {
                 if buffer.len() < section_data_offset + freeform_subtype_size {
                     Err(FirmwareFileSystemError::InvalidHeader)?;
                 }
-                // Safety: buffer is large enough to hold the freeform header type
+                // SAFETY: buffer is large enough to hold the freeform header type
                 let freeform_header = unsafe {
                     ptr::read_unaligned(
                         buffer[section_data_offset..].as_ptr() as *const section::header::FreeformSubtypeGuid

--- a/sdk/patina_ffs/src/volume.rs
+++ b/sdk/patina_ffs/src/volume.rs
@@ -71,7 +71,7 @@ impl<'a> VolumeRef<'a> {
             Err(FirmwareFileSystemError::InvalidHeader)?;
         }
 
-        // Safety: buffer is large enough to contain the header.
+        // SAFETY: buffer is large enough to contain the header.
         let fv_header = unsafe { ptr::read_unaligned(buffer.as_ptr() as *const fv::Header) };
 
         // Signature must be ASCII '_FVH'


### PR DESCRIPTION
## Summary
- Merges latest changes from `origin/main` into `feature/patina-boot`
- Resolves merge conflicts in:
  - `Cargo.toml` - keeps `patina_boot` dependency
  - `cspell.yml` - keeps `bootaa` word addition
  - `sdk/patina/src/component/params.rs` - takes main's test changes (removes unnecessary `lock_configs()`)
  - `sdk/patina/src/uefi_protocol/device_path/nodes.rs` - takes main's device path enhancements
  - `sdk/patina/src/component/storage.rs` - updates config locking defaults to match main (configs locked by default)