### PR TITLE
patina_dxe_core: Add version static for offline inspection

### DIFF
--- a/patina_dxe_core/src/lib.rs
+++ b/patina_dxe_core/src/lib.rs
@@ -158,6 +158,10 @@ macro_rules! error {
 
 pub(crate) static GCD: SpinLockedGcd = SpinLockedGcd::new(Some(events::gcd_map_change));
 
+/// Useful for offline inspection (like debugging) to determine core version.
+#[used]
+static DXE_CORE_VERSION: &str = env!("CARGO_PKG_VERSION");
+
 /// A trait to be implemented by the platform to provide configuration values and types related to memory management
 /// to be used directly by the Patina DXE Core.
 ///
@@ -394,7 +398,7 @@ impl<P: PlatformInfo> Core<P> {
     ///
     /// Returns the relocated HOB list pointer that should be used for all subsequent operations.
     fn init_memory(&self, physical_hob_list: *const c_void) -> *mut c_void {
-        log::info!("DXE Core Crate v{}", env!("CARGO_PKG_VERSION"));
+        log::info!("DXE Core Crate v{DXE_CORE_VERSION}");
 
         GCD.prioritize_32_bit_memory(P::MemoryInfo::prioritize_32_bit_memory());
 


### PR DESCRIPTION
## Description

Adds a static global to the root of the DXE core that can be used to determine the version. This is useful for offline inspection, like the debugger for determining the patina version which is needed to know how to inspect other global state. This commit creates this string to ensure its presence for future use. 

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

N/A

## Integration Instructions

N/A
