### PR TITLE
Change `TplMutex` in perf component to `RefCell`

### DIFF
--- a/components/patina_performance/src/component/performance.rs
+++ b/components/patina_performance/src/component/performance.rs
@@ -11,7 +11,7 @@
 
 use crate::{component::protocol::create_performance_measurement_efiapi, config, mm};
 use alloc::{boxed::Box, string::String, vec::Vec};
-use core::{clone::Clone, convert::AsRef};
+use core::{cell::RefCell, clone::Clone, convert::AsRef};
 use patina::{
     boot_services::{BootServices, StandardBootServices, event::EventType, tpl::Tpl},
     component::{
@@ -33,7 +33,6 @@ use patina::{
         table::FirmwareBasicBootPerfTable,
     },
     runtime_services::{RuntimeServices, StandardRuntimeServices},
-    tpl_mutex::TplMutex,
     uefi_protocol::performance_measurement::EdkiiPerformanceMeasurement,
 };
 use patina_mm::component::communicator::MmCommunication;
@@ -42,7 +41,7 @@ use r_efi::system::EVENT_GROUP_READY_TO_BOOT;
 pub use mu_rust_helpers::function;
 
 /// Context parameter for the Ready-to-Boot event callback that fetches MM performance records.
-type MmPerformanceEventContext<BB, B, F> = Box<(BB, &'static TplMutex<F, B>, Service<dyn MmCommunication>)>;
+type MmPerformanceEventContext<BB, F> = Box<(BB, &'static RefCell<F>, Service<dyn MmCommunication>)>;
 
 /// Performance Component.
 pub struct Performance;
@@ -89,7 +88,7 @@ impl Performance {
         runtime_services: RR,
         records_buffers_hobs: Option<P>,
         mm_comm_service: Option<Service<dyn MmCommunication>>,
-        fbpt: &'static TplMutex<F, B>,
+        fbpt: &'static RefCell<F>,
         timer: Service<dyn ArchTimerFunctionality>,
     ) -> Result<(), EfiError>
     where
@@ -126,7 +125,7 @@ impl Performance {
             // Initialize perf data from hob values.
 
             set_load_image_count(hob_load_image_count);
-            fbpt.lock().set_perf_records(hob_perf_records);
+            fbpt.borrow_mut().set_perf_records(hob_perf_records);
         } else {
             log::info!("Performance: No Hob performance records provided.");
         }
@@ -345,13 +344,12 @@ impl<'a> Iterator for PerformanceRecordIterator<'a> {
 }
 
 /// Processes MM performance records and adds them to the FBPT
-fn process_mm_performance_records<F, B>(
+fn process_mm_performance_records<F>(
     comm_service: &Service<dyn MmCommunication>,
-    fbpt: &TplMutex<F, B>,
+    fbpt: &RefCell<F>,
 ) -> Result<(), MmPerformanceError>
 where
     F: FirmwareBasicBootPerfTable,
-    B: BootServices + 'static,
 {
     let record_data = fetch_all_mm_record_data(comm_service)?;
 
@@ -383,7 +381,7 @@ where
                 // Print detailed record information based on type
                 print_record_details(record.record_type, record_count, record.data);
 
-                if let Err(e) = fbpt.lock().add_record(record) {
+                if let Err(e) = fbpt.borrow_mut().add_record(record) {
                     error_count += 1;
                     log::error!("Performance: Failed adding MM record #{}: {:?}", record_count, e);
                 } else {
@@ -410,7 +408,7 @@ where
 /// Adds MM performance records to the FBPT.
 pub extern "efiapi" fn fetch_and_add_mm_performance_records<BB, B, F>(
     event: r_efi::efi::Event,
-    ctx: MmPerformanceEventContext<BB, B, F>,
+    ctx: MmPerformanceEventContext<BB, F>,
 ) where
     BB: AsRef<B> + Clone,
     B: BootServices + 'static,
@@ -534,7 +532,7 @@ mod tests {
             .expect_create_event_ex::<Box<(
                 Rc<MockBootServices>,
                 Rc<MockRuntimeServices>,
-                &TplMutex<MockFirmwareBasicBootPerfTable, MockBootServices>,
+                &RefCell<MockFirmwareBasicBootPerfTable>,
             )>>()
             .once()
             .withf_st(|event_type, notify_tpl, notify_function, _notify_context, event_group| {
@@ -569,7 +567,7 @@ mod tests {
         let boot_services_rc = Rc::new(boot_services);
 
         // TplMutex owns its BootServices instance
-        let fbpt = TplMutex::new((*boot_services_rc).clone(), Tpl::NOTIFY, fbpt);
+        let fbpt = RefCell::new(fbpt);
 
         // Leak the fbpt to create a 'static reference for testing.
         let fbpt = Box::leak(Box::new(fbpt));
@@ -598,30 +596,23 @@ mod tests {
             }
         }
 
-        // Mock for TplMutex - no expectations needed since _entry_point doesn't lock the mutex
-        let tpl_mock = MockBootServices::new();
-
         // Mock for _entry_point - handles event creation and protocol installation
         let mut entry_point_mock = MockBootServices::new();
         entry_point_mock
             .expect_create_event_ex::<Box<(
                 Rc<MockBootServices>,
                 Rc<MockRuntimeServices>,
-                &TplMutex<MockFirmwareBasicBootPerfTable, MockBootServices>,
+                &RefCell<MockFirmwareBasicBootPerfTable>,
             )>>()
             .once()
             .return_const_st(Ok(TEST_EVENT_HANDLE));
         entry_point_mock
-            .expect_create_event_ex::<MmPerformanceEventContext<
-                Rc<MockBootServices>,
-                MockBootServices,
-                MockFirmwareBasicBootPerfTable,
-            >>()
+            .expect_create_event_ex::<MmPerformanceEventContext<Rc<MockBootServices>, MockFirmwareBasicBootPerfTable>>()
             .once()
             .withf_st(|_, _, f, _, group| {
                 (f.unwrap() as usize)
                     == fetch_and_add_mm_performance_records::<Rc<_>, MockBootServices, MockFirmwareBasicBootPerfTable>
-                        as * const () as usize
+                        as *const () as usize
                     && group == &EVENT_GROUP_READY_TO_BOOT
             })
             .return_const_st(Ok(TEST_EVENT_HANDLE_2));
@@ -636,9 +627,9 @@ mod tests {
         fbpt.expect_set_perf_records().never();
 
         // Move tpl_mock into TplMutex (no clone needed)
-        let fbpt_mutex = TplMutex::new(tpl_mock, Tpl::NOTIFY, fbpt);
+        let fbpt_mutex = RefCell::new(fbpt);
         // Use Box::leak for safe 'static reference
-        let fbpt_ref: &'static TplMutex<_, _> = Box::leak(Box::new(fbpt_mutex));
+        let fbpt_ref: &'static RefCell<_> = Box::leak(Box::new(fbpt_mutex));
 
         let mm_service: Service<dyn MmCommunication> = Service::mock(Box::new(FakeComm));
         let timer: Service<dyn ArchTimerFunctionality> = Service::mock(Box::new(MockTimer {}));
@@ -674,9 +665,6 @@ mod tests {
                 Err(Status::InvalidDataBuffer)
             }
         }
-        // Mock for TplMutex - no TPL expectations needed since zero records means no lock/unlock
-        let tpl_mock = MockBootServices::new();
-
         // Mock for callback - handles close_event
         let mut callback_mock = MockBootServices::new();
         callback_mock.expect_close_event().once().return_const(Ok(()));
@@ -685,9 +673,9 @@ mod tests {
         fbpt.expect_add_record().never();
 
         // Move tpl_mock into TplMutex (no clone needed)
-        let fbpt_mutex = TplMutex::new(tpl_mock, Tpl::NOTIFY, fbpt);
+        let fbpt_mutex = RefCell::new(fbpt);
         // Use Box::leak for safe 'static reference
-        let fbpt_ref: &'static TplMutex<_, _> = Box::leak(Box::new(fbpt_mutex));
+        let fbpt_ref: &'static RefCell<_> = Box::leak(Box::new(fbpt_mutex));
 
         let mm_service: Service<dyn MmCommunication> = Service::mock(Box::new(ZeroSizeComm));
         fetch_and_add_mm_performance_records::<Rc<MockBootServices>, MockBootServices, MockFirmwareBasicBootPerfTable>(
@@ -749,9 +737,9 @@ mod tests {
         fbpt.expect_add_record().once().returning(|_| Ok(()));
 
         // Move tpl_mock into TplMutex (no clone needed)
-        let fbpt_mutex = TplMutex::new(tpl_mock, Tpl::NOTIFY, fbpt);
+        let fbpt_mutex = RefCell::new(fbpt);
         // Use Box::leak for safe 'static reference
-        let fbpt_ref: &'static TplMutex<_, _> = Box::leak(Box::new(fbpt_mutex));
+        let fbpt_ref: &'static RefCell<_> = Box::leak(Box::new(fbpt_mutex));
 
         let mm_service: Service<dyn MmCommunication> = Service::mock(Box::new(OneRecordComm::new()));
         fetch_and_add_mm_performance_records::<Rc<MockBootServices>, MockBootServices, MockFirmwareBasicBootPerfTable>(
@@ -831,9 +819,9 @@ mod tests {
         fbpt.expect_add_record().times(TEST_MULTI_CHUNK_RECORD_COUNT).returning(|_| Ok(()));
 
         // Move tpl_mock into TplMutex (no clone needed)
-        let fbpt_mutex = TplMutex::new(tpl_mock, Tpl::NOTIFY, fbpt);
+        let fbpt_mutex = RefCell::new(fbpt);
         // Use Box::leak for safe 'static reference
-        let fbpt_ref: &'static TplMutex<_, _> = Box::leak(Box::new(fbpt_mutex));
+        let fbpt_ref: &'static RefCell<_> = Box::leak(Box::new(fbpt_mutex));
 
         let mm_service: Service<dyn MmCommunication> =
             Service::mock(Box::new(MultiChunks { buf: all_records, fetches: Cell::new(0) }));

--- a/sdk/patina/src/boot_services/tpl.rs
+++ b/sdk/patina/src/boot_services/tpl.rs
@@ -47,6 +47,10 @@ impl Tpl {
     /// If code requires more processing, it needs to signal an event to wait to obtain control again at whatever level it requires.
     /// This level is typically used to process low level IO to or from a device.
     pub const NOTIFY: Tpl = Tpl(efi::TPL_NOTIFY);
+
+    /// The highest task priority level.
+    /// At this level, all interrupts and event notifications are masked.
+    pub const HIGH_LEVEL: Tpl = Tpl(efi::TPL_HIGH_LEVEL);
 }
 
 impl From<Tpl> for usize {

--- a/sdk/patina/src/performance/globals.rs
+++ b/sdk/patina/src/performance/globals.rs
@@ -7,13 +7,12 @@
 //! SPDX-License-Identifier: Apache-2.0
 //!
 use crate::{
-    boot_services::{StandardBootServices, tpl::Tpl},
+    boot_services::StandardBootServices,
     component::service::{Service, perf_timer::ArchTimerFunctionality},
     performance::table::FBPT,
-    tpl_mutex::TplMutex,
 };
 use core::{
-    cell::OnceCell,
+    cell::{OnceCell, RefCell},
     sync::atomic::{AtomicBool, AtomicU32, Ordering},
 };
 
@@ -25,7 +24,7 @@ struct StaticState {
     /// Boot Services instance
     boot_services: OnceCell<StandardBootServices>,
     /// The FBPT protected by a TPL mutex.
-    fbpt: OnceCell<TplMutex<FBPT>>,
+    fbpt: RefCell<FBPT>,
     /// Flag to indicate if the static state is in the process of being initialized.
     initializing: AtomicBool,
     /// Timer service for performance measurements.
@@ -37,7 +36,7 @@ impl StaticState {
     const fn uninit() -> Self {
         Self {
             boot_services: OnceCell::new(),
-            fbpt: OnceCell::new(),
+            fbpt: RefCell::new(FBPT::new()),
             initializing: AtomicBool::new(false),
             timer: Service::new_uninit(),
         }
@@ -52,13 +51,7 @@ impl StaticState {
     fn init(&self, bs: StandardBootServices, timer: Service<dyn ArchTimerFunctionality>) -> Result<(), &'static str> {
         if self.initializing.compare_exchange(false, true, Ordering::Acquire, Ordering::Relaxed).is_ok() {
             self.boot_services.set(bs).map_err(|_| "Already initialized")?;
-            self.fbpt
-                .set(TplMutex::new(
-                    self.boot_services.get().expect("Boot Services Just Set").clone(),
-                    Tpl::NOTIFY,
-                    FBPT::new(),
-                ))
-                .map_err(|_| "Failed to set FBPT")?;
+            self.fbpt.replace(FBPT::new());
             self.timer.replace(&timer);
             self.initializing.store(false, Ordering::Release);
             return Ok(());
@@ -72,12 +65,11 @@ impl StaticState {
     /// Returns `None` if the state is not yet initialized.
     /// Returns `None` if the state is currently being initialized.
     /// Returns `Some` with references to the `StandardBootServices` and `TplMutex<FBPT>` if initialized.
-    fn inner(&self) -> Option<(&StandardBootServices, &TplMutex<FBPT>, &Service<dyn ArchTimerFunctionality>)> {
+    fn inner(&self) -> Option<(&StandardBootServices, &RefCell<FBPT>, &Service<dyn ArchTimerFunctionality>)> {
         if !self.initializing.load(Ordering::Acquire)
             && let Some(bs) = self.boot_services.get()
-            && let Some(fbpt) = self.fbpt.get()
         {
-            return Some((bs, fbpt, &self.timer));
+            return Some((bs, &self.fbpt, &self.timer));
         }
         None
     }
@@ -132,7 +124,7 @@ pub fn set_static_state(
 /// Get performance component static state.
 #[coverage(off)]
 pub fn get_static_state()
--> Option<(&'static StandardBootServices, &'static TplMutex<FBPT>, &'static Service<dyn ArchTimerFunctionality>)> {
+-> Option<(&'static StandardBootServices, &'static RefCell<FBPT>, &'static Service<dyn ArchTimerFunctionality>)> {
     STATIC_STATE.inner()
 }
 

--- a/sdk/patina/src/performance/measurement.rs
+++ b/sdk/patina/src/performance/measurement.rs
@@ -10,6 +10,7 @@ extern crate alloc;
 
 use alloc::boxed::Box;
 use core::{
+    cell::RefCell,
     clone::Clone,
     convert::AsRef,
     ffi::c_void,
@@ -38,7 +39,6 @@ use crate::{
         table::FirmwareBasicBootPerfTable,
     },
     runtime_services::RuntimeServices,
-    tpl_mutex::TplMutex,
     uefi_protocol::{performance_measurement::PerfAttribute, status_code::StatusCodeRuntimeProtocol},
 };
 
@@ -57,7 +57,7 @@ pub mod event_callback {
     /// Reports the Firmware Basic Boot Performance Table (FBPT) record buffer.
     pub extern "efiapi" fn report_fbpt_record_buffer<BB, B, RR, R, F>(
         event: efi::Event,
-        ctx: Box<(BB, RR, &TplMutex<F, B>)>,
+        ctx: Box<(BB, RR, &RefCell<F>)>,
     ) where
         BB: AsRef<B> + Clone,
         B: BootServices + 'static,
@@ -68,7 +68,7 @@ pub mod event_callback {
         let (boot_services, runtime_services, fbpt) = *ctx;
         let _ = boot_services.as_ref().close_event(event);
 
-        let Ok(fbpt_address) = fbpt.lock().report_table(
+        let Ok(fbpt_address) = fbpt.borrow_mut().report_table(
             performance::table::find_previous_table_address(runtime_services.as_ref()),
             boot_services.as_ref(),
         ) else {
@@ -229,7 +229,7 @@ fn _create_performance_measurement<B, F>(
     perf_id: u16,
     attribute: PerfAttribute,
     boot_services: &B,
-    fbpt: &TplMutex<F, B>,
+    fbpt: &RefCell<F>,
     timer: &Service<dyn ArchTimerFunctionality>,
 ) -> Result<(), Error>
 where
@@ -261,7 +261,7 @@ where
             return Err(EfiError::InvalidParameter.into());
         };
         let module_name = string.unwrap_or("unknown name");
-        fbpt.lock().add_record(DynamicStringEventRecord::new(perf_id, 0, timestamp, guid, module_name))?;
+        fbpt.borrow_mut().add_record(DynamicStringEventRecord::new(perf_id, 0, timestamp, guid, module_name))?;
         return Ok(());
     };
 
@@ -273,7 +273,7 @@ where
                 return Err(EfiError::InvalidParameter.into());
             };
             let record = GuidEventRecord::new(perf_id, 0, timestamp, guid);
-            fbpt.lock().add_record(record)?;
+            fbpt.borrow_mut().add_record(record)?;
         }
         id @ KnownPerfId::ModuleLoadImageStart | id @ KnownPerfId::ModuleLoadImageEnd => {
             if id == KnownPerfId::ModuleLoadImageStart {
@@ -285,7 +285,7 @@ where
                 return Err(EfiError::InvalidParameter.into());
             };
             let record = GuidQwordEventRecord::new(perf_id, 0, timestamp, guid, get_load_image_count() as u64);
-            fbpt.lock().add_record(record)?;
+            fbpt.borrow_mut().add_record(record)?;
         }
         KnownPerfId::ModuleDbStart
         | KnownPerfId::ModuleDbEnd
@@ -298,7 +298,7 @@ where
                 return Err(EfiError::InvalidParameter.into());
             };
             let record = GuidQwordEventRecord::new(perf_id, 0, timestamp, guid, address as u64);
-            fbpt.lock().add_record(record)?;
+            fbpt.borrow_mut().add_record(record)?;
         }
         KnownPerfId::ModuleDbStopEnd => {
             let module_handle = caller_identifier.as_handle().ok_or(EfiError::InvalidParameter)?;
@@ -308,7 +308,7 @@ where
             };
             let module_name = "";
             let record = GuidQwordStringEventRecord::new(perf_id, 0, timestamp, guid, address as u64, module_name);
-            fbpt.lock().add_record(record)?;
+            fbpt.borrow_mut().add_record(record)?;
         }
         KnownPerfId::PerfEventSignalStart
         | KnownPerfId::PerfEventSignalEnd
@@ -319,7 +319,7 @@ where
             };
             let module_guid = caller_identifier.as_guid().ok_or(EfiError::InvalidParameter)?;
             let record = DualGuidStringEventRecord::new(perf_id, 0, timestamp, *module_guid, *guid, function_string);
-            fbpt.lock().add_record(record)?;
+            fbpt.borrow_mut().add_record(record)?;
         }
 
         KnownPerfId::PerfFunctionStart
@@ -332,7 +332,7 @@ where
             let module_guid = caller_identifier.as_guid().ok_or(EfiError::InvalidParameter)?;
             let string = string.unwrap_or("unknown name");
             let record = DynamicStringEventRecord::new(perf_id, 0, timestamp, *module_guid, string);
-            fbpt.lock().add_record(record)?;
+            fbpt.borrow_mut().add_record(record)?;
         }
     }
     Ok(())
@@ -504,7 +504,7 @@ mod tests {
     use mockall::predicate;
 
     use crate::{
-        boot_services::{MockBootServices, c_ptr::CMutPtr, tpl::Tpl},
+        boot_services::{MockBootServices, c_ptr::CMutPtr},
         component::service::IntoService,
         performance::{
             globals::set_perf_measurement_mask,
@@ -572,7 +572,7 @@ mod tests {
         let mut fbpt = MockFirmwareBasicBootPerfTable::new();
         fbpt.expect_report_table::<MockBootServices>().once().returning(|_, _| Ok(1));
 
-        let fbpt = TplMutex::new(boot_services.clone(), Tpl::NOTIFY, fbpt);
+        let fbpt = RefCell::new(fbpt);
         // SAFETY: Test code - creating a static reference to the fbpt for callback testing.
         let fbpt = unsafe { &*ptr::addr_of!(fbpt) };
 
@@ -613,7 +613,7 @@ mod tests {
 
         let mut fbpt = MockFirmwareBasicBootPerfTable::new();
         fbpt.expect_add_record().times(EXPECTED_NUMBER_OF_RECORD).returning(|_| Ok(()));
-        let fbpt = TplMutex::new(boot_services.clone(), Tpl::NOTIFY, fbpt);
+        let fbpt = RefCell::new(fbpt);
 
         // These functions call create_performance_measurement with the right arguments.
         let module_handle = 1_usize as efi::Handle;
@@ -623,7 +623,7 @@ mod tests {
         let event_guid = efi::Guid::from_bytes(&[3; 16]);
 
         static mut BOOT_SERVICES: Option<&MockBootServices> = None;
-        static mut FBPT: Option<&TplMutex<MockFirmwareBasicBootPerfTable, MockBootServices>> = None;
+        static mut FBPT: Option<&RefCell<MockFirmwareBasicBootPerfTable>> = None;
 
         // SAFETY: Test code - initializing static variables with test references.
         unsafe {
@@ -699,9 +699,9 @@ mod tests {
     #[test]
     fn test_generic_create_performance_measurement() {
         let boot_services = MockBootServices::new();
-        let fbpt = TplMutex::new(boot_services.clone(), Tpl::NOTIFY, MockFirmwareBasicBootPerfTable::new());
+        let fbpt = RefCell::new(MockFirmwareBasicBootPerfTable::new());
         static mut BOOT_SERVICES: Option<&MockBootServices> = None;
-        static mut FBPT: Option<&TplMutex<MockFirmwareBasicBootPerfTable, MockBootServices>> = None;
+        static mut FBPT: Option<&RefCell<MockFirmwareBasicBootPerfTable>> = None;
         // SAFETY: Test code - initializing static variables with test references.
         unsafe {
             BOOT_SERVICES = Some(&*ptr::addr_of!(boot_services));


### PR DESCRIPTION
## Description

As noted in https://github.com/OpenDevicePartnership/patina/issues/1341, it is problematic to use TplMutex to guard the FBPT during performance measurements as raising and lowering the TPL causes queued event notifies to be executed during performance instrumentation. This PR changes the component to use RefCell. This prevents reentrancy (panics when reentrant) and allows more accurate perf measurements.

- [X] Impacts functionality? 
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested
Existing tests pass. Boot to shell in Q35 + collect FBPT records.

## Integration Instructions
N/A.