### PR TITLE
patina_dxe_core: Provide DXE Core handle to component storage

### DIFF
--- a/patina_dxe_core/src/component_dispatcher.rs
+++ b/patina_dxe_core/src/component_dispatcher.rs
@@ -177,6 +177,12 @@ impl ComponentDispatcher {
         self.storage.set_runtime_services(rs);
     }
 
+    /// Sets the image handle in storage (used as parent for LoadImage calls).
+    #[coverage(off)]
+    pub(crate) fn set_image_handle(&mut self, handle: efi::Handle) {
+        self.storage.set_image_handle(handle);
+    }
+
     /// Parses the HOB list producing a `Hob\<T\>` struct for each guided HOB found with a registered parser.
     pub(crate) fn insert_hobs(&mut self, hob_list: &HobList<'_>) {
         for hob in hob_list.iter() {

--- a/patina_dxe_core/src/lib.rs
+++ b/patina_dxe_core/src/lib.rs
@@ -540,6 +540,7 @@ impl<P: PlatformInfo> Core<P> {
 
         self.component_dispatcher.lock().set_boot_services(boot_services);
         self.component_dispatcher.lock().set_runtime_services(runtime_services);
+        self.component_dispatcher.lock().set_image_handle(protocol_db::DXE_CORE_HANDLE);
 
         Ok(())
     }


### PR DESCRIPTION
## Description

Add `set_image_handle()` to `ComponentDispatcher` so components can access the image handle (needed as parent handle for `LoadImage` calls). Called during core initialization alongside existing `set_boot_services`/`set_runtime_services`.

Split out from #1333 per review feedback.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [x] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

CI build verification. Integration tested with `patina_boot` BootDispatcher consuming the image handle on QEMU Q35.

## Integration Instructions

N/A