### PR TITLE
patina_dxe_core/pecoff: Add parse_mapped()

### DIFF
--- a/patina_dxe_core/src/gcd/spin_locked_gcd.rs
+++ b/patina_dxe_core/src/gcd/spin_locked_gcd.rs
@@ -2315,7 +2315,7 @@ impl SpinLockedGcd {
             .expect("Did not find MemoryAllocationModule Hob for DxeCore. Use patina::guid::DXE_CORE as FFS GUID.");
 
         let pe_info = unsafe {
-            UefiPeInfo::parse(core::slice::from_raw_parts(
+            UefiPeInfo::parse_mapped(core::slice::from_raw_parts(
                 dxe_core_hob.alloc_descriptor.memory_base_address as *const u8,
                 dxe_core_hob.alloc_descriptor.memory_length as usize,
             ))

--- a/patina_dxe_core/src/pecoff.rs
+++ b/patina_dxe_core/src/pecoff.rs
@@ -96,7 +96,22 @@ pub struct UefiPeInfo {
 impl UefiPeInfo {
     pub fn parse(bytes: &[u8]) -> error::Result<Self> {
         match scroll::Pread::gread_with::<u16>(bytes, &mut 0, scroll::LE)? {
-            PE32_MAGIC => UefiPeInfo::from_pe(bytes),
+            PE32_MAGIC => UefiPeInfo::from_pe(bytes, &goblin::pe::options::ParseOptions::default()),
+            TE_MAGIC => UefiPeInfo::from_te(bytes),
+            sig => Err(error::Error::BadSignature(sig)),
+        }
+    }
+
+    /// Parses a PE image that has already been loaded into memory (sections at virtual addresses).
+    ///
+    /// This method uses `resolve_rva: false` so that goblin treats RVAs as direct byte offsets into
+    /// the slice. This is useful for images where sections have been mapped to their virtual addresses.
+    pub fn parse_mapped(bytes: &[u8]) -> error::Result<Self> {
+        let mut opts = goblin::pe::options::ParseOptions::default();
+        opts.resolve_rva = false;
+        opts.parse_attribute_certificates = false;
+        match scroll::Pread::gread_with::<u16>(bytes, &mut 0, scroll::LE)? {
+            PE32_MAGIC => UefiPeInfo::from_pe(bytes, &opts),
             TE_MAGIC => UefiPeInfo::from_te(bytes),
             sig => Err(error::Error::BadSignature(sig)),
         }
@@ -142,11 +157,11 @@ impl UefiPeInfo {
     }
 
     /// Parses a PE image with a PE32 header, gathering the necessary data for operating on the image in a UEFI environment.
-    fn from_pe(bytes: &[u8]) -> error::Result<Self> {
+    fn from_pe(bytes: &[u8], opts: &goblin::pe::options::ParseOptions) -> error::Result<Self> {
         let mut pe = UefiPeInfo::default();
 
         // Parse the PE header and verify the optional header exists
-        let parsed_pe = goblin::pe::PE::parse(bytes)?;
+        let parsed_pe = goblin::pe::PE::parse_with_opts(bytes, opts)?;
         let optional_header = parsed_pe.header.optional_header.ok_or(error::Error::NoOptionalHeader)?;
 
         // Set the simple fields

--- a/patina_dxe_core/src/pi_dispatcher/image.rs
+++ b/patina_dxe_core/src/pi_dispatcher/image.rs
@@ -597,7 +597,7 @@ impl ImageData {
             )
         };
 
-        let pe_info = UefiPeInfo::parse(dxe_core_image_buffer).expect("Failed to parse PE info for DXE Core");
+        let pe_info = UefiPeInfo::parse_mapped(dxe_core_image_buffer).expect("Failed to parse PE info for DXE Core");
 
         let private_image_data =
             PrivateImageData::new_from_static_image(image_info, dxe_core_image_buffer, entry_point, &pe_info);
@@ -3281,10 +3281,15 @@ mod tests {
 
     fn create_dxe_core_hob() -> HobList<'static> {
         let mut test_file = File::open(test_paths::RUST_IMAGE).expect("failed to open test file.");
-        let mut image: Vec<u8> = Vec::new();
-        test_file.read_to_end(&mut image).expect("failed to read test file");
+        let mut raw_image: Vec<u8> = Vec::new();
+        test_file.read_to_end(&mut raw_image).expect("failed to read test file");
 
-        let image = Box::leak(image.into_boxed_slice());
+        // Map the PE sections to their virtual addresses so that parse_mapped() reads the loaded
+        // image in memory (as the DXE Core is expected to be loaded in memory by the DXE loader).
+        let pe_info = UefiPeInfo::parse(&raw_image).expect("failed to parse PE for mapping");
+        let mut mapped_image: Vec<u8> = vec![0u8; pe_info.size_of_image as usize];
+        crate::pecoff::load_image(&pe_info, &raw_image, &mut mapped_image).expect("failed to load/map PE image");
+        let image = Box::leak(mapped_image.into_boxed_slice());
 
         extern "efiapi" fn entry_point(_: *mut c_void, _: *mut efi::SystemTable) -> efi::Status {
             efi::Status::SUCCESS


### PR DESCRIPTION
## Description

Resolves https://github.com/OpenDevicePartnership/patina-dxe-core-qemu/issues/134

Right now, we have `resolve_rva` set to true when parsing the DXE Core using `UefiPeInfo::parse()`.

https://github.com/OpenDevicePartnership/patina/blob/dc285f1dffa57087a72f6bfd956d36db93e8b31f/patina_dxe_core/src/gcd/spin_locked_gcd.rs#L2317-L2323

Which calls with `goblin::pe::PE::parse(bytes)` to parse the image.

By default, goblin will attempt to resolve RVAs to file offsets when parsing a PE file. However, since the DXE Core is already loaded into memory, we want to parse it, in this case, without resolving RVAs using PointerToRawData offsets.

Depending on the content at the resolved address, this can lead to parsing errors like:

```
Failed to parse PE info for DXE Core:
Goblin(Malformed("ImageDebugDirectory size of data seems wrong: 0"))
```

It appears that this has been present for a long time, likely since the decision (around c821bf9c) to start parsing the DXE Core's own loaded PE image and a recent shift in linked contents has exposed the problem.

It is possible to disable RVA resolution by using `ParseOptions` with `resolve_rva` set to false.

A new method `parse_mapped()` is added to `UefiPeInfo` that allows sets this option and is used when parsing the DXE Core in `spin_locked_gcd.rs`.

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

- Q35 and SBSA boot to EFI shell

Before the change, SBSA failed with the goblin parsing error shown in the description.

## Integration Instructions

- N/A