### PR TITLE
Cargo.toml: Require time crate version 0.3.47 or higher

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,6 +53,7 @@ r-efi = { version = "5.0.0", default-features = false }
 scroll = { version = "0.13", default-features = false, features = ["derive"]}
 spin = { version = "^0.9" }
 syn = { version = "2" }
+time = { version = "0.3.47" }
 uart_16550 = { version = "^0.3.2" }
 uefi_corosensei = { version = "0.1.3", default-features = false }
 uuid = { version = "1.8", default-features = false }


### PR DESCRIPTION
## Description

The following security vulnerability exists in versions 0.3.45 or lower:

```
├ ID: RUSTSEC-2026-0009
├ Advisory: https://rustsec.org/advisories/RUSTSEC-2026-0009
├ ## Impact

  When user-provided input is provided to any type that parses with the RFC 2822 format, a denial of
  service attack via stack exhaustion is possible. The attack relies on formally deprecated and
  rarely-used features that are part of the RFC 2822 format used in a malicious manner. Ordinary,
  non-malicious input will never encounter this scenario.

  ## Patches

  A limit to the depth of recursion was added in v0.3.47. From this version, an error will be returned
  rather than exhausting the stack.

  ## Workarounds

  Limiting the length of user input is the simplest way to avoid stack exhaustion, as the amount of
  the stack consumed would be at most a factor of the length of the input.
├ Announcement: https://github.com/time-rs/time/blob/main/CHANGELOG.md#0347-2026-02-05
```

Comes in through:

```
    ├ time v0.3.45
      └── compile-time v0.2.0
          └── patina_dxe_core v20.0.0
              ├── (dev) patina_adv_logger v20.0.0
              └── (dev) patina_mm v20.0.0
                  └── patina_performance v20.0.0
                      └── patina_dxe_core v20.0.0 (*)
```

Since 0.3.47 is available, this requires that patch version or higher.

---

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

- `cargo update`
- `cargo make deny`

## Integration Instructions

- N/A
