### PR TITLE
dxe_core: allocator: Return Unmerged Memory Map Size in GetMemoryMap()

### DIFF
--- a/patina_dxe_core/src/allocator.rs
+++ b/patina_dxe_core/src/allocator.rs
@@ -821,6 +821,10 @@ extern "efiapi" fn get_memory_map(
     // SAFETY: caller must ensure that memory_map_size is a valid pointer. It is null-checked above.
     let map_size = unsafe { memory_map_size.read_unaligned() };
 
+    // Required map size is the unmerged size. This will be much larger than the actual size needed after merging.
+    // This is done for two reasons:
+    //   - It allows us to avoid allocating memory in get_memory_map() to calculate the merged size
+    //   - It helps prevent issues where callers do not allocate enough space, such as bootloaders across EBS calls
     let required_map_size = GCD.memory_descriptor_count_for_efi_memory_map() * mem::size_of::<efi::MemoryDescriptor>();
     assert_ne!(required_map_size, 0);
     // SAFETY: caller must ensure that memory_map_size is a valid pointer. It is null-checked above.
@@ -844,10 +848,6 @@ extern "efiapi" fn get_memory_map(
         Err(err) => return err.into(),
     };
     let actual_map_size = actual_count * mem::size_of::<efi::MemoryDescriptor>();
-
-    // Write back the actual map size after merging
-    // SAFETY: caller must ensure that memory_map_size is a valid pointer. It is null-checked above.
-    unsafe { memory_map_size.write_unaligned(actual_map_size) };
 
     // SAFETY: caller must ensure that map_key is a valid pointer if it is not null.
     unsafe {

--- a/patina_dxe_core/src/allocator/usage_tests/uefi_memory_map.rs
+++ b/patina_dxe_core/src/allocator/usage_tests/uefi_memory_map.rs
@@ -666,7 +666,7 @@ mod tests {
             .with_validation(|descriptors| {
                 MemoryMapValidation::new()
                     .expect_memory_types(vec![efi::CONVENTIONAL_MEMORY])
-                    .expect_total_memory_mb(32)
+                    .expect_total_memory_mb(64)
                     .validate(descriptors)
             });
 


### PR DESCRIPTION
## Description

Currently, we follow the same pattern edk2 does in GetMemoryMap(): we first calculate the unmerged memory map size and compare that to the caller's buffer size, if it is too little, return the unmerged memory map size. Callers then allocate the unmerged size (sometimes with a small padding) and call again. On this call, the returned memory map size is the merged size, which is equal to or smaller than the unmerged size.

In edk2, however, the merged and unmerged memory map sizes are fairly close in size, due to the lack of tracking of memory attributes in system memory pages that are used to report the EFI_MEMORY_MAP. In patina we do track these attributes and so have a greater unmerged memory map count, one that is observed to be an order of magnitude greater on platforms.

Some callers, including bootloaders, can cache the returned map size, allocate some percentage extra and use that for multiple GetMemoryMap() calls. This is not proper behavior, but we need to have compat with existing bootloaders. In patina this can fail because even if the caller allocates double the returned merged memory map size, it can still be less than the unmerged memory map size and the call can fail. Not all callers handle this gracefully (calling again with allocating the unmerged size).

This commit changes get_memory_map() to always return the unmerged size. This prevents the issues above and still allows us to not allocate memory in get_memory_map(), which is needed to calculate the merged memory map size. It will waste some memory compared to reporting the merged size, but we already require the unmerged memory map size to be allocated, so there is no change in patina behavior here.

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Tested by booting Q35 to Windows and Linux as well as running the paging audit, which failed previously because of assuming the returned size from GetMemoryMap() was close to the required size.

## Integration Instructions

N/A.
