### PR TITLE
Cargo.toml: Update ruint to 1.17.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,7 +65,7 @@ criterion = { version = "^0.5" }
 env_logger = "0.11"
 mockall = { version = "0.13.0" }
 rand = { version = "0.8" }
-ruint = { version = "1" }
+ruint = { version = "1.17.1" }
 serial_test = { version = "3.0" }
 winapi = { version = "0.3" }
 serde = { version = "1.0", default-features = false, features = ["derive"] }


### PR DESCRIPTION
## Description

Ensure a version is used that patches a Rust security vulnerability.

```
│ ruint 1.16.0 registry+https://github.com/rust-lang/crates.io-index
    │ ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ security vulnerability detected
    │
    ├ ID: RUSTSEC-2025-0137
    ├ Advisory: https://rustsec.org/advisories/RUSTSEC-2025-0137
    ├ The function `reciprocal_mg10` is marked as safe but can trigger
      undefined behavior (out-of-bounds access) because it relies on
      `debug_assert!` for safety checks instead of `assert!`.

      When compiled in release mode, the `debug_assert!` is optimized
      out, potentially allowing invalid inputs to cause memory
      corruption.
    ├ Announcement: https://github.com/recmo/uint/issues/550
    ├ Solution: Upgrade to >=1.17.1 (try `cargo update -p ruint`)
    ├ ruint v1.16.0
      └── (dev) patina_internal_collections v19.0.5
          └── patina_dxe_core v19.0.5
              ├── (dev) patina_adv_logger v19.0.5
              └── (dev) patina_mm v19.0.5
                  └── patina_performance v19.0.5
                      └── patina_dxe_core v19.0.5 (*)
```

This will use ruint version 1.17.1 or later (up to 2.0.0), so the fix is included in future compatible updates.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

- `cargo make all`

## Integration Instructions

- N/A