### PR TITLE
Update gic_manager to only initialize the current CPU's redistributor.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ repository = "https://github.com/OpenDevicePartnership/patina"
 
 [workspace.dependencies]
 alloc-no-stdlib = { version = "~2.0" }
-arm-gic = { version = "0.7.1" }
+arm-gic = { version = "0.7.2" }
 safe-mmio = { version = "0.2.5" }
 bitfield-struct = { version = "0.10" }
 brotli-decompressor = { version = "4.0.0", default-features = false }

--- a/core/patina_internal_cpu/src/interrupts/aarch64/gic_manager.rs
+++ b/core/patina_internal_cpu/src/interrupts/aarch64/gic_manager.rs
@@ -155,7 +155,15 @@ impl AArch64InterruptInitializer {
 
         // SAFETY: function safety requirements guarantee exclusive access to the GICR registers.
         let mut gic_v3 = unsafe { GicV3::new(gicd, gicr, r_count, true) };
-        gic_v3.setup(cpu_r_idx);
+
+        // Directly initialize only the current cpu's redistributor and the distributor, as these are the only
+        // components required for the interrupt model under UEFI. On some systems, interacting with the redistributor
+        // instances corresponding to other cores may cause unexpected behavior.
+        gic_v3.init_cpu(cpu_r_idx);
+        gic_v3.redistributor(cpu_r_idx).map_err(|_| EfiError::DeviceError)?.configure_default_settings();
+        gic_v3.distributor().configure_default_settings();
+
+        GicCpuInterface::enable_group1(true);
 
         // Set binary point reg to 0x7 (no preemption)
         // SAFETY: this is a legal value for BPR1 register.


### PR DESCRIPTION
## Description

This change updates the GIC setup to only configure the GIC Redistrubtor associated with the boot core. Previously, the implementation called `gic_v3.setup()`, which attempted to initialize all GIC Redistributor instances. Initializing the Redistributor instances associated with unused cores resulted in instability and is unnecessary for the Patina interrupt model; this also aligns with existing EDK2 ArmGicDxe behavior.

Also opportunistically updates `arm-gic` crate to 0.7.2.

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Boot testing on an arm hardware platform; confirmed GIC initialization and interrupts work as expected.

## Integration Instructions

N/A