### PR TITLE
patina_adv_logger: Refactor core logic from component logic

### DIFF
--- a/components/patina_adv_logger/Cargo.toml
+++ b/components/patina_adv_logger/Cargo.toml
@@ -31,5 +31,8 @@ clap = { workspace = true, features = ['derive'], optional = true }
 patina_dxe_core = { path = "../../patina_dxe_core" }
 
 [features]
-default = []
-std = ['clap']
+alloc = []
+reader = []
+component = ['alloc', 'reader']
+std = ['clap', 'alloc', 'reader']
+default = ['component']

--- a/components/patina_adv_logger/src/integration_test.rs
+++ b/components/patina_adv_logger/src/integration_test.rs
@@ -17,7 +17,7 @@ use patina::{
 };
 use r_efi::efi;
 
-use crate::{memory_log, protocol::AdvancedLoggerProtocol};
+use crate::{memory_log, protocol::AdvancedLoggerProtocol, reader::AdvancedLogReader};
 
 #[coverage(off)]
 #[patina_test]
@@ -56,7 +56,7 @@ fn adv_logger_test(bs: StandardBootServices) -> patina::test::Result {
     // Check that the strings were added to the log.
     // SAFETY: We know this memory is safe and well structure as we just created it
     //         using the counterpart functions.
-    let log = unsafe { memory_log::AdvancedLog::adopt_memory_log(protocol.log_info) };
+    let log = unsafe { AdvancedLogReader::from_address(protocol.log_info) };
     u_assert!(log.is_some(), "adv_logger_test: Failed to adopt the memory log.");
     let log_info = log.unwrap();
     let mut direct_found = false;

--- a/components/patina_adv_logger/src/lib.rs
+++ b/components/patina_adv_logger/src/lib.rs
@@ -7,14 +7,23 @@
 #![cfg_attr(all(not(feature = "std"), not(doc)), no_std)]
 #![feature(coverage_attribute)]
 
+#[cfg(any(feature = "alloc", test, doc))]
 extern crate alloc;
 
-pub mod component;
+mod memory_log;
+mod writer;
+
 pub mod logger;
+
+#[cfg(any(doc, feature = "reader"))]
+pub mod reader;
+
+#[cfg(any(doc, feature = "component"))]
+pub mod component;
+#[cfg(feature = "component")]
+mod integration_test;
+#[cfg(any(doc, feature = "component"))]
 pub mod protocol;
 
 #[cfg(any(doc, feature = "std"))]
 pub mod parser;
-
-mod integration_test;
-mod memory_log;

--- a/components/patina_adv_logger/src/logger.rs
+++ b/components/patina_adv_logger/src/logger.rs
@@ -9,7 +9,10 @@
 //!
 //! SPDX-License-Identifier: Apache-2.0
 //!
-use crate::memory_log::{self, AdvancedLog, LogEntry};
+use crate::{
+    memory_log::{self, LogEntry},
+    writer::AdvancedLogWriter,
+};
 use core::{ffi::c_void, marker::Send, ptr};
 use log::Level;
 use patina::{
@@ -35,7 +38,7 @@ where
     target_filters: &'a [(&'a str, log::LevelFilter)],
     max_level: log::LevelFilter,
     format: Format,
-    memory_log: RwLock<Option<AdvancedLog<'static>>>,
+    memory_log: RwLock<Option<AdvancedLogWriter>>,
     pub(crate) timer: Service<dyn ArchTimerFunctionality>,
 }
 
@@ -143,8 +146,8 @@ where
             }
         }
 
