### PR TITLE
patina_adv_logger: Add logger info v6 support

### DIFF
--- a/components/patina_adv_logger/src/logger.rs
+++ b/components/patina_adv_logger/src/logger.rs
@@ -20,7 +20,7 @@ use patina::{
     serial::SerialIO,
 };
 use r_efi::efi;
-use spin::Once;
+use spin::RwLock;
 
 // Exists for the debugger to find the log buffer.
 #[used]
@@ -35,7 +35,7 @@ where
     target_filters: &'a [(&'a str, log::LevelFilter)],
     max_level: log::LevelFilter,
     format: Format,
-    memory_log: Once<AdvancedLog<'static>>,
+    memory_log: RwLock<Option<AdvancedLog<'static>>>,
     pub(crate) timer: Service<dyn ArchTimerFunctionality>,
 }
 
@@ -58,7 +58,14 @@ where
         max_level: log::LevelFilter,
         hardware_port: S,
     ) -> Self {
-        Self { hardware_port, target_filters, max_level, format, memory_log: Once::new(), timer: Service::new_uninit() }
+        Self {
+            hardware_port,
+            target_filters,
+            max_level,
+            format,
+            memory_log: RwLock::new(None),
+            timer: Service::new_uninit(),
+        }
     }
 
     /// Initializes the performance timer service for timestamping log entries.
