### PR TITLE
Update logger integration check to allow for messages that are not utf8-decodable.

### DIFF
--- a/components/patina_adv_logger/src/integration_test.rs
+++ b/components/patina_adv_logger/src/integration_test.rs
@@ -19,6 +19,7 @@ use r_efi::efi;
 
 use crate::{memory_log, protocol::AdvancedLoggerProtocol};
 
+#[coverage(off)]
 #[patina_test]
 fn adv_logger_test(bs: StandardBootServices) -> patina::test::Result {
     const DIRECT_STR: &str = "adv_logger_test: Direct log message!!!";


### PR DESCRIPTION
## Description

Update logger integration check to allow for messages that are not utf8-decodable.

Test will now pass as long as the expected messages generated by the test are present in the log, in the right order, and those messages (ignoring others) are utf8-decodable. 

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [x] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

AdvLogger integration test now passes in the presence of non-UTF8-decodable entries.

## Integration Instructions

N/A