### PR TITLE
Makefile.toml: Add test-asan task for AddressSanitizer testing

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -158,6 +158,58 @@ command = "cargo"
 args = ["llvm-cov", "@@split(COV_FLAGS, )", "--no-report", "--doctests"]
 dependencies = ["individual-package-targets", "llvm-cov-clean"]
 
+[tasks.test-asan]
+description = "Run tests with AddressSanitizer enabled. Example `cargo make test-asan`. Use `cargo make test-asan --print-dll-path` to print the ASan runtime DLL directory."
+clear = true
+script_runner = "@duckscript"
+script = '''
+os = os_family
+
+if eq ${os} "windows"
+    # ASan testing is only supported on Windows x64.
+    # https://learn.microsoft.com/cpp/sanitizers/asan
+    arch = get_env PROCESSOR_ARCHITECTURE
+    if not eq ${arch} "AMD64"
+        echo "test-asan is only supported on Windows x64. Detected arch: ${arch}. Skipping."
+        exit 0
+    end
+
+    # The ASan runtime DLL (clang_rt.asan_dynamic-x86_64.dll) from the
+    # MSVC toolchain must be on PATH for ASan-instrumented test binaries to run.
+    #
+    # Resolve the VC toolset path per vswhere docs:
+    # https://github.com/microsoft/vswhere/wiki/Find-VC
+    program_files_x86 = get_env "ProgramFiles(x86)"
+    vswhere = set "${program_files_x86}/Microsoft Visual Studio/Installer/vswhere.exe"
+    output = exec "${vswhere}" -latest -products * -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath
+    install_dir = trim ${output.stdout}
+    version = readfile "${install_dir}/VC/Auxiliary/Build/Microsoft.VCToolsVersion.default.txt"
+    version = trim ${version}
+    asan_dll_path = set "${install_dir}/VC/Tools/MSVC/${version}/bin/HostX64/x64"
+
+    args = get_env CARGO_MAKE_TASK_ARGS
+    if contains "${args}" "--print-dll-path"
+        asan_dll_path = replace ${asan_dll_path} / \\
+        echo "${asan_dll_path}"
+        exit 0
+    end
+
+    current_path = get_env PATH
+    set_env PATH "${asan_dll_path};${current_path}"
+elseif eq ${os} "linux"
+    # On Linux, the ASan runtime is resolved automatically by the linker.
+    noop
+else
+    echo "test-asan is not supported on ${os}. Skipping."
+    exit 0
+end
+
+set_env RUSTFLAGS "-Zsanitizer=address"
+set_env RUSTDOCFLAGS "-Zsanitizer=address"
+target = get_env CARGO_MAKE_RUST_TARGET_TRIPLE
+exec --fail-on-error cargo test --target ${target} --workspace --features std
+'''
+
 [tasks.coverage-lcov]
 description = "Generate an LCOV coverage report from collected data."
 install_crate = false

--- a/docs/src/dev/testing/unit.md
+++ b/docs/src/dev/testing/unit.md
@@ -76,3 +76,37 @@ graph TD
     B --> C[Run Test]
     C --> D[Release Lock]
 ```
+
+## Address Sanitizer (ASan)
+
+When running unit tests, you can enable Address Sanitizer (ASan) to help detect memory errors. This is available on
+Linux and Windows X64 hosts.
+
+To run unit tests with Address Sanitizer enabled, use the following command:
+
+```sh
+cargo make test-asan
+```
+
+### Advanced Usage: Debugging ASan Test Executables Directly
+
+On Windows, the tests executables built with ASan enabled have a dependency on the ASan DLL, which is not in the system
+path by default. The `test-asan` task discovers the ASan DLL path on your system and sets it in the environment when
+running tests, but if you want to run the test executable directly, you will need to set the environment variable
+yourself.
+
+You can find the ASan DLL path by running:
+
+```sh
+cargo make test-asan --print-dll-path
+```
+
+This will include surrounding `cargo make` output. You can script the call to just get the path to facilitate setting
+the environment variable.
+
+For example, in PowerShell:
+
+```powershell
+$asanPath = (cargo make test-asan --print-dll-path) -match '^[A-Z]:\\' | Select-Object -Last 1
+$env:PATH = "$asanPath;$env:PATH"
+```


### PR DESCRIPTION
## Description

Adds a `test-asan` task that runs tests  with AddressSanitizer (`-Zsanitizer=address`) enabled. The task supports Windows x64 and Linux hosts.

Full task command: `cargo make test-asan`

On Windows [1], ASan-instrumented binaries require the MSVC ASan runtime DLL (`clang_rt.asan_dynamic-x86_64.dll`) to be on PATH at runtime so that's done as part of the task setup. The DLL location is resolved using the VC toolset installation path from `vswhere` [2].

On Linux, no additional setup is needed as the ASan runtime is resolved automatically by the linker.

[1] https://learn.microsoft.com/cpp/sanitizers/asan
[2] https://github.com/microsoft/vswhere/wiki/Find-VC

A `--print-dll-path` argument is supported on Windows to print the resolved ASan DLL path and exit, which can be useful for adding that to the system PATH when running tests outside of `cargo make`.

---

Note: I've already fixed an initial set of issues other than (mostly intentional) memory leaks. I can add this to CI in a follow up PR if there is interest in doing so. This PR is to raise awareness in the patina repo about the change. It will be added to Makefile.toml in patina-devops as well, if accepted.

---

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

- `cargo make test-asan` on Windows (with Visual Studio installed) and Ubuntu 24.04

## Integration Instructions

- N/A - New task available