### PR TITLE
Align EDKII PcdPerformanceLibraryPropertyMask with Patina enabled_measurements

### DIFF
--- a/components/patina_performance/src/component/performance_config_provider.rs
+++ b/components/patina_performance/src/component/performance_config_provider.rs
@@ -37,7 +37,7 @@ pub struct PerformanceConfigurationProvider;
 /// - BIT3: DISABLE Binding Support logging
 /// - BIT4: DISABLE Binding Start logging
 /// - BIT5: DISABLE Binding Stop logging
-/// - BIT6: DISABLE all other general Perfs
+/// - BIT6: DISABLE all other general Performance Measurements (not used here)
 ///
 /// ## Patina Format (enabled_measurements)
 /// - BIT0 (1): ENABLE StartImage


### PR DESCRIPTION
## Description

Align EDKII PcdPerformanceLibraryPropertyMask with Patina enabled_measurements
Currently there's a mismatch between the PcdPerformanceLibraryPropertyMask and Patina's enabled_measurements.
For example if we set the pcd to 1, then perf component will only log the StartImage.
Add a parser function to align the two.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Tested with real hardware, before this test with pcd 1 we can get 60 entries, after this we can get 5000 which aligned with using the static patina config.

