### PR TITLE
patina_debugger: Issue Breakpoint Only When Debugger Initialized

### DIFF
--- a/core/patina_debugger/README.md
+++ b/core/patina_debugger/README.md
@@ -165,17 +165,19 @@ GDB also works, but symbols may not resolve since Patina uses PE images with PDB
 
 ### Step 6: Set up the panic handler
 
-To break into the debugger on a panic, add a manual breakpoint in the panic handler. Only do this
-when the debugger is enabled:
+To break into the debugger on a panic, add a manual breakpoint in the panic handler.
+The `breakpoint()` function will only issue a breakpoint if the debugger is enabled
+and initialized.
 
 ```rust
-if patina_debugger::enabled() {
-    patina_debugger::breakpoint();
-}
+  patina_debugger::breakpoint();
 ```
 
 As an aside, `patina_debugger::breakpoint()` can be useful to placing in other locations
 of interest while debugging to ensure you catch a specific function or scenario.
+`patina_debugger::breakpoint_unchecked()` can be called in the rare case where you
+want to issue a breakpoint instruction even if the debugger is not enabled or
+initialized.
 
 ### Security Considerations
 

--- a/core/patina_debugger/src/arch.rs
+++ b/core/patina_debugger/src/arch.rs
@@ -45,7 +45,7 @@ pub trait DebuggerArch {
 
     type PageTable: PageTable;
 
-    /// Executes a breakpoint instruction.
+    /// Executes a breakpoint instruction if the debugger is enabled and initialized.
     fn breakpoint();
 
     /// Processes the entry into the debugger, doing any fixup needed to the

--- a/core/patina_debugger/src/debugger.rs
+++ b/core/patina_debugger/src/debugger.rs
@@ -68,6 +68,8 @@ where
     no_transport_init: bool,
     /// Debugger enabled state.
     enabled: AtomicBool,
+    /// Debugger Initialized state
+    initialized: AtomicBool,
     /// The number of seconds to wait for an initial breakpoint. If zero, wait indefinitely.
     initial_break_timeout: u32,
     /// Internal mutable debugger state.
@@ -105,6 +107,7 @@ impl<T: SerialIO> PatinaDebugger<T> {
             no_transport_init: false,
             exception_types: SystemArch::DEFAULT_EXCEPTION_TYPES,
             enabled: AtomicBool::new(false),
+            initialized: AtomicBool::new(false),
             initial_break_timeout: 0,
             internal: Mutex::new(DebuggerInternal {
                 gdb_buffer: None,
@@ -309,6 +312,11 @@ impl<T: SerialIO> PatinaDebugger<T> {
 }
 
 impl<T: SerialIO> Debugger for PatinaDebugger<T> {
+    #[cfg(test)]
+    fn test_initialize(&'static self, initialized: bool) {
+        self.initialized.store(initialized, Ordering::Relaxed);
+    }
+
     fn initialize(
         &'static self,
         interrupt_manager: &mut dyn InterruptManager,
@@ -365,6 +373,8 @@ impl<T: SerialIO> Debugger for PatinaDebugger<T> {
             }
         }
 
+        self.initialized.store(true, Ordering::Relaxed);
+
         log::error!("************************************");
         log::error!("***  Initial debug breakpoint!   ***");
         log::error!("************************************");
@@ -374,6 +384,10 @@ impl<T: SerialIO> Debugger for PatinaDebugger<T> {
 
     fn enabled(&'static self) -> bool {
         self.enabled.load(Ordering::Relaxed)
+    }
+
+    fn initialized(&'static self) -> bool {
+        self.initialized.load(Ordering::Relaxed)
     }
 
     fn notify_module_load(&'static self, module_name: &str, address: usize, length: usize) {

--- a/core/patina_debugger/src/lib.rs
+++ b/core/patina_debugger/src/lib.rs
@@ -63,11 +63,11 @@
 //!     // Poll the debugger for any pending interrupts.
 //!     patina_debugger::poll_debugger();
 //!
-//!     // Break into the debugger if the debugger is enabled.
+//!     // Break into the debugger if the debugger is enabled and initialized.
 //!     patina_debugger::breakpoint();
 //!
 //!     // Cause a debug break unconditionally. This will crash the system
-//!     // if the debugger is not enabled. This should be used with extreme caution.
+//!     // if the debugger is not enabled or initialized. This should be used with extreme caution.
 //!     patina_debugger::breakpoint_unchecked();
 //! }
 //!
@@ -150,6 +150,9 @@ pub type MonitorCommandFn = dyn Fn(&mut core::str::SplitWhitespace<'_>, &mut dyn
 /// platform specific debugger implementation. For safety, these routines should
 /// only be invoked on the global instance of the debugger.
 trait Debugger: Sync {
+    #[cfg(test)]
+    fn test_initialize(&'static self, initialized: bool);
+
     /// Initializes the debugger. Intended for core use only.
     fn initialize(
         &'static self,
@@ -159,6 +162,9 @@ trait Debugger: Sync {
 
     /// Checks if the debugger is enabled.
     fn enabled(&'static self) -> bool;
+
+    /// Checks if the debugger is initialized.
+    fn initialized(&'static self) -> bool;
 
     /// Notifies the debugger of a module load.
     fn notify_module_load(&'static self, module_name: &str, _address: usize, _length: usize);
@@ -223,17 +229,20 @@ pub fn initialize(interrupt_manager: &mut dyn InterruptManager, timer: Option<&'
     }
 }
 
-/// Invokes a debug break instruction if the debugger is enabled. This will cause
-/// the debugger to break in, if enabled. If the debugger is not enabled, this
-/// routine will have no effect.
+/// Invokes a debug break instruction if the debugger is enabled and initialized. This will cause
+/// the debugger to break in. If the debugger is not enabled and initialized, this routine will have no effect.
 pub fn breakpoint() {
     if enabled() {
-        breakpoint_unchecked();
+        if initialized() {
+            breakpoint_unchecked();
+        } else {
+            log::error!("Debugger breakpoint invoked before debugger initialized, not breaking in!");
+        }
     }
 }
 
 /// Invokes a debug break instruction unconditionally. If this routine is invoked when
-/// the debugger is not enabled, it will cause an unhandled exception.
+/// the debugger is not enabled and initialized, it will cause an unhandled exception.
 ///
 /// ## Important
 ///
@@ -267,6 +276,14 @@ pub fn poll_debugger() {
 pub fn enabled() -> bool {
     match DEBUGGER.get() {
         Some(debugger) => debugger.enabled(),
+        None => false,
+    }
+}
+
+/// Checks if the debugger is initialized.
+pub fn initialized() -> bool {
+    match DEBUGGER.get() {
+        Some(debugger) => debugger.initialized(),
         None => false,
     }
 }
@@ -372,6 +389,7 @@ mod tests {
     fn reset() {
         // Reset the global debugger for testing.
         DUMMY_DEBUGGER.enable(false);
+        DUMMY_DEBUGGER.test_initialize(false);
         if !DEBUGGER.is_completed() {
             set_debugger(&DUMMY_DEBUGGER);
         }
@@ -386,14 +404,23 @@ mod tests {
     }
 
     #[test]
+    #[serial(global_debugger)]
+    fn test_debug_break_not_initialized() {
+        reset();
+        DUMMY_DEBUGGER.enable(true);
+        // Ensure that invoking a debug break when the debugger is not initialized does not cause issues.
+        breakpoint();
+    }
+
+    #[test]
     #[should_panic(expected = "breakpoint_unchecked")]
     #[serial(global_debugger)]
-    fn test_debug_break_enabled() {
+    fn test_debug_break_enabled_and_initialized() {
         reset();
         // Enable the debugger.
         DUMMY_DEBUGGER.enable(true);
-
-        // Ensure that invoking a debug break when the debugger is enabled causes a panic.
+        DUMMY_DEBUGGER.test_initialize(true);
+        // Ensure that invoking a debug break when the debugger is enabled and initialized causes a panic.
         breakpoint();
     }
 }

--- a/docs/src/integrate/dxe_core.md
+++ b/docs/src/integrate/dxe_core.md
@@ -494,9 +494,9 @@ fn panic(info: &PanicInfo) -> ! {
         log::error!("StackTrace: {}", err);
     }
 
-    if patina_debugger::enabled() {
-        patina_debugger::breakpoint();
-    }
+    // The breakpoint() fn only issues a breakpoint instruction if
+    // the debugger is enabled and initialized.
+    patina_debugger::breakpoint();
 
     loop {}
 }


### PR DESCRIPTION
## Description

Currently, patina_debugger has two breakpoint fns: breakpoint() and breakpoint_unchecked(). breakpoint() only issues a breakpoint if the debugger is enabled and breakpoint_unchecked() always issues a breakpoint.

However, there is a time window where the debugger is enabled but not yet initialized where calling breakpoint() will cause an unhandled exception.

This commit adds a new check to breakpoint() to ensure that the debugger is also initialized when that function is called before issuing the breakpoint. If the debugger is not initialized, but is enabled, an error log will be printed to alert the developer in case they want to cause an unhandled exception; they should use breakpoint_unchecked() if so.

It was considered to not check for enabled() and only check for initialized(), as the former depends upon the latter, but the debugger is obviously not a hot path and the extra layer of safety was kept.

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Using `patina_debugger::breakpoint()` before and after the debugger is initialized and seeing that it just logged the first time and broke in the second time.

## Integration Instructions

Use `patina_debugger::breakpoint()` when wanting to break into the debugger with a breakpoint and `patina_debugger::breakpoint_unchecked()` when wanting to cause an exception no matter what.