@@ -107,8 +114,10 @@ where
 
     /// Writes a log entry to the hardware port and memory log if available.
     pub(crate) fn log_write(&self, error_level: u32, data: &[u8]) {
+        self.refresh_log_info_address();
         let mut hw_write = true;
-        if let Some(memory_log) = self.memory_log.get() {
+        let log_guard = self.memory_log.read();
+        if let Some(memory_log) = log_guard.as_ref() {
             hw_write = memory_log.hardware_write_enabled(error_level);
             let timestamp = self.timer.map_or(0, |timer| timer.cpu_count());
             let _ = memory_log.add_log_entry(LogEntry {
@@ -126,16 +135,34 @@ where
 
     /// Sets the address of the advanced logger memory log.
     pub(crate) fn set_log_info_address(&self, address: efi::PhysicalAddress) {
-        assert!(!self.memory_log.is_completed());
-        // SAFETY: The caller must ensure the address is valid for an AdvancedLog.
+        {
+            // If already initialized with the same address, there is nothing to do
+            let log_guard = self.memory_log.read();
+            if log_guard.as_ref().is_some_and(|log| log.get_address() == address) {
+                return;
+            }
+        }
+
+        // SAFETY: The caller must ensure the address is valid for an AdvancedLog type.
         if let Some(log) = unsafe { AdvancedLog::adopt_memory_log(address) } {
-            let memory_log = self.memory_log.call_once(|| log);
-            log::info!("Advanced logger buffer initialized. Address = {:#x}", memory_log.get_address());
+            let current_frequency = log.get_frequency();
+
+            {
+                let mut memory_log_guard = self.memory_log.write();
+                *memory_log_guard = Some(log);
+            }
+            // Drop the lock before logging
+
+            log::info!("Advanced logger buffer initialized. Address = {:#x}", address);
 
             // The frequency may not be initialized, if not do so now.
-            if memory_log.get_frequency() == 0 {
+            if current_frequency == 0 {
                 let frequency = self.timer.map_or(0, |timer| timer.perf_frequency());
-                memory_log.set_frequency(frequency);
+                // Re-acquire lock to set frequency
+                let log_guard = self.memory_log.read();
+                if let Some(memory_log) = log_guard.as_ref() {
+                    memory_log.set_frequency(frequency);
+                }
             }
 
             // SAFETY: This is only set for discoverability while debugging.
@@ -148,7 +175,24 @@ where
     }
 
     pub(crate) fn get_log_address(&self) -> Option<efi::PhysicalAddress> {
-        self.memory_log.get().map(|log| log.get_address())
+        let log_guard = self.memory_log.read();
+        log_guard.as_ref().map(|log| log.get_address())
+    }
+
+    fn refresh_log_info_address(&self) {
+        let (current_address, new_address) = {
+            let log_guard = self.memory_log.read();
+            let Some(log) = log_guard.as_ref() else {
+                return;
+            };
+            (log.get_address(), log.get_new_logger_info_address())
+        };
+
+        if let Some(new_address) = new_address
+            && new_address != current_address
+        {
+            self.set_log_info_address(new_address);
+        }
     }
 }
 

--- a/components/patina_adv_logger/src/memory_log.rs
+++ b/components/patina_adv_logger/src/memory_log.rs
@@ -27,6 +27,9 @@ use zerocopy_derive::*;
 pub const ADV_LOGGER_HOB_GUID: efi::Guid =
     efi::Guid::from_fields(0x4d60cfb5, 0xf481, 0x4a98, 0x9c, 0x81, &[0xbf, 0xf8, 0x64, 0x60, 0xc4, 0x3e]);
 
+pub const ADV_LOGGER_INFO_VERSION_V5: u16 = 5;
+pub const ADV_LOGGER_INFO_VERSION_V6: u16 = 6;
+
 // UEFI Debug Levels
 pub const DEBUG_LEVEL_ERROR: u32 = 0x80000000;
 pub const DEBUG_LEVEL_WARNING: u32 = 0x00000002;
@@ -59,7 +62,7 @@ impl<'a> LogEntry<'a> {
 /// serves as the idiomatic rust container for the C based structures.
 pub struct AdvancedLog<'a> {
     /// The header of the memory log.
-    pub(crate) header: &'a AdvLoggerInfo,
+    pub(crate) header: AdvLoggerInfoRef<'a>,
     /// The data portion of the memory log.
     data: LogData<'a>,
 }
@@ -81,27 +84,16 @@ impl AdvancedLog<'static> {
     /// structure and that the memory is properly sized initialized based on the
     /// information in that structure.
     pub unsafe fn adopt_memory_log(address: efi::PhysicalAddress) -> Option<Self> {
-        let log_info = address as *const AdvLoggerInfo;
-        // SAFETY: The caller should ensure that the address is valid and
-        //         that the memory is readable. Check just the header to establish
-        //         that the log is valid.
-        if unsafe {
-            (*log_info).signature != AdvLoggerInfo::SIGNATURE
-                || (*log_info).version != AdvLoggerInfo::VERSION
-                || (*log_info).log_buffer_offset < size_of::<AdvLoggerInfo>() as u32
-        } {
-            None
-        } else {
-            // SAFETY: The log_info is valid, convert the data for future safety.
-            unsafe {
-                let header = log_info.as_ref()?;
-                let data_size = header.log_buffer_size;
-                let data_start = (address + header.log_buffer_offset as u64) as *mut u8;
-                let data = slice::from_raw_parts_mut(data_start, data_size as usize);
+        // SAFETY: The safety requirements for this function transfer to the function called here.
+        let header = unsafe { AdvLoggerInfoRef::from_address(address)? };
+        let data_size = header.log_buffer_size();
+        let data_start = (address + header.log_buffer_offset() as u64) as *mut u8;
+        // SAFETY: The caller must ensure that the memory is properly sized and initialized
+        // per the safety contract of this function. from_address() validates the signature
+        // and version in the header.
+        let data = unsafe { slice::from_raw_parts_mut(data_start, data_size as usize) };
 
-                Some(Self { header, data: LogData::ReadWrite(UnsafeCell::from_mut(data)) })
-            }
-        }
+        Some(Self { header, data: LogData::ReadWrite(UnsafeCell::from_mut(data)) })
     }
 
     // Allow unused as it is used in tests and intended for future general use.
@@ -139,31 +131,13 @@ impl<'a> AdvancedLog<'a> {
     // Only used in the parser which is not always compiled.
     #[allow(dead_code)]
     pub fn open_log(log_bytes: &'a [u8]) -> Result<Self> {
-        if log_bytes.len() < size_of::<AdvLoggerInfo>() {
-            return Err(EfiError::BufferTooSmall);
-        }
-
-        // SAFETY: We have checked the length of the buffer is at least the size.
-        //         Ideally we use ZeroCopy to do this, but `efi::Time` does not
-        //         support that.
-        let header =
-            unsafe { log_bytes.as_ptr().cast::<AdvLoggerInfo>().as_ref() }.ok_or(EfiError::InvalidParameter)?;
-
-        // Check that this is a valid log header.
-        if header.signature != AdvLoggerInfo::SIGNATURE {
-            return Err(EfiError::InvalidParameter);
-        }
-
-        // Currently only supports version 5.
-        if header.version != AdvLoggerInfo::VERSION {
-            return Err(EfiError::Unsupported);
-        }
+        let header = AdvLoggerInfoRef::from_bytes(log_bytes)?;
 
         // Check that the various pointers are consistent.
-        let log_current = header.log_current_offset.load(Ordering::Relaxed);
-        if log_current < header.log_buffer_offset
+        let log_current = header.log_current_offset().load(Ordering::Relaxed);
+        if log_current < header.log_buffer_offset()
             || log_current > header.full_size()
-            || header.log_buffer_offset < size_of::<AdvLoggerInfo>() as u32
+            || header.log_buffer_offset() < header.header_size() as u32
         {
             return Err(EfiError::InvalidParameter);
         }
@@ -173,7 +147,7 @@ impl<'a> AdvancedLog<'a> {
             return Err(EfiError::BufferTooSmall);
         }
 
-        let (_, data_slice) = log_bytes.split_at(header.log_buffer_offset as usize);
+        let (_, data_slice) = log_bytes.split_at(header.log_buffer_offset() as usize);
 
         Ok(Self { header, data: LogData::ReadOnly(data_slice) })
     }
@@ -196,9 +170,9 @@ impl<'a> AdvancedLog<'a> {
         // Using relaxed here as we only want the atomic swap and are not concerned
         // with ordering. The loop should still use the atomic swap and update each
         // iteration.
-        let mut current_offset = self.header.log_current_offset.load(Ordering::Relaxed);
+        let mut current_offset = self.header.log_current_offset().load(Ordering::Relaxed);
         while current_offset + message_size <= self.header.full_size() {
-            match self.header.log_current_offset.compare_exchange(
+            match self.header.log_current_offset().compare_exchange(
                 current_offset,
                 current_offset + message_size,
                 Ordering::Relaxed,
@@ -213,11 +187,11 @@ impl<'a> AdvancedLog<'a> {
         if current_offset + message_size > self.header.full_size() {
             // Add the discarded value. No ordering needed as this is a single
             // operation.
-            self.header.discarded_size.fetch_add(message_size, Ordering::Relaxed);
+            self.header.discarded_size().fetch_add(message_size, Ordering::Relaxed);
             return Err(EfiError::OutOfResources);
         }
 
-        let data_index = (current_offset - self.header.log_buffer_offset) as usize;
+        let data_index = (current_offset - self.header.log_buffer_offset()) as usize;
 
         // SAFETY: The space hase been allocated. It should now be safe to write
         // data so long as it sticks to the range of the allocated entry. Get only
@@ -241,7 +215,7 @@ impl<'a> AdvancedLog<'a> {
     }
 
     pub fn hardware_write_enabled(&self, level: u32) -> bool {
-        !self.header.hw_port_disabled && (level & self.header.hw_print_level != 0)
+        !self.header.hw_port_disabled() && (level & self.header.hw_print_level() != 0)
     }
 
     pub fn iter(&self) -> AdvLogIterator<'_> {
@@ -249,22 +223,28 @@ impl<'a> AdvancedLog<'a> {
     }
 
     pub fn get_frequency(&self) -> u64 {
-        self.header.timer_frequency.load(Ordering::Relaxed)
+        self.header.timer_frequency().load(Ordering::Relaxed)
     }
 
     pub fn set_frequency(&self, frequency: u64) {
         // try to swap, assuming the value it initially 0. If this fails, just continue.
-        let _ = self.header.timer_frequency.compare_exchange(0, frequency, Ordering::Relaxed, Ordering::Relaxed);
+        let _ = self.header.timer_frequency().compare_exchange(0, frequency, Ordering::Relaxed, Ordering::Relaxed);
     }
 
     pub fn get_address(&self) -> efi::PhysicalAddress {
-        self.header as *const AdvLoggerInfo as efi::PhysicalAddress
+        self.header.as_ptr() as efi::PhysicalAddress
+    }
+
+    pub fn get_new_logger_info_address(&self) -> Option<efi::PhysicalAddress> {
+        self.header
+            .new_logger_info_address()
+            .and_then(|address| if address == 0 { None } else { Some(address as efi::PhysicalAddress) })
     }
 
     // Allow unused as it is used in tests and intended for future general use.
     #[allow(dead_code)]
     pub fn discarded_size(&self) -> u32 {
-        self.header.discarded_size.load(Ordering::Relaxed)
+        self.header.discarded_size().load(Ordering::Relaxed)
     }
 }
 
@@ -272,7 +252,7 @@ impl<'a> AdvancedLog<'a> {
 /// logging structure for Advanced Logger.
 #[derive(Debug)]
 #[repr(C)]
-pub(crate) struct AdvLoggerInfo {
+pub(crate) struct AdvLoggerInfoV5 {
     /// Signature 'ALOG'
     signature: u32,
     /// Current Version
@@ -309,14 +289,27 @@ pub(crate) struct AdvLoggerInfo {
     time: efi::Time,
     /// Logging level to be printed at hw port
     hw_print_level: u32,
+    /// Reserved
+    reserved4: u32,
 }
+
+/// Implementation of the ADVANCED_LOGGER_INFO V6 C struct.
+#[derive(Debug)]
+#[repr(C)]
+pub(crate) struct AdvLoggerInfoV6 {
+    v5: AdvLoggerInfoV5,
+    /// The address for a new logger info structure if it has been migrated
+    new_logger_info_address: u64,
+}
+
+type AdvLoggerInfo = AdvLoggerInfoV6;
 
 impl AdvLoggerInfo {
     /// Signature for the AdvLoggerInfo structure.
     pub const SIGNATURE: u32 = 0x474F4C41; // "ALOG"
 
     /// Version of the current AdvLoggerInfo structure.
-    pub const VERSION: u16 = 5;
+    pub const VERSION: u16 = ADV_LOGGER_INFO_VERSION_V6;
 
     fn new(
         log_buffer_size: u32,
@@ -326,32 +319,217 @@ impl AdvLoggerInfo {
         time: efi::Time,
         hw_print_level: u32,
     ) -> Self {
+        let log_buffer_offset = size_of::<AdvLoggerInfo>() as u32;
         Self {
-            signature: Self::SIGNATURE,
-            version: Self::VERSION,
-            reserved1: [0, 0, 0],
-            log_buffer_offset: size_of::<AdvLoggerInfo>() as u32,
-            reserved2: 0,
-            log_current_offset: AtomicU32::new(size_of::<AdvLoggerInfo>() as u32),
-            discarded_size: AtomicU32::new(0),
-            log_buffer_size: log_buffer_size - size_of::<AdvLoggerInfo>() as u32,
-            in_permanent_ram: true,
-            at_runtime: false,
-            gone_virtual: false,
-            hw_port_initialized: false,
-            hw_port_disabled,
-            reserved3: [false, false, false],
-            timer_frequency: AtomicU64::new(timer_frequency),
-            ticks_at_time,
-            time,
-            hw_print_level,
+            v5: AdvLoggerInfoV5 {
+                signature: Self::SIGNATURE,
+                version: Self::VERSION,
+                reserved1: [0, 0, 0],
+                log_buffer_offset,
+                reserved2: 0,
+                log_current_offset: AtomicU32::new(log_buffer_offset),
+                discarded_size: AtomicU32::new(0),
+                log_buffer_size: log_buffer_size - log_buffer_offset,
+                in_permanent_ram: true,
+                at_runtime: false,
+                gone_virtual: false,
+                hw_port_initialized: false,
+                hw_port_disabled,
+                reserved3: [false, false, false],
+                timer_frequency: AtomicU64::new(timer_frequency),
+                ticks_at_time,
+                time,
+                hw_print_level,
+                reserved4: 0,
+            },
+            new_logger_info_address: 0,
+        }
+    }
+}
+
+/// A reference to an advanced logger info structure of a supported version.
+///
+/// This enum provides a unified interface for accessing fields of supported versions.
+#[derive(Clone, Copy)]
+pub(crate) enum AdvLoggerInfoRef<'a> {
+    V5(&'a AdvLoggerInfoV5),
+    V6(&'a AdvLoggerInfoV6),
+}
+
+impl core::fmt::Debug for AdvLoggerInfoRef<'_> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            AdvLoggerInfoRef::V5(info) => info.fmt(f),
+            AdvLoggerInfoRef::V6(info) => info.fmt(f),
+        }
+    }
+}
+
+impl<'a> AdvLoggerInfoRef<'a> {
+    /// # Safety
+    ///
+    /// The caller must ensure `address` is readable and points to a valid
+    /// `AdvLoggerInfo` header.
+    unsafe fn from_address(address: efi::PhysicalAddress) -> Option<Self> {
+        let log_info = address as *const AdvLoggerInfoV5;
+
+        // SAFETY: The caller must ensure that the address is valid and
+        //         that the memory is readable per this function's safety contract.
+        let version = unsafe {
+            if (*log_info).signature != AdvLoggerInfo::SIGNATURE {
+                return None;
+            }
+
+            (*log_info).version
+        };
+
+        let header_size = Self::header_size_for_version(version)? as u32;
+
+        // SAFETY: Version is confirmed as supported, verify offsets are consistent.
+        let (log_buffer_offset, log_buffer_size, log_current_offset) = unsafe {
+            (
+                (*log_info).log_buffer_offset,
+                (*log_info).log_buffer_size,
+                (*log_info).log_current_offset.load(Ordering::Relaxed),
+            )
+        };
+
+        if log_buffer_offset < header_size {
+            return None;
+        }
+
+        let full_size = log_buffer_offset + log_buffer_size;
+        if log_current_offset < log_buffer_offset || log_current_offset > full_size {
+            return None;
+        }
+
+        // SAFETY: The log_info is valid, convert the data for future safety.
+        unsafe {
+            match version {
+                ADV_LOGGER_INFO_VERSION_V5 => log_info.as_ref().map(AdvLoggerInfoRef::V5),
+                ADV_LOGGER_INFO_VERSION_V6 => (address as *const AdvLoggerInfoV6).as_ref().map(AdvLoggerInfoRef::V6),
+                _ => None,
+            }
         }
     }
 
-    /// Returns the size of the log buffer, which is the size of the header plus
-    /// the size of the data buffer.
-    pub fn full_size(&self) -> u32 {
-        self.log_buffer_offset + self.log_buffer_size
+    fn from_bytes(log_bytes: &'a [u8]) -> Result<Self> {
+        if log_bytes.len() < size_of::<AdvLoggerInfoV5>() {
+            return Err(EfiError::BufferTooSmall);
+        }
+
+        // SAFETY: We have checked the length of the buffer is at least the size.
+        //         Ideally we use ZeroCopy to do this, but `efi::Time` does not
+        //         support it.
+        let header_v5 =
+            unsafe { log_bytes.as_ptr().cast::<AdvLoggerInfoV5>().as_ref() }.ok_or(EfiError::InvalidParameter)?;
+
+        // Check that this is a valid log header.
+        if header_v5.signature != AdvLoggerInfo::SIGNATURE {
+            return Err(EfiError::InvalidParameter);
+        }
+
+        // Check that the logger info version is supported.
+        let version = header_v5.version;
+        let header_size = Self::header_size_for_version(version).ok_or(EfiError::Unsupported)?;
+        if log_bytes.len() < header_size {
+            return Err(EfiError::BufferTooSmall);
+        }
+
+        match version {
+            ADV_LOGGER_INFO_VERSION_V5 => Ok(AdvLoggerInfoRef::V5(header_v5)),
+            ADV_LOGGER_INFO_VERSION_V6 => {
+                // SAFETY: log_bytes was validated above to check the length, structure signature,
+                // version, and header size for the version to ensure that it is valid to interpret
+                // the bytes as a V6 structure.
+                let header_v6 = unsafe { log_bytes.as_ptr().cast::<AdvLoggerInfoV6>().as_ref() }
+                    .ok_or(EfiError::InvalidParameter)?;
+                Ok(AdvLoggerInfoRef::V6(header_v6))
+            }
+            _ => Err(EfiError::Unsupported),
+        }
+    }
+
+    fn header_size_for_version(version: u16) -> Option<usize> {
+        match version {
+            ADV_LOGGER_INFO_VERSION_V5 => Some(size_of::<AdvLoggerInfoV5>()),
+            ADV_LOGGER_INFO_VERSION_V6 => Some(size_of::<AdvLoggerInfoV6>()),
+            _ => None,
+        }
+    }
+
+    fn header_size(&self) -> usize {
+        match self {
+            AdvLoggerInfoRef::V5(_) => size_of::<AdvLoggerInfoV5>(),
+            AdvLoggerInfoRef::V6(_) => size_of::<AdvLoggerInfoV6>(),
+        }
+    }
+
+    fn log_buffer_offset(&self) -> u32 {
+        match self {
+            AdvLoggerInfoRef::V5(info) => info.log_buffer_offset,
+            AdvLoggerInfoRef::V6(info) => info.v5.log_buffer_offset,
+        }
+    }
+
+    fn log_buffer_size(&self) -> u32 {
+        match self {
+            AdvLoggerInfoRef::V5(info) => info.log_buffer_size,
+            AdvLoggerInfoRef::V6(info) => info.v5.log_buffer_size,
+        }
+    }
+
+    fn log_current_offset(&self) -> &AtomicU32 {
+        match self {
+            AdvLoggerInfoRef::V5(info) => &info.log_current_offset,
+            AdvLoggerInfoRef::V6(info) => &info.v5.log_current_offset,
+        }
+    }
+
+    fn discarded_size(&self) -> &AtomicU32 {
+        match self {
+            AdvLoggerInfoRef::V5(info) => &info.discarded_size,
+            AdvLoggerInfoRef::V6(info) => &info.v5.discarded_size,
+        }
+    }
+
+    fn timer_frequency(&self) -> &AtomicU64 {
+        match self {
+            AdvLoggerInfoRef::V5(info) => &info.timer_frequency,
+            AdvLoggerInfoRef::V6(info) => &info.v5.timer_frequency,
+        }
+    }
+
+    fn hw_port_disabled(&self) -> bool {
+        match self {
+            AdvLoggerInfoRef::V5(info) => info.hw_port_disabled,
+            AdvLoggerInfoRef::V6(info) => info.v5.hw_port_disabled,
+        }
+    }
+
+    fn hw_print_level(&self) -> u32 {
+        match self {
+            AdvLoggerInfoRef::V5(info) => info.hw_print_level,
+            AdvLoggerInfoRef::V6(info) => info.v5.hw_print_level,
+        }
+    }
+
+    fn new_logger_info_address(&self) -> Option<u64> {
+        match self {
+            AdvLoggerInfoRef::V5(_) => None,
+            AdvLoggerInfoRef::V6(info) => Some(info.new_logger_info_address),
+        }
+    }
+
+    fn full_size(&self) -> u32 {
+        self.log_buffer_offset() + self.log_buffer_size()
+    }
+
+    fn as_ptr(&self) -> *const u8 {
+        match *self {
+            AdvLoggerInfoRef::V5(info) => info as *const AdvLoggerInfoV5 as *const u8,
+            AdvLoggerInfoRef::V6(info) => info as *const AdvLoggerInfoV6 as *const u8,
+        }
     }
 }
 
@@ -414,7 +592,7 @@ impl AdvLoggerMessageEntry {
     /// Major version of the AdvLoggerMessageEntry structure.
     pub const MAJOR_VERSION: u8 = 2;
     /// Minor version of the AdvLoggerMessageEntry structure.
-    pub const MINOR_VERSION: u8 = 0;
+    pub const MINOR_VERSION: u8 = 1;
 
     /// Creates the structure of AdvLoggerMessageEntry.
     ///
@@ -463,8 +641,8 @@ pub struct AdvLogIterator<'a> {
 /// Iterator for an Advanced Logger memory buffer.
 impl<'a> AdvLogIterator<'a> {
     /// Creates a new log iterator from a given AdvLoggerInfo reference.
-    const fn new(log: &'a AdvancedLog) -> Self {
-        AdvLogIterator { log, offset: log.header.log_buffer_offset as usize }
+    fn new(log: &'a AdvancedLog) -> Self {
+        AdvLogIterator { log, offset: log.header.log_buffer_offset() as usize }
     }
 }
 
@@ -474,12 +652,12 @@ impl<'a> Iterator for AdvLogIterator<'a> {
     /// Provides the next advanced logger entry in the Advanced Logger memory buffer.
     fn next(&mut self) -> Option<Self::Item> {
         if self.offset + size_of::<AdvLoggerMessageEntry>()
-            > self.log.header.log_current_offset.load(Ordering::Relaxed) as usize
+            > self.log.header.log_current_offset().load(Ordering::Relaxed) as usize
         {
             None
         } else {
             // Get the data relative offset.
-            let mut data_index = self.offset - self.log.header.log_buffer_offset as usize;
+            let mut data_index = self.offset - self.log.header.log_buffer_offset() as usize;
 
             // SAFETY: We have verified the buffer through the header, read that
             //         to check the rest of the range.
@@ -492,7 +670,7 @@ impl<'a> Iterator for AdvLogIterator<'a> {
             data_index += size_of::<AdvLoggerMessageEntry>();
 
             if self.offset + size_of::<AdvLoggerMessageEntry>() + entry_header.message_length as usize
-                > self.log.header.log_current_offset.load(Ordering::Relaxed) as usize
+                > self.log.header.log_current_offset().load(Ordering::Relaxed) as usize
             {
                 None
             } else {
@@ -522,10 +700,81 @@ impl<'a> Iterator for AdvLogIterator<'a> {
 #[coverage(off)]
 mod tests {
     extern crate std;
-    use alloc::boxed::Box;
+    use alloc::{boxed::Box, vec};
     use efi::PhysicalAddress;
 
     use super::*;
+
+    const TEST_DATA_SIZE: usize = 128;
+
+    fn create_buffer_v5(timer_frequency: u64, hw_port_disabled: bool) -> Box<[u8]> {
+        let header_size = size_of::<AdvLoggerInfoV5>();
+        let mut buffer = vec![0_u8; header_size + TEST_DATA_SIZE].into_boxed_slice();
+        let header = AdvLoggerInfoV5 {
+            signature: AdvLoggerInfo::SIGNATURE,
+            version: ADV_LOGGER_INFO_VERSION_V5,
+            reserved1: [0, 0, 0],
+            log_buffer_offset: header_size as u32,
+            reserved2: 0,
+            log_current_offset: AtomicU32::new(header_size as u32),
+            discarded_size: AtomicU32::new(0),
+            log_buffer_size: TEST_DATA_SIZE as u32,
+            in_permanent_ram: true,
+            at_runtime: false,
+            gone_virtual: false,
+            hw_port_initialized: false,
+            hw_port_disabled,
+            reserved3: [false, false, false],
+            timer_frequency: AtomicU64::new(timer_frequency),
+            ticks_at_time: 0,
+            time: efi::Time::default(),
+            hw_print_level: DEBUG_LEVEL_INFO,
+            reserved4: 0,
+        };
+
+        // SAFETY: The buffer was allocated with sufficient size (header_size + TEST_DATA_SIZE).
+        unsafe {
+            ptr::write(buffer.as_mut_ptr().cast::<AdvLoggerInfoV5>(), header);
+        }
+
+        buffer
+    }
+
+    fn create_buffer_v6(timer_frequency: u64, new_address: u64) -> Box<[u8]> {
+        let header_size = size_of::<AdvLoggerInfoV6>();
+        let mut buffer = vec![0_u8; header_size + TEST_DATA_SIZE].into_boxed_slice();
+        let header = AdvLoggerInfoV6 {
+            v5: AdvLoggerInfoV5 {
+                signature: AdvLoggerInfo::SIGNATURE,
+                version: ADV_LOGGER_INFO_VERSION_V6,
+                reserved1: [0, 0, 0],
+                log_buffer_offset: header_size as u32,
+                reserved2: 0,
+                log_current_offset: AtomicU32::new(header_size as u32),
+                discarded_size: AtomicU32::new(0),
+                log_buffer_size: TEST_DATA_SIZE as u32,
+                in_permanent_ram: true,
+                at_runtime: false,
+                gone_virtual: false,
+                hw_port_initialized: false,
+                hw_port_disabled: false,
+                reserved3: [false, false, false],
+                timer_frequency: AtomicU64::new(timer_frequency),
+                ticks_at_time: 0,
+                time: efi::Time::default(),
+                hw_print_level: DEBUG_LEVEL_INFO,
+                reserved4: 0,
+            },
+            new_logger_info_address: new_address,
+        };
+
+        // SAFETY: The buffer is sized for the header and is aligned for AdvLoggerInfoV6.
+        unsafe {
+            ptr::write(buffer.as_mut_ptr().cast::<AdvLoggerInfoV6>(), header);
+        }
+
+        buffer
+    }
 
     #[test]
     fn create_fill_check_test() {
@@ -605,5 +854,148 @@ mod tests {
         }
 
         assert!(iter.next().is_none());
+    }
+
+    #[test]
+    fn open_log_supports_v5_and_v6() {
+        let buffer_v5 = create_buffer_v5(123, false);
+        let log_v5 = AdvancedLog::open_log(&buffer_v5).unwrap();
+        assert_eq!(log_v5.get_frequency(), 123);
+        assert!(log_v5.hardware_write_enabled(DEBUG_LEVEL_INFO));
+        assert!(log_v5.get_new_logger_info_address().is_none());
+
+        let buffer_v6 = create_buffer_v6(456, 0x1122334455667788);
+        let log_v6 = AdvancedLog::open_log(&buffer_v6).unwrap();
+        assert_eq!(log_v6.get_frequency(), 456);
+        assert!(log_v6.get_new_logger_info_address().is_some());
+    }
+
+    #[test]
+    fn adopt_memory_log_accepts_v5_and_v6() {
+        let mut buffer_v5 = create_buffer_v5(0, false);
+        let address_v5 = buffer_v5.as_mut_ptr() as PhysicalAddress;
+        // SAFETY: The memory was allocated successfully in this function and has been initialized
+        // to contain a valid AdvLoggerInfoV5 header.
+        let log_v5 = unsafe { AdvancedLog::adopt_memory_log(address_v5) }.unwrap();
+        let entry_v5 = LogEntry { level: 0, phase: 0, timestamp: 0, data: b"v5" };
+        log_v5.add_log_entry(entry_v5).unwrap();
+        let mut iter = log_v5.iter();
+        assert_eq!(iter.next().unwrap().get_message(), b"v5");
+
+        let mut buffer_v6 = create_buffer_v6(0, 0);
+        let address_v6 = buffer_v6.as_mut_ptr() as PhysicalAddress;
+        // SAFETY: The memory was allocated successfully in this function and has been initialized
+        // to contain a valid AdvLoggerInfoV6 header.
+        let log_v6 = unsafe { AdvancedLog::adopt_memory_log(address_v6) }.unwrap();
+        let entry_v6 = LogEntry { level: 0, phase: 0, timestamp: 0, data: b"v6" };
+        log_v6.add_log_entry(entry_v6).unwrap();
+        let mut iter = log_v6.iter();
+        assert_eq!(iter.next().unwrap().get_message(), b"v6");
+    }
+
+    #[test]
+    fn adopt_memory_log_rejects_log_buffer_offset_less_than_header_size() {
+        let mut buffer = create_buffer_v5(0, false);
+        let header = buffer.as_mut_ptr().cast::<AdvLoggerInfoV5>();
+
+        // SAFETY: The buffer contains a valid AdvLoggerInfoV5 header, so mutating header fields is valid.
+        unsafe {
+            (*header).log_buffer_offset = (size_of::<AdvLoggerInfoV5>() as u32) - 1;
+        }
+
+        let address = buffer.as_mut_ptr() as PhysicalAddress;
+        // SAFETY: The buffer structure is valid in memory allocated above.
+        let result = unsafe { AdvancedLog::adopt_memory_log(address) };
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn adopt_memory_log_rejects_log_current_offset_before_buffer_start() {
+        let mut buffer = create_buffer_v5(0, false);
+        let header = buffer.as_mut_ptr().cast::<AdvLoggerInfoV5>();
+
+        // SAFETY: The buffer contains a valid AdvLoggerInfoV5 header, so mutating header fields is valid.
+        unsafe {
+            (*header).log_current_offset.store((*header).log_buffer_offset - 1, Ordering::Relaxed);
+        }
+
+        let address = buffer.as_mut_ptr() as PhysicalAddress;
+        // SAFETY: The buffer structure is valid in memory allocated above.
+        let result = unsafe { AdvancedLog::adopt_memory_log(address) };
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn adopt_memory_log_rejects_log_current_offset_beyond_full_size() {
+        let mut buffer = create_buffer_v5(0, false);
+        let header = buffer.as_mut_ptr().cast::<AdvLoggerInfoV5>();
+
+        // SAFETY: The buffer contains a valid AdvLoggerInfoV5 header, so mutating header fields is valid.
+        unsafe {
+            let full_size = (*header).log_buffer_offset + (*header).log_buffer_size;
+            (*header).log_current_offset.store(full_size + 1, Ordering::Relaxed);
+        }
+
+        let address = buffer.as_mut_ptr() as PhysicalAddress;
+        // SAFETY: The buffer structure is valid in memory allocated above.
+        let result = unsafe { AdvancedLog::adopt_memory_log(address) };
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn open_log_rejects_unknown_version() {
+        let mut buffer = create_buffer_v5(0, false);
+        let header = buffer.as_mut_ptr().cast::<AdvLoggerInfoV5>();
+
+        // SAFETY: The buffer contains a valid AdvLoggerInfoV5 header, so mutating the version field is in-bounds.
+        unsafe {
+            (*header).version = 7;
+        }
+
+        let result = AdvancedLog::open_log(&buffer);
+        assert!(matches!(result, Err(EfiError::Unsupported)));
+    }
+
+    #[test]
+    fn open_log_rejects_log_current_offset_before_buffer_start() {
+        let mut buffer = create_buffer_v5(0, false);
+        let header = buffer.as_mut_ptr().cast::<AdvLoggerInfoV5>();
+
+        // SAFETY: The buffer contains a valid AdvLoggerInfoV5 header, so mutating header fields is valid.
+        unsafe {
+            (*header).log_current_offset.store((*header).log_buffer_offset - 1, Ordering::Relaxed);
+        }
+
+        let result = AdvancedLog::open_log(&buffer);
+        assert!(matches!(result, Err(EfiError::InvalidParameter)));
+    }
+
+    #[test]
+    fn open_log_rejects_log_current_offset_beyond_full_size() {
+        let mut buffer = create_buffer_v5(0, false);
+        let header = buffer.as_mut_ptr().cast::<AdvLoggerInfoV5>();
+
+        // SAFETY: The buffer contains a valid AdvLoggerInfoV5 header, so mutating header fields is valid.
+        unsafe {
+            let full_size = (*header).log_buffer_offset + (*header).log_buffer_size;
+            (*header).log_current_offset.store(full_size + 1, Ordering::Relaxed);
+        }
+
+        let result = AdvancedLog::open_log(&buffer);
+        assert!(matches!(result, Err(EfiError::InvalidParameter)));
+    }
+
+    #[test]
+    fn open_log_rejects_log_buffer_offset_less_than_header_size() {
+        let mut buffer = create_buffer_v5(0, false);
+        let header = buffer.as_mut_ptr().cast::<AdvLoggerInfoV5>();
+
+        // SAFETY: The buffer contains a valid AdvLoggerInfoV5 header, so mutating header fields is valid.
+        unsafe {
+            (*header).log_buffer_offset = (size_of::<AdvLoggerInfoV5>() as u32) - 1;
+        }
+
+        let result = AdvancedLog::open_log(&buffer);
+        assert!(matches!(result, Err(EfiError::InvalidParameter)));
     }
 }


### PR DESCRIPTION
## Description

Support using the v6 logger info structure for the advanced logger.

Previously, only v5 was supported, in this change only v6 is supported. A future change may add support for both.

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

- Verify advanced logger HOB is loaded during initialization
- Dump memory log at EFI shell to verify log contents

## Integration Instructions

- This must be paired with the V6 logger changes in https://github.com/microsoft/mu_plus/pull/826