### PR TITLE
patina_acpi: do not specify resolver

### DIFF
--- a/components/patina_acpi/Cargo.toml
+++ b/components/patina_acpi/Cargo.toml
@@ -1,6 +1,5 @@
 [package]
 name = "patina_acpi"
-resolver = "2"
 version.workspace = true
 repository.workspace = true
 license.workspace = true


### PR DESCRIPTION
## Description

Updates patina_acpi toml configuration to not specify the resolver version as the resolver version is specified by the workspace configuration toml and any specified resolver version in individual crates are ignored.

Clears this warning:

<img width="738" height="73" alt="image" src="https://github.com/user-attachments/assets/bd3f646a-9a95-4ff3-abcf-4020a3ab7cba" />

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

N/A

## Integration Instructions

N/A
