### PR TITLE
.github/patina-qemu-pr-validation.yml: Skip when a PR is merged

### DIFF
--- a/.github/workflows/patina-qemu-pr-validation.yml
+++ b/.github/workflows/patina-qemu-pr-validation.yml
@@ -32,6 +32,7 @@ jobs:
       github.event.workflow_run.event == 'pull_request'
     outputs:
       pr_number: ${{ steps.pr-info.outputs.pr_number }}
+      skip: ${{ steps.pr-info.outputs.skip }}
     steps:
       - name: Get PR Information
         id: pr-info
@@ -48,9 +49,12 @@ jobs:
             --jq '.[0].number')
 
           if [[ -z "$pr_number" || "$pr_number" == "null" ]]; then
-            echo "::error::No open PR found for head $owner:$HEAD_REF"
-            exit 1
+            echo "::notice::No open PR found for head $owner:$HEAD_REF. The PR was likely closed or merged already. Skipping."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            exit 0
           fi
+
+          echo "skip=false" >> "$GITHUB_OUTPUT"
 
           echo "::group::PR Information"
           echo "  - PR Number: $pr_number"
@@ -64,7 +68,7 @@ jobs:
   qemu-pr-validation:
     name: Run Patina QEMU Validation
     needs: [prepare]
-    if: needs.prepare.result == 'success'
+    if: needs.prepare.result == 'success' && needs.prepare.outputs.skip != 'true'
     uses: OpenDevicePartnership/patina-devops/.github/workflows/PatinaQemuPrValidation.yml@patina_e2e_plat_validation
     with:
       pr-number: ${{ fromJSON(needs.prepare.outputs.pr_number) }}


### PR DESCRIPTION
## Description

The case when a PR branch is not found was considered a failure in the API to find the PR. However, this will also happen when is merged and the CI workflow runs. In either case, treat this as a "skip" instead of an "error".

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

- Run with PR branch still available
- Run with PR branch deleted

## Integration Instructions

- N/A