### PR TITLE
[feature/patina-boot] patina_dxe_core: Fix TPL violation in initialize_system_table

### DIFF
--- a/patina_dxe_core/src/lib.rs
+++ b/patina_dxe_core/src/lib.rs
@@ -501,41 +501,48 @@ impl<P: PlatformInfo> Core<P> {
         // Instantiate system table.
         systemtables::init_system_table();
 
-        let mut st = systemtables::SYSTEM_TABLE.lock();
-        let st = st.as_mut().expect("System Table not initialized!");
+        // Extract boot/runtime services pointers while holding SYSTEM_TABLE lock (TPL_NOTIFY).
+        // We must release this lock before accessing component_dispatcher (TPL_APPLICATION)
+        // to avoid TPL violation - you cannot lower TPL while holding a higher TPL lock.
+        let (boot_services_ptr, runtime_services_ptr) = {
+            let mut st = systemtables::SYSTEM_TABLE.lock();
+            let st = st.as_mut().expect("System Table not initialized!");
 
-        allocator::install_memory_services(st);
-        gcd::init_paging(self.hob_list());
-        events::init_events_support(st);
-        protocols::init_protocol_support(st);
-        misc_boot_services::init_misc_boot_services_support(st);
-        config_tables::init_config_tables_support(st);
-        runtime::init_runtime_support();
-        self.pi_dispatcher.init(self.hob_list(), st);
-        self.install_dxe_services_table(st);
-        driver_services::init_driver_services(st);
+            allocator::install_memory_services(st);
+            gcd::init_paging(self.hob_list());
+            events::init_events_support(st);
+            protocols::init_protocol_support(st);
+            misc_boot_services::init_misc_boot_services_support(st);
+            config_tables::init_config_tables_support(st);
+            runtime::init_runtime_support();
+            self.pi_dispatcher.init(self.hob_list(), st);
+            self.install_dxe_services_table(st);
+            driver_services::init_driver_services(st);
 
-        memory_attributes_protocol::install_memory_attributes_protocol();
+            memory_attributes_protocol::install_memory_attributes_protocol();
 
-        // re-checksum the system tables after above initialization.
-        st.checksum_all();
+            // re-checksum the system tables after above initialization.
+            st.checksum_all();
 
-        // Install HobList configuration table
-        let (a, b, c, &[d0, d1, d2, d3, d4, d5, d6, d7]) =
-            uuid::Uuid::from_str("7739F24C-93D7-11D4-9A3A-0090273FC14D").expect("Invalid UUID format.").as_fields();
-        let hob_list_guid: efi::Guid = efi::Guid::from_fields(a, b, c, d0, d1, &[d2, d3, d4, d5, d6, d7]);
-        config_tables::core_install_configuration_table(hob_list_guid, physical_hob_list, st)
-            .expect("Unable to create configuration table due to invalid table entry.");
+            // Install HobList configuration table
+            let (a, b, c, &[d0, d1, d2, d3, d4, d5, d6, d7]) =
+                uuid::Uuid::from_str("7739F24C-93D7-11D4-9A3A-0090273FC14D").expect("Invalid UUID format.").as_fields();
+            let hob_list_guid: efi::Guid = efi::Guid::from_fields(a, b, c, d0, d1, &[d2, d3, d4, d5, d6, d7]);
+            config_tables::core_install_configuration_table(hob_list_guid, physical_hob_list, st)
+                .expect("Unable to create configuration table due to invalid table entry.");
 
-        // Install Memory Type Info configuration table.
-        allocator::install_memory_type_info_table(st).expect("Unable to create Memory Type Info Table");
+            // Install Memory Type Info configuration table.
+            allocator::install_memory_type_info_table(st).expect("Unable to create Memory Type Info Table");
 
-        memory_attributes_table::init_memory_attributes_table_support();
+            memory_attributes_table::init_memory_attributes_table_support();
 
-        self.component_dispatcher.lock().set_boot_services(StandardBootServices::new(st.boot_services().as_mut_ptr()));
-        self.component_dispatcher
-            .lock()
-            .set_runtime_services(StandardRuntimeServices::new(st.runtime_services().as_mut_ptr()));
+            // Extract pointers before releasing the lock
+            (st.boot_services().as_mut_ptr(), st.runtime_services().as_mut_ptr())
+        }; // SYSTEM_TABLE lock released here
+
+        // Now safe to access component_dispatcher at TPL_APPLICATION
+        self.component_dispatcher.lock().set_boot_services(StandardBootServices::new(boot_services_ptr));
+        self.component_dispatcher.lock().set_runtime_services(StandardRuntimeServices::new(runtime_services_ptr));
 
         Ok(())
     }


### PR DESCRIPTION
## Description

Release SYSTEM_TABLE lock (TPL_NOTIFY) before accessing ComponentDispatcher (TPL_APPLICATION) to avoid TPL violation.

PR #1225 lowered ComponentDispatcher from TPL_NOTIFY to TPL_APPLICATION to allow components to use boot services, but this created a conflict when initialize_system_table held SYSTEM_TABLE while setting boot/runtime services on ComponentDispatcher.

Fix: Extract boot/runtime services pointers while holding SYSTEM_TABLE lock, then release it before accessing ComponentDispatcher.

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

- Unit tests pass
- QEMU Q35 boots without TPL violation panic

## Integration Instructions

N/A