### PR TITLE
Cargo.toml: Drop Profiles

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,20 +73,5 @@ serde_yaml = { version = "0.9" }
 serde_json = { version = "1.0", default-features = false, features = ["alloc"] }
 lzma-rs = { version = "0.3" }
 
-[profile.release]
-debug = true
-
-[profile.dev]
-opt-level = 3
-
-[profile.test]
-opt-level = 0
-debug = true
-debug-assertions = false
-overflow-checks = true
-lto = false
-incremental = false
-codegen-units = 1
-
 [workspace.lints.clippy]
 undocumented_unsafe_blocks = "warn"


### PR DESCRIPTION
## Description

Now that profiles are in config.toml, drop them from Cargo.toml.

This commit was intended as part of the repo file sync, but I made a mistake and it wasn't included. I checked the other repos, they all correctly have this commit.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Tested with other RFC 25 changes.

## Integration Instructions

N/A.
