### PR TITLE
dxe_core: Add get_existent_memory_descriptor_for_address() Helper Function

### DIFF
--- a/patina_dxe_core/src/allocator.rs
+++ b/patina_dxe_core/src/allocator.rs
@@ -926,7 +926,7 @@ fn process_hob_allocations(hob_list: &HobList) {
                 }
 
                 let mut address = desc.memory_base_address;
-                match GCD.get_memory_descriptor_for_address(address) {
+                match GCD.get_existent_memory_descriptor_for_address(address) {
                     // we found the region in the GCD, so we can allocate it
                     Ok(gcd_desc) => {
                         if gcd_desc.base_address == desc.memory_base_address
@@ -1027,7 +1027,7 @@ fn process_hob_allocations(hob_list: &HobList) {
                 //corresponding resource descriptor. Check the current region in the GCD to see whether a resource
                 //descriptor of the appropriate type has been reported. If not, print a warning and skip attempting
                 //to reserve it in the GCD.
-                if let Ok(existing_desc) = GCD.get_memory_descriptor_for_address(*base_address)
+                if let Ok(existing_desc) = GCD.get_existent_memory_descriptor_for_address(*base_address)
                     && (existing_desc.memory_type != dxe_services::GcdMemoryType::MemoryMappedIo
                         || existing_desc.image_handle != INVALID_HANDLE)
                 {
@@ -1074,7 +1074,7 @@ fn process_hob_allocations(hob_list: &HobList) {
             "Invalid Stack Configuration: Stack base address {stack_address:#X} for len {stack_length:#X}"
         );
 
-        match GCD.get_memory_descriptor_for_address(stack_address) {
+        match GCD.get_existent_memory_descriptor_for_address(stack_address) {
             Ok(gcd_desc) => {
                 // Set Stack region to execute protect. We use the allocated memory protection policy here because
                 // that matches our standard policy
@@ -1123,7 +1123,7 @@ fn process_hob_allocations(hob_list: &HobList) {
     // EFI_MEMORY_MAP reports as EfiConventionalMemory), which will cause a failure that is unnecessary. We do this
     // after HOB processing because we want to ensure that the GCD is fully populated with the memory map
     // before we allocate page 0, as it may not live in system memory, in which case we cannot allocate it.
-    match GCD.get_memory_descriptor_for_address(0) {
+    match GCD.get_existent_memory_descriptor_for_address(0) {
         Ok(desc) if desc.memory_type == GcdMemoryType::SystemMemory => {
             let mut address: efi::PhysicalAddress = 0;
             if core_allocate_pages(
@@ -1506,25 +1506,26 @@ mod tests {
             assert!(stack_hob.memory_length != 0);
 
             // Check Guard Page.
-            let mut stack_desc = GCD.get_memory_descriptor_for_address(stack_hob.memory_base_address).unwrap();
+            let mut stack_desc = GCD.get_existent_memory_descriptor_for_address(stack_hob.memory_base_address).unwrap();
             assert_eq!(stack_desc.memory_type, dxe_services::GcdMemoryType::SystemMemory);
             assert_eq!((stack_desc.attributes & efi::MEMORY_RP), efi::MEMORY_RP);
 
             // Check rest of the stack.
-            stack_desc =
-                GCD.get_memory_descriptor_for_address(stack_hob.memory_base_address + UEFI_PAGE_SIZE as u64).unwrap();
+            stack_desc = GCD
+                .get_existent_memory_descriptor_for_address(stack_hob.memory_base_address + UEFI_PAGE_SIZE as u64)
+                .unwrap();
             assert_eq!((stack_desc.attributes & efi::MEMORY_XP), efi::MEMORY_XP);
             assert_eq!(stack_desc.memory_type, dxe_services::GcdMemoryType::SystemMemory);
 
             // confirm the MMIO memory allocation occurred in the GCD
-            let mmio_desc = GCD.get_memory_descriptor_for_address(0x10000000).unwrap();
+            let mmio_desc = GCD.get_existent_memory_descriptor_for_address(0x10000000).unwrap();
             assert_eq!(mmio_desc.memory_type, dxe_services::GcdMemoryType::MemoryMappedIo);
             assert_eq!(mmio_desc.base_address, 0x10000000);
             assert_eq!(mmio_desc.length, 0x2000);
             assert_eq!(mmio_desc.image_handle, protocol_db::DXE_CORE_HANDLE);
 
             // confirm the rest of the MMIO region is not allocated
-            let mmio_desc = GCD.get_memory_descriptor_for_address(0x10002000).unwrap();
+            let mmio_desc = GCD.get_existent_memory_descriptor_for_address(0x10002000).unwrap();
             assert_eq!(mmio_desc.memory_type, dxe_services::GcdMemoryType::MemoryMappedIo);
             assert_eq!(mmio_desc.base_address, 0x10002000);
             assert_eq!(mmio_desc.length, 0x1000000 - 0x2000);

--- a/patina_dxe_core/src/allocator/fixed_size_block_allocator.rs
+++ b/patina_dxe_core/src/allocator/fixed_size_block_allocator.rs
@@ -599,9 +599,11 @@ impl SpinLockedFixedSizeBlockAllocator {
         }
 
         let descriptor =
-            self.gcd.get_memory_descriptor_for_address(address as efi::PhysicalAddress).map_err(|err| match err {
-                EfiError::NotFound => err,
-                _ => EfiError::InvalidParameter,
+            self.gcd.get_existent_memory_descriptor_for_address(address as efi::PhysicalAddress).map_err(|err| {
+                match err {
+                    EfiError::NotFound => err,
+                    _ => EfiError::InvalidParameter,
+                }
             })?;
 
         if descriptor.image_handle != self.handle {

--- a/patina_dxe_core/src/gcd.rs
+++ b/patina_dxe_core/src/gcd.rs
@@ -300,7 +300,7 @@ impl MemoryProtectionPolicy {
         // always map page 0 if it exists in this system, as grub will attempt to read it for legacy boot structures
         // map it WB by default, because 0 is being used as the null page, it may not have gotten cache attributes
         // populated
-        match gcd.get_memory_descriptor_for_address(0) {
+        match gcd.get_existent_memory_descriptor_for_address(0) {
             Ok(descriptor) if descriptor.memory_type == GcdMemoryType::SystemMemory => {
                 // set_memory_space_attributes will set both the GCD and paging attributes
                 if let Err(e) = gcd.set_memory_space_attributes(
@@ -319,7 +319,7 @@ impl MemoryProtectionPolicy {
         let mut address = UEFI_PAGE_SIZE; // start at 0x1000, as we already mapped page 0
         while address < LEGACY_BIOS_WB_ADDRESS {
             let mut size = UEFI_PAGE_SIZE;
-            if let Ok(descriptor) = gcd.get_memory_descriptor_for_address(address as efi::PhysicalAddress) {
+            if let Ok(descriptor) = gcd.get_existent_memory_descriptor_for_address(address as efi::PhysicalAddress) {
                 // if the legacy region is not system memory, we should not map it
                 if descriptor.memory_type == GcdMemoryType::SystemMemory {
                     size = match address + descriptor.length as usize {
@@ -358,7 +358,7 @@ impl MemoryProtectionPolicy {
             let mut addr = range.start;
             while addr < range.end {
                 let mut len = UEFI_PAGE_SIZE as u64;
-                match gcd.get_memory_descriptor_for_address(addr) {
+                match gcd.get_existent_memory_descriptor_for_address(addr) {
                     Ok(descriptor) => {
                         let attributes = descriptor.attributes & !efi::MEMORY_XP;
                         len = match descriptor.base_address + descriptor.length {
@@ -405,7 +405,7 @@ impl MemoryProtectionPolicy {
 
         // for this image map all mem RWX preserving cache attributes if we find them
         let stripped_attrs = gcd
-            .get_memory_descriptor_for_address(image_base_page as u64)
+            .get_existent_memory_descriptor_for_address(image_base_page as u64)
             .map(|desc| desc.attributes & efi::CACHE_ATTRIBUTE_MASK)
             .unwrap_or(patina::base::DEFAULT_CACHE_ATTR);
         if gcd
@@ -1062,7 +1062,7 @@ mod tests {
                 let mut addr = range.start;
                 while addr < range.end {
                     let mut len = 0x1000;
-                    if let Ok(desc) = GCD.get_memory_descriptor_for_address(addr) {
+                    if let Ok(desc) = GCD.get_existent_memory_descriptor_for_address(addr) {
                         assert_eq!(desc.attributes & efi::MEMORY_XP, efi::MEMORY_XP);
                         len = desc.length;
                     }
@@ -1082,7 +1082,7 @@ mod tests {
             let image_num_pages = 4;
             let filename = "legacy_app.efi";
 
-            let desc = GCD.get_memory_descriptor_for_address(image_base_page).unwrap();
+            let desc = GCD.get_existent_memory_descriptor_for_address(image_base_page).unwrap();
             assert_eq!(desc.attributes & efi::MEMORY_XP, efi::MEMORY_XP);
 
             // 2. Activate compatibility mode
@@ -1098,11 +1098,11 @@ mod tests {
             assert_eq!(policy.memory_allocation_default_attributes.get(), 0);
 
             // 4. Page 0 should be mapped
-            let desc = GCD.get_memory_descriptor_for_address(0).unwrap();
+            let desc = GCD.get_existent_memory_descriptor_for_address(0).unwrap();
             assert_eq!(desc.attributes & efi::CACHE_ATTRIBUTE_MASK, efi::MEMORY_WB);
 
             // 5. Legacy BIOS region (0xA0000) should be mapped if system memory
-            let legacy_desc = GCD.get_memory_descriptor_for_address(0xA0000);
+            let legacy_desc = GCD.get_existent_memory_descriptor_for_address(0xA0000);
             if let Ok(desc) = legacy_desc
                 && desc.memory_type == GcdMemoryType::SystemMemory
             {
@@ -1117,7 +1117,7 @@ mod tests {
                 let mut addr = range.start;
                 while addr < range.end {
                     let mut len = 0x1000;
-                    if let Ok(desc) = GCD.get_memory_descriptor_for_address(addr) {
+                    if let Ok(desc) = GCD.get_existent_memory_descriptor_for_address(addr) {
                         assert_eq!(desc.attributes & efi::MEMORY_XP, 0);
                         len = desc.length;
                     }
@@ -1126,7 +1126,7 @@ mod tests {
             }
 
             // 7. The image region should be mapped RWX (XP cleared)
-            let desc = GCD.get_memory_descriptor_for_address(image_base_page).unwrap();
+            let desc = GCD.get_existent_memory_descriptor_for_address(image_base_page).unwrap();
             assert_eq!(desc.attributes & efi::MEMORY_XP, 0);
         });
     }

--- a/patina_dxe_core/src/gcd/spin_locked_gcd.rs
+++ b/patina_dxe_core/src/gcd/spin_locked_gcd.rs
@@ -2320,7 +2320,7 @@ impl SpinLockedGcd {
         };
 
         let dxe_core_desc =
-            match self.get_memory_descriptor_for_address(dxe_core_hob.alloc_descriptor.memory_base_address) {
+            match self.get_existent_memory_descriptor_for_address(dxe_core_hob.alloc_descriptor.memory_base_address) {
                 Ok(desc) => desc,
                 Err(e) => panic!("DXE Core not mapped in GCD {e:?}"),
             };
@@ -2408,8 +2408,7 @@ impl SpinLockedGcd {
 
         // make sure we didn't map page 0 if it was reserved or MMIO, we are using this for null pointer detection
         // only do this if page 0 actually exists
-        if let Ok(descriptor) = self.get_memory_descriptor_for_address(0)
-            && descriptor.memory_type != GcdMemoryType::NonExistent
+        if let Ok(descriptor) = self.get_existent_memory_descriptor_for_address(0)
             && let Err(err) = self.set_memory_space_attributes(
                 0,
                 UEFI_PAGE_SIZE,
@@ -2505,11 +2504,11 @@ impl SpinLockedGcd {
             // here, we rely on the image loader to update the attributes as appropriate for the code sections. The
             // same holds true for other required attributes.
             if let Ok(base_address) = result.as_ref() {
-                let mut attributes = match self.get_memory_descriptor_for_address(*base_address as efi::PhysicalAddress)
-                {
-                    Ok(descriptor) => descriptor.attributes,
-                    Err(_) => DEFAULT_CACHE_ATTR,
-                };
+                let mut attributes =
+                    match self.get_existent_memory_descriptor_for_address(*base_address as efi::PhysicalAddress) {
+                        Ok(descriptor) => descriptor.attributes,
+                        Err(_) => DEFAULT_CACHE_ATTR,
+                    };
                 // it is safe to call set_memory_space_attributes without calling set_memory_space_capabilities here
                 // because we set efi::MEMORY_XP as a capability on all memory ranges we add to the GCD. A driver could
                 // call set_memory_space_capabilities to remove the XP capability, but that is something that should
@@ -2785,6 +2784,18 @@ impl SpinLockedGcd {
         address: efi::PhysicalAddress,
     ) -> Result<dxe_services::MemorySpaceDescriptor, EfiError> {
         self.memory.lock().get_memory_descriptor_for_address(address)
+    }
+
+    // Returns the descriptor for the given address if that memory range is not NonExistent
+    pub fn get_existent_memory_descriptor_for_address(
+        &self,
+        address: efi::PhysicalAddress,
+    ) -> Result<dxe_services::MemorySpaceDescriptor, EfiError> {
+        match self.memory.lock().get_memory_descriptor_for_address(address) {
+            Ok(desc) if desc.memory_type != GcdMemoryType::NonExistent => Ok(desc),
+            Ok(_) => Err(EfiError::NotFound),
+            Err(e) => Err(e),
+        }
     }
 
     /// returns the current count of blocks in the list.
@@ -6118,6 +6129,78 @@ mod tests {
             let count = gcd.memory_descriptor_count_for_efi_memory_map();
             // Should count: 1 SystemMemory (from create_gcd) + 1 Reserved
             assert!(count >= 2, "Expected at least 2 descriptors, got {}", count);
+        });
+    }
+
+    #[test]
+    fn test_get_existent_memory_descriptor_for_address() {
+        with_locked_state(|| {
+            static GCD: SpinLockedGcd = SpinLockedGcd::new(None);
+            GCD.init(48, 16);
+
+            let mem = unsafe { get_memory(MEMORY_BLOCK_SLICE_SIZE) };
+            let address = mem.as_ptr() as usize;
+            unsafe {
+                GCD.init_memory_blocks(
+                    dxe_services::GcdMemoryType::SystemMemory,
+                    address,
+                    MEMORY_BLOCK_SLICE_SIZE,
+                    efi::MEMORY_WB,
+                    efi::MEMORY_WB,
+                )
+                .unwrap();
+            }
+
+            // Add multiple memory regions with different types
+            unsafe {
+                GCD.add_memory_space(dxe_services::GcdMemoryType::SystemMemory, 0x1000, 0x2000, efi::MEMORY_WB)
+                    .unwrap();
+                GCD.add_memory_space(dxe_services::GcdMemoryType::MemoryMappedIo, 0x5000, 0x1000, efi::MEMORY_UC)
+                    .unwrap();
+                GCD.add_memory_space(dxe_services::GcdMemoryType::Reserved, 0x8000, 0x1000, 0).unwrap();
+            }
+
+            // Test: Address at the start of a SystemMemory block
+            let result = GCD.get_existent_memory_descriptor_for_address(0x1000);
+            assert!(result.is_ok());
+            let desc = result.unwrap();
+            assert_eq!(desc.base_address, 0x1000);
+            assert_eq!(desc.length, 0x2000);
+            assert_eq!(desc.memory_type, dxe_services::GcdMemoryType::SystemMemory);
+
+            // Test: Address in the middle of a SystemMemory block
+            let result = GCD.get_existent_memory_descriptor_for_address(0x2000);
+            assert!(result.is_ok());
+            let desc = result.unwrap();
+            assert_eq!(desc.base_address, 0x1000);
+            assert_eq!(desc.memory_type, dxe_services::GcdMemoryType::SystemMemory);
+
+            // Test: Address at the start of MMIO block
+            let result = GCD.get_existent_memory_descriptor_for_address(0x5000);
+            assert!(result.is_ok());
+            let desc = result.unwrap();
+            assert_eq!(desc.base_address, 0x5000);
+            assert_eq!(desc.length, 0x1000);
+            assert_eq!(desc.memory_type, dxe_services::GcdMemoryType::MemoryMappedIo);
+
+            // Test: Address at the start of Reserved block
+            let result = GCD.get_existent_memory_descriptor_for_address(0x8000);
+            assert!(result.is_ok());
+            let desc = result.unwrap();
+            assert_eq!(desc.base_address, 0x8000);
+            assert_eq!(desc.memory_type, dxe_services::GcdMemoryType::Reserved);
+
+            // Test: Address in a NonExistent region (between added blocks)
+            let result = GCD.get_existent_memory_descriptor_for_address(0x4000);
+            assert_eq!(result, Err(EfiError::NotFound));
+
+            // Test: Address before any added memory space (in NonExistent region)
+            let result = GCD.get_existent_memory_descriptor_for_address(0x500);
+            assert_eq!(result, Err(EfiError::NotFound));
+
+            // Test: Address way outside any added memory space
+            let result = GCD.get_existent_memory_descriptor_for_address(0xFFFF0000);
+            assert_eq!(result, Err(EfiError::NotFound));
         });
     }
 }


### PR DESCRIPTION
## Description

Currently, get_memory_descriptor_for_address() returns any descriptor found, including NonExistent descriptors. Because this function is used by the PI spec GetMemorySpaceDescriptor(), it needs to do that.

However, for the majority of Patina usage, we only want existent descriptors. Most of the cases using it is to apply attributes and we cannot do that on non-existent memory. We also would miss cases where we'd search for something, e.g. the stack region, and just move on if we found any descriptor, not specifically an existent one.

This commit adds a new helper function to return NotFound if get_memory_descriptor_for_address() returns a NonExistent descriptor. Usage across the tree is updated.

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Booting Q35 and SBSA to Windows. Observed a unit test not failing when it should have because the stack memory region was not present in the GCD. After this fix the test fails as expected.

## Integration Instructions

N/A.
