### PR TITLE
Fix ComponentDispatcher TPL level to TPL_APPLICATION

### DIFF
--- a/patina_dxe_core/src/component_dispatcher.rs
+++ b/patina_dxe_core/src/component_dispatcher.rs
@@ -120,9 +120,12 @@ unsafe impl Send for ComponentDispatcher {}
 
 impl ComponentDispatcher {
     /// Creates a new locked ComponentDispatcher.
+    ///
+    /// Uses TPL_APPLICATION so that component entry points can use boot services
+    /// that are restricted at higher TPL levels.
     #[inline(always)]
     pub(crate) const fn new_locked() -> TplMutex<Self> {
-        TplMutex::new(efi::TPL_NOTIFY, Self::new(), "ComponentDispatcher")
+        TplMutex::new(efi::TPL_APPLICATION, Self::new(), "ComponentDispatcher")
     }
 
     /// Creates a new ComponentDispatcher.


### PR DESCRIPTION
## Description

ComponentDispatcher was using TPL_NOTIFY, which prevents component entry points from calling boot services restricted at higher TPL levels. Changed to TPL_APPLICATION.

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Existing tests pass. Verified with QEMU Q35 boot.

## Integration Instructions

N/A