### PR TITLE
.git-blame-ignore-revs: Add recent Safety -> SAFETY commit

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -4,3 +4,6 @@ c905de97044bd6af95c1377864555da65b81a6ce
 
 # Repo: Apply CRLF -> LF conversion to all non-rust files
 a11e3519d22bd61323553f2ca448e1c4c173cc82
+
+# Standardize SAFETY formatting
+db4636d3b39f31cd509442ba9d190c37ba8526c3


### PR DESCRIPTION
## Description

Prevent the word replacement from showing up in git blame instead of the original change that modified/added the safety comment.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Run `git blame` on a modified line:

### Before

```
git blame -L 108,108 core\patina_internal_cpu\src\interrupts\aarch64\gic_manager.rs
db4636d3b3 (sherry fan 2026-01-22 09:51:17 -0800 108)         // SAFETY: function safety requirements guarantee exclusive access to the GICR registers.
```

### After

```
git blame -L 108,108 core\patina_internal_cpu\src\interrupts\aarch64\gic_manager.rs
163e0a56de (John Schock 2025-11-17 16:43:49 -0800 108)         // SAFETY: function safety requirements guarantee exclusive access to the GICR registers.
```

## Integration Instructions

- N/A