### PR TITLE
Add Patina Config Enforcement

### DIFF
--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -37,6 +37,7 @@
   - [Windbg Debugging](dev/debugging/windbg_debugging.md)
   - [Windbg Debugging Example](dev/debugging/windbg_example.md)
   - [Core Reload](dev/debugging/core_reload.md)
+- [Toolchain Configuration](dev/toolchain_configuration.md)
 
 # Patina DXE Core Platform Integration
 

--- a/docs/src/dev/toolchain_configuration.md
+++ b/docs/src/dev/toolchain_configuration.md
@@ -1,0 +1,58 @@
+# Toolchain Configuration
+
+Patina relies on platform bin repos copying its `.cargo/config.toml` to properly set toolchain configuration. This
+document focuses on the process to update and maintain Patina's toolchain configuration.
+
+## Background
+
+Patina must recommend a set of toolchain configuration options for platforms to use to have the best experience. With
+different options, various features may not work as intended (e.g. if `-C force-unwind-tables` is not used, the
+stack walk in a debugger will be truncated), performance or binary size may be worse, or failures could occur.
+
+EDK II achieves this same goal by maintaining custom build tools. One of Patina's philosophies is to use existing
+tools wherever possible. In pursuit of this goal, Patina has a `.cargo/config.toml` file that is used when building
+Patina in CI. It [is recommended](../integrate/patina_dxe_core_requirements.md#35-configtoml-usage) that platforms
+copy this `.cargo/config.toml` to match Patina's toolchain configuration exactly. Patina enforces the same version
+is being used in a `build.rs` file.
+
+>**Note:** Platforms still have the flexibility to change toolchain configuration as needed in this setup, they just
+> need to ensure the config version is the same as what Patina is expecting. Platforms choosing to diverge from the
+> known good Patina config accept the risk of unexpected behavior stemming from these modifications.
+
+## Updating Configuration
+
+There are some simple rules that must be followed when updating Patina's configuration.
+
+1. Consider the change. Is is appropriate for all platforms? All architectures?
+2. Add (or remove) the configuration option to `patina/.cargo/config.toml`. See [the rules](#configuration-adding-rules).
+3. Add a comment (multiline okay) above the option describing what this option does and why.
+4. Increase `PATINA_CONFIG_VERSION` by one. All config updates, no matter how trivial, must update the version.
+5. Update the `PATINA_CONFIG_VERSION` defined in `patina/patina_dxe_core/build.rs` by one. This must match the
+   `PATINA_CONFIG_VERSION` updated in step 4.
+
+### Configuration Adding Rules
+
+The following is a set of rules to follow when adding new toolchain configuration options.
+
+#### Prefer Cargo Options
+
+Per [Rust documentation](https://doc.rust-lang.org/cargo/reference/config.html#buildrustflags) all `RUSTFLAGS` that
+`Cargo` itself manages in `profile` settings (e.g. `lto`, `debug`, etc.) should be set in the relevant `profile`
+section, not directly in `RUSTFLAGS`. See [the profile docs](https://doc.rust-lang.org/cargo/reference/profiles.html)
+for which settings are managed there.
+
+#### Put RUSTFLAGS in target.\<triple\>.rustflags Section
+
+Per [Rust documentation](https://doc.rust-lang.org/cargo/reference/config.html#buildrustflags), there are four mutually
+exclusive ways to pass RUSTFLAGS:
+
+```text
+1. CARGO_ENCODED_RUSTFLAGS environment variable.
+2. RUSTFLAGS environment variable.
+3. All matching target.<triple>.rustflags and target.<cfg>.rustflags config entries joined together.
+4. build.rustflags config value.
+```
+
+Patina only uses the third option. We do not directly set environment variables as this is brittle and can conflict
+with many different scenarios. We prefer using the target triple sections because they have precedence over general
+`[Build]` sections. Do not put RUSTFLAGS in a `[Build]` section, it will be unused.

--- a/docs/src/integrate/dxe_core.md
+++ b/docs/src/integrate/dxe_core.md
@@ -133,6 +133,20 @@ Reference: [sbsa_dxe_core.rs](https://github.com/OpenDevicePartnership/patina-dx
 > While the QEMU Patina DXE Core implementations provide a good starting point, you need to modify the copied file to
 > suit your platform's specific requirements.
 
+### Copy config.toml from Patina
+
+Copy `patina/.cargo/config.toml` to `bin/.cargo/config.toml`. This ensures that the platform is using the same
+toolchain configuration as Patina has been verified with and recommends. A platform may customize the copied
+`config.toml` as it wishes, but for best performance and stability, use the recommended settings. See the
+[Patina DXE Core Requirements](./patina_dxe_core_requirements.md#35-configtoml-usage) for more details.
+
+The `patina_dxe_core` crate build will fail if the config version has changed. A platform should use this as an
+indication when updating Patina to repeat this step to get the latest config.
+
+> **Note:** Patina will validate that the `PATINA_CONFIG_VERSION` environment variable is set to the same value as its
+> `.cargo/config.toml`, so even if a platform updates toolchain configuration, it must keep the same
+> `PATINA_CONFIG_VERSION`.
+
 ## 3. Dependencies
 
 Inside your crate's Cargo.toml file, add the following, where `$(VERSION)` is replaced with the version of the

--- a/docs/src/integrate/patina_dxe_core_requirements.md
+++ b/docs/src/integrate/patina_dxe_core_requirements.md
@@ -267,6 +267,14 @@ crashes due to speculative execution trying instruction fetches from memory that
 never be touched. For x86 platforms, these regions are still protected to prevent devices having access to executable
 memory.
 
+#### 3.5 Config.toml Usage
+
+Patina relies on its `.cargo/config.toml` being copied to the platform bin wrapper repo. A `build.rs` file is used
+to enforce that the correct config is used. EDK II relies on a centralized `tools_def.template` being used by custom
+build tools to create consistent toolchain configuration. In order to use standard Rust tools, Patina has opted for
+this simpler approach. See the [integration section](./dxe_core.md#copy-configtoml-from-patina) for instructions on
+setting up a platform.
+
 ### 4. Architectural Requirements
 
 This section details Patina requirements that are specific to a particular CPU architectural requirements.

--- a/docs/src/integrate/patina_dxe_core_requirements_checklist.md
+++ b/docs/src/integrate/patina_dxe_core_requirements_checklist.md
@@ -1,7 +1,7 @@
 # Patina DXE Core Requirements Platform Checklist
 
 | ✅ | Requirement | Summary | Details |
-|---:|---|---|---|
+| ---: | --- | --- | --- |
 | [ ] | **1.1 Standalone MM is Used** | Traditional SMM and combined SMM/DXE modules aren’t supported, use **Standalone MM** instead. SMM-specific file types/DEPEX aren’t dispatched/evaluated. | [No Traditional SMM](https://opendevicepartnership.github.io/patina/integrate/patina_dxe_core_requirements.html#11-no-traditional-smm) |
 | [ ] | **1.2 A Priori Driver Dispatch Is Not Used** | Remove *A Priori* sections. Patina dispatches in **FFS listed order**. Use **DEPEX** (optionally with empty/stub protocols) to control dependencies. | [A Priori Driver Dispatch Is Not Allowed](https://opendevicepartnership.github.io/patina/integrate/patina_dxe_core_requirements.html#12-a-priori-driver-dispatch-is-not-allowed) |
 | [ ] | **1.3 All DXE Dispatchable Modules Have Page Aligned Sections** | All DXE images (including C-based drivers) must have **≥ 4 KB** section alignment. **ARM64 DXE_RUNTIME_DRIVER** images must use **64 KB**. Set linker flags accordingly (e.g., `/ALIGN:0x1000` or `-z common-page-size=0x1000`). | [Driver Section Alignment](https://opendevicepartnership.github.io/patina/integrate/patina_dxe_core_requirements.html#13-driver-section-alignment-must-be-a-multiple-of-4-kb) |
@@ -14,3 +14,4 @@
 | [ ] | **3.2 All DXE Code Used in the Platform Supports Native Address Width** | Patina allocates **top‑down**, so addresses may be **>4 GB**. All code must store pointers in **native-width** types (not 32‑bit ints). | [Native Address Width](https://opendevicepartnership.github.io/patina/integrate/patina_dxe_core_requirements.html#32-all-code-must-support-native-address-width) |
 | [ ] | **3.3 ConnectController() Is Called Explicitly** | Patina **does not** auto‑call `ConnectController()` during `StartImage()`. Drivers/platforms must call it for any handles they create/modify. | [ConnectController() Must Be Called](https://opendevicepartnership.github.io/patina/integrate/patina_dxe_core_requirements.html#33-connectcontroller-must-explicitly-be-called-for-handles-createdmodified-during-image-start) |
 | [ ] | **3.4 Uncached Memory is Not Executable** | Patina **does not** allow execution from uncached memory regions. Ensure all executable code resides in cached memory. | [Uncached Memory Not Executable](https://opendevicepartnership.github.io/patina/integrate/patina_dxe_core_requirements.html#34-efi_memory_uc-memory-must-be-non-executable) |
+| [ ] | **3.5 Patina's Config.toml Used** | Patina enforces toolchain configuration via copying its `.cargo/config.toml` to the platform | [config.toml Must Be Copied](./patina_dxe_core_requirements.md#35-configtoml-usage) |

--- a/patina_dxe_core/build.rs
+++ b/patina_dxe_core/build.rs
@@ -1,0 +1,34 @@
+//! Build script for patina_dxe_core to verify toolchain configuration.
+//!
+//! ## License
+//!
+//! Copyright (c) Microsoft Corporation.
+//!
+//! SPDX-License-Identifier: Apache-2.0
+//!
+use std::{env, process};
+
+// This must be kept in sync with .cargo/config.toml's PATINA_CONFIG_VERSION
+const PATINA_CONFIG_VERSION: &str = "1";
+
+fn main() {
+    let version = env::var_os("PATINA_CONFIG_VERSION").unwrap_or_default();
+
+    let rustflags = env::var_os("CARGO_ENCODED_RUSTFLAGS").unwrap_or_default();
+    eprintln!("CARGO_ENCODED_RUSTFLAGS={rustflags:?}");
+
+    if version != PATINA_CONFIG_VERSION {
+        eprintln!(
+            "error: Incorrect PATINA_CONFIG_VERSION, expected version \"{}\", got version {:?}",
+            PATINA_CONFIG_VERSION, version
+        );
+        eprintln!(
+            "Use Patina's latest config.toml. See https://opendevicepartnership.github.io/patina/dev/toolchain_configuration.html"
+        );
+        process::exit(1);
+    }
+
+    // Only rerun this when the rustflags or the config version changes
+    println!("cargo:rerun-if-env-changed=CARGO_ENCODED_RUSTFLAGS");
+    println!("cargo:rerun-if-env-changed=PATINA_CONFIG_VERSION");
+}


### PR DESCRIPTION
## Description

Per RFC 25, this patch adds config.toml enforcement of the Patina config version.

config.toml is updated to reflect the various settings Patina wants to use. Each is documented on why.

build.rs verifies the patina config version is the correct one and will fail the build if not.

Docs are updated.

Note this targets the major branch.

- [x] Impacts functionality?
- [ ] Impacts security?
- [x] Breaking change?
- [ ] Includes tests?
- [x] Includes documentation?

## How This Was Tested

Tested building Q35 and SBSA and booting them to Windows. Settings were validated in build.rs and by outside factors such as binary size.

## Integration Instructions

Patina's `.cargo/config.toml` must be copied to the platform's `.cargo/config.toml`. See the docs for more details.