-        // SAFETY: The caller must ensure the address is valid for an AdvancedLog type.
-        if let Some(log) = unsafe { AdvancedLog::adopt_memory_log(address) } {
+        // SAFETY: The caller must ensure the address is valid for an AdvancedLogWriter type.
+        if let Some(log) = unsafe { AdvancedLogWriter::adopt_memory_log(address) } {
             let current_frequency = log.get_frequency();
 
             {
@@ -174,6 +177,7 @@ where
         }
     }
 
+    #[allow(dead_code)]
     pub(crate) fn get_log_address(&self) -> Option<efi::PhysicalAddress> {
         let log_guard = self.memory_log.read();
         log_guard.as_ref().map(|log| log.get_address())
@@ -310,10 +314,7 @@ mod tests {
     };
     use r_efi::efi;
 
-    use crate::{
-        logger::AdvancedLogger,
-        memory_log::{self, AdvancedLog},
-    };
+    use crate::{logger::AdvancedLogger, memory_log, writer::AdvancedLogWriter};
 
     #[derive(IntoService)]
     #[service(dyn ArchTimerFunctionality)]
@@ -364,7 +365,7 @@ mod tests {
         // initialize the log so it's valid for the hob list
         //
         // SAFETY: We just allocated this memory so it's valid.
-        unsafe { AdvancedLog::initialize_memory_log(log_address, LOG_LEN as u32) };
+        unsafe { AdvancedLogWriter::initialize_memory_log(log_address, LOG_LEN as u32) };
 
         const HOB_LEN: usize = size_of::<GuidHob>() + size_of::<efi::PhysicalAddress>();
         let hob_buff = Box::into_raw(Box::new([0_u8; HOB_LEN]));

--- a/components/patina_adv_logger/src/memory_log.rs
+++ b/components/patina_adv_logger/src/memory_log.rs
@@ -1,7 +1,6 @@
 //! UEFI Advanced Logger Memory Log Support
 //!
-//! This module provides a definitions and routines to access a Advanced Logger
-//! memory log structure.
+//! This module provides definitions for core Advanced Logger memory log structures.
 //!
 //! ## License
 //!
@@ -9,10 +8,13 @@
 //!
 //! SPDX-License-Identifier: Apache-2.0
 //!
+
+// This file contains core structures used by different modules for interacting with the advanced logger. Different feature
+// sets will use different functions. For this reason, allow unused code in this module.
+#![allow(dead_code)]
+
 use core::{
-    cell::UnsafeCell,
     mem::size_of,
-    ptr, slice,
     sync::atomic::{AtomicU32, AtomicU64, Ordering},
 };
 use patina::{
@@ -20,7 +22,6 @@ use patina::{
     error::{EfiError, Result},
 };
 use r_efi::efi;
-use zerocopy::{FromBytes, IntoBytes};
 use zerocopy_derive::*;
 
 // { 0x4d60cfb5, 0xf481, 0x4a98, {0x9c, 0x81, 0xbf, 0xf8, 0x64, 0x60, 0xc4, 0x3e }}
@@ -57,197 +58,6 @@ impl<'a> LogEntry<'a> {
     }
 }
 
-/// This struct represents an advanced logger memory log. It contains the appropriate
-/// pointers and interior mutability to allow for safe access to the log data. This
-/// serves as the idiomatic rust container for the C based structures.
-pub struct AdvancedLog<'a> {
-    /// The header of the memory log.
-    pub(crate) header: AdvLoggerInfoRef<'a>,
-    /// The data portion of the memory log.
-    data: LogData<'a>,
-}
-
-// SAFETY: The only interior mutability is the UnsafeCell for the data region of
-//         the log. Safety here is checked by the allocation logic in add_log_entry
-//         which relies on atomics to safely allocate portions of the buffer.
-unsafe impl Send for AdvancedLog<'static> {}
-// SAFETY: See the Send safety comment
-unsafe impl Sync for AdvancedLog<'static> {}
-
-impl AdvancedLog<'static> {
-    /// Initializes a `AdvancedLog` from an existing advanced logger buffer at the
-    /// provided address. The caller must ensure that this memory is accessible.
-    ///
-    /// ### Safety
-    ///
-    /// This function assumes that the provided address points to a valid `AdvLoggerInfo`
-    /// structure and that the memory is properly sized initialized based on the
-    /// information in that structure.
-    pub unsafe fn adopt_memory_log(address: efi::PhysicalAddress) -> Option<Self> {
-        // SAFETY: The safety requirements for this function transfer to the function called here.
-        let header = unsafe { AdvLoggerInfoRef::from_address(address)? };
-        let data_size = header.log_buffer_size();
-        let data_start = (address + header.log_buffer_offset() as u64) as *mut u8;
-        // SAFETY: The caller must ensure that the memory is properly sized and initialized
-        // per the safety contract of this function. from_address() validates the signature
-        // and version in the header.
-        let data = unsafe { slice::from_raw_parts_mut(data_start, data_size as usize) };
-
-        Some(Self { header, data: LogData::ReadWrite(UnsafeCell::from_mut(data)) })
-    }
-
-    // Allow unused as it is used in tests and intended for future general use.
-    #[allow(dead_code)]
-    /// Initializes a new Advanced Log buffer at the provided address with the
-    /// specified length.
-    ///
-    /// ### Safety
-    ///
-    /// The caller is responsible for ensuring that the provided address is appropriately
-    /// allocated and accessible.
-    pub unsafe fn initialize_memory_log(address: efi::PhysicalAddress, length: u32) -> Option<Self> {
-        if length < size_of::<AdvLoggerInfo>() as u32
-            || !address.is_multiple_of(core::mem::align_of::<AdvLoggerInfo>() as u64)
-        {
-            return None;
-        }
-
-        let header = address as *mut AdvLoggerInfo;
-        if header.is_null() {
-            None
-        } else {
-            // SAFETY: The caller should ensure that the address is valid and
-            //         that the memory is writable.
-            unsafe { ptr::write(header, AdvLoggerInfo::new(length, false, 0, 0, efi::Time::default(), 0)) };
-
-            // SAFETY: The header is now initialized, so we can safely create the
-            //         AdvancedLog instance.
-            unsafe { Self::adopt_memory_log(address) }
-        }
-    }
-}
-
-impl<'a> AdvancedLog<'a> {
-    // Only used in the parser which is not always compiled.
-    #[allow(dead_code)]
-    pub fn open_log(log_bytes: &'a [u8]) -> Result<Self> {
-        let header = AdvLoggerInfoRef::from_bytes(log_bytes)?;
-
-        // Check that the various pointers are consistent.
-        let log_current = header.log_current_offset().load(Ordering::Relaxed);
-        if log_current < header.log_buffer_offset()
-            || log_current > header.full_size()
-            || header.log_buffer_offset() < header.header_size() as u32
-        {
-            return Err(EfiError::InvalidParameter);
-        }
-
-        // Only require that the valid portion of the log buffer be present.
-        if log_current > log_bytes.len() as u32 {
-            return Err(EfiError::BufferTooSmall);
-        }
-
-        let (_, data_slice) = log_bytes.split_at(header.log_buffer_offset() as usize);
-
-        Ok(Self { header, data: LogData::ReadOnly(data_slice) })
-    }
-
-    pub fn add_log_entry(&self, log_entry: LogEntry) -> Result<()> {
-        // Adding a log entry consists of two steps:
-        // 1. Atomically allocate space in the log buffer. This must be done before
-        //    writing the log entry to ensure that no other system can write to the
-        //    same space in the log buffer.
-        // 2. Write the log entry to the allocated space in the log buffer.
-        //
-
-        // Get the total size of the long entry with the header, including the
-        // alignment padding for 8 byte alignment.
-        let data_offset = size_of::<AdvLoggerMessageEntry>() as u16;
-        let unaligned_size = data_offset as u32 + log_entry.data.len() as u32;
-        let message_size = align_up(unaligned_size, 8).unwrap() as u32;
-
-        // try to swap in the updated value. if this grows beyond the buffer, fall out.
-        // Using relaxed here as we only want the atomic swap and are not concerned
-        // with ordering. The loop should still use the atomic swap and update each
-        // iteration.
-        let mut current_offset = self.header.log_current_offset().load(Ordering::Relaxed);
-        while current_offset + message_size <= self.header.full_size() {
-            match self.header.log_current_offset().compare_exchange(
-                current_offset,
-                current_offset + message_size,
-                Ordering::Relaxed,
-                Ordering::Relaxed,
-            ) {
-                Ok(_) => break,
-                Err(val) => current_offset = val,
-            }
-        }
-
-        // check if we fell out of bounds.
-        if current_offset + message_size > self.header.full_size() {
-            // Add the discarded value. No ordering needed as this is a single
-            // operation.
-            self.header.discarded_size().fetch_add(message_size, Ordering::Relaxed);
-            return Err(EfiError::OutOfResources);
-        }
-
-        let data_index = (current_offset - self.header.log_buffer_offset()) as usize;
-
-        // SAFETY: The space hase been allocated. It should now be safe to write
-        // data so long as it sticks to the range of the allocated entry. Get only
-        // the allocated slice to maintain safety.
-        let entry_slice = unsafe {
-            let data: *mut [u8] = self.data.get_mut()?;
-            (&mut *data).get_mut(data_index..data_index + message_size as usize).ok_or(EfiError::BufferTooSmall)?
-        };
-
-        let (header_slice, entry_slice) = entry_slice.split_at_mut(size_of::<AdvLoggerMessageEntry>());
-        let (data_slice, remainder_slice) = entry_slice.split_at_mut(log_entry.data.len());
-
-        AdvLoggerMessageEntry::from_log_entry(&log_entry)
-            .write_to(header_slice)
-            .map_err(|_| EfiError::BufferTooSmall)?;
-
-        log_entry.data.write_to(data_slice).map_err(|_| EfiError::BufferTooSmall)?;
-        remainder_slice.fill(0);
-
-        Ok(())
-    }
-
-    pub fn hardware_write_enabled(&self, level: u32) -> bool {
-        !self.header.hw_port_disabled() && (level & self.header.hw_print_level() != 0)
-    }
-
-    pub fn iter(&self) -> AdvLogIterator<'_> {
-        AdvLogIterator::new(self)
-    }
-
-    pub fn get_frequency(&self) -> u64 {
-        self.header.timer_frequency().load(Ordering::Relaxed)
-    }
-
-    pub fn set_frequency(&self, frequency: u64) {
-        // try to swap, assuming the value it initially 0. If this fails, just continue.
-        let _ = self.header.timer_frequency().compare_exchange(0, frequency, Ordering::Relaxed, Ordering::Relaxed);
-    }
-
-    pub fn get_address(&self) -> efi::PhysicalAddress {
-        self.header.as_ptr() as efi::PhysicalAddress
-    }
-
-    pub fn get_new_logger_info_address(&self) -> Option<efi::PhysicalAddress> {
-        self.header
-            .new_logger_info_address()
-            .and_then(|address| if address == 0 { None } else { Some(address as efi::PhysicalAddress) })
-    }
-
-    // Allow unused as it is used in tests and intended for future general use.
-    #[allow(dead_code)]
-    pub fn discarded_size(&self) -> u32 {
-        self.header.discarded_size().load(Ordering::Relaxed)
-    }
-}
-
 /// Implementation of the C struct ADVANCED_LOGGER_INFO for tracking in-memory
 /// logging structure for Advanced Logger.
 #[derive(Debug)]
