### PR TITLE
patina_dxe_core: Leak hobs buffer in create_dxe_core_hob()

### DIFF
--- a/patina_dxe_core/src/pi_dispatcher/image.rs
+++ b/patina_dxe_core/src/pi_dispatcher/image.rs
@@ -3308,6 +3308,8 @@ mod tests {
             )
         });
 
+        let hobs = hobs.leak();
+
         let mut hob_list = HobList::new();
         hob_list.discover_hobs(hobs.as_ptr() as *mut c_void);
 


### PR DESCRIPTION
## Description

The `create_dxe_core_hob()` test helper in `image.rs` constructs a `Vec<u8>` containing HOB data, then passes the buffer pointer to `HobList::discover_hobs()`.

When `create_dxe_core_hob()` returned, the `Vec` was dropped and its memory freed, leaving the returned `HobList<'static>` holding dangling references.

When `PI_DISPATCHER.init()` later iterated the `HobList` during `install_dxe_core_image()`, it read from freed memory, causing non-deterministic behavior.

The freed memory may not always be immediately reused by the allocator, the point where it became an issue could vary.

This change leaks the `Vec` before calling `discover_hobs()`, so that the memory buffer lives for a `'static` lifetime and the references in `HobList` remain valid.

Looks to be related to a refactor in f9fd281b where HOB logic was consolidated from local test functions into `create_dxe_core_hob()`.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

- `cargo make all`
- Run unit tests on fork
  - Before changes: `ubuntu-latest` passed 1/5 times
  - After changes: `ubuntu-latest` passed 10/10 times

## Integration Instructions

- N/A