### PR TITLE
patina_dxe_core: Add debug assert when merge free memory in memory map.

### DIFF
--- a/patina_dxe_core/src/gcd/spin_locked_gcd.rs
+++ b/patina_dxe_core/src/gcd/spin_locked_gcd.rs
@@ -1178,6 +1178,14 @@ impl GCD {
                     && prev.attribute == current.attribute
                     && prev.physical_start + (prev.number_of_pages * UEFI_PAGE_SIZE as u64) == current.physical_start
                 {
+                    // Free memory shouldn't even need to be merged because it should already be consistent and coalesced.
+                    // If this fails to be true it can cause odd behavior if applications try to allocate blocks of free
+                    // memory by address, which is a common pattern for OS loaders.
+                    debug_assert!(
+                        prev.r#type != efi::CONVENTIONAL_MEMORY,
+                        "Free memory is fragmented in memory descriptors!"
+                    );
+
                     // Merge by extending the previous descriptor
                     prev.number_of_pages += current.number_of_pages;
                     continue;


### PR DESCRIPTION
## Description

This commit adds an assert when merging memory descriptors in the memory map for free memory. Conventional memory should already be coalesced and consistent, and if this is not the case then contiguous free memory cannot be allocated contiguously, which can cause issues when allocated memory, especially by address. This is specifically problematic in Windows where almost all allocations are manually selected and allocated by address because it will cause a failure to allocate what looks to be perfectly fine free memory ranges.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Boot to OS on Q35

## Integration Instructions

N/A