@@ -256,19 +66,19 @@ pub(crate) struct AdvLoggerInfoV5 {
     /// Signature 'ALOG'
     signature: u32,
     /// Current Version
-    version: u16,
+    pub(crate) version: u16,
     /// Reserved for future
     reserved1: [u16; 3],
     /// Offset from LoggerInfo to start of log, expected to be the size of this structure 8 byte aligned
-    log_buffer_offset: u32,
+    pub(crate) log_buffer_offset: u32,
     /// Reserved for future
     reserved2: u32,
     /// Offset from LoggerInfo to where to store next log entry.
-    log_current_offset: AtomicU32,
+    pub(crate) log_current_offset: AtomicU32,
     /// Number of bytes of messages missed
     discarded_size: AtomicU32,
     /// Size of allocated buffer
-    log_buffer_size: u32,
+    pub(crate) log_buffer_size: u32,
     /// Log in permanent RAM
     in_permanent_ram: bool,
     /// After ExitBootServices
@@ -297,12 +107,12 @@ pub(crate) struct AdvLoggerInfoV5 {
 #[derive(Debug)]
 #[repr(C)]
 pub(crate) struct AdvLoggerInfoV6 {
-    v5: AdvLoggerInfoV5,
+    pub(crate) v5: AdvLoggerInfoV5,
     /// The address for a new logger info structure if it has been migrated
     new_logger_info_address: u64,
 }
 
-type AdvLoggerInfo = AdvLoggerInfoV6;
+pub(crate) type AdvLoggerInfo = AdvLoggerInfoV6;
 
 impl AdvLoggerInfo {
     /// Signature for the AdvLoggerInfo structure.
@@ -311,7 +121,7 @@ impl AdvLoggerInfo {
     /// Version of the current AdvLoggerInfo structure.
     pub const VERSION: u16 = ADV_LOGGER_INFO_VERSION_V6;
 
-    fn new(
+    pub fn new(
         log_buffer_size: u32,
         hw_port_disabled: bool,
         timer_frequency: u64,
@@ -370,7 +180,7 @@ impl<'a> AdvLoggerInfoRef<'a> {
     ///
     /// The caller must ensure `address` is readable and points to a valid
     /// `AdvLoggerInfo` header.
-    unsafe fn from_address(address: efi::PhysicalAddress) -> Option<Self> {
+    pub unsafe fn from_address(address: efi::PhysicalAddress) -> Option<Self> {
         let log_info = address as *const AdvLoggerInfoV5;
 
         // SAFETY: The caller must ensure that the address is valid and
@@ -413,7 +223,7 @@ impl<'a> AdvLoggerInfoRef<'a> {
         }
     }
 
-    fn from_bytes(log_bytes: &'a [u8]) -> Result<Self> {
+    pub fn from_bytes(log_bytes: &'a [u8]) -> Result<Self> {
         if log_bytes.len() < size_of::<AdvLoggerInfoV5>() {
             return Err(EfiError::BufferTooSmall);
         }
@@ -450,7 +260,7 @@ impl<'a> AdvLoggerInfoRef<'a> {
         }
     }
 
-    fn header_size_for_version(version: u16) -> Option<usize> {
+    pub fn header_size_for_version(version: u16) -> Option<usize> {
         match version {
             ADV_LOGGER_INFO_VERSION_V5 => Some(size_of::<AdvLoggerInfoV5>()),
             ADV_LOGGER_INFO_VERSION_V6 => Some(size_of::<AdvLoggerInfoV6>()),
@@ -458,105 +268,77 @@ impl<'a> AdvLoggerInfoRef<'a> {
         }
     }
 
-    fn header_size(&self) -> usize {
+    pub fn header_size(&self) -> usize {
         match self {
             AdvLoggerInfoRef::V5(_) => size_of::<AdvLoggerInfoV5>(),
             AdvLoggerInfoRef::V6(_) => size_of::<AdvLoggerInfoV6>(),
         }
     }
 
-    fn log_buffer_offset(&self) -> u32 {
+    pub fn log_buffer_offset(&self) -> u32 {
         match self {
             AdvLoggerInfoRef::V5(info) => info.log_buffer_offset,
             AdvLoggerInfoRef::V6(info) => info.v5.log_buffer_offset,
         }
     }
 
-    fn log_buffer_size(&self) -> u32 {
+    pub fn log_buffer_size(&self) -> u32 {
         match self {
             AdvLoggerInfoRef::V5(info) => info.log_buffer_size,
             AdvLoggerInfoRef::V6(info) => info.v5.log_buffer_size,
         }
     }
 
-    fn log_current_offset(&self) -> &AtomicU32 {
+    pub fn log_current_offset(&self) -> &AtomicU32 {
         match self {
             AdvLoggerInfoRef::V5(info) => &info.log_current_offset,
             AdvLoggerInfoRef::V6(info) => &info.v5.log_current_offset,
         }
     }
 
-    fn discarded_size(&self) -> &AtomicU32 {
+    pub fn discarded_size(&self) -> &AtomicU32 {
         match self {
             AdvLoggerInfoRef::V5(info) => &info.discarded_size,
             AdvLoggerInfoRef::V6(info) => &info.v5.discarded_size,
         }
     }
 
-    fn timer_frequency(&self) -> &AtomicU64 {
+    pub fn timer_frequency(&self) -> &AtomicU64 {
         match self {
             AdvLoggerInfoRef::V5(info) => &info.timer_frequency,
             AdvLoggerInfoRef::V6(info) => &info.v5.timer_frequency,
         }
     }
 
-    fn hw_port_disabled(&self) -> bool {
+    pub fn hw_port_disabled(&self) -> bool {
         match self {
             AdvLoggerInfoRef::V5(info) => info.hw_port_disabled,
             AdvLoggerInfoRef::V6(info) => info.v5.hw_port_disabled,
         }
     }
 
-    fn hw_print_level(&self) -> u32 {
+    pub fn hw_print_level(&self) -> u32 {
         match self {
             AdvLoggerInfoRef::V5(info) => info.hw_print_level,
             AdvLoggerInfoRef::V6(info) => info.v5.hw_print_level,
         }
     }
 
-    fn new_logger_info_address(&self) -> Option<u64> {
+    pub fn new_logger_info_address(&self) -> Option<u64> {
         match self {
             AdvLoggerInfoRef::V5(_) => None,
             AdvLoggerInfoRef::V6(info) => Some(info.new_logger_info_address),
         }
     }
 
-    fn full_size(&self) -> u32 {
+    pub fn full_size(&self) -> u32 {
         self.log_buffer_offset() + self.log_buffer_size()
     }
 
-    fn as_ptr(&self) -> *const u8 {
+    pub fn as_ptr(&self) -> *const u8 {
         match *self {
             AdvLoggerInfoRef::V5(info) => info as *const AdvLoggerInfoV5 as *const u8,
             AdvLoggerInfoRef::V6(info) => info as *const AdvLoggerInfoV6 as *const u8,
-        }
-    }
-}
-
-/// Wrapper to allow for a read-only or read-write data region for the log.
-enum LogData<'a> {
-    /// A slice of bytes representing the log message.
-    ReadOnly(&'a [u8]),
-    /// A string slice representing the log message.
-    ReadWrite(&'a UnsafeCell<[u8]>),
-}
-
-impl<'a> LogData<'a> {
-    /// Returns the data as a slice.
-    fn get(&self) -> &'a [u8] {
-        match self {
-            LogData::ReadOnly(slice) => slice,
-            // SAFETY: The allocated memory is guaranteed to be valid, and the lifetime
-            //         of the underlining data is tied to the lifetime of the `AdvancedLog`.
-            LogData::ReadWrite(cell) => unsafe { &*cell.get() },
-        }
-    }
-
-    /// Returns the data as a mutable slice.
-    fn get_mut(&self) -> Result<*mut [u8]> {
-        match self {
-            LogData::ReadOnly(_) => Err(EfiError::AccessDenied),
-            LogData::ReadWrite(cell) => Ok(cell.get()),
         }
     }
 }
@@ -566,13 +348,13 @@ impl<'a> LogData<'a> {
 #[repr(C)]
 #[repr(packed)]
 #[derive(Debug, IntoBytes, FromBytes, Immutable, KnownLayout)]
-struct AdvLoggerMessageEntry {
+pub(crate) struct AdvLoggerMessageEntry {
     /// Signature
-    signature: u32,
+    pub signature: u32,
     /// Major version of advanced logger message structure. Current = 2
-    major_version: u8,
+    pub major_version: u8,
     /// Minor version of advanced logger message structure. Current = 0
-    minor_version: u8,
+    pub minor_version: u8,
     /// Error Level
     pub level: u32,
     /// Time stamp
@@ -580,9 +362,9 @@ struct AdvLoggerMessageEntry {
     /// Boot phase that produced this message entry
     pub boot_phase: u16,
     /// Number of bytes in Message
-    message_length: u16,
+    pub message_length: u16,
     /// Offset of Message from start of structure, used to calculate the address of the Message
-    message_offset: u16,
+    pub message_offset: u16,
 }
 
 impl AdvLoggerMessageEntry {
@@ -601,7 +383,7 @@ impl AdvLoggerMessageEntry {
     /// structure values for copying into memory and should not be used to directly
     /// create stack or heap structures.
     ///
-    const fn new(boot_phase: u16, level: u32, timestamp: u64, message_length: u16) -> Self {
+    pub const fn new(boot_phase: u16, level: u32, timestamp: u64, message_length: u16) -> Self {
         Self {
             signature: Self::SIGNATURE,
             major_version: Self::MAJOR_VERSION,
@@ -615,7 +397,7 @@ impl AdvLoggerMessageEntry {
     }
 
     /// Creates the structure of AdvLoggerMessageEntry from a [`LogEntry`].
-    const fn from_log_entry(entry: &LogEntry) -> Self {
+    pub const fn from_log_entry(entry: &LogEntry) -> Self {
         Self::new(entry.phase, entry.level, entry.timestamp, entry.data.len() as u16)
     }
 
@@ -632,87 +414,51 @@ impl AdvLoggerMessageEntry {
     }
 }
 
-/// Iterator for an advanced logger memory buffer log.
-pub struct AdvLogIterator<'a> {
-    log: &'a AdvancedLog<'a>,
-    offset: usize,
-}
+#[cfg(test)]
+const TEST_DATA_SIZE: usize = 128;
 
-/// Iterator for an Advanced Logger memory buffer.
-impl<'a> AdvLogIterator<'a> {
-    /// Creates a new log iterator from a given AdvLoggerInfo reference.
-    fn new(log: &'a AdvancedLog) -> Self {
-        AdvLogIterator { log, offset: log.header.log_buffer_offset() as usize }
+#[cfg(test)]
+pub(crate) fn create_buffer_v5(timer_frequency: u64, hw_port_disabled: bool) -> alloc::boxed::Box<[u8]> {
+    let header_size = size_of::<AdvLoggerInfoV5>();
+    let mut buffer = alloc::vec![0_u8; header_size + TEST_DATA_SIZE].into_boxed_slice();
+    let header = AdvLoggerInfoV5 {
+        signature: AdvLoggerInfo::SIGNATURE,
+        version: ADV_LOGGER_INFO_VERSION_V5,
+        reserved1: [0, 0, 0],
+        log_buffer_offset: header_size as u32,
+        reserved2: 0,
+        log_current_offset: AtomicU32::new(header_size as u32),
+        discarded_size: AtomicU32::new(0),
+        log_buffer_size: TEST_DATA_SIZE as u32,
+        in_permanent_ram: true,
+        at_runtime: false,
+        gone_virtual: false,
+        hw_port_initialized: false,
+        hw_port_disabled,
+        reserved3: [false, false, false],
+        timer_frequency: AtomicU64::new(timer_frequency),
+        ticks_at_time: 0,
+        time: efi::Time::default(),
+        hw_print_level: DEBUG_LEVEL_INFO,
+        reserved4: 0,
+    };
+
+    // SAFETY: The buffer was allocated with sufficient size (header_size + TEST_DATA_SIZE).
+    unsafe {
+        core::ptr::write(buffer.as_mut_ptr().cast::<AdvLoggerInfoV5>(), header);
     }
-}
 
-impl<'a> Iterator for AdvLogIterator<'a> {
-    type Item = LogEntry<'a>;
-
-    /// Provides the next advanced logger entry in the Advanced Logger memory buffer.
-    fn next(&mut self) -> Option<Self::Item> {
-        if self.offset + size_of::<AdvLoggerMessageEntry>()
-            > self.log.header.log_current_offset().load(Ordering::Relaxed) as usize
-        {
-            None
-        } else {
-            // Get the data relative offset.
-            let mut data_index = self.offset - self.log.header.log_buffer_offset() as usize;
-
-            // SAFETY: We have verified the buffer through the header, read that
-            //         to check the rest of the range.
-            let header_slice = unsafe {
-                let data: *const [u8] = self.log.data.get();
-                (&*data).get(data_index..data_index + size_of::<AdvLoggerMessageEntry>())?
-            };
-
-            let entry_header = AdvLoggerMessageEntry::ref_from_bytes(header_slice).ok()?;
-            data_index += size_of::<AdvLoggerMessageEntry>();
-
-            if self.offset + size_of::<AdvLoggerMessageEntry>() + entry_header.message_length as usize
-                > self.log.header.log_current_offset().load(Ordering::Relaxed) as usize
-            {
-                None
-            } else {
-                // SAFETY: We know that the buffer is valid through previous checks,
-                //         and this structure should be well formed from the header
-                //         information.
-                let entry_data = unsafe {
-                    let data: *const [u8] = self.log.data.get();
-                    (&*data).get(data_index..data_index + entry_header.message_length as usize)?
-                };
-
-                // Move the offset up by the aligned total size.
-                self.offset += entry_header.aligned_len();
-
-                Some(LogEntry {
-                    phase: entry_header.boot_phase,
-                    level: entry_header.level,
-                    timestamp: entry_header.timestamp,
-                    data: entry_data,
-                })
-            }
-        }
-    }
+    buffer
 }
 
 #[cfg(test)]
-#[coverage(off)]
-mod tests {
-    extern crate std;
-    use alloc::{boxed::Box, vec};
-    use efi::PhysicalAddress;
-
-    use super::*;
-
-    const TEST_DATA_SIZE: usize = 128;
-
-    fn create_buffer_v5(timer_frequency: u64, hw_port_disabled: bool) -> Box<[u8]> {
-        let header_size = size_of::<AdvLoggerInfoV5>();
-        let mut buffer = vec![0_u8; header_size + TEST_DATA_SIZE].into_boxed_slice();
-        let header = AdvLoggerInfoV5 {
+pub(crate) fn create_buffer_v6(timer_frequency: u64, new_address: u64) -> alloc::boxed::Box<[u8]> {
+    let header_size = size_of::<AdvLoggerInfoV6>();
+    let mut buffer = alloc::vec![0_u8; header_size + TEST_DATA_SIZE].into_boxed_slice();
+    let header = AdvLoggerInfoV6 {
+        v5: AdvLoggerInfoV5 {
             signature: AdvLoggerInfo::SIGNATURE,
-            version: ADV_LOGGER_INFO_VERSION_V5,
+            version: ADV_LOGGER_INFO_VERSION_V6,
             reserved1: [0, 0, 0],
             log_buffer_offset: header_size as u32,
             reserved2: 0,
@@ -723,279 +469,21 @@ mod tests {
             at_runtime: false,
             gone_virtual: false,
             hw_port_initialized: false,
-            hw_port_disabled,
+            hw_port_disabled: false,
             reserved3: [false, false, false],
             timer_frequency: AtomicU64::new(timer_frequency),
             ticks_at_time: 0,
             time: efi::Time::default(),
             hw_print_level: DEBUG_LEVEL_INFO,
             reserved4: 0,
-        };
+        },
+        new_logger_info_address: new_address,
+    };
 
-        // SAFETY: The buffer was allocated with sufficient size (header_size + TEST_DATA_SIZE).
-        unsafe {
-            ptr::write(buffer.as_mut_ptr().cast::<AdvLoggerInfoV5>(), header);
-        }
-
-        buffer
+    // SAFETY: The buffer is sized for the header and is aligned for AdvLoggerInfoV6.
+    unsafe {
+        core::ptr::write(buffer.as_mut_ptr().cast::<AdvLoggerInfoV6>(), header);
     }
 
-    fn create_buffer_v6(timer_frequency: u64, new_address: u64) -> Box<[u8]> {
-        let header_size = size_of::<AdvLoggerInfoV6>();
-        let mut buffer = vec![0_u8; header_size + TEST_DATA_SIZE].into_boxed_slice();
-        let header = AdvLoggerInfoV6 {
-            v5: AdvLoggerInfoV5 {
-                signature: AdvLoggerInfo::SIGNATURE,
-                version: ADV_LOGGER_INFO_VERSION_V6,
-                reserved1: [0, 0, 0],
-                log_buffer_offset: header_size as u32,
-                reserved2: 0,
-                log_current_offset: AtomicU32::new(header_size as u32),
-                discarded_size: AtomicU32::new(0),
-                log_buffer_size: TEST_DATA_SIZE as u32,
-                in_permanent_ram: true,
-                at_runtime: false,
-                gone_virtual: false,
-                hw_port_initialized: false,
-                hw_port_disabled: false,
-                reserved3: [false, false, false],
-                timer_frequency: AtomicU64::new(timer_frequency),
-                ticks_at_time: 0,
-                time: efi::Time::default(),
-                hw_print_level: DEBUG_LEVEL_INFO,
-                reserved4: 0,
-            },
-            new_logger_info_address: new_address,
-        };
-
-        // SAFETY: The buffer is sized for the header and is aligned for AdvLoggerInfoV6.
-        unsafe {
-            ptr::write(buffer.as_mut_ptr().cast::<AdvLoggerInfoV6>(), header);
-        }
-
-        buffer
-    }
-
-    #[test]
-    fn create_fill_check_test() {
-        let mut buff_box = Box::new([0_u64; 0x2000]);
-        let buffer = buff_box.as_mut();
-        let address = buffer as *mut u64 as PhysicalAddress;
-        let len = buffer.len() as u32;
-
-        // SAFETY: We just allocated this memory so it's valid.
-        let log = unsafe { AdvancedLog::initialize_memory_log(address, len) }.unwrap();
-
-        // Fill the log.
-        let mut entries: u32 = 0;
-        loop {
-            let data = entries.to_be_bytes();
-            let entry: LogEntry<'_> = LogEntry { level: 0, phase: 0, timestamp: 0, data: &data };
-            let log_entry = log.add_log_entry(entry);
-            match log_entry {
-                Ok(_) => {}
-                Err(EfiError::OutOfResources) => {
-                    assert!(log.discarded_size() > 0);
-                    assert!(entries > 0);
-                    break;
-                }
-                Err(status) => {
-                    panic!("Unexpected add_log_entry returned unexpected status {status:#x?}.")
-                }
-            }
-            entries += 1;
-        }
-
-        // check the contents.
-        let mut iter = log.iter();
-        for entry_num in 0..entries {
-            let data = entry_num.to_be_bytes();
-            let log_entry = iter.next().unwrap();
-            assert_eq!(log_entry.get_message(), data);
-        }
-
-        assert!(iter.next().is_none());
-    }
-
-    #[test]
-    fn adopt_buffer_test() {
-        let buff_box = Box::new([0_u8; 0x10000]);
-        let buffer = buff_box.as_ref();
-        let address = buffer as *const u8 as PhysicalAddress;
-        let len = buffer.len() as u32;
-
-        // SAFETY: We just allocated this memory so it's valid.
-        let log = unsafe { AdvancedLog::initialize_memory_log(address, len) }.unwrap();
-
-        // Fill the log.
-        for val in 0..50 {
-            let data = (val as u32).to_be_bytes();
-            let entry = LogEntry { level: 0, phase: 0, timestamp: 0, data: &data };
-            log.add_log_entry(entry).unwrap();
-        }
-
-        // SAFETY: This is the same buffer as before, still valid.
-        let log = unsafe { AdvancedLog::adopt_memory_log(address) }.unwrap();
-
-        // Add more entries.
-        for val in 50..100 {
-            let data = (val as u32).to_be_bytes();
-            let entry = LogEntry { level: 0, phase: 0, timestamp: 0, data: &data };
-            log.add_log_entry(entry).unwrap();
-        }
-
-        // check the contents.
-        assert!(log.discarded_size() == 0);
-        let mut iter = log.iter();
-        for entry_num in 0..100 {
-            let data = (entry_num as u32).to_be_bytes();
-            let log_entry = iter.next().unwrap();
-            assert_eq!(log_entry.get_message(), data);
-        }
-
-        assert!(iter.next().is_none());
-    }
-
-    #[test]
-    fn open_log_supports_v5_and_v6() {
-        let buffer_v5 = create_buffer_v5(123, false);
-        let log_v5 = AdvancedLog::open_log(&buffer_v5).unwrap();
-        assert_eq!(log_v5.get_frequency(), 123);
-        assert!(log_v5.hardware_write_enabled(DEBUG_LEVEL_INFO));
-        assert!(log_v5.get_new_logger_info_address().is_none());
-
-        let buffer_v6 = create_buffer_v6(456, 0x1122334455667788);
-        let log_v6 = AdvancedLog::open_log(&buffer_v6).unwrap();
-        assert_eq!(log_v6.get_frequency(), 456);
-        assert!(log_v6.get_new_logger_info_address().is_some());
-    }
-
-    #[test]
-    fn adopt_memory_log_accepts_v5_and_v6() {
-        let mut buffer_v5 = create_buffer_v5(0, false);
-        let address_v5 = buffer_v5.as_mut_ptr() as PhysicalAddress;
-        // SAFETY: The memory was allocated successfully in this function and has been initialized
-        // to contain a valid AdvLoggerInfoV5 header.
-        let log_v5 = unsafe { AdvancedLog::adopt_memory_log(address_v5) }.unwrap();
-        let entry_v5 = LogEntry { level: 0, phase: 0, timestamp: 0, data: b"v5" };
-        log_v5.add_log_entry(entry_v5).unwrap();
-        let mut iter = log_v5.iter();
-        assert_eq!(iter.next().unwrap().get_message(), b"v5");
-
-        let mut buffer_v6 = create_buffer_v6(0, 0);
-        let address_v6 = buffer_v6.as_mut_ptr() as PhysicalAddress;
-        // SAFETY: The memory was allocated successfully in this function and has been initialized
-        // to contain a valid AdvLoggerInfoV6 header.
-        let log_v6 = unsafe { AdvancedLog::adopt_memory_log(address_v6) }.unwrap();
-        let entry_v6 = LogEntry { level: 0, phase: 0, timestamp: 0, data: b"v6" };
-        log_v6.add_log_entry(entry_v6).unwrap();
-        let mut iter = log_v6.iter();
-        assert_eq!(iter.next().unwrap().get_message(), b"v6");
-    }
-
-    #[test]
-    fn adopt_memory_log_rejects_log_buffer_offset_less_than_header_size() {
-        let mut buffer = create_buffer_v5(0, false);
-        let header = buffer.as_mut_ptr().cast::<AdvLoggerInfoV5>();
-
-        // SAFETY: The buffer contains a valid AdvLoggerInfoV5 header, so mutating header fields is valid.
-        unsafe {
-            (*header).log_buffer_offset = (size_of::<AdvLoggerInfoV5>() as u32) - 1;
-        }
-
-        let address = buffer.as_mut_ptr() as PhysicalAddress;
-        // SAFETY: The buffer structure is valid in memory allocated above.
-        let result = unsafe { AdvancedLog::adopt_memory_log(address) };
-        assert!(result.is_none());
-    }
-
-    #[test]
-    fn adopt_memory_log_rejects_log_current_offset_before_buffer_start() {
-        let mut buffer = create_buffer_v5(0, false);
-        let header = buffer.as_mut_ptr().cast::<AdvLoggerInfoV5>();
-
-        // SAFETY: The buffer contains a valid AdvLoggerInfoV5 header, so mutating header fields is valid.
-        unsafe {
-            (*header).log_current_offset.store((*header).log_buffer_offset - 1, Ordering::Relaxed);
-        }
-
-        let address = buffer.as_mut_ptr() as PhysicalAddress;
-        // SAFETY: The buffer structure is valid in memory allocated above.
-        let result = unsafe { AdvancedLog::adopt_memory_log(address) };
-        assert!(result.is_none());
-    }
-
-    #[test]
-    fn adopt_memory_log_rejects_log_current_offset_beyond_full_size() {
-        let mut buffer = create_buffer_v5(0, false);
-        let header = buffer.as_mut_ptr().cast::<AdvLoggerInfoV5>();
-
-        // SAFETY: The buffer contains a valid AdvLoggerInfoV5 header, so mutating header fields is valid.
-        unsafe {
-            let full_size = (*header).log_buffer_offset + (*header).log_buffer_size;
-            (*header).log_current_offset.store(full_size + 1, Ordering::Relaxed);
-        }
-
-        let address = buffer.as_mut_ptr() as PhysicalAddress;
-        // SAFETY: The buffer structure is valid in memory allocated above.
-        let result = unsafe { AdvancedLog::adopt_memory_log(address) };
-        assert!(result.is_none());
-    }
-
-    #[test]
-    fn open_log_rejects_unknown_version() {
-        let mut buffer = create_buffer_v5(0, false);
-        let header = buffer.as_mut_ptr().cast::<AdvLoggerInfoV5>();
-
-        // SAFETY: The buffer contains a valid AdvLoggerInfoV5 header, so mutating the version field is in-bounds.
-        unsafe {
-            (*header).version = 7;
-        }
-
-        let result = AdvancedLog::open_log(&buffer);
-        assert!(matches!(result, Err(EfiError::Unsupported)));
-    }
-
-    #[test]
-    fn open_log_rejects_log_current_offset_before_buffer_start() {
-        let mut buffer = create_buffer_v5(0, false);
-        let header = buffer.as_mut_ptr().cast::<AdvLoggerInfoV5>();
-
-        // SAFETY: The buffer contains a valid AdvLoggerInfoV5 header, so mutating header fields is valid.
-        unsafe {
-            (*header).log_current_offset.store((*header).log_buffer_offset - 1, Ordering::Relaxed);
-        }
-
-        let result = AdvancedLog::open_log(&buffer);
-        assert!(matches!(result, Err(EfiError::InvalidParameter)));
-    }
-
-    #[test]
-    fn open_log_rejects_log_current_offset_beyond_full_size() {
-        let mut buffer = create_buffer_v5(0, false);
-        let header = buffer.as_mut_ptr().cast::<AdvLoggerInfoV5>();
-
-        // SAFETY: The buffer contains a valid AdvLoggerInfoV5 header, so mutating header fields is valid.
-        unsafe {
-            let full_size = (*header).log_buffer_offset + (*header).log_buffer_size;
-            (*header).log_current_offset.store(full_size + 1, Ordering::Relaxed);
-        }
-
-        let result = AdvancedLog::open_log(&buffer);
-        assert!(matches!(result, Err(EfiError::InvalidParameter)));
-    }
-
-    #[test]
-    fn open_log_rejects_log_buffer_offset_less_than_header_size() {
-        let mut buffer = create_buffer_v5(0, false);
-        let header = buffer.as_mut_ptr().cast::<AdvLoggerInfoV5>();
-
-        // SAFETY: The buffer contains a valid AdvLoggerInfoV5 header, so mutating header fields is valid.
-        unsafe {
-            (*header).log_buffer_offset = (size_of::<AdvLoggerInfoV5>() as u32) - 1;
-        }
-
-        let result = AdvancedLog::open_log(&buffer);
-        assert!(matches!(result, Err(EfiError::InvalidParameter)));
-    }
+    buffer
 }

--- a/components/patina_adv_logger/src/parser.rs
+++ b/components/patina_adv_logger/src/parser.rs
@@ -7,14 +7,14 @@
 //! SPDX-License-Identifier: Apache-2.0
 //!
 
-use crate::memory_log::{AdvancedLog, LogEntry};
+use crate::{memory_log::LogEntry, reader::AdvancedLogReader};
 use alloc::format;
 use core::str;
 use patina::error::EfiError;
 
 /// Parser for the Advanced Logger buffer.
 pub struct Parser<'a> {
-    log: AdvancedLog<'a>,
+    log: AdvancedLogReader<'a>,
     entry_meta: bool,
 }
 
@@ -22,7 +22,7 @@ impl<'a> Parser<'a> {
     /// Creates a new `Parser` instance with the provided data slice from an advanced
     /// logger buffer.
     pub fn open(data: &'a [u8]) -> Result<Self, &'static str> {
-        let log = AdvancedLog::open_log(data).map_err(|err| match err {
+        let log = AdvancedLogReader::open_log(data).map_err(|err| match err {
             EfiError::InvalidParameter => "Invalid log data provided.",
             EfiError::BufferTooSmall => "Incomplete log buffer.",
             EfiError::Unsupported => "Log data format not supported.",

--- a/components/patina_adv_logger/src/reader.rs
+++ b/components/patina_adv_logger/src/reader.rs
@@ -1,0 +1,233 @@
+//! UEFI Advanced Logger Reader Support
+//!
+//! This module provides read-only access to an Advanced Logger memory log buffer
+//! and an iterator for traversing log entries.
+//!
+//! ## License
+//!
+//! Copyright (c) Microsoft Corporation.
+//!
+//! SPDX-License-Identifier: Apache-2.0
+//!
+use core::{mem::size_of, slice, sync::atomic::Ordering};
+use patina::error::{EfiError, Result};
+use r_efi::efi;
+use zerocopy::FromBytes;
+
+use crate::memory_log::{AdvLoggerInfoRef, AdvLoggerMessageEntry, LogEntry};
+
+/// A read-only handle to an advanced logger memory log. This provides the
+/// ability to iterate over log entries without modifying the underlying buffer.
+pub struct AdvancedLogReader<'a> {
+    /// The header of the memory log.
+    pub(crate) header: AdvLoggerInfoRef<'a>,
+    /// The data portion of the memory log (read-only).
+    data: &'a [u8],
+}
+
+impl AdvancedLogReader<'static> {
+    /// Creates a read-only `AdvancedLogReader` from a physical address pointing to
+    /// an existing advanced logger buffer.
+    ///
+    /// ### Safety
+    ///
+    /// The caller must ensure that the provided address points to a valid `AdvLoggerInfo`
+    /// structure and that the memory is properly sized and initialized.
+    pub unsafe fn from_address(address: efi::PhysicalAddress) -> Option<Self> {
+        // SAFETY: The safety requirements for this function transfer to the function called here.
+        let header = unsafe { AdvLoggerInfoRef::from_address(address)? };
+        let data_size = header.log_buffer_size();
+        let data_start = (address + header.log_buffer_offset() as u64) as *const u8;
+        // SAFETY: The caller must ensure that the memory is properly sized and initialized.
+        let data = unsafe { slice::from_raw_parts(data_start, data_size as usize) };
+
+        Some(Self { header, data })
+    }
+}
+
+impl<'a> AdvancedLogReader<'a> {
+    /// Opens a log from a byte slice. This is used for parsing serialized log buffers
+    /// such as those read from a file.
+    pub fn open_log(log_bytes: &'a [u8]) -> Result<Self> {
+        let header = AdvLoggerInfoRef::from_bytes(log_bytes)?;
+
+        // Check that the various pointers are consistent.
+        let log_current = header.log_current_offset().load(Ordering::Relaxed);
+        if log_current < header.log_buffer_offset()
+            || log_current > header.full_size()
+            || header.log_buffer_offset() < header.header_size() as u32
+        {
+            return Err(EfiError::InvalidParameter);
+        }
+
+        // Only require that the valid portion of the log buffer be present.
+        if log_current > log_bytes.len() as u32 {
+            return Err(EfiError::BufferTooSmall);
+        }
+
+        let (_, data_slice) = log_bytes.split_at(header.log_buffer_offset() as usize);
+
+        Ok(Self { header, data: data_slice })
+    }
+
+    /// Returns an iterator over the log entries.
+    pub fn iter(&self) -> AdvLogIterator<'_> {
+        AdvLogIterator::new(self)
+    }
+
+    /// Returns the timer frequency.
+    pub fn get_frequency(&self) -> u64 {
+        self.header.timer_frequency().load(Ordering::Relaxed)
+    }
+
+    /// Returns whether hardware port writing is enabled for the given level.
+    pub fn hardware_write_enabled(&self, level: u32) -> bool {
+        !self.header.hw_port_disabled() && (level & self.header.hw_print_level() != 0)
+    }
+
+    /// Returns the address of the log buffer header.
+    pub fn get_address(&self) -> efi::PhysicalAddress {
+        self.header.as_ptr() as efi::PhysicalAddress
+    }
+
+    /// Returns the new logger info address if one has been set.
+    pub fn get_new_logger_info_address(&self) -> Option<efi::PhysicalAddress> {
+        self.header
+            .new_logger_info_address()
+            .and_then(|address| if address == 0 { None } else { Some(address as efi::PhysicalAddress) })
+    }
+}
+
+/// Iterator for an advanced logger memory buffer log.
+pub struct AdvLogIterator<'a> {
+    log: &'a AdvancedLogReader<'a>,
+    offset: usize,
+}
+
+/// Iterator for an Advanced Logger memory buffer.
+impl<'a> AdvLogIterator<'a> {
+    /// Creates a new log iterator from a given AdvancedLogReader reference.
+    fn new(log: &'a AdvancedLogReader) -> Self {
+        AdvLogIterator { log, offset: log.header.log_buffer_offset() as usize }
+    }
+}
+
+impl<'a> Iterator for AdvLogIterator<'a> {
+    type Item = LogEntry<'a>;
+
+    /// Provides the next advanced logger entry in the Advanced Logger memory buffer.
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.offset + size_of::<AdvLoggerMessageEntry>()
+            > self.log.header.log_current_offset().load(Ordering::Relaxed) as usize
+        {
+            None
+        } else {
+            // Get the data relative offset.
+            let mut data_index = self.offset - self.log.header.log_buffer_offset() as usize;
+
+            let header_slice = self.log.data.get(data_index..data_index + size_of::<AdvLoggerMessageEntry>())?;
+
+            let entry_header = AdvLoggerMessageEntry::ref_from_bytes(header_slice).ok()?;
+            data_index += size_of::<AdvLoggerMessageEntry>();
+
+            if self.offset + size_of::<AdvLoggerMessageEntry>() + entry_header.message_length as usize
+                > self.log.header.log_current_offset().load(Ordering::Relaxed) as usize
+            {
+                None
+            } else {
+                let entry_data = self.log.data.get(data_index..data_index + entry_header.message_length as usize)?;
+
+                // Move the offset up by the aligned total size.
+                self.offset += entry_header.aligned_len();
+
+                Some(LogEntry {
+                    phase: entry_header.boot_phase,
+                    level: entry_header.level,
+                    timestamp: entry_header.timestamp,
+                    data: entry_data,
+                })
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+#[coverage(off)]
+mod tests {
+    extern crate std;
+    use core::{mem::size_of, sync::atomic::Ordering};
+
+    use super::*;
+    use crate::memory_log::*;
+
+    #[test]
+    fn open_log_supports_v5_and_v6() {
+        let buffer_v5 = create_buffer_v5(123, false);
+        let log_v5 = AdvancedLogReader::open_log(&buffer_v5).unwrap();
+        assert_eq!(log_v5.get_frequency(), 123);
+        assert!(log_v5.hardware_write_enabled(DEBUG_LEVEL_INFO));
+        assert!(log_v5.get_new_logger_info_address().is_none());
+
+        let buffer_v6 = create_buffer_v6(456, 0x1122334455667788);
+        let log_v6 = AdvancedLogReader::open_log(&buffer_v6).unwrap();
+        assert_eq!(log_v6.get_frequency(), 456);
+        assert!(log_v6.get_new_logger_info_address().is_some());
+    }
+
+    #[test]
+    fn open_log_rejects_unknown_version() {
+        let mut buffer = create_buffer_v5(0, false);
+        let header = buffer.as_mut_ptr().cast::<AdvLoggerInfoV5>();
+
+        // SAFETY: The buffer contains a valid AdvLoggerInfoV5 header, so mutating the version field is in-bounds.
+        unsafe {
+            (*header).version = 7;
+        }
+
+        let result = AdvancedLogReader::open_log(&buffer);
+        assert!(matches!(result, Err(EfiError::Unsupported)));
+    }
+
+    #[test]
+    fn open_log_rejects_log_current_offset_before_buffer_start() {
+        let mut buffer = create_buffer_v5(0, false);
+        let header = buffer.as_mut_ptr().cast::<AdvLoggerInfoV5>();
+
+        // SAFETY: The buffer contains a valid AdvLoggerInfoV5 header, so mutating header fields is valid.
+        unsafe {
+            (*header).log_current_offset.store((*header).log_buffer_offset - 1, Ordering::Relaxed);
+        }
+
+        let result = AdvancedLogReader::open_log(&buffer);
+        assert!(matches!(result, Err(EfiError::InvalidParameter)));
+    }
+
+    #[test]
+    fn open_log_rejects_log_current_offset_beyond_full_size() {
+        let mut buffer = create_buffer_v5(0, false);
+        let header = buffer.as_mut_ptr().cast::<AdvLoggerInfoV5>();
+
+        // SAFETY: The buffer contains a valid AdvLoggerInfoV5 header, so mutating header fields is valid.
+        unsafe {
+            let full_size = (*header).log_buffer_offset + (*header).log_buffer_size;
+            (*header).log_current_offset.store(full_size + 1, Ordering::Relaxed);
+        }
+
+        let result = AdvancedLogReader::open_log(&buffer);
+        assert!(matches!(result, Err(EfiError::InvalidParameter)));
+    }
+
+    #[test]
+    fn open_log_rejects_log_buffer_offset_less_than_header_size() {
+        let mut buffer = create_buffer_v5(0, false);
+        let header = buffer.as_mut_ptr().cast::<AdvLoggerInfoV5>();
+
+        // SAFETY: The buffer contains a valid AdvLoggerInfoV5 header, so mutating header fields is valid.
+        unsafe {
+            (*header).log_buffer_offset = (size_of::<AdvLoggerInfoV5>() as u32) - 1;
+        }
+
+        let result = AdvancedLogReader::open_log(&buffer);
+        assert!(matches!(result, Err(EfiError::InvalidParameter)));
+    }
+}

--- a/components/patina_adv_logger/src/writer.rs
+++ b/components/patina_adv_logger/src/writer.rs
@@ -1,0 +1,358 @@
+//! UEFI Advanced Logger Writer Support
+//!
+//! This module provides write-only access to an Advanced Logger memory log buffer.
+//!
+//! ## License
+//!
+//! Copyright (c) Microsoft Corporation.
+//!
+//! SPDX-License-Identifier: Apache-2.0
+//!
+use core::{cell::UnsafeCell, mem::size_of, ptr, slice, sync::atomic::Ordering};
+use patina::{
+    base::align_up,
+    error::{EfiError, Result},
+};
+use r_efi::efi;
+use zerocopy::IntoBytes;
+
+use crate::memory_log::{AdvLoggerInfo, AdvLoggerInfoRef, AdvLoggerMessageEntry, LogEntry};
+
+/// A write-only handle to an advanced logger memory log. This provides the
+/// ability to allocate and write log entries to the memory log buffer.
+pub struct AdvancedLogWriter {
+    /// The header of the memory log.
+    pub header: AdvLoggerInfoRef<'static>,
+    /// The data portion of the memory log.
+    data: &'static UnsafeCell<[u8]>,
+}
+
+// SAFETY: The only interior mutability is the UnsafeCell for the data region of
+//         the log. Safety here is checked by the allocation logic in add_log_entry
+//         which relies on atomics to safely allocate portions of the buffer.
+unsafe impl Send for AdvancedLogWriter {}
+// SAFETY: See the Send safety comment
+unsafe impl Sync for AdvancedLogWriter {}
+
+impl AdvancedLogWriter {
+    /// Initializes an `AdvancedLogWriter` from an existing advanced logger buffer at the
+    /// provided address. The caller must ensure that this memory is accessible.
+    ///
+    /// ### Safety
+    ///
+    /// This function assumes that the provided address points to a valid `AdvLoggerInfo`
+    /// structure and that the memory is properly sized initialized based on the
+    /// information in that structure.
+    pub unsafe fn adopt_memory_log(address: efi::PhysicalAddress) -> Option<Self> {
+        // SAFETY: The safety requirements for this function transfer to the function called here.
+        let header = unsafe { AdvLoggerInfoRef::from_address(address)? };
+        let data_size = header.log_buffer_size();
+        let data_start = (address + header.log_buffer_offset() as u64) as *mut u8;
+        // SAFETY: The caller must ensure that the memory is properly sized and initialized
+        // per the safety contract of this function. from_address() validates the signature
+        // and version in the header.
+        let data = unsafe { slice::from_raw_parts_mut(data_start, data_size as usize) };
+
+        Some(Self { header, data: UnsafeCell::from_mut(data) })
+    }
+
+    /// Initializes a new Advanced Log buffer at the provided address with the
+    /// specified length.
+    ///
+    /// ### Safety
+    ///
+    /// The caller is responsible for ensuring that the provided address is appropriately
+    /// allocated and accessible.
+    #[allow(dead_code)]
+    pub unsafe fn initialize_memory_log(address: efi::PhysicalAddress, length: u32) -> Option<Self> {
+        if length < size_of::<AdvLoggerInfo>() as u32
+            || !address.is_multiple_of(core::mem::align_of::<AdvLoggerInfo>() as u64)
+        {
+            return None;
+        }
+
+        let header = address as *mut AdvLoggerInfo;
+        if header.is_null() {
+            None
+        } else {
+            // SAFETY: The caller should ensure that the address is valid and
+            //         that the memory is writable.
+            unsafe { ptr::write(header, AdvLoggerInfo::new(length, false, 0, 0, efi::Time::default(), 0)) };
+
+            // SAFETY: The header is now initialized, so we can safely create the
+            //         AdvancedLogWriter instance.
+            unsafe { Self::adopt_memory_log(address) }
+        }
+    }
+
+    /// Adds a log entry to the memory log buffer.
+    pub fn add_log_entry(&self, log_entry: LogEntry) -> Result<()> {
+        // Adding a log entry consists of two steps:
+        // 1. Atomically allocate space in the log buffer. This must be done before
+        //    writing the log entry to ensure that no other system can write to the
+        //    same space in the log buffer.
+        // 2. Write the log entry to the allocated space in the log buffer.
+        //
+
+        // Get the total size of the long entry with the header, including the
+        // alignment padding for 8 byte alignment.
+        let data_offset = size_of::<AdvLoggerMessageEntry>() as u16;
+        let unaligned_size = data_offset as u32 + log_entry.data.len() as u32;
+        let message_size = align_up(unaligned_size, 8).unwrap() as u32;
+
+        // try to swap in the updated value. if this grows beyond the buffer, fall out.
+        // Using relaxed here as we only want the atomic swap and are not concerned
+        // with ordering. The loop should still use the atomic swap and update each
+        // iteration.
+        let mut current_offset = self.header.log_current_offset().load(Ordering::Relaxed);
+        while current_offset + message_size <= self.header.full_size() {
+            match self.header.log_current_offset().compare_exchange(
+                current_offset,
+                current_offset + message_size,
+                Ordering::Relaxed,
+                Ordering::Relaxed,
+            ) {
+                Ok(_) => break,
+                Err(val) => current_offset = val,
+            }
+        }
+
+        // check if we fell out of bounds.
+        if current_offset + message_size > self.header.full_size() {
+            // Add the discarded value. No ordering needed as this is a single
+            // operation.
+            self.header.discarded_size().fetch_add(message_size, Ordering::Relaxed);
+            return Err(EfiError::OutOfResources);
+        }
+
+        let data_index = (current_offset - self.header.log_buffer_offset()) as usize;
+
+        // SAFETY: The space has been allocated. It should now be safe to write
+        // data so long as it sticks to the range of the allocated entry. Get only
+        // the allocated slice to maintain safety.
+        let entry_slice = unsafe {
+            let data: *mut [u8] = self.data.get();
+            (&mut *data).get_mut(data_index..data_index + message_size as usize).ok_or(EfiError::BufferTooSmall)?
+        };
+
+        let (header_slice, entry_slice) = entry_slice.split_at_mut(size_of::<AdvLoggerMessageEntry>());
+        let (data_slice, remainder_slice) = entry_slice.split_at_mut(log_entry.data.len());
+
+        AdvLoggerMessageEntry::from_log_entry(&log_entry)
+            .write_to(header_slice)
+            .map_err(|_| EfiError::BufferTooSmall)?;
+
+        log_entry.data.write_to(data_slice).map_err(|_| EfiError::BufferTooSmall)?;
+        remainder_slice.fill(0);
+
+        Ok(())
+    }
+
+    /// Returns whether hardware port writing is enabled for the given level.
+    pub fn hardware_write_enabled(&self, level: u32) -> bool {
+        !self.header.hw_port_disabled() && (level & self.header.hw_print_level() != 0)
+    }
+
+    /// Returns the timer frequency.
+    pub fn get_frequency(&self) -> u64 {
+        self.header.timer_frequency().load(Ordering::Relaxed)
+    }
+
+    /// Sets the timer frequency if not already set.
+    pub fn set_frequency(&self, frequency: u64) {
+        // try to swap, assuming the value is initially 0. If this fails, just continue.
+        let _ = self.header.timer_frequency().compare_exchange(0, frequency, Ordering::Relaxed, Ordering::Relaxed);
+    }
+
+    /// Returns the address of the log buffer header.
+    pub fn get_address(&self) -> efi::PhysicalAddress {
+        self.header.as_ptr() as efi::PhysicalAddress
+    }
+
+    /// Returns the new logger info address if one has been set.
+    pub fn get_new_logger_info_address(&self) -> Option<efi::PhysicalAddress> {
+        self.header
+            .new_logger_info_address()
+            .and_then(|address| if address == 0 { None } else { Some(address as efi::PhysicalAddress) })
+    }
+
+    /// Returns the number of discarded bytes.
+    #[allow(dead_code)]
+    pub fn discarded_size(&self) -> u32 {
+        self.header.discarded_size().load(Ordering::Relaxed)
+    }
+}
+
+#[cfg(test)]
+#[coverage(off)]
+mod tests {
+    extern crate std;
+    use alloc::boxed::Box;
+    use core::{mem::size_of, sync::atomic::Ordering};
+    use efi::PhysicalAddress;
+
+    use super::*;
+    use crate::{memory_log::*, reader::AdvancedLogReader};
+
+    #[test]
+    fn create_fill_check_test() {
+        let mut buff_box = Box::new([0_u64; 0x2000]);
+        let buffer = buff_box.as_mut();
+        let address = buffer as *mut u64 as PhysicalAddress;
+        let len = buffer.len() as u32;
+
+        // SAFETY: We just allocated this memory so it's valid.
+        let writer = unsafe { AdvancedLogWriter::initialize_memory_log(address, len) }.unwrap();
+
+        // Fill the log.
+        let mut entries: u32 = 0;
+        loop {
+            let data = entries.to_be_bytes();
+            let entry: LogEntry<'_> = LogEntry { level: 0, phase: 0, timestamp: 0, data: &data };
+            let log_entry = writer.add_log_entry(entry);
+            match log_entry {
+                Ok(_) => {}
+                Err(EfiError::OutOfResources) => {
+                    assert!(writer.discarded_size() > 0);
+                    assert!(entries > 0);
+                    break;
+                }
+                Err(status) => {
+                    panic!("Unexpected add_log_entry returned unexpected status {status:#x?}.")
+                }
+            }
+            entries += 1;
+        }
+
+        // Use reader to verify the contents.
+        // SAFETY: The buffer is still valid and was just written to.
+        let reader = unsafe { AdvancedLogReader::from_address(address) }.unwrap();
+        let mut iter = reader.iter();
+        for entry_num in 0..entries {
+            let data = entry_num.to_be_bytes();
+            let log_entry = iter.next().unwrap();
+            assert_eq!(log_entry.get_message(), data);
+        }
+
+        assert!(iter.next().is_none());
+    }
+
+    #[test]
+    fn adopt_buffer_test() {
+        let buff_box = Box::new([0_u8; 0x10000]);
+        let buffer = buff_box.as_ref();
+        let address = buffer as *const u8 as PhysicalAddress;
+        let len = buffer.len() as u32;
+
+        // SAFETY: We just allocated this memory so it's valid.
+        let writer = unsafe { AdvancedLogWriter::initialize_memory_log(address, len) }.unwrap();
+
+        // Fill the log.
+        for val in 0..50 {
+            let data = (val as u32).to_be_bytes();
+            let entry = LogEntry { level: 0, phase: 0, timestamp: 0, data: &data };
+            writer.add_log_entry(entry).unwrap();
+        }
+
+        // SAFETY: This is the same buffer as before, still valid.
+        let writer = unsafe { AdvancedLogWriter::adopt_memory_log(address) }.unwrap();
+
+        // Add more entries.
+        for val in 50..100 {
+            let data = (val as u32).to_be_bytes();
+            let entry = LogEntry { level: 0, phase: 0, timestamp: 0, data: &data };
+            writer.add_log_entry(entry).unwrap();
+        }
+
+        // Use reader to verify the contents.
+        // SAFETY: The buffer is still valid.
+        let reader = unsafe { AdvancedLogReader::from_address(address) }.unwrap();
+        assert!(writer.discarded_size() == 0);
+        let mut iter = reader.iter();
+        for entry_num in 0..100 {
+            let data = (entry_num as u32).to_be_bytes();
+            let log_entry = iter.next().unwrap();
+            assert_eq!(log_entry.get_message(), data);
+        }
+
+        assert!(iter.next().is_none());
+    }
+
+    #[test]
+    fn adopt_memory_log_accepts_v5_and_v6() {
+        let mut buffer_v5 = create_buffer_v5(0, false);
+        let address_v5 = buffer_v5.as_mut_ptr() as PhysicalAddress;
+        // SAFETY: The memory was allocated successfully in this function and has been initialized
+        // to contain a valid AdvLoggerInfoV5 header.
+        let writer_v5 = unsafe { AdvancedLogWriter::adopt_memory_log(address_v5) }.unwrap();
+        let entry_v5 = LogEntry { level: 0, phase: 0, timestamp: 0, data: b"v5" };
+        writer_v5.add_log_entry(entry_v5).unwrap();
+
+        // SAFETY: Buffer is still valid.
+        let reader_v5 = unsafe { AdvancedLogReader::from_address(address_v5) }.unwrap();
+        let mut iter = reader_v5.iter();
+        assert_eq!(iter.next().unwrap().get_message(), b"v5");
+
+        let mut buffer_v6 = create_buffer_v6(0, 0);
+        let address_v6 = buffer_v6.as_mut_ptr() as PhysicalAddress;
+        // SAFETY: The memory was allocated successfully in this function and has been initialized
+        // to contain a valid AdvLoggerInfoV6 header.
+        let writer_v6 = unsafe { AdvancedLogWriter::adopt_memory_log(address_v6) }.unwrap();
+        let entry_v6 = LogEntry { level: 0, phase: 0, timestamp: 0, data: b"v6" };
+        writer_v6.add_log_entry(entry_v6).unwrap();
+
+        // SAFETY: Buffer is still valid.
+        let reader_v6 = unsafe { AdvancedLogReader::from_address(address_v6) }.unwrap();
+        let mut iter = reader_v6.iter();
+        assert_eq!(iter.next().unwrap().get_message(), b"v6");
+    }
+
+    #[test]
+    fn adopt_memory_log_rejects_log_buffer_offset_less_than_header_size() {
+        let mut buffer = create_buffer_v5(0, false);
+        let header = buffer.as_mut_ptr().cast::<AdvLoggerInfoV5>();
+
+        // SAFETY: The buffer contains a valid AdvLoggerInfoV5 header, so mutating header fields is valid.
+        unsafe {
+            (*header).log_buffer_offset = (size_of::<AdvLoggerInfoV5>() as u32) - 1;
+        }
+
+        let address = buffer.as_mut_ptr() as PhysicalAddress;
+        // SAFETY: The buffer structure is valid in memory allocated above.
+        let result = unsafe { AdvancedLogWriter::adopt_memory_log(address) };
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn adopt_memory_log_rejects_log_current_offset_before_buffer_start() {
+        let mut buffer = create_buffer_v5(0, false);
+        let header = buffer.as_mut_ptr().cast::<AdvLoggerInfoV5>();
+
+        // SAFETY: The buffer contains a valid AdvLoggerInfoV5 header, so mutating header fields is valid.
+        unsafe {
+            (*header).log_current_offset.store((*header).log_buffer_offset - 1, Ordering::Relaxed);
+        }
+
+        let address = buffer.as_mut_ptr() as PhysicalAddress;
+        // SAFETY: The buffer structure is valid in memory allocated above.
+        let result = unsafe { AdvancedLogWriter::adopt_memory_log(address) };
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn adopt_memory_log_rejects_log_current_offset_beyond_full_size() {
+        let mut buffer = create_buffer_v5(0, false);
+        let header = buffer.as_mut_ptr().cast::<AdvLoggerInfoV5>();
+
+        // SAFETY: The buffer contains a valid AdvLoggerInfoV5 header, so mutating header fields is valid.
+        unsafe {
+            let full_size = (*header).log_buffer_offset + (*header).log_buffer_size;
+            (*header).log_current_offset.store(full_size + 1, Ordering::Relaxed);
+        }
+
+        let address = buffer.as_mut_ptr() as PhysicalAddress;
+        // SAFETY: The buffer structure is valid in memory allocated above.
+        let result = unsafe { AdvancedLogWriter::adopt_memory_log(address) };
+        assert!(result.is_none());
+    }
+}


### PR DESCRIPTION
## Description

Currently the adv logger crate exposes all of the component and integration test, etc. by default. However, for consumers wanting to log to the advanced from more minimal environments, this is not ideal. This commit refactors this base support to be the minimal core logic, and then a component feature on top used by DXE.

Base: Exposes the core logger logic, and nothing else. Does no use alloc.

Component: Exposes the component, protocol, and integrations test logic.

To achieve this, this refactors the write and reader into separate modules and simplifies to use a read-only and write-only paradigm to simplify the wrapper logic.

With this change, consumers can use patina_adv_logger without default features to get a minimal advanced logger implementation.

Issue #1318 

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

- [x] Q35 w/ integration tests
- [x] Unit tests

## Integration Instructions

N/A
