### PR TITLE
StackTrace: AArch64: Add Frame pointer based stack trace support for GCC compiled PE binaries

### DIFF
--- a/core/patina_internal_cpu/src/interrupts/aarch64.rs
+++ b/core/patina_internal_cpu/src/interrupts/aarch64.rs
@@ -9,7 +9,7 @@
 
 use crate::log_registers;
 use patina::{error::EfiError, pi::protocols::cpu_arch::EfiSystemContext};
-use patina_stacktrace::{StackFrame, StackTrace};
+use patina_stacktrace::{StackFrame, StackTrace, error::Error};
 
 #[cfg(target_arch = "aarch64")]
 pub mod gic_manager;
@@ -31,10 +31,27 @@ impl super::EfiSystemContextFactory for ExceptionContextAArch64 {
 impl super::EfiExceptionStackTrace for ExceptionContextAArch64 {
     fn dump_stack_trace(&self) {
         let stack_frame = StackFrame { pc: self.elr, sp: self.sp, fp: self.fp };
-        // SAFETY: Called during exception handling with CPU context registers. The exception context
-        // is considered valid to dump at this time.
-        if let Err(err) = unsafe { StackTrace::dump_with(stack_frame) } {
-            log::error!("StackTrace: {err}");
+        // SAFETY: Called during exception handling with CPU context registers.
+        // The exception context is considered valid to dump at this time.
+        match unsafe { StackTrace::dump_with(stack_frame) } {
+            Ok(_) => (),
+            Err(Error::ExceptionDirectoryNotFound { module }) => {
+                let no_name = "<no module>";
+                let image_name = module.unwrap_or(no_name);
+                log::error!(
+                    "StackTrace: `{image_name}` does not contain an exception directory. Trying fp/lr based stack trace instead."
+                );
+                // SAFETY: Called during exception handling with PC, SP, and FP
+                // captured from the exception context. The frame pointer chain is
+                // walked as a best effort fallback mainly to cater binaries
+                // compiled with the GCC toolchain.
+                if let Err(err) = unsafe { StackTrace::dump_with_fp_chain(stack_frame) } {
+                    log::error!("StackTrace: {err}");
+                }
+            }
+            Err(err) => {
+                log::error!("StackTrace: {err}");
+            }
         }
     }
 

--- a/core/patina_internal_cpu/src/interrupts/aarch64/interrupt_manager.rs
+++ b/core/patina_internal_cpu/src/interrupts/aarch64/interrupt_manager.rs
@@ -14,7 +14,6 @@ use patina::{
     error::EfiError,
 };
 use patina_paging::{PageTable, PagingType};
-use patina_stacktrace::{StackFrame, StackTrace};
 
 use crate::interrupts::{
     EfiExceptionStackTrace, EfiSystemContext, HandlerType, InterruptManager, aarch64::ExceptionContextAArch64,
@@ -196,12 +195,7 @@ extern "efiapi" fn synchronous_exception_handler(_exception_type: isize, context
     log::debug!("Full Context: {aarch64_context:#X?}");
 
     log::error!("Dumping Exception Stack Trace:");
-    let stack_frame = StackFrame { pc: aarch64_context.elr, sp: aarch64_context.sp, fp: aarch64_context.fp };
-    // SAFETY: Called during exception handling with CPU context registers. The exception context
-    // is considered valid to dump at this time.
-    if let Err(err) = unsafe { StackTrace::dump_with(stack_frame) } {
-        log::error!("StackTrace: {err}");
-    }
+    aarch64_context.dump_stack_trace();
 
     panic!("EXCEPTION: Synchronous Exception");
 }

--- a/core/patina_stacktrace/src/lib.rs
+++ b/core/patina_stacktrace/src/lib.rs
@@ -49,8 +49,8 @@
 //!
 //! ## Public API
 //!
-//! The primary public API is the `dump()/dump_with()` function in the
-//! `StackTrace` module.
+//! The primary public API is the `dump()/dump_with()/dump_with_fp_chain()`
+//! function in the `StackTrace` module.
 //!
 //! ```ignore
 //!    /// Dumps the stack trace for the given PC, SP, and FP values.
@@ -96,6 +96,57 @@
 //!    /// 7 0000005E2AEFFD50      0000000000000000       ntdll+75AEC
 //!    /// ```
 //!    pub unsafe fn dump() -> StResult<()>;
+//!
+//!    /// Dumps the stack trace by walking the FP/LR registers, without relying on unwind
+//!    /// information. This is an AArch64-only fallback mechanism.
+//!    ///
+//!    /// For GCC built PE images, .pdata/.xdata sections are not generated, causing stack
+//!    /// trace dumping to fail. In this case, we attempt to dump the stack trace using an
+//!    /// FP/LR register walk with the following limitations:
+//!    ///
+//!    ///  1. Patina binaries produced with LLVM almost always do not save FP/LR register
+//!    ///     pairs as part of the function prologue for non-leaf functions, even though
+//!    ///     the ABI mandates it.
+//!    ///     https://github.com/ARM-software/abi-aa/blob/main/aapcs64/aapcs64.rst#646the-frame-pointer
+//!    ///
+//!    ///  2. Forcing this with the `-C force-frame-pointers=yes` compiler flag can produce
+//!    ///     strange results. In some cases, instead of saving fp/lr using `stp x29, x30,
+//!    ///     [sp, #16]!`, it saves lr/fp using `stp x30, x29, [sp, #16]!`, completely
+//!    ///     breaking the stack walk.
+//!    ///
+//!    ///  3. Due to the above reasons, the stack walk cannot be reliably terminated.
+//!    ///
+//!    /// The only reason this is being introduced is to identify the driver/app causing
+//!    /// the exception. For example, a Shell app built with GCC that triggers an
+//!    /// assertion can still produce a reasonable stack trace.
+//!    ///
+//!    ///  ```text
+//!    /// Dumping stack trace with PC: 000001007AB72ED0, SP: 0000010078885D50, FP: 0000010078885D50
+//!    ///     # Child-SP              Return Address         Call Site
+//!    ///     0 0000010078885D50      000001007AB12770       Shell+66ED0
+//!    ///     1 0000010078885E90      0000010007B98DCC       Shell+6770
+//!    ///     2 0000010078885FF0      0000010007B98E54       qemu_sbsa_dxe_core+18DCC
+//!    ///     3 0000010007FFF4C0      0000010007B98F48       qemu_sbsa_dxe_core+18E54
+//!    ///     4 0000010007FFF800      000001007AF54D08       qemu_sbsa_dxe_core+18F48
+//!    ///     5 0000010007FFFA90      0000010007BAC388       BdsDxe+8D08
+//!    ///     6 0000010007FFFF80      0000000010008878       qemu_sbsa_dxe_core+2C388 --.
+//!    ///                                                                               |
+//!    ///     0:000> u qemu_sbsa_dxe_core!patina_dxe_core::call_bds                     |
+//!    ///     00000000`1002c1b0 f81f0ff3 str x19,[sp,#-0x10]!                           |
+//!    ///     00000000`1002c1b4 f90007fe str lr,[sp,#8]     <---------------------------'
+//!    ///     00000000`1002c1b8 d10183ff sub sp,sp,#0x60
+//!    ///
+//!    ///     The FP is not saved, so the return address in frame #6 is garbage.
+//!    /// ```
+//!    /// Symbol to source file resolution(Resolving #2 frame):
+//!    /// Since some modules in the stack trace are built with GCC and do not generate PDB
+//!    /// files, their symbols must be resolved manually as shown below.
+//!    /// ```text
+//!    /// $ addr2line -e Shell.debug -f -C 0x6770
+//!    /// UefiMain
+//!    /// ~/repos/patina-qemu/MU_BASECORE/ShellPkg/Application/Shell/Shell.c:372
+//!    /// ```
+//!    pub unsafe fn dump_with_fp_chain(_stack_frame: StackFrame) -> StResult<()>
 //! ```
 //!
 //! ## API usage

--- a/core/patina_stacktrace/src/pe.rs
+++ b/core/patina_stacktrace/src/pe.rs
@@ -23,8 +23,10 @@ const DEBUG_RECORD_RVA_OFFSET: usize = 0x14;
 const DEBUG_RECORD_SIZE: usize = 0x10;
 const DEBUG_RECORD_TYPE_OFFSET: usize = 0xC;
 const DEBUG_RECORD_TYPE_CODEVIEW: u32 = 0x2; // 2 => The Visual C++ debug information.
+const CODEVIEW_SIGNATURE_NB10: u32 = 0x3031_424E; // NB10
 const CODEVIEW_PDB70_SIGNATURE: u32 = 0x5344_5352; // RSDS
-const CODEVIEW_PDB_FILE_NAME_OFFSET: usize = 0x18;
+const CODEVIEW_NB10_FILE_NAME_OFFSET: usize = 0x10;
+const CODEVIEW_PDB70_FILE_NAME_OFFSET: usize = 0x18;
 
 /// Provides in-memory PE file parsing utilities.
 #[derive(Clone)]
@@ -170,17 +172,21 @@ impl PE<'_> {
         // SAFETY: `debug_data` is within the caller-provided PE image and points to
         // the beginning of the CodeView structure.
         let codeview_signature = unsafe { *(debug_data as *const u32) };
-        if codeview_signature != CODEVIEW_PDB70_SIGNATURE {
-            return None;
-        }
+
+        // Determine the file name offset based on the CodeView format
+        let file_name_offset = match codeview_signature {
+            CODEVIEW_SIGNATURE_NB10 => CODEVIEW_NB10_FILE_NAME_OFFSET,
+            CODEVIEW_PDB70_SIGNATURE => CODEVIEW_PDB70_FILE_NAME_OFFSET,
+            _ => return None, // Unsupported CodeView format
+        };
 
         // Extract the PDB file path.
         // SAFETY: The caller guarantees that the CodeView record, including the
-        // file-name payload, is fully mapped and readable.
+        // file name payload, is fully mapped and readable.
         let file_name_bytes = unsafe {
             core::slice::from_raw_parts(
-                (debug_data + CODEVIEW_PDB_FILE_NAME_OFFSET as u64) as *const u8,
-                debug_data_size as usize - CODEVIEW_PDB_FILE_NAME_OFFSET,
+                (debug_data + file_name_offset as u64) as *const u8,
+                debug_data_size as usize - file_name_offset,
             )
         };
 
@@ -188,9 +194,11 @@ impl PE<'_> {
         let Ok(file_name) = core::str::from_utf8(file_name_bytes) else {
             return None;
         };
-        if let Some(file_name_with_ext) = file_name.rsplit('\\').next()
-            && let Some((file_name, _ext)) = file_name_with_ext.rsplit_once('.')
-        {
+
+        // Handle both Windows (\) and Linux (/) path separators
+        let file_name_with_ext = file_name.rsplit(['\\', '/']).next().unwrap_or(file_name);
+
+        if let Some((file_name, _ext)) = file_name_with_ext.rsplit_once('.') {
             return Some(file_name);
         }
 
@@ -287,7 +295,7 @@ mod tests {
 
         // Insert a fake PDB path (RSDS... + "C:\\path\\app.exe\0")
         let fake_pdb_path = b"C:\\path\\app.exe\0";
-        let name_off = debug_data_offset + CODEVIEW_PDB_FILE_NAME_OFFSET;
+        let name_off = debug_data_offset + CODEVIEW_PDB70_FILE_NAME_OFFSET;
         bytes[name_off..name_off + fake_pdb_path.len()].copy_from_slice(fake_pdb_path);
 
         bytes
@@ -325,5 +333,24 @@ mod tests {
         // SAFETY: Test creates a fake PE image with corrupted signature for validation.
         let image_name = unsafe { PE::get_image_name(base, 0x400, 0x1C) };
         assert_eq!(image_name, None);
+    }
+
+    #[test]
+    fn test_get_image_name_nb10_signature() {
+        let mut bytes = make_fake_pe_image();
+        let base = bytes.as_ptr() as u64;
+
+        // Overwrite the CodeView signature with NB10.
+        let debug_data_offset = 0x800usize;
+        bytes[debug_data_offset..debug_data_offset + 4].copy_from_slice(&CODEVIEW_SIGNATURE_NB10.to_le_bytes());
+
+        // Write a fake PDB path at the NB10 file name offset (0x10).
+        let fake_pdb_path = b"/home/build/driver.dll\0";
+        let name_off = debug_data_offset + CODEVIEW_NB10_FILE_NAME_OFFSET;
+        bytes[name_off..name_off + fake_pdb_path.len()].copy_from_slice(fake_pdb_path);
+
+        // SAFETY: Test creates a fake PE image with NB10 CodeView signature for validation.
+        let image_name = unsafe { PE::get_image_name(base, 0x400, 0x1C) };
+        assert_eq!(image_name, Some("driver"));
     }
 }

--- a/core/patina_stacktrace/src/stacktrace.rs
+++ b/core/patina_stacktrace/src/stacktrace.rs
@@ -7,6 +7,7 @@ use core::{
 cfg_if::cfg_if! {
     if #[cfg(all(target_os = "uefi", target_arch = "aarch64"))] {
         use crate::aarch64::runtime_function::RuntimeFunction;
+        use crate::byte_reader::read_pointer64;
     } else {
         use crate::x64::runtime_function::RuntimeFunction;
     }
@@ -185,6 +186,107 @@ impl StackTrace {
         // SAFETY: `stack_frame` originates from trusted register snapshots; all
         // invariants for `dump_with` are upheld locally before forwarding.
         unsafe { StackTrace::dump_with(stack_frame) }
+    }
+
+    /// Dumps the stack trace by walking the FP/LR registers, without relying on unwind
+    /// information. This is an AArch64-only fallback mechanism.
+    ///
+    /// # Safety
+    ///
+    /// For GCC built PE images, .pdata/.xdata sections are not generated, causing stack
+    /// trace dumping to fail. In this case, we attempt to dump the stack trace using an
+    /// FP/LR register walk with the following limitations:
+    ///
+    ///  1. Patina binaries produced with LLVM almost always do not save FP/LR register
+    ///     pairs as part of the function prologue for non-leaf functions, even though
+    ///     the ABI mandates it.
+    ///     <https://github.com/ARM-software/abi-aa/blob/main/aapcs64/aapcs64.rst#646the-frame-pointer>
+    ///
+    ///  2. Forcing this with the `-C force-frame-pointers=yes` compiler flag can produce
+    ///     strange results. In some cases, instead of saving fp/lr using `stp x29, x30,
+    ///     [sp, #16]!`, it saves lr/fp using `stp x30, x29, [sp, #16]!`, completely
+    ///     breaking the stack walk.
+    ///
+    ///  3. Due to the above reasons, the stack walk cannot be reliably terminated.
+    ///
+    /// The only reason this is being introduced is to identify the driver/app causing
+    /// the exception. For example, a Shell app built with GCC that triggers an
+    /// assertion can still produce a reasonable stack trace.
+    ///
+    ///  ```text
+    /// Dumping stack trace with PC: 000001007AB72ED0, SP: 0000010078885D50, FP: 0000010078885D50
+    ///     # Child-SP              Return Address         Call Site
+    ///     0 0000010078885D50      000001007AB12770       Shell+66ED0
+    ///     1 0000010078885E90      0000010007B98DCC       Shell+6770
+    ///     2 0000010078885FF0      0000010007B98E54       qemu_sbsa_dxe_core+18DCC
+    ///     3 0000010007FFF4C0      0000010007B98F48       qemu_sbsa_dxe_core+18E54
+    ///     4 0000010007FFF800      000001007AF54D08       qemu_sbsa_dxe_core+18F48
+    ///     5 0000010007FFFA90      0000010007BAC388       BdsDxe+8D08
+    ///     6 0000010007FFFF80      0000000010008878       qemu_sbsa_dxe_core+2C388 --.
+    ///                                                                               |
+    ///     0:000> u qemu_sbsa_dxe_core!patina_dxe_core::call_bds                     |
+    ///     00000000`1002c1b0 f81f0ff3 str x19,[sp,#-0x10]!                           |
+    ///     00000000`1002c1b4 f90007fe str lr,[sp,#8]     <---------------------------'
+    ///     00000000`1002c1b8 d10183ff sub sp,sp,#0x60
+    ///
+    ///     The FP is not saved, so the return address in frame #6 is garbage.
+    /// ```
+    /// Symbol to source file resolution(Resolving #2 frame):
+    /// Since some modules in the stack trace are built with GCC and do not generate PDB
+    /// files, their symbols must be resolved manually as shown below.
+    /// ```text
+    /// $ addr2line -e Shell.debug -f -C 0x6770
+    /// UefiMain
+    /// ~/repos/patina-qemu/MU_BASECORE/ShellPkg/Application/Shell/Shell.c:372
+    /// ```
+    #[coverage(off)]
+    #[inline(never)]
+    pub unsafe fn dump_with_fp_chain(_stack_frame: StackFrame) -> StResult<()> {
+        cfg_if::cfg_if! {
+            if #[cfg(all(target_os = "uefi", target_arch = "aarch64"))] {
+                log::warn!("Dumping stack trace with fp chain for {}", _stack_frame);
+                log::warn!("Use `addr2line -e <.debug file> -f -C <offset>` to resolve offset to source lines");
+                log::warn!("      # Child-SP              Return Address         Call Site");
+
+                let mut i = 0;
+                let mut fp = _stack_frame.fp;
+                let mut pc = _stack_frame.pc; // start with PC/elr
+                loop {
+                    let no_name = "<no module>";
+
+                    // SAFETY: The caller of `dump_with_fp_chain` supplies a
+                    // valid PC captured from a live stack frame. We rely on
+                    // that guarantee to probe memory for the surrounding PE
+                    // image without triggering undefined behavior.
+                    let image = unsafe { PE::locate_image(pc) }?;
+                    log::debug!("{image}");
+
+                    let pc_rva = pc - image.base_address;
+                    let image_name = image.image_name.unwrap_or(no_name);
+
+                    // SAFETY: The assumption here is that the stack frame
+                    // layout is as follows: [fp] [lr] are saved on the stack in
+                    // that order, typically via stp x29, x30, [sp, #-16]!
+                    let prev_pc = unsafe { read_pointer64(fp + 8).unwrap() }; // deref lr
+                    let prev_fp = unsafe { read_pointer64(fp).unwrap() };
+                    log::warn!("     {i:>2} {:016X}      {:016X}       {image_name}+{pc_rva:X}", fp, prev_pc);
+
+                    pc = prev_pc;
+                    fp = prev_fp;
+
+                    if fp == 0 {
+                        log::warn!("Finished dumping stack trace");
+                        break;
+                    }
+
+                    i += 1;
+                }
+            } else {
+                log::error!("FP/LR register walk stack trace dumping is only supported on AArch64.");
+            }
+        }
+
+        Ok(())
     }
 }
 

--- a/core/patina_stacktrace/src/stacktrace.rs
+++ b/core/patina_stacktrace/src/stacktrace.rs
@@ -251,6 +251,7 @@ impl StackTrace {
                 let mut i = 0;
                 let mut fp = _stack_frame.fp;
                 let mut pc = _stack_frame.pc; // start with PC/elr
+                const MAX_FRAME_COUNT: usize = 20;
                 loop {
                     let no_name = "<no module>";
 
@@ -267,9 +268,14 @@ impl StackTrace {
                     // SAFETY: The assumption here is that the stack frame
                     // layout is as follows: [fp] [lr] are saved on the stack in
                     // that order, typically via stp x29, x30, [sp, #-16]!
-                    let prev_pc = unsafe { read_pointer64(fp + 8).unwrap() }; // deref lr
-                    let prev_fp = unsafe { read_pointer64(fp).unwrap() };
+                    let prev_pc = unsafe { read_pointer64(fp + 8)? }; // deref lr
+                    let prev_fp = unsafe { read_pointer64(fp)? };
                     log::warn!("     {i:>2} {:016X}      {:016X}       {image_name}+{pc_rva:X}", fp, prev_pc);
+
+                    if fp == prev_fp {
+                        log::error!("FP didn't change. Possible stack corruption detected. Stopping stack trace.");
+                        break;
+                    }
 
                     pc = prev_pc;
                     fp = prev_fp;
@@ -280,6 +286,11 @@ impl StackTrace {
                     }
 
                     i += 1;
+
+                    if i > MAX_FRAME_COUNT {
+                        log::error!("Frame count exceeded {}. Possible stack corruption detected. Stopping stack trace.", MAX_FRAME_COUNT);
+                        break;
+                    }
                 }
             } else {
                 log::error!("FP/LR register walk stack trace dumping is only supported on AArch64.");


### PR DESCRIPTION
## Description

Dumps the stack trace by walking the FP/LR registers, without relying on unwind information. This is an AArch64-only fallback mechanism.

For GCC built PE images, .pdata/.xdata sections are not generated, causing stack trace dumping to fail. In this case, we attempt to dump the stack trace using an FP/LR register walk with the following limitations:

1. Patina binaries produced with LLVM almost always do not save FP/LR register pairs as part of the function prologue for non-leaf functions, even though the ABI mandates it. https://github.com/ARM-software/abi-aa/blob/main/aapcs64/aapcs64.rst#646the-frame-pointer

2. Forcing this with the `-C force-frame-pointers=yes` compiler flag can produce strange results. In some cases, instead of saving fp/lr using `stp x29, x30, [sp, #16]!`, it saves lr/fp using `stp x30, x29, [sp, #16]!`, completely breaking the stack walk. https://godbolt.org/z/7s9fG9vWe

3. Due to the above reasons, the stack walk cannot be reliably terminated.

The only reason this is being introduced is to identify the driver/app causing the exception. For example, a Shell app built with GCC that triggers an assertion can still produce a reasonable stack trace.

```text
Dumping stack trace with PC: 000001007AB72ED0, SP: 0000010078885D50, FP: 0000010078885D50
    # Child-SP              Return Address         Call Site
    0 0000010078885D50      000001007AB12770       Shell+66ED0
    1 0000010078885E90      0000010007B98DCC       Shell+6770
    2 0000010078885FF0      0000010007B98E54       qemu_sbsa_dxe_core+18DCC
    3 0000010007FFF4C0      0000010007B98F48       qemu_sbsa_dxe_core+18E54
    4 0000010007FFF800      000001007AF54D08       qemu_sbsa_dxe_core+18F48
    5 0000010007FFFA90      0000010007BAC388       BdsDxe+8D08
    6 0000010007FFFF80      0000000010008878       qemu_sbsa_dxe_core+2C388 --.
                                                                              |
    0:000> u qemu_sbsa_dxe_core!patina_dxe_core::call_bds                     |
    00000000`1002c1b0 f81f0ff3 str x19,[sp,#-0x10]!                           |
    00000000`1002c1b4 f90007fe str lr,[sp,#8]     <---------------------------'
    00000000`1002c1b8 d10183ff sub sp,sp,#0x60

    The FP is not saved, so the return address in frame #6 is garbage.
```
Symbol to source file resolution(Resolving frame 2): Since some modules in the stack trace are built with GCC and do not generate PDB files, their symbols must be resolved manually as shown below.
```text
$ addr2line -e Shell.debug -f -C 0x6770
UefiMain
~/repos/patina-qemu/MU_BASECORE/ShellPkg/Application/Shell/Shell.c:372

   371:  ASSERT (FALSE);
 > 372:  Status = gST->ConOut->ClearScreen (gST->ConOut);
   373:  if (EFI_ERROR (Status)) {
   374:     return (Status);
   375:  }
```

---

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Validated on SBSA Q35.

## Integration Instructions

The change is already hooked into the exception handler for AArch64.