### PR TITLE
Add Patina QEMU PR Validation [Rebase & FF]

### DIFF
--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -40,14 +40,14 @@ concurrency:
 jobs:
   ci_workflow:
     name: Run
-    uses: OpenDevicePartnership/patina-devops/.github/workflows/CiWorkflow.yml@v0.3.8
+    uses: OpenDevicePartnership/patina-devops/.github/workflows/CiWorkflow.yml@patina_e2e_plat_validation
     with:
       build-tasks: build,build-x64,build-aarch64
       run-cargo-vet: false
     secrets: inherit
   mdbook_docs_test:
     name: Run
-    uses: OpenDevicePartnership/patina-devops/.github/workflows/MdbookWorkflow.yml@v0.3.8
+    uses: OpenDevicePartnership/patina-devops/.github/workflows/MdbookWorkflow.yml@patina_e2e_plat_validation
     with:
       mdbook-path: "docs"
       build-cmd: cargo make build-lib

--- a/.github/workflows/patina-qemu-pr-validation-post.yml
+++ b/.github/workflows/patina-qemu-pr-validation-post.yml
@@ -1,0 +1,27 @@
+# @file patina-qemu-pr-validation-post.yml
+#
+# A workflow that runs after Patina QEMU PR Validation completes and delegates
+# post-processing to a patina-devops workflow that will ultimately assess the
+# validation results and report them back to the PR.
+#
+# Copyright (c) Microsoft Corporation.
+# SPDX-License-Identifier: Apache-2.0
+##
+name: Patina QEMU PR Validation Post
+
+on:
+  workflow_run:
+    workflows: ["Patina QEMU PR Validation"]
+    types: ["completed"]
+
+permissions:
+  contents: read
+  actions: read
+
+jobs:
+  post-process:
+    if: github.event.workflow_run.conclusion != 'cancelled'
+    uses: OpenDevicePartnership/patina-devops/.github/workflows/PatinaQemuPrValidationPost.yml@patina_e2e_plat_validation
+    with:
+      triggering-run-id: ${{ fromJSON(github.event.workflow_run.id) }}
+    secrets: inherit

--- a/.github/workflows/patina-qemu-pr-validation.yml
+++ b/.github/workflows/patina-qemu-pr-validation.yml
@@ -1,0 +1,72 @@
+# @file patina-qemu-pr-validation.yml
+#
+# A workflow that runs QEMU-based validation after CI succeeds for a pull request.
+#
+# Copyright (c) Microsoft Corporation.
+# SPDX-License-Identifier: Apache-2.0
+##
+name: Patina QEMU PR Validation
+
+on:
+  workflow_run:
+    workflows: ["CI"]
+    types: ["completed"]
+
+# Do not allow more than one instance of this workflow to run at the same
+# time for the same PR branch.
+concurrency:
+  group: qemu-pr-${{ github.event.workflow_run.head_branch }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  actions: read
+  pull-requests: read
+
+jobs:
+  prepare:
+    runs-on: ubuntu-latest
+    name: Gather Incoming PR Metadata
+    if: |
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.event == 'pull_request'
+    outputs:
+      pr_number: ${{ steps.pr-info.outputs.pr_number }}
+    steps:
+      - name: Get PR Information
+        id: pr-info
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+          HEAD_REF: ${{ github.event.workflow_run.head_branch }}
+          HEAD_REPO: ${{ github.event.workflow_run.head_repository.full_name }}
+        run: |
+          owner="${HEAD_REPO%%/*}"
+          pr_number=$(gh api "repos/${GITHUB_REPOSITORY}/pulls" \
+            --method GET -f state=open -f head="${owner}:${HEAD_REF}" \
+            --jq '.[0].number')
+
+          if [[ -z "$pr_number" || "$pr_number" == "null" ]]; then
+            echo "::error::No open PR found for head $owner:$HEAD_REF"
+            exit 1
+          fi
+
+          echo "::group::PR Information"
+          echo "  - PR Number: $pr_number"
+          echo "  - Head SHA:  $HEAD_SHA"
+          echo "  - Head Ref:  $HEAD_REF"
+          echo "  - Source:    $HEAD_REPO"
+          echo "::endgroup::"
+
+          echo "pr_number=$pr_number" >> "$GITHUB_OUTPUT"
+
+  qemu-pr-validation:
+    name: Run Patina QEMU Validation
+    needs: [prepare]
+    if: needs.prepare.result == 'success'
+    uses: OpenDevicePartnership/patina-devops/.github/workflows/PatinaQemuPrValidation.yml@patina_e2e_plat_validation
+    with:
+      pr-number: ${{ fromJSON(needs.prepare.outputs.pr_number) }}
+      patina-ref: ${{ github.event.workflow_run.head_sha }}
+    secrets: inherit


### PR DESCRIPTION
## Description

Two commits to add Patina QEMU testing on PRs in this repository.

See https://github.com/OpenDevicePartnership/patina-devops/pull/81 for more details about the workflows themselves.

---

**.github: And Patina QEMU validation workflows**

Adds:

- `.github/workflows/patina-qemu-pr-validation.yml`: Validates the
  patina PR changes on QEMU.
- `.github/workflows/patina-qemu-pr-validation-post.yml`: Posts the
  results from the QEMU run back to the patina PR.

Temporarily sets the patina-devops branch to `patina_e2e_plat_validation`
in OpenDevicePartnership/patina-devops during a "rollout" phase of the
new workflow so any adjustments can be quickly made. Once the workflow
is stable, workflows in the patina-devops release will be referenced
instead.

---

**.github/ci-workflow.yml: Prevent concurrent runs**

Create a concurrency group to enforce only a single CI workflow is run
per PR at a time.

---

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

- Various PR scenarios on fork:
  - Successful run
  - Compilation failure
  - Boot failure
  - Cancellation of workflow due to a new PR push
  - Log artifacts uploaded successfully
  - Creation of comment in a new PR
  - Amendment of comments in an existing PR

## Integration Instructions

- N/A - Only used for CI in this repo