### PR TITLE
Centralize SmbiosError to EFI Status conversion using From impl

### DIFF
--- a/components/patina_smbios/src/error.rs
+++ b/components/patina_smbios/src/error.rs
@@ -77,14 +77,15 @@ impl From<SmbiosError> for patina::error::EfiError {
             // Resource allocation errors map to OUT_OF_RESOURCES
             SmbiosError::AllocationFailed | SmbiosError::HandleExhausted => patina::error::EfiError::OutOfResources,
 
+            // Size errors map to BUFFER_TOO_SMALL
+            SmbiosError::RecordTooSmall | SmbiosError::StringPoolTooSmall => patina::error::EfiError::BufferTooSmall,
+
             // Invalid parameters map to INVALID_PARAMETER
             SmbiosError::StringTooLong
             | SmbiosError::StringContainsNull
             | SmbiosError::EmptyStringInPool
-            | SmbiosError::RecordTooSmall
             | SmbiosError::MalformedRecordHeader
             | SmbiosError::InvalidStringPoolTermination
-            | SmbiosError::StringPoolTooSmall
             | SmbiosError::StringIndexOutOfRange
             | SmbiosError::Type127Managed
             | SmbiosError::HandleInUse
@@ -188,6 +189,13 @@ mod tests {
 
         let efi_err: patina::error::EfiError = SmbiosError::HandleOutOfRange.into();
         assert_eq!(efi_err, patina::error::EfiError::InvalidParameter);
+
+        // Test size errors map to BUFFER_TOO_SMALL
+        let efi_err: patina::error::EfiError = SmbiosError::RecordTooSmall.into();
+        assert_eq!(efi_err, patina::error::EfiError::BufferTooSmall);
+
+        let efi_err: patina::error::EfiError = SmbiosError::StringPoolTooSmall.into();
+        assert_eq!(efi_err, patina::error::EfiError::BufferTooSmall);
 
         // Test not found errors map to NOT_FOUND
         let efi_err: patina::error::EfiError = SmbiosError::RecordNotFound.into();

--- a/components/patina_smbios/src/manager/protocol.rs
+++ b/components/patina_smbios/src/manager/protocol.rs
@@ -18,10 +18,7 @@ use core::ffi::c_char;
 use patina::{tpl_mutex::TplMutex, uefi_protocol::ProtocolInterface};
 use r_efi::efi;
 
-use crate::{
-    error::SmbiosError,
-    service::{SMBIOS_HANDLE_PI_RESERVED, SmbiosHandle, SmbiosTableHeader, SmbiosType},
-};
+use crate::service::{SMBIOS_HANDLE_PI_RESERVED, SmbiosHandle, SmbiosTableHeader, SmbiosType};
 
 use super::core::SmbiosManager;
 
@@ -199,21 +196,7 @@ impl SmbiosProtocol {
 
                 efi::Status::SUCCESS
             }
-            Err(SmbiosError::StringContainsNull) => efi::Status::INVALID_PARAMETER,
-            Err(SmbiosError::EmptyStringInPool) => efi::Status::INVALID_PARAMETER,
-            Err(SmbiosError::RecordTooSmall) => efi::Status::BUFFER_TOO_SMALL,
-            Err(SmbiosError::MalformedRecordHeader) => efi::Status::INVALID_PARAMETER,
-            Err(SmbiosError::InvalidStringPoolTermination) => efi::Status::INVALID_PARAMETER,
-            Err(SmbiosError::StringPoolTooSmall) => efi::Status::BUFFER_TOO_SMALL,
-            Err(SmbiosError::HandleExhausted) => efi::Status::OUT_OF_RESOURCES,
-            Err(SmbiosError::HandleOutOfRange) => efi::Status::INVALID_PARAMETER,
-            Err(SmbiosError::HandleInUse) => efi::Status::INVALID_PARAMETER,
-            Err(SmbiosError::AllocationFailed) => efi::Status::OUT_OF_RESOURCES,
-            Err(SmbiosError::StringTooLong) => efi::Status::INVALID_PARAMETER,
-            Err(e) => {
-                log::error!("[SMBIOS Add] Error: {:?}", e);
-                efi::Status::DEVICE_ERROR
-            }
+            Err(e) => patina::error::EfiError::from(e).into(),
         }
     }
 
@@ -263,11 +246,7 @@ impl SmbiosProtocol {
 
                 efi::Status::SUCCESS
             }
-            Err(SmbiosError::StringContainsNull) => efi::Status::INVALID_PARAMETER,
-            Err(SmbiosError::RecordNotFound) => efi::Status::NOT_FOUND,
-            Err(SmbiosError::StringIndexOutOfRange) => efi::Status::INVALID_PARAMETER,
-            Err(SmbiosError::StringTooLong) => efi::Status::INVALID_PARAMETER,
-            Err(_) => efi::Status::DEVICE_ERROR,
+            Err(e) => patina::error::EfiError::from(e).into(),
         }
     }
 
@@ -297,8 +276,7 @@ impl SmbiosProtocol {
 
                 efi::Status::SUCCESS
             }
-            Err(SmbiosError::RecordNotFound) => efi::Status::NOT_FOUND,
-            Err(_) => efi::Status::DEVICE_ERROR,
+            Err(e) => patina::error::EfiError::from(e).into(),
         }
     }
 
@@ -384,7 +362,7 @@ impl SmbiosProtocol {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::manager::SmbiosManager;
+    use crate::{error::SmbiosError, manager::SmbiosManager};
     extern crate std;
     use std::vec::Vec;
 


### PR DESCRIPTION
## Description

Centralize the `SmbiosError` to `efi::Status` conversion in protocol.rs by using the existing `From<SmbiosError> for EfiError` impl and the `EfiError` → `efi::Status` conversion chain, instead of manual match arms in each FFI function (`add_ext`, `update_string_ext`, `remove_ext`).

Additionally, `RecordTooSmall` and `StringPoolTooSmall` are remapped from `EfiError::InvalidParameter` to `EfiError::BufferTooSmall` for more accurate error semantics.

Closes #1163

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [x] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Ran `cargo test -p patina_smbios` — all 134 tests pass, including updated assertions for the new `BufferTooSmall` mappings in `test_smbios_error_to_efi_error_conversion`.

## Integration Instructions

N/A