### PR TITLE
dxe_core: Fix TPL Inversion in initialize_system_table

### DIFF
--- a/patina_dxe_core/src/lib.rs
+++ b/patina_dxe_core/src/lib.rs
@@ -501,8 +501,8 @@ impl<P: PlatformInfo> Core<P> {
         // Instantiate system table.
         systemtables::init_system_table();
 
-        let mut st = systemtables::SYSTEM_TABLE.lock();
-        let st = st.as_mut().expect("System Table not initialized!");
+        let mut st_guard = systemtables::SYSTEM_TABLE.lock();
+        let st = st_guard.as_mut().expect("System Table not initialized!");
 
         allocator::install_memory_services(st);
         gcd::init_paging(self.hob_list());
@@ -532,10 +532,14 @@ impl<P: PlatformInfo> Core<P> {
 
         memory_attributes_table::init_memory_attributes_table_support();
 
-        self.component_dispatcher.lock().set_boot_services(StandardBootServices::new(st.boot_services().as_mut_ptr()));
-        self.component_dispatcher
-            .lock()
-            .set_runtime_services(StandardRuntimeServices::new(st.runtime_services().as_mut_ptr()));
+        // The component dispatcher has a TPL_APPLICATION TPLMutex, so we need to drop the TPL_NOTIFY st_guard before
+        // attempting to unlock the component dispatcher to prevent TPL inversion
+        let boot_services = StandardBootServices::new(st.boot_services().as_mut_ptr());
+        let runtime_services = StandardRuntimeServices::new(st.runtime_services().as_mut_ptr());
+        drop(st_guard);
+
+        self.component_dispatcher.lock().set_boot_services(boot_services);
+        self.component_dispatcher.lock().set_runtime_services(runtime_services);
 
         Ok(())
     }


### PR DESCRIPTION
## Description

Commit e013eee9c4471d13f50c34c901141cb8bc44092e changed the TPLMutex level of the component dispatcher to TPL_APPLICATION instead of TPL_NOTIFY. However, the component dispatcher is invoked when the TPL has been raised to TPL_NOTIFY by the system table lock in patina_dxe_core\lib.rs. This causes a TPL inversion and panics.

This fixes that by dropping the system table lock (lowering the TPL) before attempting to use the component dispatcher.

Fixes #1311 

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Tested by observing the failure on Q35, applying the fix, then booting to Windows.

## Integration Instructions

N/A.
