### PR TITLE
patina_dxe_core: Fix invalid access in test_fv_functionality()

### DIFF
--- a/patina_dxe_core/src/pi_dispatcher/fv.rs
+++ b/patina_dxe_core/src/pi_dispatcher/fv.rs
@@ -1042,13 +1042,14 @@ mod tests {
             //let fv_attributes3: *mut fw_fs::EfiFvAttributes = &mut fv_att;
 
             /* Instance 2 - Create a FV  interface with Bad physical address to handle Error cases. */
-            let mut fv_interface3 = MockProtocolData::new_fv_protocol(parent_handle);
+            let fv_interface3 = MockProtocolData::new_fv_protocol(parent_handle);
 
             let fv_ptr3 = NonNull::from(&*fv_interface3).cast::<c_void>();
             let fv_ptr3_const = fv_ptr3.cast::<pi::protocols::firmware_volume::Protocol>().as_ptr();
 
-            /* Corrupt the base address to cover error conditions  */
-            let base_no2: u64 = fv_interface3.as_mut() as *mut _ as u64 + 0x1000;
+            /* Allocate a readable buffer with invalid content (no valid _FVH signature) */
+            let bad_fv_buf = vec![0u8; size_of::<fv::Header>()].leak();
+            let base_no2: u64 = bad_fv_buf.as_ptr() as u64;
             let metadata2 = Metadata::new_fv(fv_interface3, base_no2);
             //save the protocol structure we're about to install in the private data.
             CORE.pi_dispatcher.fv_data.lock().fv_metadata.insert(fv_ptr3.addr(), metadata2);


### PR DESCRIPTION
## Description

The `test_fv_functionality()` test created an invalid firmware volume base address by adding 0x1000 to a protocol interface pointer:

```rust
/* Corrupt the base address to cover error conditions  */
let base_no2: u64 = fv_interface3.as_mut() as *mut _ as u64 + 0x1000;
```

This produced an address pointing into unrelated memory.

A read from that address is attempted later in a call stack starting from `fv_get_volume_attributes_efiapi()`:

- `test_fv_functionality()` calls `fv_get_volume_attributes_efiapi(fv_ptr3_const, fv_attributes)`
- `fv_get_volume_attributes_efiapi()` calls into `fv_get_volume_attributes()`
- `fv_get_volume_attributes()` calls `VolumeRef::new_from_address(physical_address)`
- `VolumeRef::new_from_address()` does `ptr::read_unaligned(base_address as *const fv::Header)`

This change updates the test to avoid reading from an arbitrary invalid address, replacing it with a pointer to a leaked buffer of zeros.

The buffer is sized to hold an `fv::Header`. Since the buffer is filled with zeros, it does not contain a valid `_FVH` signature, so the signature check fails and returns `DataCorrupt` as the test expects.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [x] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

- `cargo make all`

## Integration Instructions

- N/A