### PR TITLE
patina_dxe_core: Provide DXE Core handle to component storage

### DIFF
--- a/patina_dxe_core/src/component_dispatcher.rs
+++ b/patina_dxe_core/src/component_dispatcher.rs
@@ -174,6 +174,16 @@ impl ComponentDispatcher {
         self.storage.set_runtime_services(rs);
     }
 
+    /// Sets the image handle in storage.
+    ///
+    /// This handle is used as the parent image handle for `LoadImage()` calls
+    /// when loading boot applications.
+    #[coverage(off)]
+    #[inline(always)]
+    pub(crate) fn set_image_handle(&mut self, handle: r_efi::efi::Handle) {
+        self.storage.set_image_handle(handle);
+    }
+
     /// Parses the HOB list producing a `Hob\<T\>` struct for each guided HOB found with a registered parser.
     pub(crate) fn insert_hobs(&mut self, hob_list: &HobList<'_>) {
         for hob in hob_list.iter() {

--- a/patina_dxe_core/src/lib.rs
+++ b/patina_dxe_core/src/lib.rs
@@ -536,6 +536,7 @@ impl<P: PlatformInfo> Core<P> {
         self.component_dispatcher
             .lock()
             .set_runtime_services(StandardRuntimeServices::new(st.runtime_services().as_mut_ptr()));
+        self.component_dispatcher.lock().set_image_handle(protocol_db::DXE_CORE_HANDLE);
 
         Ok(())
     }


### PR DESCRIPTION
## Description

Expose `set_image_handle()` on ComponentDispatcher to allow setting the parent image handle in component storage. Initialize component storage with `DXE_CORE_HANDLE` during system table initialization.

Components that call `LoadImage()` require a parent image handle parameter. The component storage already has `set_image_handle()` but it was never called, leaving the handle as `None`.

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Built and verified on QEMU Q35 platform.

## Integration Instructions

N/A