### PR TITLE
patina_acpi: Unit test stability fixes [Rebase & FF]

### DIFF
--- a/components/patina_acpi/src/acpi.rs
+++ b/components/patina_acpi/src/acpi.rs
@@ -890,10 +890,10 @@ mod tests {
         provider.initialize(MockBootServices::new(), Service::mock(Box::new(StdMemoryManager::new()))).unwrap();
         create_dummy_rsdp(&provider);
 
-        let header1 = AcpiTableHeader { signature: 0x1, length: 100, ..Default::default() };
+        let header1 = AcpiTableHeader { signature: 0x1, length: ACPI_HEADER_LEN as u32, ..Default::default() };
         // SAFETY: The constructed table is a valid ACPI table.
         let table1 = unsafe { AcpiTable::new(header1, provider.memory_manager.get().unwrap()) };
-        let header2 = AcpiTableHeader { signature: 0x2, length: 100, ..Default::default() };
+        let header2 = AcpiTableHeader { signature: 0x2, length: ACPI_HEADER_LEN as u32, ..Default::default() };
         // SAFETY: The constructed table is a valid ACPI table.
         let table2 = unsafe { AcpiTable::new(header2, provider.memory_manager.get().unwrap()) };
         provider.install_standard_table(table1.unwrap()).expect("Install should succeed.");
@@ -903,9 +903,9 @@ mod tests {
         let result = provider.collect_tables();
         assert_eq!(result.len(), 2);
         assert_eq!(result[0].signature(), 0x1);
-        assert_eq!(result[0].header().length(), 100);
+        assert_eq!(result[0].header().length(), ACPI_HEADER_LEN as u32);
         assert_eq!(result[1].signature(), 0x2);
-        assert_eq!(result[1].header().length(), 100);
+        assert_eq!(result[1].header().length(), ACPI_HEADER_LEN as u32);
     }
 
     #[test]
@@ -1486,7 +1486,7 @@ mod tests {
         provider.register_notify(true, notify_fn).expect("should register notify");
 
         // Install a standard table and check if notify was called.
-        let header = AcpiTableHeader { signature: 0x0101, length: 100, ..Default::default() };
+        let header = AcpiTableHeader { signature: 0x0101, length: ACPI_HEADER_LEN as u32, ..Default::default() };
         // SAFETY: `header` has a valid header format.
         let table = unsafe { AcpiTable::new(header, provider.memory_manager.get().unwrap()).unwrap() };
         let _ = provider.install_acpi_table(table).unwrap();
@@ -1512,12 +1512,12 @@ mod tests {
         create_dummy_rsdp(&provider);
 
         // Install two standard tables
-        let header1 = AcpiTableHeader { signature: 0x10, length: 101, ..Default::default() };
+        let header1 = AcpiTableHeader { signature: 0x10, length: ACPI_HEADER_LEN as u32, ..Default::default() };
         // SAFETY: `table1` has the correct format by construction.
         let table1 = unsafe { AcpiTable::new(header1, provider.memory_manager.get().unwrap()).unwrap() };
         let key1 = provider.install_standard_table(table1).unwrap();
 
-        let header2 = AcpiTableHeader { signature: 0x11, length: 102, ..Default::default() };
+        let header2 = AcpiTableHeader { signature: 0x11, length: ACPI_HEADER_LEN as u32, ..Default::default() };
         // SAFETY: `table2` has the correct format by construction.
         let table2 = unsafe { AcpiTable::new(header2, provider.memory_manager.get().unwrap()).unwrap() };
         let key2 = provider.install_standard_table(table2).unwrap();
@@ -1526,13 +1526,13 @@ mod tests {
         let (got_key1, got_table1) = provider.get_table_at_idx(0).unwrap();
         assert_eq!(got_key1, key1);
         assert_eq!(got_table1.signature(), 0x10);
-        assert_eq!(got_table1.header().length(), 101);
+        assert_eq!(got_table1.header().length(), ACPI_HEADER_LEN as u32);
 
         // Index 1 should return the second table
         let (got_key2, got_table2) = provider.get_table_at_idx(1).unwrap();
         assert_eq!(got_key2, key2);
         assert_eq!(got_table2.signature(), 0x11);
-        assert_eq!(got_table2.header().length(), 102);
+        assert_eq!(got_table2.header().length(), ACPI_HEADER_LEN as u32);
 
         // Index out of bounds should return error
         let err = provider.get_table_at_idx(3).unwrap_err();

--- a/components/patina_acpi/src/acpi_table.rs
+++ b/components/patina_acpi/src/acpi_table.rs
@@ -435,11 +435,29 @@ pub struct AcpiTable {
 
 impl AcpiTable {
     /// Creates a new AcpiTable from a given table.
+    ///
+    /// For this function, the header `length` field must exactly equal `size_of::<T>()`. Because
+    /// `table` is passed by value, only `size_of::<T>()` bytes are guaranteed to be available.
+    /// A `length` that exceeds the struct size could cause an out-of-bounds copy in the underlying
+    /// allocation.
+    ///
+    /// Tables with trailing variable-length data (e.g. header followed by AML bytecode) must be
+    /// installed through the pointer-based [`Self::new_from_ptr`] path instead, where the caller
+    /// guarantees that `length` bytes are readable at the source table address.
+    ///
     /// ## Safety
     ///
     /// - Caller must ensure the provided table, `T`, has a C compatible layout (typically using `#[repr(C)]`).
     /// - Caller must ensure that the table's first field is [AcpiTableHeader].
     pub unsafe fn new<T: 'static>(table: T, mm: &Service<dyn MemoryManager>) -> Result<Self, AcpiError> {
+        // When T is provided by value, enforce that the table length is equal to `size_of::<T>()`.
+        // SAFETY: Caller guarantees T starts with an AcpiTableHeader and has a C-compatible layout.
+        let length =
+            unsafe { AcpiTableHeader::read_length_from_ptr(&table as *const T as *const AcpiTableHeader) } as usize;
+        if length != mem::size_of::<T>() {
+            return Err(AcpiError::InvalidTableFormat);
+        }
+
         // SAFETY: If the caller preconditions are met, the signature, header, and table fields of the union are valid.
         let table = unsafe { Table::new(table) }?;
 
@@ -697,5 +715,51 @@ mod tests {
         let bytes = unsafe { acpi_table.as_bytes() };
         let body_offset = mem::size_of::<AcpiTableHeader>();
         assert_eq!(&bytes[body_offset..body_offset + 3], &[42, 43, 44]);
+
+        // Verify new_from_ptr correctly copies trailing data beyond the struct.
+        let trailing: &[u8] = &[0xAA, 0xBB, 0xCC, 0xDD];
+        let struct_size = mem::size_of::<TestTable>();
+        let total_len = struct_size + trailing.len();
+        let mut buf = vec![0u8; total_len];
+
+        // SAFETY: raw_ptr still points to the heap-allocated TestTable from above.
+        unsafe {
+            ptr::copy_nonoverlapping(raw_ptr as *const u8, buf.as_mut_ptr(), struct_size);
+        }
+        // Follow up with the trailing data.
+        buf[struct_size..].copy_from_slice(trailing);
+        // Patch the length field to cover the trailing data.
+        buf[4..8].copy_from_slice(&(total_len as u32).to_le_bytes());
+
+        // SAFETY: buf points to a contiguous buffer of total_len bytes with a valid header.
+        let table_with_trailing =
+            unsafe { AcpiTable::new_from_ptr(buf.as_ptr() as *const AcpiTableHeader, None, &mm) }.unwrap();
+        assert_eq!(table_with_trailing.header().length(), total_len as u32);
+
+        // SAFETY: The length is set correctly by the test.
+        let all_bytes = unsafe { table_with_trailing.as_bytes() };
+        assert_eq!(&all_bytes[struct_size..], trailing);
+    }
+
+    #[test]
+    fn test_new_rejects_length_greater_than_struct_size() {
+        let header = AcpiTableHeader { signature: TEST_SIGNATURE, length: 100, ..Default::default() };
+        let mm: Service<dyn MemoryManager> = Service::mock(Box::new(StdMemoryManager::new()));
+
+        // length > size_of::<AcpiTableHeader>(), so it should be rejected.
+        // SAFETY: The header has a valid layout. This tests that the length mismatch is caught.
+        let result = unsafe { AcpiTable::new(header, &mm) };
+        assert!(matches!(result, Err(AcpiError::InvalidTableFormat)));
+    }
+
+    #[test]
+    fn test_new_rejects_length_less_than_struct_size() {
+        let header = AcpiTableHeader { signature: TEST_SIGNATURE, length: 10, ..Default::default() };
+        let mm: Service<dyn MemoryManager> = Service::mock(Box::new(StdMemoryManager::new()));
+
+        // length < size_of::<AcpiTableHeader>(), so it should be rejected.
+        // SAFETY: The header has a valid layout. This tests that the length mismatch is caught.
+        let result = unsafe { AcpiTable::new(header, &mm) };
+        assert!(matches!(result, Err(AcpiError::InvalidTableFormat)));
     }
 }

--- a/components/patina_acpi/src/service.rs
+++ b/components/patina_acpi/src/service.rs
@@ -169,6 +169,7 @@ pub(crate) trait AcpiProvider {
 #[coverage(off)]
 mod tests {
     use alloc::boxed::Box;
+    use core::mem;
     use patina::component::service::memory::StdMemoryManager;
 
     use crate::acpi_table::AcpiFadt;
@@ -188,7 +189,10 @@ mod tests {
         // SAFETY: The constructed table is a valid ACPI table.
         let table = unsafe {
             AcpiTable::new(
-                AcpiFadt { header: AcpiTableHeader { length: 245, ..Default::default() }, ..Default::default() },
+                AcpiFadt {
+                    header: AcpiTableHeader { length: mem::size_of::<AcpiFadt>() as u32, ..Default::default() },
+                    ..Default::default()
+                },
                 &Service::mock(Box::new(StdMemoryManager::new())),
             )
             .unwrap()


### PR DESCRIPTION
## Description

Fixes two issues that impact stability of host-based unit tests in `patina_acpi`.

---

**patina_acpi: Prevent cloning invalid buffers**

Various places in the `acpi` module use this pattern check a table's signature or read it length from a raw pointer.

`if (unsafe { (*xsdt_header).clone() }).signature != signature::XSDT {`

`AcpiTableHeader` is defined as:

```rust
pub struct AcpiTableHeader {
    pub signature: u32,
    pub length: u32,
    pub revision: u8,
    pub checksum: u8,
    pub oem_id: [u8; 6],
    pub oem_table_id: [u8; 8],
    pub oem_revision: u32,
    pub creator_id: u32,
    pub creator_revision: u32,
}
```

Which is 36 bytes in size. The issue is that some tests like `mock_rsdp()` intentionally create tables with invalid length fields that are less than 36 bytes. For example, this is backed by 35 bytes:

```rust
StandardAcpiProvider::<MockBootServices>::get_xsdt_address_from_rsdp(mock_rsdp(
    signature::ACPI_RSDP_TABLE,
    true,
    ACPI_HEADER_LEN - 1,
    signature::XSDT,
))
```

This resulted in `.clone()` reading 36 bytes from a 35 byte buffer.

This is fixed by replacing those `(*ptr).clone()` on `AcpiTableHeader` calls with targeted `read_signature_from_ptr()` and `read_length_from_ptr()` helpers that read only the needed 4-byte field.

Also , `mock_rsdp()` is updated to always allocate at least `ACPI_HEADER_LEN` bytes for the XSDT buffer, decoupling the allocation size from the (possibly invalid) length field value under test.

---

**patina_acpi: Fix stack buffer access in ACPI tests**

A few tests in the module created ACPI table structs on the stack like:

```rust
let header1 = AcpiTableHeader { signature: 0x10, length: 101, ..Default::default() };
let table1 = unsafe { AcpiTable::new(header1, ...).unwrap() };
````

Note that `AcpiTableHeader` is actually 36 bytes, but the `length` field (for testing) claimed 101 bytes. Eventaully, this code is executed:

```rust
// Copy entire table into the new allocation.
// SAFETY: If function preconditions are met, the pointer is valid and points to a valid ACPI table header.
// SAFETY: If function preconditions are met, the table length is guaranteed to be correct.
// SAFETY: If allocation succeeds, the destination is valid for writes of `table_length` bytes.
unsafe {
    ptr::copy_nonoverlapping(header_ptr as *const u8, dest_alloc, table_length);
}
```

Now, a copy is being made of 101 bytes from a 36-byte stack variable.

This change prevents this by updating `AcpiTable::new<T>()` to require that the header `length` field exactly matches the size of the struct `T`. The size check is made before `Table::new()` is called.

Tables with variable-length data should use `AcpiTable::new_from_ptr()` instead, where the caller guarantees that the table length is correct.

Also updates a test in service.rs that created an `AcpiFadt` to use the struct size for the table length.

A test was not found that checks the `AcpiTable::new_from_ptr()` case where the `length` exceeds the struct size, so code for that was added to `test_new_from_ptr_creates_valid_acpi_table()`.

---

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [x] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

- `cargo make all`

## Integration Instructions

- Review the updated expectations for `AcpiTable::new<T>()`.

---

## More Details

[Address Sanitizer](https://github.com/OpenDevicePartnership/patina/pull/1368) output before `**patina_acpi: Prevent cloning invalid buffers**` commit:

```
==54216==ERROR: AddressSanitizer: heap-buffer-overflow on address 0x1201608ae173 at pc 0x7ff7f7136d1a bp 0x0096809fe850 sp 0x0096809fe860
READ of size 4 at 0x1201608ae173 thread T7
    #0 0x7ff7f7136d19 in <patina_acpi::acpi_table::AcpiTableHeader as core::clone::Clone>::clone C:\src\patina\components\patina_acpi\src\acpi_table.rs:292
    #1 0x7ff7f7103f2e in <patina_acpi::acpi::StandardAcpiProvider<patina::boot_services::MockBootServices>>::get_xsdt_address_from_rsdp C:\src\patina\components\patina_acpi\src\acpi.rs:258
    #2 0x7ff7f706e908 in patina_acpi::acpi::tests::test_get_xsdt_address C:\src\patina\components\patina_acpi\src\acpi.rs:1287
    #3 0x7ff7f70f3da7 in patina_acpi::acpi::tests::test_get_xsdt_address::{closure#0} C:\src\patina\components\patina_acpi\src\acpi.rs:1247
    #4 0x7ff7f70d5f71 in <patina_acpi::acpi::tests::test_get_xsdt_address::{closure#0} as core::ops::function::FnOnce<()>>::call_once C:\Users\mikuback\.rustup\toolchains\nightly-2025-12-12-x86_64-pc-windows-msvc\lib\rustlib\src\rust\library\core\src\ops\function.rs:250
    #5 0x7ff7f713779f in core::ops::function::FnOnce::call_once /rustc/f5209000832c9d3bc29c91f4daef4ca9f28dc797/library\core\src\ops\function.rs:250
    #6 0x7ff7f713779f in test::__rust_begin_short_backtrace<enum2$<core::result::Result<tuple$<>,alloc::string::String> >,enum2$<core::result::Result<tuple$<>,alloc::string::String> > (*)()> /rustc/f5209000832c9d3bc29c91f4daef4ca9f28dc797/library\test\src\lib.rs:663
    #7 0x7ff7f7144f5c in test::run_test_in_process::closure$0 /rustc/f5209000832c9d3bc29c91f4daef4ca9f28dc797/library\test\src\lib.rs:686
    #8 0x7ff7f7144f5c in core::panic::unwind_safe::impl$25::call_once /rustc/f5209000832c9d3bc29c91f4daef4ca9f28dc797/library\core\src\panic\unwind_safe.rs:274
    #9 0x7ff7f7144f5c in std::panicking::catch_unwind::do_call /rustc/f5209000832c9d3bc29c91f4daef4ca9f28dc797/library\std\src\panicking.rs:581
    #10 0x7ff7f7144f5c in std::panicking::catch_unwind /rustc/f5209000832c9d3bc29c91f4daef4ca9f28dc797/library\std\src\panicking.rs:544
    #11 0x7ff7f7144f5c in std::panic::catch_unwind /rustc/f5209000832c9d3bc29c91f4daef4ca9f28dc797/library\std\src\panic.rs:359
    #12 0x7ff7f7144f5c in test::run_test_in_process /rustc/f5209000832c9d3bc29c91f4daef4ca9f28dc797/library\test\src\lib.rs:686
    #13 0x7ff7f7144f5c in test::run_test::closure$0 /rustc/f5209000832c9d3bc29c91f4daef4ca9f28dc797/library\test\src\lib.rs:607
    #14 0x7ff7f713f29b in test::run_test::closure$1 /rustc/f5209000832c9d3bc29c91f4daef4ca9f28dc797/library\test\src\lib.rs:637
    #15 0x7ff7f713f29b in std::sys::backtrace::__rust_begin_short_backtrace::<test::run_test::{closure#1}, ()> /rustc/f5209000832c9d3bc29c91f4daef4ca9f28dc797/library\std\src\sys\backtrace.rs:160
    #16 0x7ff7f7148941 in std::thread::lifecycle::spawn_unchecked::closure$1::closure$0 /rustc/f5209000832c9d3bc29c91f4daef4ca9f28dc797/library\std\src\thread\lifecycle.rs:92
    #17 0x7ff7f7148941 in core::panic::unwind_safe::impl$25::call_once /rustc/f5209000832c9d3bc29c91f4daef4ca9f28dc797/library\core\src\panic\unwind_safe.rs:274
    #18 0x7ff7f7148941 in std::panicking::catch_unwind::do_call /rustc/f5209000832c9d3bc29c91f4daef4ca9f28dc797/library\std\src\panicking.rs:581
    #19 0x7ff7f7148941 in std::panicking::catch_unwind /rustc/f5209000832c9d3bc29c91f4daef4ca9f28dc797/library\std\src\panicking.rs:544
    #20 0x7ff7f7148941 in std::panic::catch_unwind /rustc/f5209000832c9d3bc29c91f4daef4ca9f28dc797/library\std\src\panic.rs:359
    #21 0x7ff7f7148941 in std::thread::lifecycle::spawn_unchecked::closure$1 /rustc/f5209000832c9d3bc29c91f4daef4ca9f28dc797/library\std\src\thread\lifecycle.rs:90
    #22 0x7ff7f7148941 in core::ops::function::FnOnce::call_once<std::thread::lifecycle::spawn_unchecked::closure_env$1<test::run_test::closure_env$1,tuple$<> >,tuple$<> > /rustc/f5209000832c9d3bc29c91f4daef4ca9f28dc797/library\core\src\ops\function.rs:250
    #23 0x7ff7f72b2357 in alloc::boxed::impl$31::call_once /rustc/f5209000832c9d3bc29c91f4daef4ca9f28dc797/library\alloc\src\boxed.rs:2206
    #24 0x7ff7f72b2357 in std::sys::thread::windows::impl$0::new::thread_start /rustc/f5209000832c9d3bc29c91f4daef4ca9f28dc797/library\std\src\sys\thread\windows.rs:59
    #25 0x7ffdeafcd19c in asan_thread_start D:\a\_work\1\s\src\vctools\asan\llvm\compiler-rt\lib\asan\asan_win.cpp:170
    #26 0x7ffeb7e7e8d6  (C:\WINDOWS\System32\KERNEL32.DLL+0x18002e8d6)
    #27 0x7ffeb9acc53b  (C:\WINDOWS\SYSTEM32\ntdll.dll+0x18008c53b)

0x1201608ae173 is located 0 bytes after 35-byte region [0x1201608ae150,0x1201608ae173)
allocated by thread T7 here:
    #0 0x7ffdeafbac48 in RtlAllocateHeap D:\a\_work\1\s\src\vctools\asan\llvm\compiler-rt\lib\asan\asan_malloc_win.cpp:1476
    #1 0x7ff7f727de75 in alloc::alloc::alloc C:\Users\mikuback\.rustup\toolchains\nightly-2025-12-12-x86_64-pc-windows-msvc\lib\rustlib\src\rust\library\alloc\src\alloc.rs:178
    #2 0x7ff7f727de75 in alloc::alloc::Global::alloc_impl C:\Users\mikuback\.rustup\toolchains\nightly-2025-12-12-x86_64-pc-windows-msvc\lib\rustlib\src\rust\library\alloc\src\alloc.rs:190
    #3 0x7ff7f727e5ba in <alloc::alloc::Global as core::alloc::Allocator>::allocate_zeroed C:\Users\mikuback\.rustup\toolchains\nightly-2025-12-12-x86_64-pc-windows-msvc\lib\rustlib\src\rust\library\alloc\src\alloc.rs:257
    #4 0x7ff7f727d822 in <alloc::raw_vec::RawVecInner>::try_allocate_in C:\Users\mikuback\.rustup\toolchains\nightly-2025-12-12-x86_64-pc-windows-msvc\lib\rustlib\src\rust\library\alloc\src\raw_vec\mod.rs:470
    #5 0x7ff7f722c6c3 in alloc::raw_vec::RawVecInner<alloc::alloc::Global>::with_capacity_zeroed_in C:\Users\mikuback\.rustup\toolchains\nightly-2025-12-12-x86_64-pc-windows-msvc\lib\rustlib\src\rust\library\alloc\src\raw_vec\mod.rs:443
    #6 0x7ff7f722c6c3 in alloc::raw_vec::RawVec<u8,alloc::alloc::Global>::with_capacity_zeroed_in C:\Users\mikuback\.rustup\toolchains\nightly-2025-12-12-x86_64-pc-windows-msvc\lib\rustlib\src\rust\library\alloc\src\raw_vec\mod.rs:208
    #7 0x7ff7f722c6c3 in <u8 as alloc::vec::spec_from_elem::SpecFromElem>::from_elem::<alloc::alloc::Global> C:\Users\mikuback\.rustup\toolchains\nightly-2025-12-12-x86_64-pc-windows-msvc\lib\rustlib\src\rust\library\alloc\src\vec\spec_from_elem.rs:51
    #8 0x7ff7f7183679 in alloc::vec::from_elem::<u8> C:\Users\mikuback\.rustup\toolchains\nightly-2025-12-12-x86_64-pc-windows-msvc\lib\rustlib\src\rust\library\alloc\src\vec\mod.rs:3563
    #9 0x7ff7f7065925 in patina_acpi::acpi::tests::mock_rsdp C:\src\patina\components\patina_acpi\src\acpi.rs:1212
    #10 0x7ff7f706e8f4 in patina_acpi::acpi::tests::test_get_xsdt_address C:\src\patina\components\patina_acpi\src\acpi.rs:1287
    #11 0x7ff7f70f3da7 in patina_acpi::acpi::tests::test_get_xsdt_address::{closure#0} C:\src\patina\components\patina_acpi\src\acpi.rs:1247
    #12 0x7ff7f70d5f71 in <patina_acpi::acpi::tests::test_get_xsdt_address::{closure#0} as core::ops::function::FnOnce<()>>::call_once C:\Users\mikuback\.rustup\toolchains\nightly-2025-12-12-x86_64-pc-windows-msvc\lib\rustlib\src\rust\library\core\src\ops\function.rs:250
    #13 0x7ff7f713779f in core::ops::function::FnOnce::call_once /rustc/f5209000832c9d3bc29c91f4daef4ca9f28dc797/library\core\src\ops\function.rs:250
    #14 0x7ff7f713779f in test::__rust_begin_short_backtrace<enum2$<core::result::Result<tuple$<>,alloc::string::String> >,enum2$<core::result::Result<tuple$<>,alloc::string::String> > (*)()> /rustc/f5209000832c9d3bc29c91f4daef4ca9f28dc797/library\test\src\lib.rs:663
    #15 0x7ff7f7144f5c in test::run_test_in_process::closure$0 /rustc/f5209000832c9d3bc29c91f4daef4ca9f28dc797/library\test\src\lib.rs:686
    #16 0x7ff7f7144f5c in core::panic::unwind_safe::impl$25::call_once /rustc/f5209000832c9d3bc29c91f4daef4ca9f28dc797/library\core\src\panic\unwind_safe.rs:274
    #17 0x7ff7f7144f5c in std::panicking::catch_unwind::do_call /rustc/f5209000832c9d3bc29c91f4daef4ca9f28dc797/library\std\src\panicking.rs:581
    #18 0x7ff7f7144f5c in std::panicking::catch_unwind /rustc/f5209000832c9d3bc29c91f4daef4ca9f28dc797/library\std\src\panicking.rs:544
    #19 0x7ff7f7144f5c in std::panic::catch_unwind /rustc/f5209000832c9d3bc29c91f4daef4ca9f28dc797/library\std\src\panic.rs:359
    #20 0x7ff7f7144f5c in test::run_test_in_process /rustc/f5209000832c9d3bc29c91f4daef4ca9f28dc797/library\test\src\lib.rs:686
    #21 0x7ff7f7144f5c in test::run_test::closure$0 /rustc/f5209000832c9d3bc29c91f4daef4ca9f28dc797/library\test\src\lib.rs:607
    #22 0x7ff7f713f29b in test::run_test::closure$1 /rustc/f5209000832c9d3bc29c91f4daef4ca9f28dc797/library\test\src\lib.rs:637
    #23 0x7ff7f713f29b in std::sys::backtrace::__rust_begin_short_backtrace::<test::run_test::{closure#1}, ()> /rustc/f5209000832c9d3bc29c91f4daef4ca9f28dc797/library\std\src\sys\backtrace.rs:160
    #24 0x7ff7f7148941 in std::thread::lifecycle::spawn_unchecked::closure$1::closure$0 /rustc/f5209000832c9d3bc29c91f4daef4ca9f28dc797/library\std\src\thread\lifecycle.rs:92
    #25 0x7ff7f7148941 in core::panic::unwind_safe::impl$25::call_once /rustc/f5209000832c9d3bc29c91f4daef4ca9f28dc797/library\core\src\panic\unwind_safe.rs:274
    #26 0x7ff7f7148941 in std::panicking::catch_unwind::do_call /rustc/f5209000832c9d3bc29c91f4daef4ca9f28dc797/library\std\src\panicking.rs:581
    #27 0x7ff7f7148941 in std::panicking::catch_unwind /rustc/f5209000832c9d3bc29c91f4daef4ca9f28dc797/library\std\src\panicking.rs:544
    #28 0x7ff7f7148941 in std::panic::catch_unwind /rustc/f5209000832c9d3bc29c91f4daef4ca9f28dc797/library\std\src\panic.rs:359
    #29 0x7ff7f7148941 in std::thread::lifecycle::spawn_unchecked::closure$1 /rustc/f5209000832c9d3bc29c91f4daef4ca9f28dc797/library\std\src\thread\lifecycle.rs:90
    #30 0x7ff7f7148941 in core::ops::function::FnOnce::call_once<std::thread::lifecycle::spawn_unchecked::closure_env$1<test::run_test::closure_env$1,tuple$<> >,tuple$<> > /rustc/f5209000832c9d3bc29c91f4daef4ca9f28dc797/library\core\src\ops\function.rs:250
    #31 0x7ff7f72b2357 in alloc::boxed::impl$31::call_once /rustc/f5209000832c9d3bc29c91f4daef4ca9f28dc797/library\alloc\src\boxed.rs:2206
    #32 0x7ff7f72b2357 in std::sys::thread::windows::impl$0::new::thread_start /rustc/f5209000832c9d3bc29c91f4daef4ca9f28dc797/library\std\src\sys\thread\windows.rs:59
    #33 0x7ffdeafcd19c in asan_thread_start D:\a\_work\1\s\src\vctools\asan\llvm\compiler-rt\lib\asan\asan_win.cpp:170
    #34 0x7ffeb7e7e8d6  (C:\WINDOWS\System32\KERNEL32.DLL+0x18002e8d6)
    #35 0x7ffeb9acc53b  (C:\WINDOWS\SYSTEM32\ntdll.dll+0x18008c53b)

Thread T7 created by T0 here:
    #0 0x7ffdeafcd597 in CreateThread D:\a\_work\1\s\src\vctools\asan\llvm\compiler-rt\lib\asan\asan_win.cpp:228
    #1 0x7ff7f729c7b6 in <std::sys::thread::windows::Thread>::new /rustc/f5209000832c9d3bc29c91f4daef4ca9f28dc797/library\std\src\sys\thread\windows.rs:32
    #2 0x7ff7f714ba29 in std::thread::lifecycle::spawn_unchecked /rustc/f5209000832c9d3bc29c91f4daef4ca9f28dc797/library\std\src\thread\lifecycle.rs:138
    #3 0x7ff7f714ba29 in std::thread::builder::Builder::spawn_unchecked /rustc/f5209000832c9d3bc29c91f4daef4ca9f28dc797/library\std\src\thread\builder.rs:265
    #4 0x7ff7f714ba29 in std::thread::builder::Builder::spawn /rustc/f5209000832c9d3bc29c91f4daef4ca9f28dc797/library\std\src\thread\builder.rs:194
    #5 0x7ff7f714ba29 in test::run_test /rustc/f5209000832c9d3bc29c91f4daef4ca9f28dc797/library\test\src\lib.rs:637
    #6 0x7ff7f7163685 in test::run_tests /rustc/f5209000832c9d3bc29c91f4daef4ca9f28dc797/library\test\src\lib.rs:447
    #7 0x7ff7f7163685 in test::console::run_tests_console /rustc/f5209000832c9d3bc29c91f4daef4ca9f28dc797/library\test\src\console.rs:327
    #8 0x7ff7f714d6a4 in test::test_main_with_exit_callback /rustc/f5209000832c9d3bc29c91f4daef4ca9f28dc797/library\test\src\lib.rs:160
    #9 0x7ff7f714d6a4 in test::test_main /rustc/f5209000832c9d3bc29c91f4daef4ca9f28dc797/library\test\src\lib.rs:101
    #10 0x7ff7f7149a02 in test::test_main_static /rustc/f5209000832c9d3bc29c91f4daef4ca9f28dc797/library\test\src\lib.rs:183
    #11 0x7ff7f7113d34 in patina_acpi::main C:\src\patina\components\patina_acpi\src\lib.rs:1
    #12 0x7ff7f70d531a in <fn() as core::ops::function::FnOnce<()>>::call_once C:\Users\mikuback\.rustup\toolchains\nightly-2025-12-12-x86_64-pc-windows-msvc\lib\rustlib\src\rust\library\core\src\ops\function.rs:250
    #13 0x7ff7f70e7f8d in std::sys::backtrace::__rust_begin_short_backtrace::<fn(), ()> C:\Users\mikuback\.rustup\toolchains\nightly-2025-12-12-x86_64-pc-windows-msvc\lib\rustlib\src\rust\library\std\src\sys\backtrace.rs:160
    #14 0x7ff7f70a0dcc in std::rt::lang_start::<()>::{closure#0} C:\Users\mikuback\.rustup\toolchains\nightly-2025-12-12-x86_64-pc-windows-msvc\lib\rustlib\src\rust\library\std\src\rt.rs:206
    #15 0x7ff7f72ab03e in core::ops::function::impls::impl$2::call_once /rustc/f5209000832c9d3bc29c91f4daef4ca9f28dc797/library\core\src\ops\function.rs:287
    #16 0x7ff7f72ab03e in std::panicking::catch_unwind::do_call /rustc/f5209000832c9d3bc29c91f4daef4ca9f28dc797/library\std\src\panicking.rs:581
    #17 0x7ff7f72ab03e in std::panicking::catch_unwind /rustc/f5209000832c9d3bc29c91f4daef4ca9f28dc797/library\std\src\panicking.rs:544
    #18 0x7ff7f72ab03e in std::panic::catch_unwind /rustc/f5209000832c9d3bc29c91f4daef4ca9f28dc797/library\std\src\panic.rs:359
    #19 0x7ff7f72ab03e in std::rt::lang_start_internal::closure$0 /rustc/f5209000832c9d3bc29c91f4daef4ca9f28dc797/library\std\src\rt.rs:175
    #20 0x7ff7f72ab03e in std::panicking::catch_unwind::do_call /rustc/f5209000832c9d3bc29c91f4daef4ca9f28dc797/library\std\src\panicking.rs:581
    #21 0x7ff7f72ab03e in std::panicking::catch_unwind /rustc/f5209000832c9d3bc29c91f4daef4ca9f28dc797/library\std\src\panicking.rs:544
    #22 0x7ff7f72ab03e in std::panic::catch_unwind /rustc/f5209000832c9d3bc29c91f4daef4ca9f28dc797/library\std\src\panic.rs:359
    #23 0x7ff7f72ab03e in std::rt::lang_start_internal /rustc/f5209000832c9d3bc29c91f4daef4ca9f28dc797/library\std\src\rt.rs:171
    #24 0x7ff7f70a0d2c in std::rt::lang_start::<()> C:\Users\mikuback\.rustup\toolchains\nightly-2025-12-12-x86_64-pc-windows-msvc\lib\rustlib\src\rust\library\std\src\rt.rs:205
    #25 0x7ff7f7113d58 in main (C:\src\patina\target\x86_64-pc-windows-msvc\debug\deps\patina_acpi-aff837649f2acbca.exe+0x1400b3d58)
    #26 0x7ff7f72cad2f in invoke_main D:\a\_work\1\s\src\vctools\crt\vcstartup\src\startup\exe_common.inl:78
    #27 0x7ff7f72cad2f in __scrt_common_main_seh D:\a\_work\1\s\src\vctools\crt\vcstartup\src\startup\exe_common.inl:288
    #28 0x7ffeb7e7e8d6  (C:\WINDOWS\System32\KERNEL32.DLL+0x18002e8d6)
    #29 0x7ffeb9acc53b  (C:\WINDOWS\SYSTEM32\ntdll.dll+0x18008c53b)

SUMMARY: AddressSanitizer: heap-buffer-overflow C:\src\patina\components\patina_acpi\src\acpi_table.rs:292 in <patina_acpi::acpi_table::AcpiTableHeader as core::clone::Clone>::clone
Shadow bytes around the buggy address:
  0x1201608ade80: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x1201608adf00: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x1201608adf80: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x1201608ae000: fa fa 00 00 00 00 00 00 fa fa 00 00 00 00 04 fa
  0x1201608ae080: fa fa 00 00 00 00 04 fa fa fa 00 00 00 00 04 fa
=>0x1201608ae100: fa fa 00 00 00 00 04 fa fa fa 00 00 00 00[03]fa
  0x1201608ae180: fa fa 00 00 00 00 04 fa fa fa fd fd fd fd fd fd
  0x1201608ae200: fa fa fd fd fd fd fd fa fa fa fd fd fd fd fd fa
  0x1201608ae280: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x1201608ae300: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x1201608ae380: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07 
  Heap left redzone:       fa
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  Array cookie:            ac
  Intra object redzone:    bb
  ASan internal:           fe
  Left alloca redzone:     ca
  Right alloca redzone:    cb
==54216==ABORTING
error: test failed, to rerun pass `-p patina_acpi --lib`
```

---

[Address Sanitizer](https://github.com/OpenDevicePartnership/patina/pull/1368) output before `**patina_acpi: Fix stack buffer access in ACPI tests**` commit:

```
==56540==ERROR: AddressSanitizer: stack-buffer-overflow on address 0x0020413fbc64 at pc 0x7ffdeafb6437 bp 0x0020413fb580 sp 0x0020413fad10
READ of size 101 at 0x0020413fbc64 thread T6
    #0 0x7ffdeafb6436 in __asan_memcpy D:\a\_work\1\s\src\vctools\asan\llvm\compiler-rt\lib\asan\asan_interceptors_memintrinsics.cpp:64
    #1 0x7ff7f6c40699 in core::ptr::copy_nonoverlapping C:\Users\mikuback\.rustup\toolchains\nightly-2025-12-12-x86_64-pc-windows-msvc\lib\rustlib\src\rust\library\core\src\ptr\mod.rs:547
    #2 0x7ff7f6c40699 in <patina_acpi::acpi_table::AcpiTable>::new_from_ptr C:\src\patina\components\patina_acpi\src\acpi_table.rs:472
    #3 0x7ff7f6b9be8a in <patina_acpi::acpi_table::AcpiTable>::new::<patina_acpi::acpi_table::AcpiTableHeader> C:\src\patina\components\patina_acpi\src\acpi_table.rs:428
    #4 0x7ff7f6b839ff in patina_acpi::acpi::tests::test_get_table_at_idx_basic C:\src\patina\components\patina_acpi\src\acpi.rs:1514
    #5 0x7ff7f6c01ca7 in patina_acpi::acpi::tests::test_get_table_at_idx_basic::{closure#0} C:\src\patina\components\patina_acpi\src\acpi.rs:1506
    #6 0x7ff7f6be41e1 in <patina_acpi::acpi::tests::test_get_table_at_idx_basic::{closure#0} as core::ops::function::FnOnce<()>>::call_once C:\Users\mikuback\.rustup\toolchains\nightly-2025-12-12-x86_64-pc-windows-msvc\lib\rustlib\src\rust\library\core\src\ops\function.rs:250
    #7 0x7ff7f6c455bf in core::ops::function::FnOnce::call_once /rustc/f5209000832c9d3bc29c91f4daef4ca9f28dc797/library\core\src\ops\function.rs:250
    #8 0x7ff7f6c455bf in test::__rust_begin_short_backtrace<enum2$<core::result::Result<tuple$<>,alloc::string::String> >,enum2$<core::result::Result<tuple$<>,alloc::string::String> > (*)()> /rustc/f5209000832c9d3bc29c91f4daef4ca9f28dc797/library\test\src\lib.rs:663
    #9 0x7ff7f6c52d7c in test::run_test_in_process::closure$0 /rustc/f5209000832c9d3bc29c91f4daef4ca9f28dc797/library\test\src\lib.rs:686
    #10 0x7ff7f6c52d7c in core::panic::unwind_safe::impl$25::call_once /rustc/f5209000832c9d3bc29c91f4daef4ca9f28dc797/library\core\src\panic\unwind_safe.rs:274
    #11 0x7ff7f6c52d7c in std::panicking::catch_unwind::do_call /rustc/f5209000832c9d3bc29c91f4daef4ca9f28dc797/library\std\src\panicking.rs:581
    #12 0x7ff7f6c52d7c in std::panicking::catch_unwind /rustc/f5209000832c9d3bc29c91f4daef4ca9f28dc797/library\std\src\panicking.rs:544
    #13 0x7ff7f6c52d7c in std::panic::catch_unwind /rustc/f5209000832c9d3bc29c91f4daef4ca9f28dc797/library\std\src\panic.rs:359
    #14 0x7ff7f6c52d7c in test::run_test_in_process /rustc/f5209000832c9d3bc29c91f4daef4ca9f28dc797/library\test\src\lib.rs:686
    #15 0x7ff7f6c52d7c in test::run_test::closure$0 /rustc/f5209000832c9d3bc29c91f4daef4ca9f28dc797/library\test\src\lib.rs:607
    #16 0x7ff7f6c4d0bb in test::run_test::closure$1 /rustc/f5209000832c9d3bc29c91f4daef4ca9f28dc797/library\test\src\lib.rs:637
    #17 0x7ff7f6c4d0bb in std::sys::backtrace::__rust_begin_short_backtrace::<test::run_test::{closure#1}, ()> /rustc/f5209000832c9d3bc29c91f4daef4ca9f28dc797/library\std\src\sys\backtrace.rs:160
    #18 0x7ff7f6c56761 in std::thread::lifecycle::spawn_unchecked::closure$1::closure$0 /rustc/f5209000832c9d3bc29c91f4daef4ca9f28dc797/library\std\src\thread\lifecycle.rs:92
    #19 0x7ff7f6c56761 in core::panic::unwind_safe::impl$25::call_once /rustc/f5209000832c9d3bc29c91f4daef4ca9f28dc797/library\core\src\panic\unwind_safe.rs:274
    #20 0x7ff7f6c56761 in std::panicking::catch_unwind::do_call /rustc/f5209000832c9d3bc29c91f4daef4ca9f28dc797/library\std\src\panicking.rs:581
    #21 0x7ff7f6c56761 in std::panicking::catch_unwind /rustc/f5209000832c9d3bc29c91f4daef4ca9f28dc797/library\std\src\panicking.rs:544
    #22 0x7ff7f6c56761 in std::panic::catch_unwind /rustc/f5209000832c9d3bc29c91f4daef4ca9f28dc797/library\std\src\panic.rs:359
    #23 0x7ff7f6c56761 in std::thread::lifecycle::spawn_unchecked::closure$1 /rustc/f5209000832c9d3bc29c91f4daef4ca9f28dc797/library\std\src\thread\lifecycle.rs:90
    #24 0x7ff7f6c56761 in core::ops::function::FnOnce::call_once<std::thread::lifecycle::spawn_unchecked::closure_env$1<test::run_test::closure_env$1,tuple$<> >,tuple$<> > /rustc/f5209000832c9d3bc29c91f4daef4ca9f28dc797/library\core\src\ops\function.rs:250
    #25 0x7ff7f6dbfc17 in alloc::boxed::impl$31::call_once /rustc/f5209000832c9d3bc29c91f4daef4ca9f28dc797/library\alloc\src\boxed.rs:2206
    #26 0x7ff7f6dbfc17 in std::sys::thread::windows::impl$0::new::thread_start /rustc/f5209000832c9d3bc29c91f4daef4ca9f28dc797/library\std\src\sys\thread\windows.rs:59
    #27 0x7ffdeafcd19c in asan_thread_start D:\a\_work\1\s\src\vctools\asan\llvm\compiler-rt\lib\asan\asan_win.cpp:170
    #28 0x7ffeb7e7e8d6  (C:\WINDOWS\System32\KERNEL32.DLL+0x18002e8d6)
    #29 0x7ffeb9acc53b  (C:\WINDOWS\SYSTEM32\ntdll.dll+0x18008c53b)

Address 0x0020413fbc64 is located in stack of thread T6 at offset 324 in frame
    #0 0x7ff7f6b9bb9f in <patina_acpi::acpi_table::AcpiTable>::new::<patina_acpi::acpi_table::AcpiTableHeader> C:\src\patina\components\patina_acpi\src\acpi_table.rs:422

  This frame has 5 object(s):
    [32, 48) '_14' (line 428)
    [64, 88) '_13' (line 428)
    [128, 168) '_5' (line 424)
    [208, 248) '_4' (line 424)
    [288, 324) 'table1' (line 424) <== Memory access at offset 324 overflows this variable
HINT: this may be a false positive if your program uses some custom stack unwind mechanism, swapcontext or vfork
      (longjmp, SEH and C++ exceptions *are* supported)
Thread T6 created by T0 here:
    #0 0x7ffdeafcd597 in CreateThread D:\a\_work\1\s\src\vctools\asan\llvm\compiler-rt\lib\asan\asan_win.cpp:228
    #1 0x7ff7f6daa076 in <std::sys::thread::windows::Thread>::new /rustc/f5209000832c9d3bc29c91f4daef4ca9f28dc797/library\std\src\sys\thread\windows.rs:32
    #2 0x7ff7f6c59849 in std::thread::lifecycle::spawn_unchecked /rustc/f5209000832c9d3bc29c91f4daef4ca9f28dc797/library\std\src\thread\lifecycle.rs:138
    #3 0x7ff7f6c59849 in std::thread::builder::Builder::spawn_unchecked /rustc/f5209000832c9d3bc29c91f4daef4ca9f28dc797/library\std\src\thread\builder.rs:265
    #4 0x7ff7f6c59849 in std::thread::builder::Builder::spawn /rustc/f5209000832c9d3bc29c91f4daef4ca9f28dc797/library\std\src\thread\builder.rs:194
    #5 0x7ff7f6c59849 in test::run_test /rustc/f5209000832c9d3bc29c91f4daef4ca9f28dc797/library\test\src\lib.rs:637
    #6 0x7ff7f6c714a5 in test::run_tests /rustc/f5209000832c9d3bc29c91f4daef4ca9f28dc797/library\test\src\lib.rs:447
    #7 0x7ff7f6c714a5 in test::console::run_tests_console /rustc/f5209000832c9d3bc29c91f4daef4ca9f28dc797/library\test\src\console.rs:327
    #8 0x7ff7f6c5b4c4 in test::test_main_with_exit_callback /rustc/f5209000832c9d3bc29c91f4daef4ca9f28dc797/library\test\src\lib.rs:160
    #9 0x7ff7f6c5b4c4 in test::test_main /rustc/f5209000832c9d3bc29c91f4daef4ca9f28dc797/library\test\src\lib.rs:101
    #10 0x7ff7f6c57822 in test::test_main_static /rustc/f5209000832c9d3bc29c91f4daef4ca9f28dc797/library\test\src\lib.rs:183
    #11 0x7ff7f6c21b74 in patina_acpi::main C:\src\patina\components\patina_acpi\src\lib.rs:1
    #12 0x7ff7f6be34ea in <fn() as core::ops::function::FnOnce<()>>::call_once C:\Users\mikuback\.rustup\toolchains\nightly-2025-12-12-x86_64-pc-windows-msvc\lib\rustlib\src\rust\library\core\src\ops\function.rs:250
    #13 0x7ff7f6bf5efd in std::sys::backtrace::__rust_begin_short_backtrace::<fn(), ()> C:\Users\mikuback\.rustup\toolchains\nightly-2025-12-12-x86_64-pc-windows-msvc\lib\rustlib\src\rust\library\std\src\sys\backtrace.rs:160
    #14 0x7ff7f6baef9c in std::rt::lang_start::<()>::{closure#0} C:\Users\mikuback\.rustup\toolchains\nightly-2025-12-12-x86_64-pc-windows-msvc\lib\rustlib\src\rust\library\std\src\rt.rs:206
    #15 0x7ff7f6db88fe in core::ops::function::impls::impl$2::call_once /rustc/f5209000832c9d3bc29c91f4daef4ca9f28dc797/library\core\src\ops\function.rs:287
    #16 0x7ff7f6db88fe in std::panicking::catch_unwind::do_call /rustc/f5209000832c9d3bc29c91f4daef4ca9f28dc797/library\std\src\panicking.rs:581
    #17 0x7ff7f6db88fe in std::panicking::catch_unwind /rustc/f5209000832c9d3bc29c91f4daef4ca9f28dc797/library\std\src\panicking.rs:544
    #18 0x7ff7f6db88fe in std::panic::catch_unwind /rustc/f5209000832c9d3bc29c91f4daef4ca9f28dc797/library\std\src\panic.rs:359
    #19 0x7ff7f6db88fe in std::rt::lang_start_internal::closure$0 /rustc/f5209000832c9d3bc29c91f4daef4ca9f28dc797/library\std\src\rt.rs:175
    #20 0x7ff7f6db88fe in std::panicking::catch_unwind::do_call /rustc/f5209000832c9d3bc29c91f4daef4ca9f28dc797/library\std\src\panicking.rs:581
    #21 0x7ff7f6db88fe in std::panicking::catch_unwind /rustc/f5209000832c9d3bc29c91f4daef4ca9f28dc797/library\std\src\panicking.rs:544
    #22 0x7ff7f6db88fe in std::panic::catch_unwind /rustc/f5209000832c9d3bc29c91f4daef4ca9f28dc797/library\std\src\panic.rs:359
    #23 0x7ff7f6db88fe in std::rt::lang_start_internal /rustc/f5209000832c9d3bc29c91f4daef4ca9f28dc797/library\std\src\rt.rs:171
    #24 0x7ff7f6baeefc in std::rt::lang_start::<()> C:\Users\mikuback\.rustup\toolchains\nightly-2025-12-12-x86_64-pc-windows-msvc\lib\rustlib\src\rust\library\std\src\rt.rs:205
    #25 0x7ff7f6c21b98 in main (C:\src\patina\target\x86_64-pc-windows-msvc\debug\deps\patina_acpi-aff837649f2acbca.exe+0x1400b1b98)
    #26 0x7ff7f6dd85ef in invoke_main D:\a\_work\1\s\src\vctools\crt\vcstartup\src\startup\exe_common.inl:78
    #27 0x7ff7f6dd85ef in __scrt_common_main_seh D:\a\_work\1\s\src\vctools\crt\vcstartup\src\startup\exe_common.inl:288
    #28 0x7ffeb7e7e8d6  (C:\WINDOWS\System32\KERNEL32.DLL+0x18002e8d6)
    #29 0x7ffeb9acc53b  (C:\WINDOWS\SYSTEM32\ntdll.dll+0x18008c53b)

SUMMARY: AddressSanitizer: stack-buffer-overflow C:\Users\mikuback\.rustup\toolchains\nightly-2025-12-12-x86_64-pc-windows-msvc\lib\rustlib\src\rust\library\core\src\ptr\mod.rs:547 in core::ptr::copy_nonoverlapping
Shadow bytes around the buggy address:
  0x0020413fb980: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x0020413fba00: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x0020413fba80: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x0020413fbb00: 00 00 00 00 f1 f1 f1 f1 f8 f8 f2 f2 00 00 00 f2
  0x0020413fbb80: f2 f2 f2 f2 f8 f8 f8 f8 f8 f2 f2 f2 f2 f2 f8 f8
=>0x0020413fbc00: f8 f8 f8 f2 f2 f2 f2 f2 00 00 00 00[04]f3 f3 f3
  0x0020413fbc80: f3 f3 f3 f3 00 00 00 00 00 00 00 00 00 00 00 00
  0x0020413fbd00: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x0020413fbd80: 00 00 00 00 00 00 00 00 f1 f1 f1 f1 f8 f2 f8 f2
  0x0020413fbe00: f8 f2 f8 f2 f8 f2 f8 f2 f8 f2 f8 f8 f8 f2 f2 f2
  0x0020413fbe80: f2 f2 f8 f8 f8 f8 f8 f2 f2 f2 f2 f2 f8 f8 f8 f2
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07 
  Heap left redzone:       fa
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  Array cookie:            ac
  Intra object redzone:    bb
  ASan internal:           fe
  Left alloca redzone:     ca
  Right alloca redzone:    cb
==56540==ABORTING
error: test failed, to rerun pass `-p patina_acpi --lib`
```