### PR TITLE
Add summary line to Recorder output

### DIFF
--- a/patina_dxe_core/src/core_patina_tests/audit_tests.rs
+++ b/patina_dxe_core/src/core_patina_tests/audit_tests.rs
@@ -12,6 +12,8 @@
 use crate::GCD;
 use alloc::vec::Vec;
 use patina::{test::patina_test, u_assert};
+// used in the macro, but not directly referenced; causes a warning if patina tests not enabled.
+#[allow(unused)]
 use r_efi::efi;
 
 // Verify that all adjacent free memory descriptors in the GCD are merged together

--- a/sdk/patina/src/test.rs
+++ b/sdk/patina/src/test.rs
@@ -244,9 +244,12 @@ impl Display for Recorder {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         // SAFETY: This is safe due to the invariance of this struct so long as it is only accessed via the component system.
         let data = unsafe { self.results.get().as_mut().expect("Pointer is not null.") };
-
+        let mut total_passes = 0;
+        let mut total_fails = 0;
         writeln!(f, "Patina on-system unit-test results:")?;
         for (name, (passes, fails, msg)) in data.iter() {
+            total_passes += *passes;
+            total_fails += *fails;
             if *fails == 0 && *passes == 0 {
                 writeln!(f, "  {name} ... not triggered")?;
                 continue;
@@ -257,6 +260,7 @@ impl Display for Recorder {
                 writeln!(f, "  {name} ... fail ({fails} fails, {passes} passes): {msg}")?;
             }
         }
+        writeln!(f, "Patina on-system unit-test result totals: {total_passes} passes, {total_fails} fails")?;
 
         Ok(())
     }


### PR DESCRIPTION
## Description

Adds a summary line to the test runner Recorder output.

also fixes an unused import warning when patina_test is not enabled. 

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Compiled and observed output as expected.

## Integration Instructions

N/A