### PR TITLE
Remove resolver = 2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,5 @@
 [workspace]
-resolver = "2"
-
+resolver = "3"
 members = ["components/*", "core/*", "sdk/*", "patina_dxe_core"]
 
 [workspace.package]

--- a/components/patina_adv_logger/Cargo.toml
+++ b/components/patina_adv_logger/Cargo.toml
@@ -1,6 +1,5 @@
 [package]
 name = "patina_adv_logger"
-resolver = "2"
 version.workspace = true
 repository.workspace = true
 license.workspace = true

--- a/components/patina_mm/Cargo.toml
+++ b/components/patina_mm/Cargo.toml
@@ -1,6 +1,5 @@
 [package]
 name = "patina_mm"
-resolver = "2"
 version.workspace = true
 repository.workspace = true
 license.workspace = true

--- a/components/patina_performance/Cargo.toml
+++ b/components/patina_performance/Cargo.toml
@@ -1,6 +1,5 @@
 [package]
 name = "patina_performance"
-resolver = "2"
 version.workspace = true
 repository.workspace = true
 license.workspace = true

--- a/components/patina_samples/Cargo.toml
+++ b/components/patina_samples/Cargo.toml
@@ -1,6 +1,5 @@
 [package]
 name = "patina_samples"
-resolver = "2"
 version.workspace = true
 repository.workspace = true
 license.workspace = true

--- a/core/patina_debugger/Cargo.toml
+++ b/core/patina_debugger/Cargo.toml
@@ -1,6 +1,5 @@
 [package]
 name = "patina_debugger"
-resolver = "2"
 version.workspace = true
 repository.workspace = true
 license.workspace = true

--- a/core/patina_internal_collections/Cargo.toml
+++ b/core/patina_internal_collections/Cargo.toml
@@ -1,6 +1,5 @@
 [package]
 name = "patina_internal_collections"
-resolver = "2"
 version.workspace = true
 repository.workspace = true
 license.workspace = true

--- a/core/patina_internal_cpu/Cargo.toml
+++ b/core/patina_internal_cpu/Cargo.toml
@@ -1,6 +1,5 @@
 [package]
 name = "patina_internal_cpu"
-resolver = "2"
 version.workspace = true
 repository.workspace = true
 license.workspace = true

--- a/core/patina_internal_depex/Cargo.toml
+++ b/core/patina_internal_depex/Cargo.toml
@@ -1,6 +1,5 @@
 [package]
 name = "patina_internal_depex"
-resolver = "2"
 version.workspace = true
 repository.workspace = true
 license.workspace = true

--- a/core/patina_internal_device_path/Cargo.toml
+++ b/core/patina_internal_device_path/Cargo.toml
@@ -1,6 +1,5 @@
 [package]
 name = "patina_internal_device_path"
-resolver = "2"
 version.workspace = true
 repository.workspace = true
 license.workspace = true

--- a/core/patina_stacktrace/Cargo.toml
+++ b/core/patina_stacktrace/Cargo.toml
@@ -1,6 +1,5 @@
 [package]
 name = "patina_stacktrace"
-resolver = "2"
 version.workspace = true
 repository.workspace = true
 license.workspace = true

--- a/docs/src/files/Cargo.toml
+++ b/docs/src/files/Cargo.toml
@@ -1,6 +1,4 @@
 [workspace]
-resolver = "2"
-
 members = [
     "PlatformPkg/PlatformDxeCore",
 ]

--- a/patina_dxe_core/Cargo.toml
+++ b/patina_dxe_core/Cargo.toml
@@ -1,6 +1,5 @@
 [package]
 name = "patina_dxe_core"
-resolver = "2"
 version.workspace = true
 repository.workspace = true
 license.workspace = true

--- a/sdk/patina/Cargo.toml
+++ b/sdk/patina/Cargo.toml
@@ -1,6 +1,5 @@
 [package]
 name = "patina"
-resolver = "2"
 version.workspace = true
 repository.workspace = true
 license.workspace = true

--- a/sdk/patina_ffs/Cargo.toml
+++ b/sdk/patina_ffs/Cargo.toml
@@ -1,6 +1,5 @@
 [package]
 name = "patina_ffs"
-resolver = "2"
 version.workspace = true
 repository.workspace = true
 license.workspace = true

--- a/sdk/patina_ffs_extractors/Cargo.toml
+++ b/sdk/patina_ffs_extractors/Cargo.toml
@@ -1,6 +1,5 @@
 [package]
 name = "patina_ffs_extractors"
-resolver = "2"
 version.workspace = true
 repository.workspace = true
 license.workspace = true

--- a/sdk/patina_macro/Cargo.toml
+++ b/sdk/patina_macro/Cargo.toml
@@ -1,6 +1,5 @@
 [package]
 name = "patina_macro"
-resolver = "2"
 version.workspace = true
 repository.workspace = true
 license.workspace = true


### PR DESCRIPTION
## Description

We are currently setting resolver = 2 in most of our Cargo.tomls, however, Rust edition 2024's default resolver version is 3. We appear to have moved to resolver version 2 in the older Rust edition in order to pick up resolver.incompatible-rust-version=fallback support, but this is also the default in resolver version 3. That line will be removed from config.toml in a patina-devops PR.

This drops the explicit resolver downgrade in all Cargo.tomls except for the top level virtual workspace. This must specify the resolver version because it does not have a package section that specifies the Rust edition to get the default from. This is bumped to 3.

See https://doc.rust-lang.org/cargo/reference/resolver.html#resolver-versions for details.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

N/A.

## Integration Instructions

N/A.
