### PR TITLE
patina_debugger: Cleanup features and feature usage

### DIFF
--- a/core/patina_debugger/Cargo.toml
+++ b/core/patina_debugger/Cargo.toml
@@ -28,6 +28,5 @@ serial_test = { workspace = true }
 patina_mtrr = { workspace = true }
 
 [features]
-default = ["alloc", "windbg_workarounds"]
+default = []
 alloc = []
-windbg_workarounds = []

--- a/core/patina_debugger/README.md
+++ b/core/patina_debugger/README.md
@@ -67,10 +67,9 @@ In addition, active examples are available in the
 
 ## Feature flags
 
-- `windbg_workarounds` (default): adjusts protocol behaviors for Windbg compatibility, including suppressing repeated
-  reads that stall early-boot sessions.
 - `alloc`: replaces static communication buffers with dynamically allocated storage and enables monitor command
-  registration; this requires a functional allocator but unlocks richer diagnostics.
+  registration; this requires a functional allocator but unlocks richer diagnostics. This is intended for use by the
+  core crate, and not for platform use.
 
 ---
 

--- a/core/patina_debugger/src/dbg_target.rs
+++ b/core/patina_debugger/src/dbg_target.rs
@@ -34,8 +34,8 @@ use crate::{
 };
 
 /// Addresses that windbg will attempt to read in a loop, reads from these addresses
-/// will just return 0 to avoid long retry delays.
-#[cfg(feature = "windbg_workarounds")]
+/// will just return 0 to avoid long retry delays. This has been fixed in windbg, but leaving this
+/// here for a while to support older versions of windbg. Will remove in the future.
 const WINDBG_MOCK_ADDRESSES: [u64; 3] = [0xfffff78000000268, 0, 0x34c00];
 
 /// Patina target for GDB.
@@ -82,21 +82,21 @@ impl Target for PatinaTarget {
         gdbstub::target::ext::base::BaseOps::SingleThread(self)
     }
 
-    #[cfg(feature = "windbg_workarounds")]
     #[inline(always)]
     fn use_no_ack_mode(&self) -> bool {
+        // Windbg doesn't support no-ack mode.
         false
     }
 
-    #[cfg(feature = "windbg_workarounds")]
     #[inline(always)]
     fn use_rle(&self) -> bool {
+        // Windbg doesn't support RLE.
         false
     }
 
-    #[cfg(feature = "windbg_workarounds")]
     #[inline(always)]
     fn use_x_upcase_packet(&self) -> bool {
+        // Windbg doesn't support x-upcase packet.
         false
     }
 
@@ -136,7 +136,6 @@ impl SingleThreadBase for PatinaTarget {
     ) -> TargetResult<usize, Self> {
         // Windbg will try to find some well known windows structures. Return
         // 0s instead of failing to prevent long retry delays.
-        #[cfg(feature = "windbg_workarounds")]
         if WINDBG_MOCK_ADDRESSES.contains(&start_addr) {
             data.fill(0);
             return Ok(data.len());

--- a/core/patina_debugger/src/lib.rs
+++ b/core/patina_debugger/src/lib.rs
@@ -91,10 +91,9 @@
 //!
 //! ## Features
 //!
-//! `windbg_workarounds` - (Default) Enables workarounds for Windbg compatibility.
-//!
 //! `alloc` - Uses allocated buffers rather than static buffers for all memory. This provides additional functionality
-//! but prevents debugging prior to allocations being available.
+//! but prevents debugging prior to allocations being available. This is intended for use by the core crate, and not
+//! for platform use.
 //!
 //! ## License
 //!

--- a/patina_dxe_core/Cargo.toml
+++ b/patina_dxe_core/Cargo.toml
@@ -31,7 +31,7 @@ patina = { workspace = true, features = ["core"] }
 patina_ffs = { workspace = true }
 patina_internal_collections = { workspace = true  }
 patina_internal_cpu = { workspace = true }
-patina_debugger = { workspace = true }
+patina_debugger = { workspace = true, features = ["alloc"] }
 patina_internal_depex = { workspace = true}
 patina_performance = { workspace = true }
 


### PR DESCRIPTION
## Description

This commit addresses two issues with the patina_debugger features:

1. Removes the `windbg_workarounds` feature. Windbg is the primary supported scenario for patina_debugger, and these workaround do not inhibit other debuggers from working. Removing the feature reduces complexity and removes the ability for users to accidentally break windbg support.

2. Removes the default features from patina_debugger for the workspace crate. This allows the features to be enabled for the appropriate core and by end platforms if applicable.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Regression tested with windbg on Q35

## Integration Instructions

N/A
