### PR TITLE
Patina QEMU PR Workflow: Add unique comment for merged/closed PRs

### DIFF
--- a/.github/workflows/patina-qemu-pr-validation.yml
+++ b/.github/workflows/patina-qemu-pr-validation.yml
@@ -33,6 +33,7 @@ jobs:
     outputs:
       pr_number: ${{ steps.pr-info.outputs.pr_number }}
       skip: ${{ steps.pr-info.outputs.skip }}
+      skip_reason: ${{ steps.pr-info.outputs.skip_reason }}
     steps:
       - name: Get PR Information
         id: pr-info
@@ -49,8 +50,33 @@ jobs:
             --jq '.[0].number')
 
           if [[ -z "$pr_number" || "$pr_number" == "null" ]]; then
-            echo "::notice::No open PR found for head $owner:$HEAD_REF. The PR was likely closed or merged already. Skipping."
+            echo "::notice::No open PR found for head $owner:$HEAD_REF. Checking for closed/merged PRs."
             echo "skip=true" >> "$GITHUB_OUTPUT"
+
+            # Look for the most recently updated closed/merged PR with this head branch
+            closed_pr_json=$(gh api "repos/${GITHUB_REPOSITORY}/pulls" \
+              --method GET -f state=closed -f head="${owner}:${HEAD_REF}" \
+              -f sort=updated -f direction=desc -f per_page=1 \
+              --jq '.[0] | select(. != null) | {number, merged: (.merged_at != null)}')
+
+            if [[ -n "$closed_pr_json" ]]; then
+              closed_pr_number=$(echo "$closed_pr_json" | jq -r '.number')
+              closed_pr_merged=$(echo "$closed_pr_json" | jq -r '.merged')
+
+              echo "pr_number=$closed_pr_number" >> "$GITHUB_OUTPUT"
+
+              if [[ "$closed_pr_merged" == "true" ]]; then
+                echo "::notice::PR #$closed_pr_number was merged before validation started."
+                echo "skip_reason=merged" >> "$GITHUB_OUTPUT"
+              else
+                echo "::notice::PR #$closed_pr_number was closed before validation started."
+                echo "skip_reason=closed" >> "$GITHUB_OUTPUT"
+              fi
+            else
+              echo "::notice::No PR (open or closed) found for head $owner:$HEAD_REF."
+              echo "skip_reason=branch_unavailable" >> "$GITHUB_OUTPUT"
+            fi
+
             exit 0
           fi
 
@@ -64,6 +90,30 @@ jobs:
           echo "::endgroup::"
 
           echo "pr_number=$pr_number" >> "$GITHUB_OUTPUT"
+
+  upload-skip-metadata:
+    name: Upload Skip Metadata
+    runs-on: ubuntu-latest
+    needs: [prepare]
+    if: needs.prepare.outputs.skip == 'true' && needs.prepare.outputs.pr_number != ''
+    steps:
+      - name: Create Skip Metadata
+        shell: bash
+        run: |
+          mkdir -p metadata
+          cat > metadata/pr-metadata.json <<'EOF'
+          {
+            "pr_number": ${{ needs.prepare.outputs.pr_number }},
+            "skipped": true,
+            "skip_reason": "${{ needs.prepare.outputs.skip_reason }}"
+          }
+          EOF
+
+      - name: Upload PR Metadata
+        uses: actions/upload-artifact@v6
+        with:
+          name: patina-qemu-pr-metadata
+          path: metadata/pr-metadata.json
 
   qemu-pr-validation:
     name: Run Patina QEMU Validation


### PR DESCRIPTION
## Description

Updates the `patina-qemu-pr-validation.yml` workflow to post a comment when a PR is either merged or the PR is closed when the workflow starts.

This provides an obvious final state for the comment in those cases.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

- Tested the closed and merged cases in PR on fork (with a PR from another GitHub org)
- Tested the successful case (PR remains open) continues to work

## Integration Instructions

- N/A

---

### Examples of New Messages

**PR Closed (Branch Deleted)**

<img width="871" height="310" alt="image" src="https://github.com/user-attachments/assets/7d6cdb78-5754-4972-985f-a5a98eaa3bfb" />

**PR Merged**

<img width="876" height="309" alt="image" src="https://github.com/user-attachments/assets/4d206ae9-2765-45a9-a588-0a458e26f924" />

### Example of GitHub Annotations

**PR Closed (Branch Deleted)**

<img width="927" height="224" alt="image" src="https://github.com/user-attachments/assets/94b432d8-d01c-45a6-ae66-ef7003bd7f03" />
