### PR TITLE
Add QEMU validation pending notification workflow

### DIFF
--- a/.github/workflows/patina-qemu-pr-validation-pending.yml
+++ b/.github/workflows/patina-qemu-pr-validation-pending.yml
@@ -1,0 +1,38 @@
+# @file patina-qemu-pr-validation-pending.yml
+#
+# A workflow that posts a "pending" QEMU validation comment immediately when
+# a pull request is opened or updated. This provides early feedback that QEMU
+# validation will run after CI completes, rather than leaving the previous
+# result visible until the QEMU validation workflow starts.
+#
+# Note: The pull_request_target trigger is used so that secrets are available
+# even for PRs from forks. This workflow only posts a comment and does not
+# checkout or execute any code from the PR branch.
+#
+# Copyright (c) Microsoft Corporation.
+# SPDX-License-Identifier: Apache-2.0
+##
+name: Patina QEMU PR Validation Pending
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+    branches:
+      - main
+      - major
+      - feature/**/*
+
+concurrency:
+  group: qemu-pr-pending-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  notify-pending:
+    name: Run
+    uses: OpenDevicePartnership/patina-devops/.github/workflows/PatinaQemuPrValidationPending.yml@patina_e2e_plat_validation
+    with:
+      pr-number: ${{ github.event.pull_request.number }}
+    secrets: inherit


### PR DESCRIPTION
## Description

Add a workflow that posts a "pending" comment on PRs immediately when pushed, indicating QEMU validation is waiting for CI to complete.

This prevents prior stale results from sitting around while CI runs and lets users know QEMU validation will happen soon if the workflow has not previously been run on the PR.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

- Verify comment is posted/updated as expected on fork (with a PR from another fork)

## Integration Instructions

- N/A