### PR TITLE
Initial implementation of supervisor

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace]
 resolver = "3"
-members = ["components/*", "core/*", "sdk/*", "patina_dxe_core"]
+members = ["components/*", "core/*", "sdk/*", "patina_dxe_core", "patina_mm_supervisor", "patina_mm_user_core"]
 
 [workspace.package]
 version = "22.2.1"
@@ -41,6 +41,8 @@ patina_internal_mm_common = { version = "22.2.1", path = "core/patina_internal_m
 lzma-rust2 = { version = "0.16", default-features = false }
 patina_macro = { version = "22.2.1", path = "sdk/patina_macro" }
 patina_mm = { version = "22.2.1", path = "components/patina_mm" }
+patina_mm_cpu = { version = "22.2.1", path = "components/patina_mm_cpu" }
+patina_mm_supervisor = { version = "22.2.1", path = "patina_mm_supervisor" }
 patina_mtrr = { version = "1.1.6" }
 patina_paging = { version = "11.0.4" }
 patina_performance = { version = "22.2.1", path = "components/patina_performance" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,7 @@ patina_ffs = { version = "22.2.1", path = "sdk/patina_ffs" }
 patina_ffs_extractors = { version = "22.2.1", path = "sdk/patina_ffs_extractors" }
 patina_internal_core = { version = "22.2.1", path = "core/patina_internal_core", default-features = false }
 patina_internal_cpu = { version = "22.2.1", path = "core/patina_internal_cpu" }
+patina_internal_mm_common = { version = "22.2.1", path = "core/patina_internal_mm_common" }
 lzma-rust2 = { version = "0.16", default-features = false }
 patina_macro = { version = "22.2.1", path = "sdk/patina_macro" }
 patina_mm = { version = "22.2.1", path = "components/patina_mm" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,7 @@ patina_macro = { version = "22.2.1", path = "sdk/patina_macro" }
 patina_mm = { version = "22.2.1", path = "components/patina_mm" }
 patina_mm_cpu = { version = "22.2.1", path = "components/patina_mm_cpu" }
 patina_mm_supervisor = { version = "22.2.1", path = "patina_mm_supervisor" }
+patina_mm_user_core = { version = "22.2.1", path = "patina_mm_user_core" }
 patina_mtrr = { version = "1.1.6" }
 patina_paging = { version = "11.0.4" }
 patina_performance = { version = "22.2.1", path = "components/patina_performance" }

--- a/components/patina_mm_cpu/Cargo.toml
+++ b/components/patina_mm_cpu/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "patina_mm_cpu"
+version.workspace = true
+repository.workspace = true
+license.workspace = true
+edition.workspace = true
+description = "MM CPU component producing the EFI_MM_CPU_PROTOCOL (save-state access) in the MM User Core."
+
+[lints]
+workspace = true
+
+[dependencies]
+log = { workspace = true }
+r-efi = { workspace = true }
+
+patina = { workspace = true, features = ["alloc"] }
+
+[features]
+std = []
+# All non-std features to test in CI
+ci_features = []

--- a/components/patina_mm_cpu/src/component.rs
+++ b/components/patina_mm_cpu/src/component.rs
@@ -1,0 +1,166 @@
+//! The MM CPU component.
+//!
+//! ## License
+//!
+//! Copyright (c) Microsoft Corporation.
+//!
+//! SPDX-License-Identifier: Apache-2.0
+//!
+
+use core::ffi::c_void;
+
+use patina::{
+    component::component,
+    error::{EfiError, Result},
+    mm_services::MmServiceProvider,
+};
+use r_efi::efi;
+
+use crate::protocol::{self, MM_CPU_PROTOCOL_GUID, MmCpuProtocol};
+
+/// The static `EFI_MM_CPU_PROTOCOL` interface installed by [`MmCpuComponent`].
+///
+/// Function pointers are `Send`/`Sync`, so this is safe to place in a `static`
+/// and hand to consumers as a stable interface pointer.
+static MM_CPU_PROTOCOL: MmCpuProtocol =
+    MmCpuProtocol { read_save_state: mm_cpu_read_save_state, write_save_state: mm_cpu_write_save_state };
+
+/// Component that produces the `EFI_MM_CPU_PROTOCOL` in the MM User Core.
+///
+/// Replaces the C `MmSupervisorPkg/Drivers/MmSupervisedCpu` driver. It installs
+/// `gEfiMmCpuProtocolGuid`; its `ReadSaveState` forwards save-state reads to the
+/// MM Supervisor, which owns SMRAM and enforces the save-state security policy.
+#[derive(Default)]
+pub struct MmCpuComponent;
+
+impl MmCpuComponent {
+    /// Creates a new [`MmCpuComponent`].
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+#[component]
+impl MmCpuComponent {
+    fn entry_point(self, mm: MmServiceProvider) -> Result<()> {
+        // SAFETY: `MM_CPU_PROTOCOL` is a valid, `'static` interface; a `None` handle
+        // requests a freshly allocated handle for the installed interface.
+        let result = unsafe {
+            mm.install_protocol_interface(
+                None,
+                &MM_CPU_PROTOCOL_GUID,
+                &MM_CPU_PROTOCOL as *const MmCpuProtocol as *mut c_void,
+            )
+        };
+
+        match result {
+            Ok(handle) => {
+                log::info!("Installed EFI_MM_CPU_PROTOCOL on handle {handle:p}");
+                Ok(())
+            }
+            Err(status) => {
+                log::error!("Failed to install EFI_MM_CPU_PROTOCOL: {status:?}");
+                EfiError::status_to_result(status)
+            }
+        }
+    }
+}
+
+/// `EFI_MM_CPU_PROTOCOL.ReadSaveState` implementation.
+///
+/// Only `PROCESSOR_ID`, `RAX`, and `IO` are supported; any other register is not
+/// defined for the save state and returns `EFI_NOT_FOUND` (per the PI spec). The
+/// supported registers are forwarded to the MM Supervisor, which reads SMRAM,
+/// enforces the save-state policy, and assembles the composite
+/// `EFI_MM_SAVE_STATE_IO_INFO` for the `IO` pseudo-register.
+extern "efiapi" fn mm_cpu_read_save_state(
+    this: *const MmCpuProtocol,
+    width: usize,
+    register: u32,
+    cpu_index: usize,
+    buffer: *mut c_void,
+) -> efi::Status {
+    if this.is_null() || buffer.is_null() {
+        return efi::Status::INVALID_PARAMETER;
+    }
+
+    // Whitelist the supported registers. Returning early here both satisfies the
+    // PI contract (`EFI_NOT_FOUND` for undefined registers) and avoids issuing a
+    // syscall the supervisor would reject.
+    match register {
+        protocol::REGISTER_PROCESSOR_ID | protocol::REGISTER_RAX | protocol::REGISTER_IO => {}
+        _ => return efi::Status::NOT_FOUND,
+    }
+
+    // SAFETY: `buffer` is a caller-provided output buffer of at least `width`
+    // bytes (for `IO`, at least `size_of::<EFI_MM_SAVE_STATE_IO_INFO>()`). The
+    // supervisor validates that the buffer is user-owned before writing to it.
+    unsafe {
+        crate::save_state::read_save_state_register(this as usize, width, register, cpu_index, buffer.cast::<u8>())
+    }
+}
+
+/// `EFI_MM_CPU_PROTOCOL.WriteSaveState` implementation.
+///
+/// Writing the MM save state is not supported, mirroring the C `MmSupervisedCpu`
+/// driver, which installs a NULL `WriteSaveState`.
+extern "efiapi" fn mm_cpu_write_save_state(
+    _this: *const MmCpuProtocol,
+    _width: usize,
+    _register: u32,
+    _cpu_index: usize,
+    _buffer: *const c_void,
+) -> efi::Status {
+    efi::Status::UNSUPPORTED
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A non-null protocol pointer for tests. The read path never dereferences
+    /// `this`; it only forwards its address to the (stubbed) syscall.
+    fn dummy_this() -> *const MmCpuProtocol {
+        &MM_CPU_PROTOCOL as *const MmCpuProtocol
+    }
+
+    #[test]
+    fn test_mm_cpu_read_save_state_rejects_null_this() {
+        let mut buf = [0u8; 8];
+        let status = mm_cpu_read_save_state(core::ptr::null(), 8, protocol::REGISTER_RAX, 0, buf.as_mut_ptr().cast());
+        assert_eq!(status, efi::Status::INVALID_PARAMETER);
+    }
+
+    #[test]
+    fn test_mm_cpu_read_save_state_rejects_null_buffer() {
+        let status = mm_cpu_read_save_state(dummy_this(), 8, protocol::REGISTER_RAX, 0, core::ptr::null_mut());
+        assert_eq!(status, efi::Status::INVALID_PARAMETER);
+    }
+
+    #[test]
+    fn test_mm_cpu_read_save_state_unsupported_register_is_not_found() {
+        let mut buf = [0u8; 8];
+        // 39 = RBX — a valid PI register, but not one this component exposes.
+        let status = mm_cpu_read_save_state(dummy_this(), 8, 39, 0, buf.as_mut_ptr().cast());
+        assert_eq!(status, efi::Status::NOT_FOUND);
+    }
+
+    #[test]
+    fn test_mm_cpu_read_save_state_supported_register_forwards_to_syscall() {
+        let mut buf = [0u8; 8];
+        // A supported register passes the whitelist and forwards to the syscall
+        // wrapper, which on the host (non-UEFI) target is a stub reporting the
+        // operation as unsupported. Reaching UNSUPPORTED proves the forward path.
+        for register in [protocol::REGISTER_PROCESSOR_ID, protocol::REGISTER_RAX, protocol::REGISTER_IO] {
+            let status = mm_cpu_read_save_state(dummy_this(), 8, register, 0, buf.as_mut_ptr().cast());
+            assert_eq!(status, efi::Status::UNSUPPORTED);
+        }
+    }
+
+    #[test]
+    fn test_mm_cpu_write_save_state_is_unsupported() {
+        let buf = [0u8; 8];
+        let status = mm_cpu_write_save_state(dummy_this(), 8, protocol::REGISTER_RAX, 0, buf.as_ptr().cast());
+        assert_eq!(status, efi::Status::UNSUPPORTED);
+    }
+}

--- a/components/patina_mm_cpu/src/lib.rs
+++ b/components/patina_mm_cpu/src/lib.rs
@@ -1,0 +1,44 @@
+//! MM CPU Component
+//!
+//! This crate provides the [`MmCpuComponent`](component::MmCpuComponent), which
+//! produces the PI `EFI_MM_CPU_PROTOCOL` (`gEfiMmCpuProtocolGuid`) inside the MM
+//! User Core. That protocol lets MM drivers read architecture-standard registers
+//! from any CPU's MM save state (for example, the trapping I/O instruction that
+//! generated a software MMI).
+//!
+//! The MM save state lives in supervisor-only SMRAM, so `ReadSaveState` forwards
+//! each read to the MM Supervisor, which enforces the save-state security policy
+//! before returning the value. This component is the Rust replacement for the C
+//! `MmSupervisorPkg/Drivers/MmSupervisedCpu` driver.
+//!
+//! ## Usage
+//!
+//! Register the component with the MM User Core via the platform's
+//! `MmComponentInfo` implementation:
+//!
+//! ```rust,ignore
+//! use patina_mm_user_core::component_dispatcher::{Add, Component, MmComponentInfo};
+//!
+//! struct MyMmPlatform;
+//! impl MmComponentInfo for MyMmPlatform {
+//!     fn components(mut add: Add<Component>) {
+//!         add.component(patina_mm_cpu::component::MmCpuComponent::new());
+//!     }
+//! }
+//! ```
+//!
+//! ## License
+//!
+//! Copyright (c) Microsoft Corporation.
+//!
+//! SPDX-License-Identifier: Apache-2.0
+//!
+#![cfg_attr(all(not(feature = "std"), not(test)), no_std)]
+#![deny(missing_docs)]
+
+extern crate alloc;
+
+pub mod component;
+pub mod protocol;
+
+mod save_state;

--- a/components/patina_mm_cpu/src/protocol.rs
+++ b/components/patina_mm_cpu/src/protocol.rs
@@ -1,0 +1,58 @@
+//! `EFI_MM_CPU_PROTOCOL` ABI definitions.
+//!
+//! Rust definitions of the PI 1.5 `EFI_MM_CPU_PROTOCOL` (`gEfiMmCpuProtocolGuid`)
+//! and the subset of `EFI_MM_SAVE_STATE_REGISTER` values this component supports.
+//! These mirror `MdePkg/Include/Protocol/MmCpu.h`.
+//!
+//! ## License
+//!
+//! Copyright (c) Microsoft Corporation.
+//!
+//! SPDX-License-Identifier: Apache-2.0
+//!
+
+use core::ffi::c_void;
+
+use r_efi::efi;
+
+/// `gEfiMmCpuProtocolGuid` — `eb346b97-975f-4a9f-8b22-f8e92bb3d569`.
+pub const MM_CPU_PROTOCOL_GUID: efi::Guid =
+    efi::Guid::from_fields(0xeb34_6b97, 0x975f, 0x4a9f, 0x8b, 0x22, &[0xf8, 0xe9, 0x2b, 0xb3, 0xd5, 0x69]);
+
+/// `EFI_MM_SAVE_STATE_REGISTER_RAX` — the general-purpose RAX register.
+pub const REGISTER_RAX: u32 = 38;
+
+/// `EFI_MM_SAVE_STATE_REGISTER_IO` — pseudo-register describing the I/O
+/// instruction that was in progress when the MMI was triggered. Reading it
+/// yields an `EFI_MM_SAVE_STATE_IO_INFO`.
+pub const REGISTER_IO: u32 = 512;
+
+/// `EFI_MM_SAVE_STATE_REGISTER_PROCESSOR_ID` — pseudo-register for the CPU's ID.
+pub const REGISTER_PROCESSOR_ID: u32 = 514;
+
+/// `EFI_MM_READ_SAVE_STATE` — read a register from a CPU's MM save state.
+pub type MmReadSaveState = extern "efiapi" fn(
+    this: *const MmCpuProtocol,
+    width: usize,
+    register: u32,
+    cpu_index: usize,
+    buffer: *mut c_void,
+) -> efi::Status;
+
+/// `EFI_MM_WRITE_SAVE_STATE` — write a register to a CPU's MM save state.
+pub type MmWriteSaveState = extern "efiapi" fn(
+    this: *const MmCpuProtocol,
+    width: usize,
+    register: u32,
+    cpu_index: usize,
+    buffer: *const c_void,
+) -> efi::Status;
+
+/// `EFI_MM_CPU_PROTOCOL` — access to CPU save-state registers while in MM.
+#[repr(C)]
+pub struct MmCpuProtocol {
+    /// Reads a register from the specified CPU's MM save state.
+    pub read_save_state: MmReadSaveState,
+    /// Writes a register to the specified CPU's MM save state.
+    pub write_save_state: MmWriteSaveState,
+}

--- a/components/patina_mm_cpu/src/save_state.rs
+++ b/components/patina_mm_cpu/src/save_state.rs
@@ -1,0 +1,71 @@
+//! MM save-state read syscalls (Ring 3 user MM → MM Supervisor).
+//!
+//! The MM save state lives in supervisor-only SMRAM, so the CPU protocol's
+//! `ReadSaveState` cannot read it directly; it issues these syscalls to have the
+//! MM Supervisor perform the read (and its security-policy check) in Ring 0.
+//!
+//! ## ABI
+//!
+//! The read is a two-phase syscall (mirroring the historical `SysCallLib.h`
+//! interface consumed by the C `MmSupervisedCpu` driver):
+//!
+//! 1. [`SyscallIndex::SaveStateRead`] — arg1 = `this` token, arg2 = register,
+//!    arg3 = CPU index. Validates the request and records it.
+//! 2. [`SyscallIndex::SaveStateRead2`] — arg1 = `this` token, arg2 = width,
+//!    arg3 = output buffer. Applies the MM security policy, reads the register
+//!    (assembling the composite `EFI_MM_SAVE_STATE_IO_INFO` for the `IO`
+//!    pseudo-register), and copies the result into the caller's buffer.
+//!
+//! The supervisor returns the `EFI_STATUS` for each phase in `RAX`, and the
+//! `this` token is echoed across both phases for a consistency check.
+//!
+//! ## License
+//!
+//! Copyright (c) Microsoft Corporation.
+//!
+//! SPDX-License-Identifier: Apache-2.0
+//!
+
+use patina::management_mode::supervisor::{SyscallIndex, raw_syscall};
+use r_efi::efi;
+
+/// Read `width` bytes of the given save-state `register` from the specified
+/// CPU's MM save state into `buffer`, via the MM Supervisor.
+///
+/// `register` is a raw `EFI_MM_SAVE_STATE_REGISTER` value. `this` is an opaque
+/// token echoed across the two syscall phases for a consistency check (the CPU
+/// protocol producer passes its protocol interface pointer).
+///
+/// Returns `EFI_SUCCESS` on success, or the supervisor's error status
+/// (`EFI_NOT_FOUND`, `EFI_ACCESS_DENIED`, `EFI_INVALID_PARAMETER`, …).
+///
+/// ## Safety
+///
+/// `buffer` must point to at least `width` bytes of user-owned, writable memory.
+/// The supervisor validates that the buffer is user-owned before writing, but
+/// the caller must still guarantee the pointer and length are valid.
+pub(crate) unsafe fn read_save_state_register(
+    this: usize,
+    width: usize,
+    register: u32,
+    cpu_index: usize,
+    buffer: *mut u8,
+) -> efi::Status {
+    // Phase 1: record the register and CPU index.
+    // SAFETY: `SaveStateRead` takes the `this` token, register, and CPU index as
+    // scalar arguments; no memory is dereferenced by the supervisor in this phase.
+    let phase1 =
+        unsafe { raw_syscall(SyscallIndex::SaveStateRead.as_u64(), this as u64, register as u64, cpu_index as u64) };
+    let phase1 = efi::Status::from_usize(phase1 as usize);
+    if phase1 != efi::Status::SUCCESS {
+        return phase1;
+    }
+
+    // Phase 2: apply policy, read, and copy into the caller's buffer.
+    // SAFETY: `SaveStateRead2` writes up to `width` bytes into `buffer`; the caller
+    // guarantees (per this function's contract) that `buffer` is valid for `width`
+    // bytes, and the supervisor additionally validates user ownership before writing.
+    let phase2 =
+        unsafe { raw_syscall(SyscallIndex::SaveStateRead2.as_u64(), this as u64, width as u64, buffer as u64) };
+    efi::Status::from_usize(phase2 as usize)
+}

--- a/core/patina_internal_cpu/Cargo.toml
+++ b/core/patina_internal_cpu/Cargo.toml
@@ -16,7 +16,7 @@ features = ["doc", "std"]
 [dependencies]
 log = { workspace = true }
 r-efi = { workspace = true }
-patina = { workspace = true }
+patina = { version = "22.0.1", path = "../../sdk/patina", default-features = false }
 spin = { workspace = true, features = ["rwlock"] }
 patina_paging = { workspace = true }
 cfg-if = { workspace = true }
@@ -36,5 +36,7 @@ serial_test = { workspace = true }
 default = []
 std = []
 doc = []
+save_state_intel = []
+save_state_amd = []
 # All non-std features to test in CI
 ci_features = []

--- a/core/patina_internal_cpu/src/lib.rs
+++ b/core/patina_internal_cpu/src/lib.rs
@@ -14,3 +14,4 @@
 pub mod cpu;
 pub mod interrupts;
 pub mod paging;
+pub mod save_state;

--- a/core/patina_internal_cpu/src/save_state.rs
+++ b/core/patina_internal_cpu/src/save_state.rs
@@ -1,0 +1,426 @@
+//! SMRAM Save State Architecture Definitions
+//!
+//! Provides platform-independent types and feature-gated vendor-specific
+//! register maps for reading the SMRAM save state area.
+//!
+//! ## Vendor Selection
+//!
+//! Both vendor lookup tables (`intel` and `amd`) are always compiled. The
+//! *active* vendor used by the dispatch functions ([`vendor_constants`],
+//! [`register_info`], [`parse_io_field`]) is selected at **build time** via
+//! Cargo features on the `patina_internal_cpu` crate:
+//!
+//! - `save_state_intel` — Intel x64 SMRAM save state map.
+//! - `save_state_amd`   — AMD64 SMRAM save state map.
+//!
+//! Intel is the default: AMD is active only when `save_state_amd` is enabled
+//! and `save_state_intel` is not. When both (or neither) feature is enabled,
+//! Intel is used. This keeps `--all-features` builds (used by CI for clippy,
+//! coverage, and docs) unambiguous while still compiling and testing both
+//! vendor tables.
+//!
+//! ## Overview
+//!
+//! The common types (`MmSaveStateRegister`, `RegisterInfo`, etc.) are always
+//! available.  The vendor modules contain only the register-to-offset lookup
+//! table and any vendor-specific constants (e.g. IO trap field layout).
+//!
+//! ## License
+//!
+//! Copyright (c) Microsoft Corporation.
+//!
+//! SPDX-License-Identifier: Apache-2.0
+
+// Vendor-specific submodules.
+//
+// Both vendor lookup tables are always compiled so that each one is type-checked
+// and unit-tested in every build (including `--all-features`, which CI uses for
+// clippy/coverage/doc). The *active* vendor for the dispatch functions below is
+// still selected by feature, with Intel as the default (see `vendor_constants`,
+// `register_info`, and `parse_io_field`).
+pub mod intel;
+
+pub mod amd;
+
+/// `EFI_MM_SAVE_STATE_REGISTER` values from the PI Specification.
+///
+/// These correspond to the registers that can be read from the SMRAM save
+/// state area via `EFI_MM_CPU_PROTOCOL.ReadSaveState()`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u64)]
+pub enum MmSaveStateRegister {
+    // Descriptor table bases
+    /// GDT base address.
+    GdtBase = 4,
+    /// IDT base address.
+    IdtBase = 5,
+    /// LDT base address.
+    LdtBase = 6,
+    /// GDT limit.
+    GdtLimit = 7,
+    /// IDT limit.
+    IdtLimit = 8,
+    /// LDT limit.
+    LdtLimit = 9,
+    /// LDT information.
+    LdtInfo = 10,
+
+    // Segment selectors
+    /// ES selector.
+    Es = 20,
+    /// CS selector.
+    Cs = 21,
+    /// SS selector.
+    Ss = 22,
+    /// DS selector.
+    Ds = 23,
+    /// FS selector.
+    Fs = 24,
+    /// GS selector.
+    Gs = 25,
+    /// LDTR selector.
+    LdtrSel = 26,
+    /// TR selector.
+    TrSel = 27,
+
+    // Debug registers
+    /// DR7.
+    Dr7 = 28,
+    /// DR6.
+    Dr6 = 29,
+
+    // Extended general-purpose registers (x86_64 only)
+    /// R8.
+    R8 = 30,
+    /// R9.
+    R9 = 31,
+    /// R10.
+    R10 = 32,
+    /// R11.
+    R11 = 33,
+    /// R12.
+    R12 = 34,
+    /// R13.
+    R13 = 35,
+    /// R14.
+    R14 = 36,
+    /// R15.
+    R15 = 37,
+
+    // General-purpose registers
+    /// RAX.
+    Rax = 38,
+    /// RBX.
+    Rbx = 39,
+    /// RCX.
+    Rcx = 40,
+    /// RDX.
+    Rdx = 41,
+    /// RSP.
+    Rsp = 42,
+    /// RBP.
+    Rbp = 43,
+    /// RSI.
+    Rsi = 44,
+    /// RDI.
+    Rdi = 45,
+    /// RIP.
+    Rip = 46,
+
+    // Flags and control registers
+    /// RFLAGS.
+    Rflags = 51,
+    /// CR0.
+    Cr0 = 52,
+    /// CR3.
+    Cr3 = 53,
+    /// CR4.
+    Cr4 = 54,
+
+    // Pseudo-registers
+    /// I/O operation information.
+    Io = 512,
+    /// Long Mode Active indicator.
+    Lma = 513,
+    /// Processor identifier (APIC ID).
+    ProcessorId = 514,
+}
+
+impl MmSaveStateRegister {
+    /// Creates a register from a raw `EFI_MM_SAVE_STATE_REGISTER` value.
+    pub fn from_u64(value: u64) -> Option<Self> {
+        match value {
+            4 => Some(Self::GdtBase),
+            5 => Some(Self::IdtBase),
+            6 => Some(Self::LdtBase),
+            7 => Some(Self::GdtLimit),
+            8 => Some(Self::IdtLimit),
+            9 => Some(Self::LdtLimit),
+            10 => Some(Self::LdtInfo),
+            20 => Some(Self::Es),
+            21 => Some(Self::Cs),
+            22 => Some(Self::Ss),
+            23 => Some(Self::Ds),
+            24 => Some(Self::Fs),
+            25 => Some(Self::Gs),
+            26 => Some(Self::LdtrSel),
+            27 => Some(Self::TrSel),
+            28 => Some(Self::Dr7),
+            29 => Some(Self::Dr6),
+            30 => Some(Self::R8),
+            31 => Some(Self::R9),
+            32 => Some(Self::R10),
+            33 => Some(Self::R11),
+            34 => Some(Self::R12),
+            35 => Some(Self::R13),
+            36 => Some(Self::R14),
+            37 => Some(Self::R15),
+            38 => Some(Self::Rax),
+            39 => Some(Self::Rbx),
+            40 => Some(Self::Rcx),
+            41 => Some(Self::Rdx),
+            42 => Some(Self::Rsp),
+            43 => Some(Self::Rbp),
+            44 => Some(Self::Rsi),
+            45 => Some(Self::Rdi),
+            46 => Some(Self::Rip),
+            51 => Some(Self::Rflags),
+            52 => Some(Self::Cr0),
+            53 => Some(Self::Cr3),
+            54 => Some(Self::Cr4),
+            512 => Some(Self::Io),
+            513 => Some(Self::Lma),
+            514 => Some(Self::ProcessorId),
+            _ => None,
+        }
+    }
+}
+
+/// Size of [`MmSaveStateIoInfo`] in bytes.
+pub const IO_INFO_SIZE: usize = 24;
+
+/// `EFI_MM_SAVE_STATE_IO_TYPE_INPUT` (1).
+pub const IO_TYPE_INPUT: u32 = 1;
+/// `EFI_MM_SAVE_STATE_IO_TYPE_OUTPUT` (2).
+pub const IO_TYPE_OUTPUT: u32 = 2;
+
+/// `EFI_MM_SAVE_STATE_IO_WIDTH_UINT8` (0).
+pub const IO_WIDTH_UINT8: u32 = 0;
+/// `EFI_MM_SAVE_STATE_IO_WIDTH_UINT16` (1).
+pub const IO_WIDTH_UINT16: u32 = 1;
+/// `EFI_MM_SAVE_STATE_IO_WIDTH_UINT32` (2).
+pub const IO_WIDTH_UINT32: u32 = 2;
+
+/// IA32_EFER.LMA bit (bit 10).
+pub const IA32_EFER_LMA: u64 = 1 << 10;
+
+/// LMA value: processor was in 32-bit mode.
+pub const LMA_32BIT: u64 = 32;
+/// LMA value: processor was in 64-bit mode.
+pub const LMA_64BIT: u64 = 64;
+
+/// Size of one `EFI_PROCESSOR_INFORMATION` entry (PI 1.7+).
+///
+/// Layout: `ProcessorId`(8) + `StatusFlag`(4) + `CpuPhysicalLocation`(12) +
+/// `ExtendedProcessorInformation`(24) = 48 bytes.
+pub const PROCESSOR_INFO_ENTRY_SIZE: usize = 48;
+
+/// Layout descriptor for a register in the SMRAM save state map.
+///
+/// For 8-byte registers the value may be stored as two u32 at potentially
+/// non-contiguous offsets (e.g. Intel GDT/IDT/LDT base).  `lo_offset` gives
+/// the low dword; `hi_offset` gives the high dword.
+///
+/// For registers narrower than 8 bytes, `hi_offset` is 0 and only the low
+/// dword location is used.
+#[derive(Debug, Clone, Copy)]
+pub struct RegisterInfo {
+    /// Offset of the low (or only) dword from the save state base.
+    pub lo_offset: u16,
+    /// Offset of the high dword.  0 for registers < 8 bytes.
+    pub hi_offset: u16,
+    /// Native width in bytes as stored in the save state (1, 2, 4, or 8).
+    pub native_width: u8,
+}
+
+/// Vendor-specific save state field offsets and behaviour that differ between
+/// Intel and AMD.  Provided by the active vendor module.
+pub struct VendorConstants {
+    /// Offset of `SMMRevId` within the save state map.
+    pub smmrevid_offset: u16,
+    /// Offset of the IO information field (Intel `IOMisc`, AMD `IO_DWord`).
+    pub io_info_offset: u16,
+    /// Offset of `IA32_EFER` / `EFER`.
+    pub efer_offset: u16,
+    /// Offset of `_RAX` (used for IO data reads).
+    pub rax_offset: u16,
+    /// Minimum `SMMRevId` that supports IO information.
+    pub min_rev_id_io: u32,
+    /// Whether the LMA pseudo-register always returns 64-bit.
+    ///
+    /// AMD64 processors always operate in 64-bit mode during SMM, so
+    /// they skip the EFER.LMA check and always return LMA_64BIT.
+    pub lma_always_64: bool,
+}
+
+/// Parsed I/O trap information extracted from the vendor-specific IO field.
+///
+/// Returned by [`parse_io_field`] after decoding the vendor's raw IO bits.
+#[derive(Debug, Clone, Copy)]
+pub struct ParsedIoInfo {
+    /// I/O type: [`IO_TYPE_INPUT`] (1) or [`IO_TYPE_OUTPUT`] (2).
+    pub io_type: u32,
+    /// I/O width: [`IO_WIDTH_UINT8`], [`IO_WIDTH_UINT16`], or [`IO_WIDTH_UINT32`].
+    pub io_width: u32,
+    /// Number of bytes transferred (1, 2, or 4).
+    pub byte_count: usize,
+    /// I/O port address.
+    pub io_port: u16,
+}
+
+/// `EFI_MM_SAVE_STATE_IO_INFO` — written to the user buffer when reading
+/// the IO pseudo-register.
+#[repr(C)]
+#[derive(Debug, Clone, Copy, Default)]
+pub struct MmSaveStateIoInfo {
+    /// I/O data value (from RAX, zero-extended).
+    pub io_data: u64,
+    /// I/O port address.
+    pub io_port: u16,
+    /// I/O width enum (`EFI_MM_SAVE_STATE_IO_WIDTH`).
+    pub io_width: u32,
+    /// I/O type enum (`EFI_MM_SAVE_STATE_IO_TYPE`).
+    pub io_type: u32,
+}
+
+const _: () = assert!(core::mem::size_of::<MmSaveStateIoInfo>() == IO_INFO_SIZE);
+
+/// Returns the [`VendorConstants`] for the active vendor (selected at build time).
+///
+/// The active vendor is AMD only when `save_state_amd` is enabled and
+/// `save_state_intel` is not; otherwise Intel is used (this includes the
+/// default case where neither feature is enabled).
+#[cfg(all(feature = "save_state_amd", not(feature = "save_state_intel")))]
+pub fn vendor_constants() -> &'static VendorConstants {
+    &amd::VENDOR_CONSTANTS
+}
+
+/// Returns the [`VendorConstants`] for the active vendor (selected at build time).
+///
+/// Intel is the default vendor and is used whenever `save_state_amd` is not the
+/// sole selected vendor (i.e. Intel-only, both vendors, or no vendor enabled).
+#[cfg(not(all(feature = "save_state_amd", not(feature = "save_state_intel"))))]
+pub fn vendor_constants() -> &'static VendorConstants {
+    &intel::VENDOR_CONSTANTS
+}
+
+/// Returns the [`RegisterInfo`] for a given register in the active vendor's
+/// save state map.
+///
+/// Returns `None` for pseudo-registers (IO, LMA, ProcessorId) and for
+/// registers not supported by the active vendor's 64-bit save state layout.
+///
+/// AMD is the active vendor only when `save_state_amd` is enabled and
+/// `save_state_intel` is not; otherwise Intel is used (the default).
+#[cfg(all(feature = "save_state_amd", not(feature = "save_state_intel")))]
+pub fn register_info(reg: MmSaveStateRegister) -> Option<RegisterInfo> {
+    amd::register_info(reg)
+}
+
+/// Returns the [`RegisterInfo`] for a given register in the active vendor's
+/// save state map.
+///
+/// Returns `None` for pseudo-registers (IO, LMA, ProcessorId) and for
+/// registers not supported by the active vendor's 64-bit save state layout.
+#[cfg(not(all(feature = "save_state_amd", not(feature = "save_state_intel"))))]
+pub fn register_info(reg: MmSaveStateRegister) -> Option<RegisterInfo> {
+    intel::register_info(reg)
+}
+
+/// Parses the vendor-specific I/O information field from the save state.
+///
+/// Returns `None` if the field indicates no I/O instruction triggered the SMI
+/// (Intel: `SmiFlag` not set) or if the I/O type/width is not a simple IN/OUT.
+///
+/// AMD is the active vendor only when `save_state_amd` is enabled and
+/// `save_state_intel` is not; otherwise Intel is used (the default).
+#[cfg(all(feature = "save_state_amd", not(feature = "save_state_intel")))]
+pub fn parse_io_field(io_field: u32) -> Option<ParsedIoInfo> {
+    amd::parse_io_field(io_field)
+}
+
+/// Parses the vendor-specific I/O information field from the save state.
+///
+/// Returns `None` if the field indicates no I/O instruction triggered the SMI
+/// (Intel: `SmiFlag` not set) or if the I/O type/width is not a simple IN/OUT.
+#[cfg(not(all(feature = "save_state_amd", not(feature = "save_state_intel"))))]
+pub fn parse_io_field(io_field: u32) -> Option<ParsedIoInfo> {
+    intel::parse_io_field(io_field)
+}
+
+/// Returns whether the AMD's SMRAM save state map exposes I/O trap
+/// information for a save state with the given raw `SMMRevId`.
+///
+#[cfg(all(feature = "save_state_amd", not(feature = "save_state_intel")))]
+pub fn io_info_supported(smm_rev_id: u32) -> bool {
+    amd::io_info_supported(smm_rev_id)
+}
+
+/// Returns whether the Intel's SMRAM save state map exposes I/O trap
+/// information for a save state with the given raw `SMMRevId`.
+///
+#[cfg(not(all(feature = "save_state_amd", not(feature = "save_state_intel"))))]
+pub fn io_info_supported(smm_rev_id: u32) -> bool {
+    intel::io_info_supported(smm_rev_id)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_register_from_u64() {
+        assert_eq!(MmSaveStateRegister::from_u64(38), Some(MmSaveStateRegister::Rax));
+        assert_eq!(MmSaveStateRegister::from_u64(512), Some(MmSaveStateRegister::Io));
+        assert_eq!(MmSaveStateRegister::from_u64(514), Some(MmSaveStateRegister::ProcessorId));
+        assert_eq!(MmSaveStateRegister::from_u64(999), None);
+        assert_eq!(MmSaveStateRegister::from_u64(0), None);
+    }
+
+    #[test]
+    fn test_io_info_struct_layout() {
+        assert_eq!(core::mem::size_of::<MmSaveStateIoInfo>(), 24);
+        assert_eq!(core::mem::offset_of!(MmSaveStateIoInfo, io_data), 0);
+        assert_eq!(core::mem::offset_of!(MmSaveStateIoInfo, io_port), 8);
+        assert_eq!(core::mem::offset_of!(MmSaveStateIoInfo, io_width), 12);
+        assert_eq!(core::mem::offset_of!(MmSaveStateIoInfo, io_type), 16);
+    }
+
+    /// Verifies the active-vendor dispatch resolves to AMD only when
+    /// `save_state_amd` is enabled and `save_state_intel` is not.
+    #[cfg(all(feature = "save_state_amd", not(feature = "save_state_intel")))]
+    #[test]
+    fn test_active_vendor_dispatches_to_amd() {
+        // `Rax` lives at a different offset on each vendor, so its low offset
+        // distinguishes which table the dispatch functions resolved to.
+        assert_eq!(register_info(MmSaveStateRegister::Rax).unwrap().lo_offset, 0x03F8);
+        assert_eq!(vendor_constants().io_info_offset, amd::VENDOR_CONSTANTS.io_info_offset);
+        assert!(vendor_constants().lma_always_64);
+        assert!(io_info_supported(0));
+    }
+
+    /// Verifies the active-vendor dispatch resolves to Intel by default — i.e.
+    /// when `save_state_intel` is enabled, when both vendors are enabled, or
+    /// when neither vendor is enabled.
+    #[cfg(not(all(feature = "save_state_amd", not(feature = "save_state_intel"))))]
+    #[test]
+    fn test_active_vendor_dispatches_to_intel_by_default() {
+        // `Rax` lives at a different offset on each vendor, so its low offset
+        // distinguishes which table the dispatch functions resolved to.
+        assert_eq!(register_info(MmSaveStateRegister::Rax).unwrap().lo_offset, 0x035C);
+        assert_eq!(vendor_constants().io_info_offset, intel::VENDOR_CONSTANTS.io_info_offset);
+        assert!(!vendor_constants().lma_always_64);
+        assert!(!io_info_supported(intel::VENDOR_CONSTANTS.min_rev_id_io - 1));
+        assert!(io_info_supported(intel::VENDOR_CONSTANTS.min_rev_id_io));
+    }
+}

--- a/core/patina_internal_cpu/src/save_state/amd.rs
+++ b/core/patina_internal_cpu/src/save_state/amd.rs
@@ -1,0 +1,390 @@
+//! AMD64 SMRAM Save State Map
+//!
+//! Register-to-offset lookup table for the AMD 64-bit SMRAM save state
+//! layout (`AMD_SMRAM_SAVE_STATE_MAP64`).  The save state area starts at
+//! `SMBASE + 0xFC00` (the address stored in `CpuSaveState[CpuIndex]`).
+//! All offsets are relative to that base.
+//!
+//! Reference: AMD64 Architecture Programmer's Manual Vol 2, Table 10-2;
+//! MdePkg `AmdSmramSaveStateMap.h`.
+//!
+//! ## Key Differences from Intel
+//!
+//! - Segment selectors are 2 bytes (UINT16) vs Intel's 4-byte fields.
+//! - GDT, IDT, and LDT limits **are** supported (Intel returns `None`).
+//! - CR4 is 8 bytes (Intel stores only 4 bytes).
+//! - All 8-byte registers are stored contiguously (Intel splits DT bases).
+//! - IO information uses `IO_DWord` at offset 0x2C0 with a different bit
+//!   layout from Intel's `IOMisc`.
+//! - AMD64 always operates in 64-bit mode during SMM, so the LMA
+//!   pseudo-register always returns 64-bit without checking EFER.LMA.
+//!
+//! ## License
+//!
+//! Copyright (c) Microsoft Corporation.
+//!
+//! SPDX-License-Identifier: Apache-2.0
+
+use super::{
+    IO_TYPE_INPUT, IO_TYPE_OUTPUT, IO_WIDTH_UINT8, IO_WIDTH_UINT16, IO_WIDTH_UINT32, MmSaveStateRegister, ParsedIoInfo,
+    RegisterInfo, VendorConstants,
+};
+
+/// IO_DWord bit 0: direction (0 = WRITE/OUT, 1 = READ/IN).
+const IO_DIRECTION_IN: u32 = 1;
+//const IO_DIRECTION_OUT: u32 = 0;
+
+/// IO_DWord bit 1: set when the field holds a valid I/O trap record.
+const IO_TRAP_VALID: u32 = 1 << 1;
+
+/// IO_DWord bit 4: SZ8 — 8-bit (byte) access.
+const IO_SIZE_BYTE: u32 = 1 << 4;
+/// IO_DWord bit 5: SZ16 — 16-bit (word) access.
+const IO_SIZE_WORD: u32 = 1 << 5;
+// IO_DWord bit 6 (SZ32, 32-bit) is the default when neither SZ8 nor SZ16 is
+// set, so it does not need a named constant in the decode path.
+
+/// AMD-specific offsets and behaviour constants.
+pub static VENDOR_CONSTANTS: VendorConstants = VendorConstants {
+    smmrevid_offset: 0x02FC,
+    io_info_offset: 0x02C0,
+    efer_offset: 0x02D0,
+    rax_offset: 0x03F8,
+    min_rev_id_io: 0x30064,
+    lma_always_64: true,
+};
+
+///
+/// AMD save state struct layout (from SMBASE + 0xFC00):
+///
+///   +0x000 – 0x1FF: Reserved (padding).
+///   +0x200 – 0x25F: Segment descriptors (ES, CS, SS, DS, FS, GS) — 16 bytes each.
+///   +0x260 – 0x29F: System descriptors (GDTR, IDTR, LDTR, TR) — 16 bytes each.
+///   +0x2A0 – 0x2BF: MSRs (KernelGsBase, STAR, LSTAR, CSTAR).
+///   +0x2C0:         IO_DWord (4 bytes).
+///   +0x2D0:         EFER (8 bytes).
+///   +0x2FC:         SMMRevId (4 bytes).
+///   +0x338 – 0x3FF: Registers (DR7, DR6, CR4, CR3, CR0, RFLAGS, RIP, R15..R8,
+///                               RBP, RSP, RBX, RDI, RSI, RDX, RCX, RAX).
+///
+/// Each segment descriptor is 16 bytes:
+///   +0: Selector (UINT16)
+///   +2: Attributes (UINT16)
+///   +4: Limit (UINT32)
+///   +8: BaseLoDword (UINT32)
+///   +C: BaseHiDword (UINT32)
+///
+/// Looks up the AMD64 save state register info for a PI register.
+///
+/// Returns `None` for pseudo-registers (IO, LMA, ProcessorId) and for
+/// `LdtInfo` (not supported in AMD's save state map).
+pub fn register_info(reg: MmSaveStateRegister) -> Option<RegisterInfo> {
+    match reg {
+        MmSaveStateRegister::GdtBase => Some(RegisterInfo { lo_offset: 0x0268, hi_offset: 0x026C, native_width: 8 }),
+        MmSaveStateRegister::IdtBase => Some(RegisterInfo { lo_offset: 0x0278, hi_offset: 0x027C, native_width: 8 }),
+        // NOTE: The C reference code has a copy-paste bug where both lo and
+        // hi point to `_LDTRBaseLoDword` (0x288).  The correct hi offset is
+        // `_LDTRBaseHiDword` (0x28C).
+        MmSaveStateRegister::LdtBase => Some(RegisterInfo { lo_offset: 0x0288, hi_offset: 0x028C, native_width: 8 }),
+
+        // GDT and IDT limits are architecturally 16-bit, stored in UINT32
+        // fields.  Only the lower 2 bytes are meaningful.
+        MmSaveStateRegister::GdtLimit => Some(RegisterInfo { lo_offset: 0x0264, hi_offset: 0, native_width: 2 }),
+        MmSaveStateRegister::IdtLimit => Some(RegisterInfo { lo_offset: 0x0274, hi_offset: 0, native_width: 2 }),
+        // LDT limit is a system-segment limit (up to 32 bits in long mode).
+        MmSaveStateRegister::LdtLimit => Some(RegisterInfo { lo_offset: 0x0284, hi_offset: 0, native_width: 4 }),
+
+        // LdtInfo is not supported.
+        MmSaveStateRegister::LdtInfo => None,
+
+        MmSaveStateRegister::Es => Some(RegisterInfo { lo_offset: 0x0200, hi_offset: 0, native_width: 2 }),
+        MmSaveStateRegister::Cs => Some(RegisterInfo { lo_offset: 0x0210, hi_offset: 0, native_width: 2 }),
+        MmSaveStateRegister::Ss => Some(RegisterInfo { lo_offset: 0x0220, hi_offset: 0, native_width: 2 }),
+        MmSaveStateRegister::Ds => Some(RegisterInfo { lo_offset: 0x0230, hi_offset: 0, native_width: 2 }),
+        MmSaveStateRegister::Fs => Some(RegisterInfo { lo_offset: 0x0240, hi_offset: 0, native_width: 2 }),
+        MmSaveStateRegister::Gs => Some(RegisterInfo { lo_offset: 0x0250, hi_offset: 0, native_width: 2 }),
+        MmSaveStateRegister::LdtrSel => Some(RegisterInfo { lo_offset: 0x0280, hi_offset: 0, native_width: 2 }),
+        MmSaveStateRegister::TrSel => Some(RegisterInfo { lo_offset: 0x0290, hi_offset: 0, native_width: 2 }),
+        MmSaveStateRegister::Dr7 => Some(RegisterInfo { lo_offset: 0x0338, hi_offset: 0x033C, native_width: 8 }),
+        MmSaveStateRegister::Dr6 => Some(RegisterInfo { lo_offset: 0x0340, hi_offset: 0x0344, native_width: 8 }),
+        MmSaveStateRegister::R8 => Some(RegisterInfo { lo_offset: 0x03B8, hi_offset: 0x03BC, native_width: 8 }),
+        MmSaveStateRegister::R9 => Some(RegisterInfo { lo_offset: 0x03B0, hi_offset: 0x03B4, native_width: 8 }),
+        MmSaveStateRegister::R10 => Some(RegisterInfo { lo_offset: 0x03A8, hi_offset: 0x03AC, native_width: 8 }),
+        MmSaveStateRegister::R11 => Some(RegisterInfo { lo_offset: 0x03A0, hi_offset: 0x03A4, native_width: 8 }),
+        MmSaveStateRegister::R12 => Some(RegisterInfo { lo_offset: 0x0398, hi_offset: 0x039C, native_width: 8 }),
+        MmSaveStateRegister::R13 => Some(RegisterInfo { lo_offset: 0x0390, hi_offset: 0x0394, native_width: 8 }),
+        MmSaveStateRegister::R14 => Some(RegisterInfo { lo_offset: 0x0388, hi_offset: 0x038C, native_width: 8 }),
+        MmSaveStateRegister::R15 => Some(RegisterInfo { lo_offset: 0x0380, hi_offset: 0x0384, native_width: 8 }),
+        MmSaveStateRegister::Rax => Some(RegisterInfo { lo_offset: 0x03F8, hi_offset: 0x03FC, native_width: 8 }),
+        MmSaveStateRegister::Rbx => Some(RegisterInfo { lo_offset: 0x03D0, hi_offset: 0x03D4, native_width: 8 }),
+        MmSaveStateRegister::Rcx => Some(RegisterInfo { lo_offset: 0x03F0, hi_offset: 0x03F4, native_width: 8 }),
+        MmSaveStateRegister::Rdx => Some(RegisterInfo { lo_offset: 0x03E8, hi_offset: 0x03EC, native_width: 8 }),
+        MmSaveStateRegister::Rsp => Some(RegisterInfo { lo_offset: 0x03C8, hi_offset: 0x03CC, native_width: 8 }),
+        MmSaveStateRegister::Rbp => Some(RegisterInfo { lo_offset: 0x03C0, hi_offset: 0x03C4, native_width: 8 }),
+        MmSaveStateRegister::Rsi => Some(RegisterInfo { lo_offset: 0x03E0, hi_offset: 0x03E4, native_width: 8 }),
+        MmSaveStateRegister::Rdi => Some(RegisterInfo { lo_offset: 0x03D8, hi_offset: 0x03DC, native_width: 8 }),
+        MmSaveStateRegister::Rip => Some(RegisterInfo { lo_offset: 0x0378, hi_offset: 0x037C, native_width: 8 }),
+        // Flags and Control Registers
+        MmSaveStateRegister::Rflags => Some(RegisterInfo { lo_offset: 0x0370, hi_offset: 0x0374, native_width: 8 }),
+        MmSaveStateRegister::Cr0 => Some(RegisterInfo { lo_offset: 0x0358, hi_offset: 0x035C, native_width: 8 }),
+        MmSaveStateRegister::Cr3 => Some(RegisterInfo { lo_offset: 0x0350, hi_offset: 0x0354, native_width: 8 }),
+        // CR4 is 8 bytes on AMD (vs 4 bytes on Intel).
+        MmSaveStateRegister::Cr4 => Some(RegisterInfo { lo_offset: 0x0348, hi_offset: 0x034C, native_width: 8 }),
+
+        // Pseudo-registers are not in the architectural register map.
+        MmSaveStateRegister::Io | MmSaveStateRegister::Lma | MmSaveStateRegister::ProcessorId => None,
+    }
+}
+
+/// Parses AMD's `IO_DWord` field from the SMRAM save state.
+///
+/// AMD `IO_DWord` bit layout:
+/// - Bit 0:      Direction — 0 = WRITE (OUT), 1 = READ (IN).
+/// - Bit 1:      Valid — set when the field holds a valid I/O trap record.
+/// - Bits \[3:2\]:  Reserved.
+/// - Bit 4:      SZ8 — 8-bit (byte) access.
+/// - Bit 5:      SZ16 — 16-bit (word) access.
+/// - Bit 6:      SZ32 — 32-bit (dword) access.
+/// - Bits \[15:7\]: Reserved.
+/// - Bits \[31:16\]: I/O port address.
+///
+/// Returns `None` if the data-size encoding is invalid (value 2 is reserved).
+pub fn parse_io_field(io_field: u32) -> Option<ParsedIoInfo> {
+    if io_field & IO_TRAP_VALID == 0 {
+        return None;
+    }
+
+    let io_type = if io_field & IO_DIRECTION_IN != 0 { IO_TYPE_INPUT } else { IO_TYPE_OUTPUT };
+    let port = ((io_field >> 16) & 0xFFFF) as u16;
+
+    let (io_width, byte_count) = if io_field & IO_SIZE_BYTE != 0 {
+        (IO_WIDTH_UINT8, 1usize)
+    } else if io_field & IO_SIZE_WORD != 0 {
+        (IO_WIDTH_UINT16, 2usize)
+    } else {
+        (IO_WIDTH_UINT32, 4usize)
+    };
+
+    Some(ParsedIoInfo { io_type, io_width, byte_count, io_port: port })
+}
+
+/// Returns whether the AMD SMRAM save state map exposes I/O trap information
+/// for a save state with the given raw `SMMRevId`.
+/// Always return true because this is not really used.
+///
+pub fn io_info_supported(_smm_rev_id: u32) -> bool {
+    true
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ----------------------------------------------------------------
+    // Register map tests
+    // ----------------------------------------------------------------
+
+    #[test]
+    fn test_gpr_offsets() {
+        let rax = register_info(MmSaveStateRegister::Rax).unwrap();
+        assert_eq!(rax.lo_offset, 0x03F8);
+        assert_eq!(rax.hi_offset, 0x03FC);
+        assert_eq!(rax.native_width, 8);
+
+        let rcx = register_info(MmSaveStateRegister::Rcx).unwrap();
+        assert_eq!(rcx.lo_offset, 0x03F0);
+        assert_eq!(rcx.hi_offset, 0x03F4);
+    }
+
+    #[test]
+    fn test_segment_selectors_are_2_bytes() {
+        let cs = register_info(MmSaveStateRegister::Cs).unwrap();
+        assert_eq!(cs.lo_offset, 0x0210);
+        assert_eq!(cs.native_width, 2);
+        assert_eq!(cs.hi_offset, 0);
+    }
+
+    #[test]
+    fn test_descriptor_table_bases_contiguous() {
+        let gdt = register_info(MmSaveStateRegister::GdtBase).unwrap();
+        assert_eq!(gdt.lo_offset, 0x0268);
+        assert_eq!(gdt.hi_offset, 0x026C);
+        assert_eq!(gdt.native_width, 8);
+        // AMD uses contiguous lo/hi (unlike Intel's split layout).
+        assert_eq!(gdt.hi_offset, gdt.lo_offset + 4);
+    }
+
+    #[test]
+    fn test_limits_supported_on_amd() {
+        let gdt_limit = register_info(MmSaveStateRegister::GdtLimit).unwrap();
+        assert_eq!(gdt_limit.native_width, 2);
+        assert_eq!(gdt_limit.lo_offset, 0x0264);
+
+        let idt_limit = register_info(MmSaveStateRegister::IdtLimit).unwrap();
+        assert_eq!(idt_limit.native_width, 2);
+        assert_eq!(idt_limit.lo_offset, 0x0274);
+
+        let ldt_limit = register_info(MmSaveStateRegister::LdtLimit).unwrap();
+        assert_eq!(ldt_limit.native_width, 4);
+        assert_eq!(ldt_limit.lo_offset, 0x0284);
+    }
+
+    #[test]
+    fn test_cr4_is_8_bytes_on_amd() {
+        let cr4 = register_info(MmSaveStateRegister::Cr4).unwrap();
+        assert_eq!(cr4.native_width, 8);
+        assert_eq!(cr4.lo_offset, 0x0348);
+        assert_eq!(cr4.hi_offset, 0x034C);
+    }
+
+    #[test]
+    fn test_ldt_info_unsupported() {
+        assert!(register_info(MmSaveStateRegister::LdtInfo).is_none());
+    }
+
+    #[test]
+    fn test_pseudo_registers_return_none() {
+        assert!(register_info(MmSaveStateRegister::Io).is_none());
+        assert!(register_info(MmSaveStateRegister::Lma).is_none());
+        assert!(register_info(MmSaveStateRegister::ProcessorId).is_none());
+    }
+
+    #[test]
+    fn test_register_coverage() {
+        // All architectural registers except LdtInfo should be supported.
+        let supported_regs = [
+            MmSaveStateRegister::GdtBase,
+            MmSaveStateRegister::IdtBase,
+            MmSaveStateRegister::LdtBase,
+            MmSaveStateRegister::GdtLimit,
+            MmSaveStateRegister::IdtLimit,
+            MmSaveStateRegister::LdtLimit,
+            MmSaveStateRegister::Es,
+            MmSaveStateRegister::Cs,
+            MmSaveStateRegister::Ss,
+            MmSaveStateRegister::Ds,
+            MmSaveStateRegister::Fs,
+            MmSaveStateRegister::Gs,
+            MmSaveStateRegister::LdtrSel,
+            MmSaveStateRegister::TrSel,
+            MmSaveStateRegister::Dr7,
+            MmSaveStateRegister::Dr6,
+            MmSaveStateRegister::R8,
+            MmSaveStateRegister::R9,
+            MmSaveStateRegister::R10,
+            MmSaveStateRegister::R11,
+            MmSaveStateRegister::R12,
+            MmSaveStateRegister::R13,
+            MmSaveStateRegister::R14,
+            MmSaveStateRegister::R15,
+            MmSaveStateRegister::Rax,
+            MmSaveStateRegister::Rbx,
+            MmSaveStateRegister::Rcx,
+            MmSaveStateRegister::Rdx,
+            MmSaveStateRegister::Rsp,
+            MmSaveStateRegister::Rbp,
+            MmSaveStateRegister::Rsi,
+            MmSaveStateRegister::Rdi,
+            MmSaveStateRegister::Rip,
+            MmSaveStateRegister::Rflags,
+            MmSaveStateRegister::Cr0,
+            MmSaveStateRegister::Cr3,
+            MmSaveStateRegister::Cr4,
+        ];
+
+        for reg in &supported_regs {
+            assert!(register_info(*reg).is_some(), "Missing AMD lookup for {:?}", reg);
+        }
+    }
+
+    // ----------------------------------------------------------------
+    // IO_DWord parsing tests
+    // ----------------------------------------------------------------
+
+    #[test]
+    fn test_parse_io_field_in_byte() {
+        // Direction=1 (IN), SZ8 (bit 4), Port=0x80
+        let io_field: u32 = (0x0080 << 16) | IO_SIZE_BYTE | IO_DIRECTION_IN | IO_TRAP_VALID;
+        let parsed = parse_io_field(io_field).unwrap();
+        assert_eq!(parsed.io_type, IO_TYPE_INPUT);
+        assert_eq!(parsed.io_width, IO_WIDTH_UINT8);
+        assert_eq!(parsed.byte_count, 1);
+        assert_eq!(parsed.io_port, 0x80);
+    }
+
+    #[test]
+    fn test_parse_io_field_out_dword() {
+        // Direction=0 (OUT), SZ32 (bit 6), Port=0xCF8
+        let io_field: u32 = (0x0CF8 << 16) | (1 << 6) | IO_TRAP_VALID;
+        let parsed = parse_io_field(io_field).unwrap();
+        assert_eq!(parsed.io_type, IO_TYPE_OUTPUT);
+        assert_eq!(parsed.io_width, IO_WIDTH_UINT32);
+        assert_eq!(parsed.byte_count, 4);
+        assert_eq!(parsed.io_port, 0x0CF8);
+    }
+
+    #[test]
+    fn test_parse_io_field_in_word() {
+        // Direction=1 (IN), SZ16 (bit 5), Port=0x3F8
+        let io_field: u32 = (0x03F8 << 16) | IO_SIZE_WORD | IO_DIRECTION_IN | IO_TRAP_VALID;
+        let parsed = parse_io_field(io_field).unwrap();
+        assert_eq!(parsed.io_type, IO_TYPE_INPUT);
+        assert_eq!(parsed.io_width, IO_WIDTH_UINT16);
+        assert_eq!(parsed.byte_count, 2);
+        assert_eq!(parsed.io_port, 0x03F8);
+    }
+
+    #[test]
+    fn test_parse_io_field_defaults_to_dword() {
+        // No size bit set → dword (matches the AMD reference's `else` branch).
+        let io_field: u32 = (0x0CF8 << 16) | IO_TRAP_VALID;
+        let parsed = parse_io_field(io_field).unwrap();
+        assert_eq!(parsed.io_width, IO_WIDTH_UINT32);
+        assert_eq!(parsed.byte_count, 4);
+    }
+
+    #[test]
+    fn test_parse_io_field_byte_takes_priority_over_word() {
+        // Both SZ8 and SZ16 set → byte wins (bit 4 checked first), matching the
+        // AMD reference if/else order.
+        let io_field: u32 = (0x0080 << 16) | IO_SIZE_BYTE | IO_SIZE_WORD | IO_TRAP_VALID;
+        let parsed = parse_io_field(io_field).unwrap();
+        assert_eq!(parsed.io_width, IO_WIDTH_UINT8);
+        assert_eq!(parsed.byte_count, 1);
+    }
+
+    #[test]
+    fn test_parse_io_field_valid_bit_clear() {
+        // Valid bit (bit 1) clear → SMI not caused by I/O → None, even though
+        // the direction and size encodings are otherwise well-formed.
+        let io_field: u32 = (0x0080 << 16) | IO_SIZE_BYTE | IO_DIRECTION_IN;
+        assert!(parse_io_field(io_field).is_none());
+    }
+
+    #[test]
+    fn test_io_info_supported_always_true_on_amd() {
+        // AMD does not gate on SMMRevId; any value reports info as available.
+        assert!(io_info_supported(0));
+        assert!(io_info_supported(VENDOR_CONSTANTS.min_rev_id_io));
+        assert!(io_info_supported(u32::MAX));
+    }
+
+    #[test]
+    fn test_idt_base_hi_is_correct() {
+        // Verify we use the correct hi offset (0x27C), not the buggy
+        // C code value (0x278 = lo offset repeated).
+        let idt = register_info(MmSaveStateRegister::IdtBase).unwrap();
+        assert_eq!(idt.lo_offset, 0x0278);
+        assert_eq!(idt.hi_offset, 0x027C);
+        assert_ne!(idt.lo_offset, idt.hi_offset, "hi must differ from lo");
+    }
+
+    #[test]
+    fn test_ldt_base_hi_is_correct() {
+        // Same bug fix for LdtBase: hi should be 0x28C, not 0x288.
+        let ldt = register_info(MmSaveStateRegister::LdtBase).unwrap();
+        assert_eq!(ldt.lo_offset, 0x0288);
+        assert_eq!(ldt.hi_offset, 0x028C);
+        assert_ne!(ldt.lo_offset, ldt.hi_offset, "hi must differ from lo");
+    }
+}

--- a/core/patina_internal_cpu/src/save_state/intel.rs
+++ b/core/patina_internal_cpu/src/save_state/intel.rs
@@ -1,0 +1,327 @@
+//! Intel x64 SMRAM Save State Map
+//!
+//! Register-to-offset lookup table for the Intel 64-bit SMRAM save state
+//! layout (`SMRAM_SAVE_STATE_MAP64`).  The save state area starts at
+//! `SMBASE + 0x7C00` (the address stored in `CpuSaveState[CpuIndex]`).
+//!
+//! Reference: Intel SDM Vol 3C, Table 31-3; MdePkg `SmramSaveStateMap.h`.
+//!
+//! ## License
+//!
+//! Copyright (c) Microsoft Corporation.
+//!
+//! SPDX-License-Identifier: Apache-2.0
+
+use super::{
+    IO_TYPE_INPUT, IO_TYPE_OUTPUT, IO_WIDTH_UINT8, IO_WIDTH_UINT16, IO_WIDTH_UINT32, MmSaveStateRegister, ParsedIoInfo,
+    RegisterInfo, VendorConstants,
+};
+
+/// IOMisc Type field value: OUT instruction (port in DX).
+const IO_MISC_TYPE_OUT: u32 = 0;
+/// IOMisc Type field value: IN instruction (port in DX).
+const IO_MISC_TYPE_IN: u32 = 1;
+/// IOMisc Type field value: OUT instruction (immediate port operand).
+const IO_MISC_TYPE_OUT_IMMEDIATE: u32 = 8;
+/// IOMisc Type field value: IN instruction (immediate port operand).
+const IO_MISC_TYPE_IN_IMMEDIATE: u32 = 9;
+
+/// Intel-specific offsets and behaviour constants.
+pub static VENDOR_CONSTANTS: VendorConstants = VendorConstants {
+    smmrevid_offset: 0x02FC,
+    io_info_offset: 0x03A4,
+    efer_offset: 0x03E0,
+    rax_offset: 0x035C,
+    min_rev_id_io: 0x30004,
+    lma_always_64: false,
+};
+
+/// Looks up the Intel x64 save state register info for a PI register.
+///
+/// Returns `None` for pseudo-registers (IO, LMA, ProcessorId) — those are
+/// handled separately — and for unsupported registers (limits, LdtInfo).
+pub fn register_info(reg: MmSaveStateRegister) -> Option<RegisterInfo> {
+    match reg {
+        // Descriptor table bases (split hi/lo u32 — non-contiguous on Intel)
+        MmSaveStateRegister::GdtBase => Some(RegisterInfo { lo_offset: 0x028C, hi_offset: 0x01D0, native_width: 8 }),
+        MmSaveStateRegister::IdtBase => Some(RegisterInfo { lo_offset: 0x0294, hi_offset: 0x01D8, native_width: 8 }),
+        MmSaveStateRegister::LdtBase => Some(RegisterInfo { lo_offset: 0x029C, hi_offset: 0x01D4, native_width: 8 }),
+
+        // Limits / LdtInfo — not supported in Intel 64-bit save state map.
+        MmSaveStateRegister::GdtLimit
+        | MmSaveStateRegister::IdtLimit
+        | MmSaveStateRegister::LdtLimit
+        | MmSaveStateRegister::LdtInfo => None,
+
+        // Segment selectors (4-byte fields on Intel)
+        MmSaveStateRegister::Es => Some(RegisterInfo { lo_offset: 0x03A8, hi_offset: 0, native_width: 4 }),
+        MmSaveStateRegister::Cs => Some(RegisterInfo { lo_offset: 0x03AC, hi_offset: 0, native_width: 4 }),
+        MmSaveStateRegister::Ss => Some(RegisterInfo { lo_offset: 0x03B0, hi_offset: 0, native_width: 4 }),
+        MmSaveStateRegister::Ds => Some(RegisterInfo { lo_offset: 0x03B4, hi_offset: 0, native_width: 4 }),
+        MmSaveStateRegister::Fs => Some(RegisterInfo { lo_offset: 0x03B8, hi_offset: 0, native_width: 4 }),
+        MmSaveStateRegister::Gs => Some(RegisterInfo { lo_offset: 0x03BC, hi_offset: 0, native_width: 4 }),
+        MmSaveStateRegister::LdtrSel => Some(RegisterInfo { lo_offset: 0x03C0, hi_offset: 0, native_width: 4 }),
+        MmSaveStateRegister::TrSel => Some(RegisterInfo { lo_offset: 0x03C4, hi_offset: 0, native_width: 4 }),
+
+        // Debug registers (8-byte, contiguous)
+        MmSaveStateRegister::Dr7 => Some(RegisterInfo { lo_offset: 0x03C8, hi_offset: 0x03CC, native_width: 8 }),
+        MmSaveStateRegister::Dr6 => Some(RegisterInfo { lo_offset: 0x03D0, hi_offset: 0x03D4, native_width: 8 }),
+
+        // Extended registers R8–R15 (8-byte, contiguous, descending addresses)
+        MmSaveStateRegister::R8 => Some(RegisterInfo { lo_offset: 0x0354, hi_offset: 0x0358, native_width: 8 }),
+        MmSaveStateRegister::R9 => Some(RegisterInfo { lo_offset: 0x034C, hi_offset: 0x0350, native_width: 8 }),
+        MmSaveStateRegister::R10 => Some(RegisterInfo { lo_offset: 0x0344, hi_offset: 0x0348, native_width: 8 }),
+        MmSaveStateRegister::R11 => Some(RegisterInfo { lo_offset: 0x033C, hi_offset: 0x0340, native_width: 8 }),
+        MmSaveStateRegister::R12 => Some(RegisterInfo { lo_offset: 0x0334, hi_offset: 0x0338, native_width: 8 }),
+        MmSaveStateRegister::R13 => Some(RegisterInfo { lo_offset: 0x032C, hi_offset: 0x0330, native_width: 8 }),
+        MmSaveStateRegister::R14 => Some(RegisterInfo { lo_offset: 0x0324, hi_offset: 0x0328, native_width: 8 }),
+        MmSaveStateRegister::R15 => Some(RegisterInfo { lo_offset: 0x031C, hi_offset: 0x0320, native_width: 8 }),
+
+        // General-purpose registers (8-byte, contiguous)
+        MmSaveStateRegister::Rax => Some(RegisterInfo { lo_offset: 0x035C, hi_offset: 0x0360, native_width: 8 }),
+        MmSaveStateRegister::Rbx => Some(RegisterInfo { lo_offset: 0x0374, hi_offset: 0x0378, native_width: 8 }),
+        MmSaveStateRegister::Rcx => Some(RegisterInfo { lo_offset: 0x0364, hi_offset: 0x0368, native_width: 8 }),
+        MmSaveStateRegister::Rdx => Some(RegisterInfo { lo_offset: 0x036C, hi_offset: 0x0370, native_width: 8 }),
+        MmSaveStateRegister::Rsp => Some(RegisterInfo { lo_offset: 0x037C, hi_offset: 0x0380, native_width: 8 }),
+        MmSaveStateRegister::Rbp => Some(RegisterInfo { lo_offset: 0x0384, hi_offset: 0x0388, native_width: 8 }),
+        MmSaveStateRegister::Rsi => Some(RegisterInfo { lo_offset: 0x038C, hi_offset: 0x0390, native_width: 8 }),
+        MmSaveStateRegister::Rdi => Some(RegisterInfo { lo_offset: 0x0394, hi_offset: 0x0398, native_width: 8 }),
+        MmSaveStateRegister::Rip => Some(RegisterInfo { lo_offset: 0x03D8, hi_offset: 0x03DC, native_width: 8 }),
+
+        // Flags and control registers
+        MmSaveStateRegister::Rflags => Some(RegisterInfo { lo_offset: 0x03E8, hi_offset: 0x03EC, native_width: 8 }),
+        MmSaveStateRegister::Cr0 => Some(RegisterInfo { lo_offset: 0x03F8, hi_offset: 0x03FC, native_width: 8 }),
+        MmSaveStateRegister::Cr3 => Some(RegisterInfo { lo_offset: 0x03F0, hi_offset: 0x03F4, native_width: 8 }),
+        // CR4 is only 4 bytes in the Intel x64 save state map.
+        MmSaveStateRegister::Cr4 => Some(RegisterInfo { lo_offset: 0x0240, hi_offset: 0, native_width: 4 }),
+
+        // Pseudo-registers are not in the architectural register map.
+        MmSaveStateRegister::Io | MmSaveStateRegister::Lma | MmSaveStateRegister::ProcessorId => None,
+    }
+}
+
+/// Parses Intel's `IOMisc` field from the SMRAM save state.
+///
+/// Intel IOMisc bit layout:
+/// - Bit 0:      `SmiFlag` — 1 if the SMI was caused by an I/O instruction.
+/// - Bits \[3:1\]:  `Length` — I/O width in bytes (1, 2, or 4).
+/// - Bits \[7:4\]:  `Type` — 0/8 = OUT (DX/immediate), 1/9 = IN (DX/immediate).
+/// - Bits \[31:16\]: `Port` — I/O port address.
+///
+/// Returns `None` if `SmiFlag` is 0 (SMI was not caused by I/O) or the I/O
+/// type is not a simple IN or OUT (e.g. string / REP I/O).
+pub fn parse_io_field(io_field: u32) -> Option<ParsedIoInfo> {
+    log::trace!("Parsing IOMisc field: 0x{:08x}", io_field);
+
+    // Check SmiFlag.
+    let smi_flag = io_field & 1;
+    if smi_flag == 0 {
+        return None;
+    }
+
+    let length = (io_field >> 1) & 0x7;
+    let io_type_raw = (io_field >> 4) & 0xF;
+    let port = ((io_field >> 16) & 0xFFFF) as u16;
+
+    // Simple IN/OUT in both DX and immediate-port forms are supported.
+    let io_type = match io_type_raw {
+        IO_MISC_TYPE_OUT | IO_MISC_TYPE_OUT_IMMEDIATE => IO_TYPE_OUTPUT,
+        IO_MISC_TYPE_IN | IO_MISC_TYPE_IN_IMMEDIATE => IO_TYPE_INPUT,
+        _ => return None,
+    };
+
+    // Map length to IO width enum and byte count.
+    let (io_width, byte_count) = match length {
+        1 => (IO_WIDTH_UINT8, 1usize),
+        2 => (IO_WIDTH_UINT16, 2usize),
+        4 => (IO_WIDTH_UINT32, 4usize),
+        _ => return None,
+    };
+
+    log::trace!(
+        "Parsed IO field: io_type = {}, io_width = {}, byte_count = {}, io_port = 0x{:x}",
+        io_type,
+        io_width,
+        byte_count,
+        port
+    );
+    Some(ParsedIoInfo { io_type, io_width, byte_count, io_port: port })
+}
+
+/// Returns whether the Intel SMRAM save state map exposes I/O trap information
+/// for a save state with the given raw `SMMRevId`.
+/// Must be above 0x30004
+///
+/// older revisions do not carry I/O trap information.
+pub fn io_info_supported(smm_rev_id: u32) -> bool {
+    smm_rev_id >= VENDOR_CONSTANTS.min_rev_id_io
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_gpr_offsets() {
+        let rax = register_info(MmSaveStateRegister::Rax).unwrap();
+        assert_eq!(rax.lo_offset, 0x035C);
+        assert_eq!(rax.hi_offset, 0x0360);
+        assert_eq!(rax.native_width, 8);
+
+        let r15 = register_info(MmSaveStateRegister::R15).unwrap();
+        assert_eq!(r15.lo_offset, 0x031C);
+        assert_eq!(r15.hi_offset, 0x0320);
+        assert_eq!(r15.native_width, 8);
+    }
+
+    #[test]
+    fn test_segment_selectors() {
+        let es = register_info(MmSaveStateRegister::Es).unwrap();
+        assert_eq!(es.lo_offset, 0x03A8);
+        assert_eq!(es.hi_offset, 0);
+        assert_eq!(es.native_width, 4);
+    }
+
+    #[test]
+    fn test_descriptor_table_bases_are_split() {
+        let gdt = register_info(MmSaveStateRegister::GdtBase).unwrap();
+        assert_eq!(gdt.lo_offset, 0x028C);
+        assert_eq!(gdt.hi_offset, 0x01D0);
+        assert_eq!(gdt.native_width, 8);
+        // Verify they are non-contiguous on Intel.
+        assert_ne!(gdt.hi_offset, gdt.lo_offset + 4);
+    }
+
+    #[test]
+    fn test_limits_unsupported_on_intel() {
+        assert!(register_info(MmSaveStateRegister::GdtLimit).is_none());
+        assert!(register_info(MmSaveStateRegister::IdtLimit).is_none());
+        assert!(register_info(MmSaveStateRegister::LdtLimit).is_none());
+        assert!(register_info(MmSaveStateRegister::LdtInfo).is_none());
+    }
+
+    #[test]
+    fn test_cr4_is_4_bytes_on_intel() {
+        let cr4 = register_info(MmSaveStateRegister::Cr4).unwrap();
+        assert_eq!(cr4.native_width, 4);
+        assert_eq!(cr4.hi_offset, 0);
+    }
+
+    #[test]
+    fn test_pseudo_registers_return_none() {
+        assert!(register_info(MmSaveStateRegister::Io).is_none());
+        assert!(register_info(MmSaveStateRegister::Lma).is_none());
+        assert!(register_info(MmSaveStateRegister::ProcessorId).is_none());
+    }
+
+    #[test]
+    fn test_parse_io_field_in() {
+        // SmiFlag=1, Length=1 (byte), Type=1 (IN), Port=0x80
+        // Bits: Port(31:16)=0x0080, Type(7:4)=1, Length(3:1)=1, SmiFlag(0)=1
+        let io_field: u32 = (0x0080 << 16) | (1 << 4) | (1 << 1) | 1;
+        let parsed = parse_io_field(io_field).unwrap();
+        assert_eq!(parsed.io_type, IO_TYPE_INPUT);
+        assert_eq!(parsed.io_width, IO_WIDTH_UINT8);
+        assert_eq!(parsed.byte_count, 1);
+        assert_eq!(parsed.io_port, 0x80);
+    }
+
+    #[test]
+    fn test_parse_io_field_out() {
+        // SmiFlag=1, Length=4 (dword), Type=0 (OUT), Port=0xCF8
+        let io_field: u32 = (0x0CF8 << 16) | (4 << 1) | 1;
+        let parsed = parse_io_field(io_field).unwrap();
+        assert_eq!(parsed.io_type, IO_TYPE_OUTPUT);
+        assert_eq!(parsed.io_width, IO_WIDTH_UINT32);
+        assert_eq!(parsed.byte_count, 4);
+        assert_eq!(parsed.io_port, 0x0CF8);
+    }
+
+    #[test]
+    fn test_parse_io_field_out_immediate() {
+        // SmiFlag=1, Length=1 (byte), Type=8 (OUT_IMMEDIATE), Port=0xB2
+        let io_field: u32 = (0x00B2 << 16) | (8 << 4) | (1 << 1) | 1;
+        let parsed = parse_io_field(io_field).unwrap();
+        assert_eq!(parsed.io_type, IO_TYPE_OUTPUT);
+        assert_eq!(parsed.io_width, IO_WIDTH_UINT8);
+        assert_eq!(parsed.byte_count, 1);
+        assert_eq!(parsed.io_port, 0xB2);
+    }
+
+    #[test]
+    fn test_parse_io_field_in_immediate() {
+        // SmiFlag=1, Length=1 (byte), Type=9 (IN_IMMEDIATE), Port=0x80
+        let io_field: u32 = (0x0080 << 16) | (9 << 4) | (1 << 1) | 1;
+        let parsed = parse_io_field(io_field).unwrap();
+        assert_eq!(parsed.io_type, IO_TYPE_INPUT);
+        assert_eq!(parsed.io_width, IO_WIDTH_UINT8);
+        assert_eq!(parsed.byte_count, 1);
+        assert_eq!(parsed.io_port, 0x80);
+    }
+
+    #[test]
+    fn test_parse_io_field_no_smi_flag() {
+        // SmiFlag=0 → should return None
+        let io_field: u32 = (0x0080 << 16) | (1 << 4) | (1 << 1);
+        assert!(parse_io_field(io_field).is_none());
+    }
+
+    #[test]
+    fn test_parse_io_field_string_io() {
+        // SmiFlag=1, Length=1, Type=4 (string, not IN/OUT) → None
+        let io_field: u32 = (0x0080 << 16) | (4 << 4) | (1 << 1) | 1;
+        assert!(parse_io_field(io_field).is_none());
+    }
+
+    #[test]
+    fn test_io_info_supported_gated_on_rev_id() {
+        // IOMisc is only present once SMMRevId >= min_rev_id_io.
+        assert!(!io_info_supported(VENDOR_CONSTANTS.min_rev_id_io - 1));
+        assert!(io_info_supported(VENDOR_CONSTANTS.min_rev_id_io));
+        assert!(io_info_supported(VENDOR_CONSTANTS.min_rev_id_io + 1));
+    }
+
+    #[test]
+    fn test_register_coverage() {
+        let architectural_regs = [
+            MmSaveStateRegister::GdtBase,
+            MmSaveStateRegister::IdtBase,
+            MmSaveStateRegister::LdtBase,
+            MmSaveStateRegister::Es,
+            MmSaveStateRegister::Cs,
+            MmSaveStateRegister::Ss,
+            MmSaveStateRegister::Ds,
+            MmSaveStateRegister::Fs,
+            MmSaveStateRegister::Gs,
+            MmSaveStateRegister::LdtrSel,
+            MmSaveStateRegister::TrSel,
+            MmSaveStateRegister::Dr7,
+            MmSaveStateRegister::Dr6,
+            MmSaveStateRegister::R8,
+            MmSaveStateRegister::R9,
+            MmSaveStateRegister::R10,
+            MmSaveStateRegister::R11,
+            MmSaveStateRegister::R12,
+            MmSaveStateRegister::R13,
+            MmSaveStateRegister::R14,
+            MmSaveStateRegister::R15,
+            MmSaveStateRegister::Rax,
+            MmSaveStateRegister::Rbx,
+            MmSaveStateRegister::Rcx,
+            MmSaveStateRegister::Rdx,
+            MmSaveStateRegister::Rsp,
+            MmSaveStateRegister::Rbp,
+            MmSaveStateRegister::Rsi,
+            MmSaveStateRegister::Rdi,
+            MmSaveStateRegister::Rip,
+            MmSaveStateRegister::Rflags,
+            MmSaveStateRegister::Cr0,
+            MmSaveStateRegister::Cr3,
+            MmSaveStateRegister::Cr4,
+        ];
+
+        for reg in &architectural_regs {
+            assert!(register_info(*reg).is_some(), "Missing Intel lookup for {:?}", reg);
+        }
+    }
+}

--- a/cspell.yml
+++ b/cspell.yml
@@ -60,6 +60,7 @@ words:
   - coverity
   - cpuid
   - csodimm
+  - cstar
   - ctable
   - ctypes
   - cudimm
@@ -133,10 +134,12 @@ words:
   - lpddr
   - lrdimm
   - lrpair
+  - lstar
   - lzmatest
   - maxnp
   - mdbook
   - mdscr
+  - mmbase
   - mmiport
   - mmram
   - mpidr
@@ -194,8 +197,10 @@ words:
   - rwlock
   - sgram
   - smbus
+  - smbase
   - smcport
   - smiport
+  - smmrevid
   - smram
   - socketm
   - socketr

--- a/cspell.yml
+++ b/cspell.yml
@@ -206,6 +206,7 @@ words:
   - socketr
   - sodimm
   - srimm
+  - swapgs
   - swmmis
   - syscall
   - syscalls

--- a/patina_mm_supervisor/Cargo.toml
+++ b/patina_mm_supervisor/Cargo.toml
@@ -1,0 +1,39 @@
+[package]
+name = "patina_mm_supervisor"
+version.workspace = true
+repository.workspace = true
+license.workspace = true
+edition.workspace = true
+readme = "README.md"
+description = "A pure Rust implementation of the MM Supervisor Core for standalone MM mode environments."
+
+# Metadata to tell docs.rs how to build the documentation when uploading
+[package.metadata.docs.rs]
+features = ["doc"]
+
+[lints]
+workspace = true
+
+[dependencies]
+log = { workspace = true }
+patina = { version = "22.0.1", path = "../sdk/patina", default-features = false }
+patina_internal_cpu = { workspace = true }
+patina_paging = { workspace = true, features = [
+    "supervisor"
+] }
+patina_stacktrace = { workspace = true }
+r-efi = { workspace = true }
+spin = { workspace = true }
+zerocopy = { workspace = true }
+zerocopy-derive = { workspace = true }
+
+[dev-dependencies]
+mockall = { workspace = true }
+serial_test = { workspace = true }
+
+[features]
+default = []
+std = []
+doc = []
+save_state_intel = ["patina_internal_cpu/save_state_intel"]
+save_state_amd = ["patina_internal_cpu/save_state_amd"]

--- a/patina_mm_supervisor/README.md
+++ b/patina_mm_supervisor/README.md
@@ -1,0 +1,177 @@
+# Patina MM Supervisor Core
+
+A pure Rust implementation of the MM Supervisor Core for standalone MM mode environments.
+
+## Overview
+
+This crate provides the core functionality for the MM (Management Mode) Supervisor in a standalone MM environment. It is
+designed to run on x64 systems where:
+
+- Page tables are already set up by the pre-MM phase
+- All images are loaded and ready to execute
+- The BSP (Bootstrap Processor) orchestrates incoming requests
+- APs (Application Processors) wait in a holding pen, checking a mailbox for work
+
+## Memory Model
+
+**This is a core component that does not use heap allocation.** All data structures use fixed-size arrays with compile-time
+constants provided via const generics:
+
+- `MAX_CPUS` - Maximum number of CPUs supported, supplied as a const generic argument to `MmSupervisorCore`
+- `MAX_HANDLERS` - Maximum number of request handlers
+
+This allows the entire supervisor to be instantiated as a `static` with no runtime allocation.
+
+## Building a PE/COFF Binary
+
+### Prerequisites
+
+1. Install the Rust UEFI target:
+
+   ```bash
+   rustup target add x86_64-unknown-uefi
+   ```
+
+2. Ensure you have the nightly toolchain (required for `#![feature(...)]`):
+
+   ```bash
+   rustup override set nightly
+   ```
+
+### Build Command
+
+Build the example MM Supervisor binary:
+
+```bash
+cargo build --target x86_64-unknown-uefi --bin example_mm_supervisor --features x64,save_state_amd,supv --no-default-features
+```
+
+The output PE/COFF binary with AMD features enabled will be at:
+
+```text
+target/x86_64-unknown-uefi/release/example_mm_supervisor.efi
+```
+
+### Entry Point
+
+The MM Supervisor exports `MmSupervisorMain` as its entry point, matching the EDK2 convention:
+
+```rust
+#[unsafe(export_name = "MmSupervisorMain")]
+pub extern "efiapi" fn mm_supervisor_main(hob_list: *const c_void) -> ! {
+    SUPERVISOR.entry_point(hob_list)
+}
+```
+
+The MM IPL (Initial Program Loader) calls this entry point on **all processors** after:
+
+1. Loading the supervisor image into MMRAM
+2. Setting up page tables
+3. Constructing the HOB list with MMRAM ranges
+
+## Architecture
+
+### Entry Point Model
+
+The entry point is executed on all cores simultaneously:
+
+1. **BSP (Bootstrap Processor)**:
+   - First CPU to arrive (determined by atomic counter)
+   - Performs one-time initialization
+   - Sets up the request handling infrastructure
+   - Enters the main request serving loop
+
+2. **APs (Application Processors)**:
+   - All other CPUs
+   - Wait for BSP initialization to complete
+   - Enter a holding pen and poll mailboxes for commands
+
+### Mailbox System
+
+The mailbox system provides inter-processor communication:
+
+- Each AP has a dedicated mailbox (cache-line aligned to avoid false sharing)
+- BSP sends commands to APs via mailboxes
+- APs respond with results through the same mailbox
+- Supports synchronization primitives for coordinated operations
+
+## Usage
+
+### Basic Platform Implementation
+
+```rust
+#![no_std]
+#![no_main]
+
+use core::{ffi::c_void, panic::PanicInfo};
+use patina_mm_supervisor::*;
+
+struct MyPlatform;
+
+impl CpuInfo for MyPlatform {
+    fn ap_poll_timeout_us() -> u64 { 1000 }
+}
+
+impl PlatformInfo for MyPlatform {
+    type CpuInfo = Self;
+}
+
+// Static instance - no heap allocation required.
+// The const generic argument is the maximum CPU count used to size internal arrays.
+static SUPERVISOR: MmSupervisorCore<MyPlatform, 8> = MmSupervisorCore::new();
+
+#[panic_handler]
+fn panic(_info: &PanicInfo) -> ! {
+    loop { core::hint::spin_loop(); }
+}
+
+#[unsafe(export_name = "MmSupervisorMain")]
+pub extern "efiapi" fn mm_supervisor_main(hob_list: *const c_void) -> ! {
+    SUPERVISOR.entry_point(hob_list)
+}
+```
+
+### Registering Request Handlers
+
+Platforms register additional supervisor MMI handlers by implementing
+`PlatformInfo::mmi_handlers`, which returns a static slice of handlers. The core dispatches
+its built-in handlers first, then the platform handlers.
+
+```rust
+use patina_mm_supervisor::*;
+use r_efi::efi;
+
+fn my_handler(comm_buffer: *mut u8, comm_buffer_size: &mut usize) -> efi::Status {
+    // Handle the request
+    efi::Status::SUCCESS
+}
+
+static MY_HANDLERS: &[SupervisorMmiHandler] = &[SupervisorMmiHandler {
+    name: "MyHandler",
+    handler_guid: patina::BinaryGuid::from_string("12345678-1234-5678-1234-567800000000").into_inner(),
+    handle: my_handler,
+}];
+
+impl PlatformInfo for MyPlatform {
+    type CpuInfo = Self;
+
+    fn mmi_handlers() -> &'static [SupervisorMmiHandler] {
+        MY_HANDLERS
+    }
+}
+```
+
+### Integration with MM IPL
+
+The MM IPL (from EDK2/MmSupervisorPkg) loads this binary and calls the entry point. The HOB list passed contains:
+
+- `gEfiMmPeiMmramMemoryReserveGuid` - MMRAM ranges
+- `gMmCommBufferHobGuid` - Communication buffer information
+- `gMmCommonRegionHobGuid` - Common memory regions
+- FV HOBs for MM driver firmware volumes
+
+## License
+
+Copyright (c) Microsoft Corporation.
+
+SPDX-License-Identifier: Apache-2.0

--- a/patina_mm_supervisor/src/cpu.rs
+++ b/patina_mm_supervisor/src/cpu.rs
@@ -1,0 +1,682 @@
+//! CPU Management Module
+//!
+//! This module provides CPU identification and management for the MM Supervisor Core.
+//! It handles BSP/AP detection, CPU registration, and state tracking.
+//!
+//! ## Memory Model
+//!
+//! This module does not perform heap allocation. All structures use fixed-size arrays
+//! with compile-time constants provided via const generics.
+//!
+//! ## License
+//!
+//! Copyright (c) Microsoft Corporation.
+//!
+//! SPDX-License-Identifier: Apache-2.0
+//!
+
+use core::{
+    arch::{x86_64, x86_64::CpuidResult},
+    sync::atomic::{AtomicU8, AtomicU32, Ordering},
+};
+
+/// MSR index for IA32_APIC_BASE.
+const IA32_APIC_BASE_MSR_INDEX: u32 = 0x1B;
+
+/// BSP flag bit in IA32_APIC_BASE MSR (bit 8).
+const IA32_APIC_BSP: u64 = 1 << 8;
+
+/// A trait to be implemented by the platform to provide CPU-related configuration.
+///
+/// ## Examples
+///
+/// ```rust,no_run
+/// # #[cfg(target_arch = "x86_64")]
+/// # mod example {
+/// use patina_mm_supervisor::CpuInfo;
+///
+/// struct ExamplePlatform;
+///
+/// impl CpuInfo for ExamplePlatform {
+///     fn ap_poll_timeout_us() -> u64 { 500 }
+/// }
+/// # }
+/// ```
+#[cfg_attr(test, mockall::automock)]
+pub trait CpuInfo {
+    /// Returns the timeout in microseconds for AP mailbox polling.
+    ///
+    /// By default, this returns 1000 (1ms) which is a reasonable polling interval.
+    #[inline(always)]
+    fn ap_poll_timeout_us() -> u64 {
+        1000
+    }
+
+    /// Returns the performance counter frequency in Hz, if known by the platform.
+    ///
+    /// For example, on QEMU Q35 the platform can calibrate the TSC frequency
+    /// from the ACPI PM Timer and return it here.
+    ///
+    /// If `None` is returned (the default), the supervisor will attempt
+    /// auto-detection via CPUID.
+    fn perf_timer_frequency() -> Option<u64> {
+        None
+    }
+}
+
+/// The state of an Application Processor (AP).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u8)]
+pub enum ApState {
+    /// The AP has not been registered yet.
+    NotPresent = 0,
+    /// The AP is in the holding pen, waiting for work.
+    InHoldingPen = 1,
+    /// The AP is currently executing a task.
+    Busy = 2,
+    /// The AP has been halted.
+    Halted = 3,
+}
+
+impl From<u8> for ApState {
+    fn from(value: u8) -> Self {
+        match value {
+            0 => ApState::NotPresent,
+            1 => ApState::InHoldingPen,
+            2 => ApState::Busy,
+            3 => ApState::Halted,
+            _ => ApState::NotPresent,
+        }
+    }
+}
+
+/// Information about a registered CPU stored in a fixed-size slot.
+#[repr(C)]
+struct CpuSlot {
+    /// The CPU's APIC ID. u32::MAX means slot is unused.
+    cpu_id: AtomicU32,
+    /// Whether this CPU is the BSP (0 = AP, 1 = BSP).
+    is_bsp: AtomicU8,
+    /// Current state (for APs only).
+    state: AtomicU8,
+    /// Padding for alignment.
+    _padding: [u8; 2],
+    /// Rendezvous semaphore for the SMI exit barrier.
+    run: AtomicU32,
+}
+
+impl CpuSlot {
+    /// Creates a new empty CPU slot.
+    const fn new() -> Self {
+        Self {
+            cpu_id: AtomicU32::new(u32::MAX),
+            is_bsp: AtomicU8::new(0),
+            state: AtomicU8::new(ApState::NotPresent as u8),
+            _padding: [0; 2],
+            run: AtomicU32::new(0),
+        }
+    }
+
+    /// Checks if this slot is in use.
+    fn is_used(&self) -> bool {
+        self.cpu_id.load(Ordering::Acquire) != u32::MAX
+    }
+
+    /// Gets the CPU ID if the slot is used.
+    fn get_cpu_id(&self) -> Option<u32> {
+        let id = self.cpu_id.load(Ordering::Acquire);
+        if id == u32::MAX { None } else { Some(id) }
+    }
+}
+
+/// Signals a counting rendezvous semaphore (atomic increment).
+#[inline]
+fn sem_signal(sem: &AtomicU32) {
+    sem.fetch_add(1, Ordering::AcqRel);
+}
+
+/// Blocks (spins, no timer) until the semaphore is positive, then consumes one count.
+#[inline]
+fn sem_wait(sem: &AtomicU32) {
+    loop {
+        let value = sem.load(Ordering::Acquire);
+        if value != 0 && sem.compare_exchange_weak(value, value - 1, Ordering::AcqRel, Ordering::Acquire).is_ok() {
+            return;
+        }
+        core::hint::spin_loop();
+    }
+}
+
+/// Consumes one count if the semaphore is positive. Non-blocking; returns whether a
+/// count was taken.
+#[inline]
+fn sem_try_take(sem: &AtomicU32) -> bool {
+    let mut value = sem.load(Ordering::Acquire);
+    while value != 0 {
+        match sem.compare_exchange_weak(value, value - 1, Ordering::AcqRel, Ordering::Acquire) {
+            Ok(_) => return true,
+            Err(current) => value = current,
+        }
+    }
+    false
+}
+
+/// Manager for CPU-related operations.
+///
+/// Tracks registered CPUs and their states using fixed-size arrays.
+///
+/// ## Const Generic Parameters
+///
+/// * `MAX_CPUS` - The maximum number of CPUs that can be registered.
+pub struct CpuManager<const MAX_CPUS: usize> {
+    /// CPU slots - fixed size array.
+    slots: [CpuSlot; MAX_CPUS],
+    /// Number of CPUs currently registered.
+    registered_count: AtomicU32,
+    /// The APIC ID of the BSP.
+    bsp_id: AtomicU32,
+}
+
+impl<const MAX_CPUS: usize> CpuManager<MAX_CPUS> {
+    /// Creates a new CPU manager.
+    ///
+    /// This is a const fn and performs no heap allocation.
+    pub const fn new() -> Self {
+        Self {
+            slots: [const { CpuSlot::new() }; MAX_CPUS],
+            registered_count: AtomicU32::new(0),
+            bsp_id: AtomicU32::new(u32::MAX),
+        }
+    }
+
+    /// Registers a CPU with the manager.
+    ///
+    /// `cpu_id` is the APIC ID read from CPUID (sparse, not 0-based), while `cpu_index` is
+    /// the dense, 0-based UEFI processor index that selects this CPU's slot.
+    ///
+    /// Returns `Some(cpu_index)` on success. Re-registering the same CPU is idempotent and
+    /// returns the same index. Returns `None` if `cpu_index` is out of range or the
+    /// slot is already occupied by a different CPU.
+    pub fn register_cpu(&self, cpu_id: u32, cpu_index: usize, is_bsp: bool) -> Option<usize> {
+        if cpu_index >= MAX_CPUS {
+            log::warn!(
+                "cpu_index {} exceeds maximum CPU count ({}), cannot register CPU {}",
+                cpu_index,
+                MAX_CPUS,
+                cpu_id
+            );
+            return None;
+        }
+
+        // Each physical CPU owns a distinct, stable `cpu_index`, so this slot is only
+        // ever written by this CPU. That makes the load-check-then-store below safe
+        // without a compare-exchange.
+        let slot = self.slots.get(cpu_index)?;
+        match slot.get_cpu_id() {
+            Some(existing) if existing == cpu_id => {
+                // Idempotent re-registration.
+                log::trace!("CPU {} already registered at index {}", cpu_id, cpu_index);
+                return Some(cpu_index);
+            }
+            Some(existing) => {
+                log::error!(
+                    "cpu_index {} already occupied by APIC {}, cannot register APIC {}",
+                    cpu_index,
+                    existing,
+                    cpu_id
+                );
+                return None;
+            }
+            None => {}
+        }
+
+        slot.is_bsp.store(if is_bsp { 1 } else { 0 }, Ordering::Release);
+        slot.state.store(if is_bsp { ApState::Busy as u8 } else { ApState::NotPresent as u8 }, Ordering::Release);
+        // Publish the CPU ID last so readers that observe it also see the fields above.
+        slot.cpu_id.store(cpu_id, Ordering::Release);
+
+        self.registered_count.fetch_add(1, Ordering::SeqCst);
+
+        if is_bsp {
+            self.bsp_id.store(cpu_id, Ordering::SeqCst);
+            log::info!("Registered BSP with APIC ID {} at index {}", cpu_id, cpu_index);
+        } else {
+            log::trace!("Registered AP with APIC ID {} at index {}", cpu_id, cpu_index);
+        }
+
+        Some(cpu_index)
+    }
+
+    /// Gets the number of registered CPUs.
+    pub fn registered_count(&self) -> usize {
+        self.registered_count.load(Ordering::SeqCst) as usize
+    }
+
+    /// Gets the maximum number of CPUs supported.
+    pub const fn max_cpus(&self) -> usize {
+        MAX_CPUS
+    }
+
+    /// Gets the APIC ID of the BSP.
+    pub fn bsp_id(&self) -> Option<u32> {
+        let id = self.bsp_id.load(Ordering::SeqCst);
+        if id == u32::MAX { None } else { Some(id) }
+    }
+
+    /// Checks if the given CPU ID is the BSP.
+    pub fn is_bsp(&self, cpu_id: u32) -> bool {
+        self.bsp_id() == Some(cpu_id)
+    }
+
+    /// Finds the slot index for a given CPU ID (APIC ID).
+    fn find_slot(&self, cpu_id: u32) -> Option<usize> {
+        for (index, slot) in self.slots.iter().enumerate() {
+            if slot.get_cpu_id() == Some(cpu_id) {
+                return Some(index);
+            }
+        }
+        None
+    }
+
+    /// Finds the slot index for a given CPU ID (public wrapper).
+    pub fn find_cpu_index(&self, cpu_id: u32) -> Option<usize> {
+        self.find_slot(cpu_id)
+    }
+
+    /// Gets the APIC ID of the CPU at the given slot index.
+    ///
+    /// Returns `None` if the index is out of range or the slot is unused.
+    pub fn get_cpu_id_by_index(&self, index: usize) -> Option<u32> {
+        self.slots.get(index)?.get_cpu_id()
+    }
+
+    /// Gets the AP state by slot index.
+    ///
+    /// Returns `None` if the index is out of range or the slot is unused.
+    pub fn get_ap_state_by_index(&self, index: usize) -> Option<ApState> {
+        let slot = self.slots.get(index)?;
+        if slot.is_used() { Some(ApState::from(slot.state.load(Ordering::Acquire))) } else { None }
+    }
+
+    /// Gets the state of an AP.
+    pub fn get_ap_state(&self, cpu_id: u32) -> Option<ApState> {
+        let index = self.find_slot(cpu_id)?;
+        let slot = self.slots.get(index)?;
+        Some(ApState::from(slot.state.load(Ordering::Acquire)))
+    }
+
+    /// Sets the state of an AP.
+    pub fn set_ap_state(&self, cpu_id: u32, state: ApState) -> bool {
+        let index = match self.find_slot(cpu_id) {
+            Some(idx) => idx,
+            None => return false,
+        };
+
+        let Some(slot) = self.slots.get(index) else {
+            return false;
+        };
+
+        // Don't allow changing BSP state
+        if slot.is_bsp.load(Ordering::Acquire) != 0 {
+            log::warn!("Attempted to change BSP state, ignoring");
+            return false;
+        }
+
+        slot.state.store(state as u8, Ordering::Release);
+        true
+    }
+
+    /// Iterates over all registered AP IDs.
+    ///
+    /// Calls the provided closure for each registered AP.
+    pub fn for_each_ap<F: FnMut(u32)>(&self, mut f: F) {
+        for slot in &self.slots {
+            if let Some(cpu_id) = slot.get_cpu_id()
+                && slot.is_bsp.load(Ordering::Acquire) == 0
+            {
+                f(cpu_id);
+            }
+        }
+    }
+
+    /// Counts APs in a specific state.
+    pub fn count_aps_in_state(&self, state: ApState) -> usize {
+        let mut count = 0;
+        for slot in &self.slots {
+            if slot.is_used()
+                && slot.is_bsp.load(Ordering::Acquire) == 0
+                && slot.state.load(Ordering::Acquire) == state as u8
+            {
+                count += 1;
+            }
+        }
+        count
+    }
+
+    /// Releases every registered AP from the exit barrier by signaling each AP's
+    /// rendezvous semaphore. (Called by the BSP)
+    ///
+    pub fn release_all_aps(&self) {
+        for slot in &self.slots {
+            if slot.is_used() && slot.is_bsp.load(Ordering::Acquire) == 0 {
+                sem_signal(&slot.run);
+            }
+        }
+    }
+
+    /// Consumes a pending exit-barrier release for the AP at `cpu_index`, if the BSP has
+    /// signaled one. Non-blocking; returns whether the AP was released.
+    ///
+    /// Called by an AP spinning in the holding pen.
+    pub fn take_release_by_index(&self, cpu_index: usize) -> bool {
+        let Some(slot) = self.slots.get(cpu_index) else {
+            return false;
+        };
+        sem_try_take(&slot.run)
+    }
+
+    /// Acknowledges to the BSP that this AP has left the holding pen by signaling the
+    /// BSP's rendezvous semaphore.
+    ///
+    pub fn ack_exit_to_bsp(&self) {
+        if let Some(bsp_id) = self.bsp_id()
+            && let Some(index) = self.find_slot(bsp_id)
+            && let Some(slot) = self.slots.get(index)
+        {
+            sem_signal(&slot.run);
+        }
+    }
+
+    /// Blocks (spins, no timer) until `ap_count` APs have acknowledged leaving the pen.
+    ///
+    pub fn wait_for_ap_exit_acks(&self, ap_count: usize) {
+        let bsp_index = match self.bsp_id().and_then(|bsp_id| self.find_slot(bsp_id)) {
+            Some(index) => index,
+            None => return,
+        };
+        let Some(slot) = self.slots.get(bsp_index) else {
+            return;
+        };
+        for _ in 0..ap_count {
+            sem_wait(&slot.run);
+        }
+    }
+}
+
+impl<const MAX_CPUS: usize> Default for CpuManager<MAX_CPUS> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Gets the current CPU's APIC ID.
+///
+/// On x86_64, this reads the APIC ID from the Local APIC or CPUID.
+#[cfg(target_arch = "x86_64")]
+pub fn get_current_cpu_id() -> u32 {
+    // Use CPUID to get the initial APIC ID
+    // CPUID function 0x01, EBX[31:24] contains the initial APIC ID
+
+    // CPUID is always available on x86_64 and `__cpuid` is a safe intrinsic.
+    let CpuidResult { ebx, .. } = x86_64::__cpuid(0x01);
+
+    (ebx >> 24) & 0xff
+}
+
+/// Gets the current CPU's APIC ID (stub for non-x86_64).
+#[cfg(not(target_arch = "x86_64"))]
+pub fn get_current_cpu_id() -> u32 {
+    0
+}
+
+/// Reads a Model-Specific Register (MSR) by index.
+///
+/// ## Safety
+///
+/// The caller must ensure the MSR index is valid and readable on the current platform.
+#[cfg(target_arch = "x86_64")]
+pub unsafe fn read_msr(msr: u32) -> Result<u64, &'static str> {
+    let lo: u32;
+    let hi: u32;
+    // SAFETY: Reading the MSR is memory safe as long as the caller ensures the MSR index is valid.
+    //         But this could also reveal the contents of the MSR, which is why we should guard this
+    //         behind the syscall gate and only allow access to certain MSRs.
+    unsafe {
+        core::arch::asm!(
+            "rdmsr",
+            in("ecx") msr,
+            out("eax") lo,
+            out("edx") hi,
+            options(nomem, nostack),
+        );
+    }
+    Ok(((hi as u64) << 32) | (lo as u64))
+}
+
+/// Reads a Model-Specific Register (stub for non-x86_64).
+#[cfg(not(target_arch = "x86_64"))]
+pub unsafe fn read_msr(_msr: u32) -> Result<u64, &'static str> {
+    Err("rdmsr not supported on this architecture")
+}
+
+/// Writes a 64-bit value to a Model-Specific Register (MSR).
+///
+/// ## Safety
+///
+/// The caller must ensure the MSR index is valid and writable on the current platform.
+#[cfg(target_arch = "x86_64")]
+pub unsafe fn write_msr(msr: u32, value: u64) -> Result<(), &'static str> {
+    let lo = value as u32;
+    let hi = (value >> 32) as u32;
+    // SAFETY: Writing the MSR is memory safe as long as the caller ensures the MSR index is valid
+    //         and writable (guaranteed by this function's `unsafe` contract). `wrmsr` writes only
+    //         the selected MSR from EDX:EAX and touches no memory (nomem, nostack).
+    unsafe {
+        core::arch::asm!(
+            "wrmsr",
+            in("ecx") msr,
+            in("eax") lo,
+            in("edx") hi,
+            options(nomem, nostack),
+        );
+    }
+    Ok(())
+}
+
+/// Writes a Model-Specific Register (stub for non-x86_64).
+#[cfg(not(target_arch = "x86_64"))]
+pub unsafe fn write_msr(_msr: u32, _value: u64) -> Result<(), &'static str> {
+    Err("wrmsr not supported on this architecture")
+}
+
+/// Checks if the current processor is the Bootstrap Processor (BSP).
+///
+/// This reads the IA32_APIC_BASE MSR and checks the BSP flag (bit 8).
+/// The BSP flag is set by hardware during reset and indicates which
+/// processor is the bootstrap processor.
+#[cfg(target_arch = "x86_64")]
+pub fn is_bsp() -> bool {
+    // SAFETY: The IA32_APIC_BASE MSR is safe to read on x86_64.
+    let apic_base = unsafe { read_msr(IA32_APIC_BASE_MSR_INDEX) }.expect("IA32_APIC_BASE is always readable on x86_64");
+    (apic_base & IA32_APIC_BSP) != 0
+}
+
+/// Checks if the current processor is the BSP (stub for non-x86_64).
+#[cfg(not(target_arch = "x86_64"))]
+pub fn is_bsp() -> bool {
+    true // Assume BSP on non-x86_64 platforms
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_cpu_manager_creation() {
+        let manager: CpuManager<4> = CpuManager::new();
+        assert_eq!(manager.registered_count(), 0);
+        assert!(manager.bsp_id().is_none());
+        assert_eq!(manager.max_cpus(), 4);
+    }
+
+    #[test]
+    fn test_cpu_manager_is_const() {
+        // Verify we can create a static instance
+        static _MANAGER: CpuManager<8> = CpuManager::new();
+    }
+
+    #[test]
+    fn test_cpu_registration() {
+        let manager: CpuManager<4> = CpuManager::new();
+
+        // Register BSP
+        let bsp_idx = manager.register_cpu(0, 0, true);
+        assert_eq!(bsp_idx, Some(0));
+        assert_eq!(manager.bsp_id(), Some(0));
+        assert!(manager.is_bsp(0));
+
+        // Register APs
+        let ap1_idx = manager.register_cpu(1, 1, false);
+        assert_eq!(ap1_idx, Some(1));
+        assert!(!manager.is_bsp(1));
+
+        let ap2_idx = manager.register_cpu(2, 2, false);
+        assert_eq!(ap2_idx, Some(2));
+
+        assert_eq!(manager.registered_count(), 3);
+    }
+
+    #[test]
+    fn test_duplicate_registration() {
+        let manager: CpuManager<4> = CpuManager::new();
+
+        // Registering the same CPU twice is idempotent: the second call returns the
+        // same index and does not consume another slot.
+        let idx = manager.register_cpu(1, 1, false);
+        assert!(idx.is_some());
+        assert_eq!(manager.register_cpu(1, 1, false), idx);
+        assert_eq!(manager.registered_count(), 1);
+    }
+
+    #[test]
+    fn test_register_decouples_apic_id_from_cpu_index() {
+        // APIC IDs are sparse and unordered; cpu_index is dense and 0-based. The CPU
+        // must land in slots[cpu_index] regardless of APIC ID or registration order.
+        let manager: CpuManager<4> = CpuManager::new();
+
+        // Register out of order with non-contiguous APIC IDs.
+        assert_eq!(manager.register_cpu(0x20, 2, false), Some(2));
+        assert_eq!(manager.register_cpu(0x00, 0, true), Some(0));
+        assert_eq!(manager.register_cpu(0x10, 1, false), Some(1));
+
+        // cpu_index -> APIC ID
+        assert_eq!(manager.get_cpu_id_by_index(0), Some(0x00));
+        assert_eq!(manager.get_cpu_id_by_index(1), Some(0x10));
+        assert_eq!(manager.get_cpu_id_by_index(2), Some(0x20));
+
+        // APIC ID -> cpu_index
+        assert_eq!(manager.find_cpu_index(0x00), Some(0));
+        assert_eq!(manager.find_cpu_index(0x10), Some(1));
+        assert_eq!(manager.find_cpu_index(0x20), Some(2));
+
+        // A different APIC ID cannot take an already-occupied cpu_index.
+        assert_eq!(manager.register_cpu(0x30, 1, false), None);
+    }
+
+    #[test]
+    fn test_ap_state_management() {
+        let manager: CpuManager<4> = CpuManager::new();
+        manager.register_cpu(0, 0, true);
+        manager.register_cpu(1, 1, false);
+
+        // APs register as NotPresent and only enter the holding pen on check-in.
+        assert_eq!(manager.get_ap_state(1), Some(ApState::NotPresent));
+
+        // Change state
+        assert!(manager.set_ap_state(1, ApState::Busy));
+        assert_eq!(manager.get_ap_state(1), Some(ApState::Busy));
+
+        // Cannot change BSP state
+        assert!(!manager.set_ap_state(0, ApState::Halted));
+    }
+
+    #[test]
+    fn test_for_each_ap() {
+        let manager: CpuManager<4> = CpuManager::new();
+        manager.register_cpu(0, 0, true);
+        manager.register_cpu(1, 1, false);
+        manager.register_cpu(2, 2, false);
+
+        let mut ap_ids = [0u32; 4];
+        let mut count = 0;
+        manager.for_each_ap(|id| {
+            if count < 4 {
+                ap_ids[count] = id;
+                count += 1;
+            }
+        });
+
+        assert_eq!(count, 2);
+        assert!(ap_ids[..count].contains(&1));
+        assert!(ap_ids[..count].contains(&2));
+    }
+
+    #[test]
+    fn test_max_cpu_limit() {
+        let manager: CpuManager<2> = CpuManager::new();
+        assert!(manager.register_cpu(0, 0, true).is_some());
+        assert!(manager.register_cpu(1, 1, false).is_some());
+        // cpu_index 2 is out of range for CpuManager<2>.
+        assert!(manager.register_cpu(2, 2, false).is_none()); // Should fail
+    }
+
+    #[test]
+    fn test_count_aps_in_state() {
+        let manager: CpuManager<4> = CpuManager::new();
+        manager.register_cpu(0, 0, true);
+        manager.register_cpu(1, 1, false);
+        manager.register_cpu(2, 2, false);
+
+        // APs register as NotPresent; they only count as InHoldingPen after checking in.
+        assert_eq!(manager.count_aps_in_state(ApState::NotPresent), 2);
+        assert_eq!(manager.count_aps_in_state(ApState::InHoldingPen), 0);
+
+        // Simulate both APs checking in to the holding pen.
+        manager.set_ap_state(1, ApState::InHoldingPen);
+        manager.set_ap_state(2, ApState::InHoldingPen);
+        assert_eq!(manager.count_aps_in_state(ApState::InHoldingPen), 2);
+        assert_eq!(manager.count_aps_in_state(ApState::Busy), 0);
+
+        manager.set_ap_state(1, ApState::Busy);
+        assert_eq!(manager.count_aps_in_state(ApState::InHoldingPen), 1);
+        assert_eq!(manager.count_aps_in_state(ApState::Busy), 1);
+    }
+
+    #[test]
+    fn test_exit_barrier_rendezvous() {
+        let manager: CpuManager<4> = CpuManager::new();
+        manager.register_cpu(0, 0, true); // BSP at slot 0
+        manager.register_cpu(10, 1, false); // AP at slot 1
+        manager.register_cpu(20, 2, false); // AP at slot 2
+
+        // Nothing is pending before the BSP releases.
+        assert!(!manager.take_release_by_index(1));
+        assert!(!manager.take_release_by_index(2));
+
+        // BSP releases all APs; each AP consumes its release exactly once.
+        manager.release_all_aps();
+        assert!(manager.take_release_by_index(1));
+        assert!(!manager.take_release_by_index(1));
+        assert!(manager.take_release_by_index(2));
+        assert!(!manager.take_release_by_index(2));
+
+        // Each AP acknowledges exit; the BSP's barrier then completes without blocking
+        // (the acks were already counted into the BSP's semaphore).
+        manager.ack_exit_to_bsp();
+        manager.ack_exit_to_bsp();
+        manager.wait_for_ap_exit_acks(2);
+
+        // The semaphores are balanced again, ready for the next round.
+        assert!(!manager.take_release_by_index(1));
+    }
+}

--- a/patina_mm_supervisor/src/entry_point.asm
+++ b/patina_mm_supervisor/src/entry_point.asm
@@ -1,0 +1,19 @@
+#
+# Exception entry point logic for X64.
+#
+# Copyright (c) Microsoft Corporation.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+.section .data
+
+.section .text
+.global rust_main
+.global efi_main
+
+.align 8
+# Shim layer that redefines the contract between runtime module and init.
+efi_main:
+
+    jmp     rust_main

--- a/patina_mm_supervisor/src/init.rs
+++ b/patina_mm_supervisor/src/init.rs
@@ -1,0 +1,970 @@
+//! MM Supervisor Core Initialization
+//!
+//! This module contains all one-time initialization logic for the MM Supervisor Core,
+//! including BSP initialization, per-core setup, HOB discovery, policy gate initialization,
+//! and SMI handler IDT patching.
+//!
+//! ## License
+//!
+//! Copyright (c) Microsoft Corporation.
+//!
+//! SPDX-License-Identifier: Apache-2.0
+//!
+
+use core::ffi::c_void;
+
+use patina::{
+    base::{UEFI_PAGE_SIZE, align_range},
+    management_mode::{
+        MmCommBufferStatus,
+        comm_buffer_hob::{MM_COMM_BUFFER_HOB_GUID, MmCommonBufferHobData},
+        supervisor::{MM_SUPERVISOR_HOB_MEMORY_ALLOC_MODULE_GUID, MM_SUPERVISOR_USER_GUID},
+    },
+    pi::hob::{self, Hob, PhaseHandoffInformationTable},
+};
+use patina_paging::{
+    MemoryAttributes, PageTable, PagingType,
+    x64::{X64PageTable, disable_write_protection, enable_write_protection},
+};
+
+use crate::{
+    AllocationType, CommBufferConfig, MmSupervisorCore, PageOwnership, PlatformInfo, SharedPagingAllocator,
+    is_buffer_inside_mmram, mem,
+    mm_policy::{self, MemDescriptorV1_0, dump_policy, gate::PolicyGate, walk_page_table},
+    query_address_ownership, read_cr3,
+    save_state::SaveStateInfo,
+    state::{init_state, security_state},
+};
+
+use patina_internal_cpu::interrupts::Interrupts;
+use zerocopy::FromBytes;
+
+/// Errors that can occur during policy initialization.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PolicyInitError {
+    /// The HOB list pointer is null.
+    NullHobList,
+    /// Some HOB not found.
+    HobNotFound,
+    /// Invalid PassDown HOB revision.
+    InvalidRevision {
+        /// The revision value found in the PassDown HOB.
+        found: u32,
+        /// The revision value the supervisor expected.
+        expected: u32,
+    },
+    /// Firmware policy buffer is null or empty.
+    NullFirmwarePolicyBuffer,
+    /// Invalid policy data.
+    InvalidPolicyData,
+    /// Memory allocation failed for policy buffers.
+    MemoryAllocationFailed,
+    /// One or more communication buffers are not properly initialized.
+    MissingCommunicationBuffer,
+}
+
+/// Offset from SMBASE where the SMI handler code is located.
+const SMM_HANDLER_OFFSET: u64 = 0x8000;
+
+/// Index into the Fixup64 array for the SMI handler IDTR pointer.
+const FIXUP64_SMI_HANDLER_IDTR: usize = 5;
+
+/// MM Common Region HOB Data Structure
+///
+/// Describes the supervisor MM communication region published by the C MM
+/// IPL under `gMmCommonRegionHobGuid`. Carries the buffer location/size and
+/// a dedicated `MmCommBufferStatus` mailbox in `status_addr`. The layout
+/// matches the C `MM_COMM_REGION_HOB` from `MmCommonRegion.h`; the
+/// `region_type` discriminator exists for C ABI parity but is always
+/// `MM_SUPERVISOR_BUFFER_T` (0) in practice — the user channel uses the
+/// separate `gMmCommBufferHobGuid` HOB.
+#[repr(C)]
+#[derive(Debug, Clone, Copy, zerocopy_derive::FromBytes, zerocopy_derive::Immutable)]
+pub struct MmCommonRegionHobData {
+    /// Region type discriminator. Always `MM_SUPERVISOR_BUFFER_T` (0) for
+    /// the HOB the supervisor consumes.
+    pub region_type: u64,
+    /// Base address of the communication buffer region.
+    pub addr: u64,
+    /// Number of pages in the communication buffer region.
+    pub number_of_pages: u64,
+    /// Address of the `MmCommBufferStatus` structure that pairs with this region.
+    pub status_addr: u64,
+}
+
+/// MM Supervisor PassDown HOB Data Structure
+///
+/// This structure contains various buffer pointers and sizes passed from
+/// the PEI phase to the MM Supervisor.
+///
+/// All fields are naturally aligned (`u32`, `u32`, then `u64`s), so `repr(C)`
+/// has the same byte layout the C producer emits while still allowing safe,
+/// reference-based field access once parsed via `zerocopy`.
+#[repr(C)]
+#[derive(Debug, Clone, Copy, zerocopy_derive::FromBytes, zerocopy_derive::Immutable)]
+pub struct MmSupvPassDownHobData {
+    /// Revision of this HOB structure
+    pub revision: u32,
+    /// Reserved for future use
+    pub reserved: u32,
+    /// Base address of CPL3 stack for MM Supervisor
+    pub mm_supervisor_cpl3_stack_base: u64,
+    /// Per-CPU stack size for CPL3
+    pub mm_supervisor_cpl3_per_core_stack_size: u64,
+    /// Pointer to the per-CPU SMBASE array (`u64[number_of_cpus]`), indexed by the
+    /// UEFI processor index (the same `cpu_index` the supervisor registers).
+    ///
+    /// The save-state region base for a CPU is `sm_base[cpu_index] +
+    /// SMRAM_SAVE_STATE_MAP_OFFSET`. The BSP's own entry also serves as the
+    /// IDT-patch fallback when `IA32_MSR_SMBASE` reads 0 (e.g. on QEMU).
+    pub sm_base: u64,
+    /// MM Initialized buffer base address
+    pub mm_initialized_buffer: u64,
+    /// MM Supervisor firmware policy buffer base address
+    pub mm_supv_firmware_policy_buffer: u64,
+    /// Size of MM Supervisor firmware policy buffer
+    pub mm_supv_firmware_policy_buffer_size: u64,
+    /// Size of the MMI entry point structure (for validating against expected size in supervisor)
+    pub mmi_entrypoint_size: u64,
+}
+
+/// Per-core MMI entry structure header.
+///
+/// This packed structure is embedded at the end of the SMI handler binary template.
+/// It contains offsets (relative to the header start) to fixup arrays that the
+/// relocation code uses to patch per-CPU values into the binary.
+///
+/// Layout matches the C `PER_CORE_MMI_ENTRY_STRUCT_HDR` from SeaResponder.h.
+#[repr(C, packed)]
+#[derive(Debug, Clone, Copy)]
+struct PerCoreMmiEntryStructHdr {
+    /// Header version (4 for version 4).
+    header_version: u32,
+    /// Offset from header start to FixUpStruct array.
+    fixup_struct_offset: u8,
+    /// Number of FixUpStruct array entries.
+    fixup_struct_num: u8,
+    /// Offset from header start to Fixup64 array.
+    fixup64_offset: u8,
+    /// Number of Fixup64 array entries.
+    fixup64_num: u8,
+    /// Offset from header start to Fixup32 array.
+    fixup32_offset: u8,
+    /// Number of Fixup32 array entries.
+    fixup32_num: u8,
+    /// Offset from header start to Fixup8 array.
+    fixup8_offset: u8,
+    /// Number of Fixup8 array entries.
+    fixup8_num: u8,
+    /// SMI entry binary version.
+    binary_version: u16,
+    /// SPL value for SMI entry binary.
+    spl_value: u32,
+    /// Reserved for future use.
+    reserved: u32,
+}
+
+/// Pointer structure used by the `SIDT` / `LIDT` (and `SGDT` / `LGDT`) instructions.
+///
+/// Layout matches the Intel SDM: a 16-bit limit followed by a 64-bit base.
+/// `packed(2)` produces the expected 10-byte on-the-wire representation with no
+/// internal padding between `limit` and `base`.
+#[repr(C, packed(2))]
+#[derive(Debug, Clone, Copy)]
+struct DescriptorTablePointer {
+    /// Size of the descriptor table in bytes, minus 1.
+    limit: u16,
+    /// Linear address of the descriptor table.
+    base: u64,
+}
+
+/// Read the current IDT Register (IDTR) via the `SIDT` instruction.
+///
+/// Returns a [`DescriptorTablePointer`] containing the IDT base and limit.
+fn read_idtr() -> DescriptorTablePointer {
+    let rt_descriptor = DescriptorTablePointer { limit: 0, base: 0 };
+
+    // On the real firmware target, populate it via `SIDT`. The asm-free builds
+    // (tests / non-x86_64) keep the zero-initialized value, so no mutable binding
+    // is introduced where it would go unused.
+    #[cfg(all(not(test), target_arch = "x86_64"))]
+    let rt_descriptor = {
+        let mut descriptor = rt_descriptor;
+        // SAFETY: SIDT stores the 10-byte IDTR pseudo-descriptor to the specified
+        // memory location. This is a read-only operation on CPU state.
+        unsafe {
+            core::arch::asm!(
+                "sidt [{}]",
+                in(reg) &mut descriptor as *mut DescriptorTablePointer,
+                options(nostack, preserves_flags)
+            );
+        }
+        descriptor
+    };
+
+    rt_descriptor
+}
+
+impl<P: PlatformInfo, const MAX_CPUS: usize> MmSupervisorCore<P, MAX_CPUS> {
+    /// BSP-specific initialization.
+    ///
+    /// This is called only on the BSP after basic setup is complete. It
+    /// initializes interrupts, the page and paging allocators, the global page
+    /// table, discovers the user module entry point, initializes the security
+    /// policy, and remaps the HOB list so the demoted user core can read it.
+    pub(crate) fn bsp_init(&'static self, hob_list: *const c_void) {
+        log::info!("BSP performing one-time initialization...");
+
+        let mut interrupt_manager = Interrupts::new();
+        interrupt_manager.initialize().unwrap_or_else(|err| {
+            panic!("Failed to initialize Interrupt Manager: {:?}", err);
+        });
+
+        // SAFETY: `hob_list` is provided by the MM IPL and is guaranteed to be a
+        // valid HOB list (the caller asserts it is non-null before dispatching).
+        unsafe {
+            self.init_page_allocators(hob_list);
+        }
+
+        self.init_page_table();
+
+        // SAFETY: `hob_list` is provided by the MM IPL and is guaranteed to be a
+        // valid HOB list (the caller asserts it is non-null before dispatching).
+        unsafe {
+            self.discover_and_store_user_entry(hob_list);
+            self.init_policy_and_validate(hob_list);
+            self.remap_hob_list_to_user(hob_list);
+        }
+
+        log::trace!("BSP one-time initialization complete.");
+    }
+
+    /// Initializes the page and paging allocators from the HOB list.
+    ///
+    /// Sets up SMRAM memory tracking from the HOB list, reserves a pool of
+    /// pages for paging structures (done before paging is initialized to avoid
+    /// a circular dependency), and initializes the paging allocator with that
+    /// pool.
+    ///
+    /// ## Safety
+    ///
+    /// The caller must ensure that `hob_list` points to a valid HOB list.
+    unsafe fn init_page_allocators(&self, hob_list: *const c_void) {
+        // Initialize the page allocator from the HOB list. This finds all SMRAM
+        // regions and sets up memory tracking.
+        // SAFETY: `hob_list` is a valid HOB list per this function's contract.
+        if let Err(e) = unsafe { security_state().page_allocator().init_from_hob_list(hob_list) } {
+            panic!("Failed to initialize page allocator: {:?}", e);
+        }
+
+        // Reserve pages from the page allocator for paging structures. This is
+        // done before paging is initialized to avoid a circular dependency.
+        let paging_pool_base = match security_state().page_allocator().allocate_pages(mem::DEFAULT_PAGING_POOL_PAGES) {
+            Ok(base) => base,
+            Err(e) => {
+                panic!("Failed to reserve pages for paging structures: {:?}", e);
+            }
+        };
+        log::info!(
+            "Reserved {} pages at 0x{:016x} for paging structures",
+            mem::DEFAULT_PAGING_POOL_PAGES,
+            paging_pool_base
+        );
+
+        // Initialize the paging allocator with the reserved pool.
+        // SAFETY: `paging_pool_base` was just reserved from the page allocator, so it is a
+        // page-aligned region of `DEFAULT_PAGING_POOL_PAGES` pages in SMRAM owned exclusively by
+        // the paging allocator.
+        let init_result =
+            unsafe { security_state().paging_allocator().init(paging_pool_base, mem::DEFAULT_PAGING_POOL_PAGES) };
+        if let Err(e) = init_result {
+            panic!("Failed to initialize paging allocator: {:?}", e);
+        }
+    }
+
+    /// Initializes the global page table from the active CR3.
+    ///
+    /// This allows the supervisor to modify page attributes on newly allocated
+    /// pages. Must be called after [`init_page_allocators`](Self::init_page_allocators)
+    /// because the page table draws its backing memory from the paging allocator.
+    fn init_page_table(&self) {
+        let cr3 = read_cr3();
+        let paging_alloc = SharedPagingAllocator::new(security_state().paging_allocator());
+        // SAFETY: `cr3` is read from the active control register, so it points to
+        // the valid page table hierarchy currently in use by this core, and
+        // `paging_alloc` owns the pool from which new paging structures are drawn.
+        let page_table = unsafe { X64PageTable::from_existing(cr3, paging_alloc, PagingType::Paging4Level) }
+            .expect("Failed to create page table from active CR3");
+        *security_state().lock_page_table() = Some(page_table);
+        log::info!("Page table initialized from CR3=0x{:016x}", cr3);
+    }
+
+    /// Discovers the MM Supervisor User module entry point from the HOB list and
+    /// stores it for use during request processing.
+    ///
+    /// We look for `EFI_HOB_TYPE_MEMORY_ALLOCATION` HOBs whose
+    /// `MemoryAllocationHeader.Name` is `gMmSupervisorHobMemoryAllocModuleGuid`
+    /// and whose `ModuleName` is `gMmSupervisorUserGuid`.
+    ///
+    /// ## Safety
+    ///
+    /// The caller must ensure that `hob_list` points to a valid HOB list.
+    unsafe fn discover_and_store_user_entry(&self, hob_list: *const c_void) {
+        // SAFETY: `hob_list` is a valid HOB list per this function's contract.
+        match unsafe { self.discover_user_module_entry(hob_list) } {
+            Some(entry) => {
+                log::info!("Discovered MM User module entry point: 0x{:016x}", entry);
+                init_state().set_user_entry_point(entry);
+            }
+            None => log::warn!("MM User module entry point not found in HOB list"),
+        }
+    }
+
+    /// Initializes the policy gate from the PassDown HOB and runs an initial
+    /// security validation.
+    ///
+    /// ## Safety
+    ///
+    /// The caller must ensure that `hob_list` points to a valid HOB list.
+    unsafe fn init_policy_and_validate(&self, hob_list: *const c_void) {
+        // SAFETY: `hob_list` is a valid HOB list per this function's contract.
+        if let Err(e) = unsafe { self.init_policy_from_hob_list(hob_list) } {
+            log::error!("Failed to initialize policy gate: {:?}", e);
+        }
+
+        // Now that we have the policy, run an initial security validation.
+        if let Some(gate) = security_state().policy_gate() {
+            // SAFETY: `gate.as_ptr()` returns the firmware policy buffer pointer
+            // validated while constructing the policy gate above.
+            if let Err(e) = unsafe { mm_policy::helpers::security_policy_check(gate.as_ptr()) } {
+                panic!("Security policy check failed during init: {:?}", e);
+            }
+            log::info!("Security policy check passed");
+        }
+    }
+
+    /// Remaps the HOB list as user-accessible so the demoted user core can walk
+    /// it during `StartUserCore`.
+    ///
+    /// Once all HOB content has been consumed, the page-aligned HOB range is
+    /// remapped as read-only + non-executable for the user level.
+    ///
+    /// ## Safety
+    ///
+    /// The caller must ensure that `hob_list` points to a valid HOB list.
+    unsafe fn remap_hob_list_to_user(&self, hob_list: *const c_void) {
+        let hob_base = hob_list as u64;
+        // SAFETY: `hob_list` is a valid HOB list per this function's contract.
+        let hob_list_size = unsafe { hob::get_pi_hob_list_size(hob_list) } as u64;
+
+        let (aligned_base, hob_region_size) = align_range(hob_base, hob_list_size, UEFI_PAGE_SIZE as u64)
+            .unwrap_or_else(|e| panic!("Failed to page-align HOB list region: {:?}", e));
+        let aligned_end = aligned_base + hob_region_size;
+        log::info!(
+            "HOB list at 0x{:016x} size 0x{:x}, aligned region 0x{:016x}-0x{:016x} (0x{:x} bytes)",
+            hob_base,
+            hob_list_size,
+            aligned_base,
+            aligned_end,
+            hob_region_size
+        );
+
+        if hob_region_size == 0 {
+            return;
+        }
+
+        let attrs = MemoryAttributes::ReadOnly | MemoryAttributes::ExecuteProtect;
+        let mut pt_guard = security_state().lock_page_table();
+        let Some(pt) = pt_guard.as_mut() else {
+            panic!("Page table not initialized, cannot remap HOB list to user level");
+        };
+
+        if let Err(e) = pt.map_memory_region(aligned_base, hob_region_size, attrs) {
+            panic!(
+                "Failed to remap HOB list to user level at 0x{:016x} (0x{:x} bytes): {:?}",
+                aligned_base, hob_region_size, e
+            );
+        }
+        log::info!("Remapped HOB list 0x{:016x}-0x{:016x} as user read-only", aligned_base, aligned_end);
+    }
+
+    /// Patches every core's SMI-handler IDT descriptor to point to the Rust IDT.
+    ///
+    /// Each per-core MMI entry (copied to `sm_base[i] + 0x8000` during C relocation)
+    /// carries a `Fixup64[FIXUP64_SMI_HANDLER_IDTR]` slot holding the address of the
+    /// `IA32_DESCRIPTOR` that core's SMI entry `lidt`s.
+    ///
+    /// `sm_base_array` is the per-CPU SMBASE array (`u64[number_of_cpus]`) from the PassDown
+    /// HOB; `number_of_cpus` is its length.
+    fn patch_smi_handler_idt(sm_base_array: u64, number_of_cpus: u64, mmi_entry_size: u64) {
+        if mmi_entry_size == 0 {
+            log::warn!("MMI entry size is 0 in PassDown HOB, cannot navigate fixup structure");
+            return;
+        }
+        if sm_base_array == 0 || number_of_cpus == 0 {
+            log::warn!("SMBASE array is null or CPU count is 0, cannot patch SMI handler IDT");
+            return;
+        }
+
+        let idtr = read_idtr();
+        // Copy packed fields into aligned locals before formatting; taking a reference to a
+        // field of a `packed(2)` struct (as `log::info!` would) is undefined behavior.
+        let idtr_base = idtr.base;
+        let idtr_limit = idtr.limit;
+
+        // Read the whole SMBASE array once as a slice (same pattern as the save-state read path).
+        // SAFETY: `sm_base_array` references a valid `u64[number_of_cpus]` array in SMRAM from the
+        // PassDown HOB (both operands validated non-zero above), so the slice spans only valid,
+        // initialized memory. We cannot do too much other null check, from above.
+        let sm_bases = unsafe { core::slice::from_raw_parts(sm_base_array as *const u64, number_of_cpus as usize) };
+
+        for (cpu, &smbase) in sm_bases.iter().enumerate() {
+            if smbase == 0 {
+                log::warn!("CPU {}: SMBASE is 0, skipping SMI handler IDT patch", cpu);
+                continue;
+            }
+
+            let mmi_entry_base = smbase + SMM_HANDLER_OFFSET;
+
+            // The last u32 in the MMI entry binary is the total fixup structure size.
+            let whole_struct_size_addr = mmi_entry_base + mmi_entry_size - 4;
+            // SAFETY: points into this core's SMI handler template in SMRAM.
+            let whole_struct_size = unsafe { core::ptr::read_unaligned(whole_struct_size_addr as *const u32) };
+
+            // The structure header starts before the trailing size field.
+            let hdr_addr =
+                (mmi_entry_base + mmi_entry_size - 4 - whole_struct_size as u64) as *const PerCoreMmiEntryStructHdr;
+            // SAFETY: hdr_addr points to the packed fixup header within this core's SMI handler binary.
+            let hdr = unsafe { core::ptr::read_unaligned(hdr_addr) };
+            let f64_offset = hdr.fixup64_offset;
+            let f64_num = hdr.fixup64_num;
+
+            // Validate the Fixup64 array has the IDTR entry.
+            if (FIXUP64_SMI_HANDLER_IDTR as u8) >= f64_num {
+                log::error!(
+                    "CPU {}: Fixup64 array too small: need index {} but only {} entries",
+                    cpu,
+                    FIXUP64_SMI_HANDLER_IDTR,
+                    f64_num
+                );
+                continue;
+            }
+
+            // Navigate to this core's Fixup64 array and read the descriptor pointer it holds.
+            let fixup64_base = (hdr_addr as u64 + f64_offset as u64) as *const u64;
+            // SAFETY: fixup64_base + index is within this core's fixup array.
+            let idt_desc_addr = unsafe { core::ptr::read_unaligned(fixup64_base.add(FIXUP64_SMI_HANDLER_IDTR)) };
+
+            if idt_desc_addr == 0 {
+                log::warn!("CPU {}: Fixup64[{}] (SMI_HANDLER_IDTR) is null", cpu, FIXUP64_SMI_HANDLER_IDTR);
+                continue;
+            }
+
+            // Overwrite the IA32_DESCRIPTOR this core references with the Rust IDT base/limit.
+            let idt_desc_ptr = idt_desc_addr as *mut DescriptorTablePointer;
+            // SAFETY: idt_desc_ptr references an IA32_DESCRIPTOR in SMRAM (allocated by the C
+            // relocation via AllocateCodePages). DescriptorTablePointer (packed(2)) and
+            // IA32_DESCRIPTOR (packed(1)) share the same 10-byte {u16, u64} layout.
+            unsafe { core::ptr::write_unaligned(idt_desc_ptr, idtr) };
+
+            log::info!(
+                "CPU {}: patched SMI handler IDT descriptor at 0x{:016x}: base=0x{:016x}, limit=0x{:04x}",
+                cpu,
+                idt_desc_addr,
+                idtr_base,
+                idtr_limit
+            );
+        }
+    }
+
+    /// Per-core initialization.
+    ///
+    /// This is called on every core (BSP and APs) during the first entry.
+    /// Use this for setting up per-CPU state like syscall MSRs, GS base, etc.
+    pub(crate) fn per_core_init(&'static self, cpu_id: u32, is_bsp: bool) {
+        let core_type = if is_bsp { "BSP" } else { "AP" };
+        log::trace!("{} (CPU {}) performing per-core initialization...", core_type, cpu_id);
+
+        // TODO: Initialize per-CPU data structures
+
+        log::trace!("{} (CPU {}) per-core initialization complete.", core_type, cpu_id);
+    }
+
+    /// Discovers the MM Supervisor User module entry point from the HOB list.
+    ///
+    /// This function iterates through the HOB list looking for `MemoryAllocationModule` HOBs
+    /// that match the MM Supervisor memory allocation module GUID and have the MM Supervisor
+    /// User GUID as their module name.
+    ///
+    /// ## Safety
+    ///
+    /// The caller must ensure that `hob_list` points to a valid HOB list.
+    unsafe fn discover_user_module_entry(&self, hob_list: *const c_void) -> Option<u64> {
+        if hob_list.is_null() {
+            return None;
+        }
+
+        // Get the HOB list header
+        // SAFETY: `hob_list` was checked non-null above and, per this function's contract, points
+        // to a valid HOB list, so reinterpreting it as the handoff table header and taking a
+        // shared reference is sound.
+        let hob_list_info = unsafe { (hob_list as *const PhaseHandoffInformationTable).as_ref()? };
+
+        let hob = Hob::Handoff(hob_list_info);
+
+        // Iterate through the HOB list looking for MemoryAllocationModule HOBs
+        for current_hob in &hob {
+            if let Hob::MemoryAllocationModule(mem_alloc_mod) = current_hob {
+                // Check if this is an MM Supervisor module allocation
+                // (MemoryAllocationHeader.Name == gMmSupervisorHobMemoryAllocModuleGuid)
+                if mem_alloc_mod.alloc_descriptor.name == MM_SUPERVISOR_HOB_MEMORY_ALLOC_MODULE_GUID {
+                    log::debug!(
+                        "Found MM Supervisor module HOB: module_name={:?}, entry_point=0x{:016x}",
+                        mem_alloc_mod.module_name,
+                        mem_alloc_mod.entry_point
+                    );
+
+                    // Check if this is the User module (ModuleName == gMmSupervisorUserGuid)
+                    if mem_alloc_mod.module_name == MM_SUPERVISOR_USER_GUID {
+                        log::info!(
+                            "Found MM User module: entry_point=0x{:016x}, base=0x{:016x}, size=0x{:x}",
+                            mem_alloc_mod.entry_point,
+                            mem_alloc_mod.alloc_descriptor.memory_base_address,
+                            mem_alloc_mod.alloc_descriptor.memory_length
+                        );
+                        return Some(mem_alloc_mod.entry_point);
+                    }
+                }
+            }
+        }
+
+        None
+    }
+
+    /// Initializes services from the HOB list.
+    ///
+    /// Discovers and processes the following HOBs in sequence:
+    /// 1. `MM_SUPV_PASS_DOWN_HOB_GUID` — policy gate, syscall interface, memory policy, IDT patching
+    /// 2. `MM_COMMON_REGION_HOB_GUID` — supervisor communication buffer
+    /// 3. `MM_COMM_BUFFER_HOB_GUID` — user communication buffer + status buffer
+    ///
+    /// Finally, allocates the supervisor-to-user data buffer and stores the
+    /// assembled [`CommBufferConfig`].
+    ///
+    /// ## Safety
+    ///
+    /// The caller must ensure that `hob_list` points to a valid HOB list.
+    unsafe fn init_policy_from_hob_list(&self, hob_list: *const c_void) -> Result<(), PolicyInitError> {
+        if hob_list.is_null() {
+            return Err(PolicyInitError::NullHobList);
+        }
+
+        // SAFETY: `hob_list` was checked non-null above and, per this function's contract, points
+        // to a valid HOB list, so taking a shared reference to the handoff table header is sound.
+        let hob_list_info =
+            unsafe { (hob_list as *const PhaseHandoffInformationTable).as_ref().ok_or(PolicyInitError::NullHobList)? };
+
+        // 1. Process the PassDown HOB (policy, syscall, memory policy)
+        let pass_down_data =
+            find_guid_hob(hob_list_info, crate::MM_SUPV_PASS_DOWN_HOB_GUID).ok_or(PolicyInitError::HobNotFound)?;
+        // SAFETY: `pass_down_data` is a slice into the validated HOB list, so the buffer pointers
+        // it carries reference live memory as `init_from_pass_down_hob` requires.
+        let (sm_base, mmi_entry_size) = unsafe { self.init_from_pass_down_hob(pass_down_data)? };
+
+        // 1b. Process the MP Information HOB (`gMpInformationHobGuid`) for the CPU
+        //     count and the `EFI_PROCESSOR_INFORMATION` array (APIC IDs).
+        let (number_of_cpus, processor_info) = find_guid_hob(hob_list_info, crate::MP_INFORMATION_HOB_GUID)
+            .and_then(parse_mp_information_hob)
+            .ok_or(PolicyInitError::HobNotFound)?;
+        security_state().set_save_state_info(SaveStateInfo { number_of_cpus, processor_info, sm_base });
+        log::info!("Save-state metadata initialized for {} CPU(s)", number_of_cpus);
+
+        // 1c. Patch every core's SMI-handler IDT descriptor to the Rust IDT now that the
+        //     CPU count is known (the SMI entry blocks were already copied per SMBASE, so
+        //     each core must be patched, not just the BSP).
+        Self::patch_smi_handler_idt(sm_base, number_of_cpus, mmi_entry_size);
+
+        // 2. Process the supervisor communication buffer HOB. Only one
+        //    MM_COMM_REGION_HOB is published (the supervisor one); the user
+        //    channel flows through MM_COMM_BUFFER_HOB_GUID below.
+        let supv_region_data =
+            find_guid_hob(hob_list_info, crate::MM_COMMON_REGION_HOB_GUID).ok_or(PolicyInitError::HobNotFound)?;
+        let (supv_comm_buffer, supv_comm_buffer_size, supv_comm_buffer_internal, supv_status_buffer) =
+            init_supv_comm_buffer(supv_region_data)?;
+
+        // 3. Process the user communication buffer HOB. This still uses the
+        //    legacy `MM_COMM_BUFFER_HOB_GUID` so the user core's own HOB walk
+        //    keeps working (see the HACKHACK at the tail of
+        //    init_user_comm_buffer).
+        let user_buffer_data =
+            find_guid_hob(hob_list_info, MM_COMM_BUFFER_HOB_GUID).ok_or(PolicyInitError::HobNotFound)?;
+        // SAFETY: `user_buffer_data` aliases the original, writable HOB buffer in the live HOB
+        // list, satisfying `init_user_comm_buffer`'s contract that it may rewrite the HOB's
+        // `physical_start` field in place.
+        let (user_comm_buffer, user_comm_buffer_size, user_comm_buffer_internal, user_status_buffer) =
+            unsafe { init_user_comm_buffer(user_buffer_data)? };
+
+        // 4. Allocate the supervisor-to-user data buffer
+        let supv_to_user_buffer =
+            security_state().page_allocator().allocate_pages_with_type(1, AllocationType::User).map_err(|e| {
+                log::error!("Failed to allocate page for supervisor-to-user buffer: {:?}", e);
+                PolicyInitError::MemoryAllocationFailed
+            })?;
+
+        // Validate all buffers are non-zero
+        if supv_comm_buffer == 0
+            || user_comm_buffer == 0
+            || user_status_buffer == 0
+            || supv_status_buffer == 0
+            || supv_to_user_buffer == 0
+        {
+            log::error!("One or more communication buffers are not properly initialized");
+            return Err(PolicyInitError::MissingCommunicationBuffer);
+        }
+
+        // Store the assembled communication buffer configuration
+        security_state().set_comm_buffer_config(CommBufferConfig {
+            supv_comm_buffer,
+            supv_comm_buffer_internal,
+            supv_comm_buffer_size,
+            user_comm_buffer,
+            user_comm_buffer_internal,
+            user_comm_buffer_size,
+            user_status_buffer,
+            supv_status_buffer,
+            supv_to_user_buffer,
+            supv_to_user_buffer_size: UEFI_PAGE_SIZE as u64,
+        });
+        log::info!(
+            "Comm buffers: supv=0x{:x}/0x{:x} size=0x{:x} status=0x{:x}, user=0x{:x}/0x{:x} size=0x{:x} status=0x{:x}",
+            supv_comm_buffer,
+            supv_comm_buffer_internal,
+            supv_comm_buffer_size,
+            supv_status_buffer,
+            user_comm_buffer,
+            user_comm_buffer_internal,
+            user_comm_buffer_size,
+            user_status_buffer
+        );
+
+        Ok(())
+    }
+
+    /// Processes the MM Supervisor PassDown HOB.
+    ///
+    /// Handles: revision validation, per-core buffer setup,
+    /// policy gate initialization, syscall interface setup, memory policy walk,
+    /// and unblocked memory tracker initialization.
+    ///
+    /// Returns `(sm_base_array, mmi_entry_size)` carried by the HOB.
+    ///
+    /// ## Safety
+    ///
+    /// The buffer pointers carried in `data` (e.g. the firmware policy buffer)
+    /// must reference valid memory, as they are dereferenced during setup.
+    unsafe fn init_from_pass_down_hob(&self, data: &[u8]) -> Result<(u64, u64), PolicyInitError> {
+        // Copy the HOB bytes once into an owned, naturally-aligned struct so the rest of
+        // the function uses ordinary, safe field access. `read_from_prefix` validates the
+        // length and copies the bytes, imposing no alignment or validity precondition on
+        // the caller's buffer.
+        let (pass_down, _) = MmSupvPassDownHobData::read_from_prefix(data).map_err(|_| {
+            log::error!(
+                "PassDown HOB data too small: {} < {}",
+                data.len(),
+                core::mem::size_of::<MmSupvPassDownHobData>()
+            );
+            PolicyInitError::InvalidPolicyData
+        })?;
+
+        let revision = pass_down.revision;
+        let mm_initialized_buffer = pass_down.mm_initialized_buffer;
+        let firmware_policy_buffer = pass_down.mm_supv_firmware_policy_buffer;
+        let firmware_policy_buffer_size = pass_down.mm_supv_firmware_policy_buffer_size;
+        let cpl3_stack_buffer = pass_down.mm_supervisor_cpl3_stack_base;
+        let cpl3_stack_buffer_size = pass_down.mm_supervisor_cpl3_per_core_stack_size;
+        let mmi_entry_size = pass_down.mmi_entrypoint_size;
+        let sm_base = pass_down.sm_base;
+
+        // Validate revision
+        if revision != crate::MM_SUPV_PASS_DOWN_HOB_REVISION {
+            log::error!(
+                "Invalid PassDown HOB revision: {} (expected {})",
+                revision,
+                crate::MM_SUPV_PASS_DOWN_HOB_REVISION
+            );
+            return Err(PolicyInitError::InvalidRevision {
+                found: revision,
+                expected: crate::MM_SUPV_PASS_DOWN_HOB_REVISION,
+            });
+        }
+
+        // Store per-core initialized buffer address
+        if mm_initialized_buffer != 0 {
+            init_state().set_mm_initialized_buffer(mm_initialized_buffer);
+            log::info!("MM Initialized buffer set to 0x{:016x}", mm_initialized_buffer);
+        } else {
+            log::warn!("MM Initialized buffer is null in PassDown HOB");
+        }
+
+        // Log the per-CPU SMBASE array passed down for the save-state read syscall.
+        if sm_base != 0 {
+            log::info!("CPU SMBASE array at 0x{:016x}", sm_base);
+        } else {
+            log::warn!("CPU SMBASE array pointer is null in PassDown HOB");
+        }
+
+        // Initialize the policy gate
+        if firmware_policy_buffer == 0 || firmware_policy_buffer_size == 0 {
+            log::error!("Firmware policy buffer is null or empty");
+            return Err(PolicyInitError::NullFirmwarePolicyBuffer);
+        }
+
+        let policy_ptr = firmware_policy_buffer as *const u8;
+        let memory_policy_buffer = security_state().page_allocator().allocate_pages(1).map_err(|e| {
+            log::error!("Failed to allocate page for memory policy buffer: {:?}", e);
+            PolicyInitError::MemoryAllocationFailed
+        })?;
+
+        // SAFETY: `policy_ptr` is the firmware policy buffer from the PassDown HOB, validated
+        // non-zero above, and stays resident for the supervisor's lifetime.
+        match unsafe { PolicyGate::new(policy_ptr) } {
+            Ok(mut gate) => {
+                log::info!("Policy gate initialized successfully");
+                // SAFETY: `policy_ptr` is the same valid, resident firmware policy buffer.
+                unsafe { dump_policy(policy_ptr) };
+
+                let mem_policy_max_count = UEFI_PAGE_SIZE / core::mem::size_of::<MemDescriptorV1_0>();
+                gate.set_memory_policy_buffer(memory_policy_buffer as *mut MemDescriptorV1_0, mem_policy_max_count);
+                security_state().set_policy_gate(gate);
+            }
+            Err(e) => {
+                log::error!("Failed to create policy gate: {:?}", e);
+                return Err(PolicyInitError::InvalidPolicyData);
+            }
+        }
+
+        // Initialize syscall interface
+        self.syscall_interface
+            .init(
+                self.cpu_manager.max_cpus(),
+                cpl3_stack_buffer,
+                cpl3_stack_buffer_size
+                    .try_into()
+                    .unwrap_or_else(|err| panic!("Invalid CPL3 stack buffer size: {:?}", err)),
+            )
+            .unwrap_or_else(|err| panic!("Failed to initialize syscall interface: {:?}", err));
+
+        // Walk page table and generate memory policy
+        let cr3 = read_cr3();
+        // SAFETY: `cr3` is read from the active control register, so it points to the live PML4
+        // table, and `memory_policy_buffer` is the page just allocated above with room for
+        // `UEFI_PAGE_SIZE` bytes of descriptors.
+        let count = unsafe {
+            walk_page_table(cr3, memory_policy_buffer as *mut MemDescriptorV1_0, UEFI_PAGE_SIZE, is_buffer_inside_mmram)
+        };
+
+        if let Ok(descriptor_count) = count {
+            log::info!("Successfully generated {} memory policy descriptors", descriptor_count);
+            // SAFETY: `walk_page_table` succeeded, so `memory_policy_buffer` holds `descriptor_count`
+            // valid `MemDescriptorV1_0` entries.
+            if let Err(e) = unsafe {
+                security_state()
+                    .unblocked_tracker()
+                    .init_from_buffer(memory_policy_buffer as *const MemDescriptorV1_0, descriptor_count)
+            } {
+                log::error!("Failed to initialize unblocked memory tracker: {:?}", e);
+            } else {
+                log::info!("Unblocked memory tracker initialized");
+                security_state().unblocked_tracker().dump_regions();
+            }
+        } else {
+            log::error!("Failed to generate memory policy descriptors: {:?}", count.err());
+        }
+
+        log::info!("Generated {} memory policy descriptors", count.unwrap_or(0));
+        Ok((sm_base, mmi_entry_size))
+    }
+}
+
+/// Finds the first GUID HOB matching `target_guid` and returns its data slice.
+///
+/// Returns `None` if no matching HOB is found.
+fn find_guid_hob(hob_list_info: &PhaseHandoffInformationTable, target_guid: patina::BinaryGuid) -> Option<&[u8]> {
+    let hob = Hob::Handoff(hob_list_info);
+    for current_hob in &hob {
+        if let Hob::GuidHob(guid_hob, data) = current_hob
+            && guid_hob.name == target_guid
+        {
+            return Some(data);
+        }
+    }
+    None
+}
+
+/// Parses an `MP_INFORMATION_HOB_DATA` payload (`gMpInformationHobGuid`).
+///
+/// Returns `(number_of_cpus, processor_info_ptr)` where `processor_info_ptr`
+/// points at the first `EFI_PROCESSOR_INFORMATION` entry.
+fn parse_mp_information_hob(data: &[u8]) -> Option<(u64, u64)> {
+    /// Offset of `ProcessorInfoBuffer[]` within `MP_INFORMATION_HOB_DATA`.
+    const PROCESSOR_INFO_BUFFER_OFFSET: usize = 16;
+
+    if data.len() < PROCESSOR_INFO_BUFFER_OFFSET {
+        log::error!("MP Information HOB too small: {} < {}", data.len(), PROCESSOR_INFO_BUFFER_OFFSET);
+        return None;
+    }
+
+    let number_of_cpus = u64::from_le_bytes(data.get(0..8)?.try_into().ok()?);
+    let processor_info = data.get(PROCESSOR_INFO_BUFFER_OFFSET..)?.as_ptr() as u64;
+    Some((number_of_cpus, processor_info))
+}
+
+/// Processes the supervisor communication buffer HOB (`MM_COMMON_REGION_HOB_GUID`).
+///
+/// Returns `(buffer_addr, buffer_size, internal_copy_addr, status_buffer_addr)`.
+fn init_supv_comm_buffer(data: &[u8]) -> Result<(u64, u64, u64, u64), PolicyInitError> {
+    log::info!("Found MM Common Region HOB (supervisor)");
+
+    // Copy the HOB bytes once into an owned struct for safe field access.
+    let (supv_buffer_hob, _) = MmCommonRegionHobData::read_from_prefix(data).map_err(|_| {
+        log::error!(
+            "MM Common Region HOB data too small: {} < {}",
+            data.len(),
+            core::mem::size_of::<MmCommonRegionHobData>()
+        );
+        PolicyInitError::InvalidPolicyData
+    })?;
+    let supv_comm_buffer = supv_buffer_hob.addr;
+    let supv_comm_buffer_pages = supv_buffer_hob.number_of_pages;
+    let supv_status_buffer = supv_buffer_hob.status_addr;
+
+    let supv_comm_buffer_size = supv_comm_buffer_pages.checked_mul(UEFI_PAGE_SIZE as u64).unwrap_or_else(|| {
+        panic!(
+            "Invalid supervisor common buffer size: {} pages * {} page size overflows",
+            supv_comm_buffer_pages, UEFI_PAGE_SIZE
+        );
+    });
+
+    // Validate ownership if outside MMRAM
+    if !is_buffer_inside_mmram(supv_comm_buffer, supv_comm_buffer_size) {
+        match query_address_ownership(supv_comm_buffer, supv_comm_buffer_size) {
+            Some(PageOwnership::Supervisor) => { /* expected */ }
+            Some(PageOwnership::User) => {
+                panic!(
+                    "Supervisor common buffer at 0x{:016x}-0x{:016x} is not marked as supervisor-owned",
+                    supv_comm_buffer,
+                    supv_comm_buffer + supv_comm_buffer_size
+                );
+            }
+            None => {
+                panic!("Failed to query page ownership for supervisor common buffer at 0x{:016x}", supv_comm_buffer);
+            }
+        };
+    }
+
+    // Allocate internal copy
+    let supv_comm_buffer_internal = security_state()
+        .page_allocator()
+        .allocate_pages_with_type(supv_comm_buffer_pages as usize, AllocationType::Supervisor)
+        .map_err(|e| {
+            log::error!("Failed to allocate internal supervisor common buffer: {:?}", e);
+            PolicyInitError::MemoryAllocationFailed
+        })?;
+
+    Ok((supv_comm_buffer, supv_comm_buffer_size, supv_comm_buffer_internal, supv_status_buffer))
+}
+
+/// Processes the user communication buffer HOB (`MM_COMM_BUFFER_HOB_GUID`).
+///
+/// Returns `(buffer_addr, buffer_size, internal_copy_addr, status_buffer_addr)`.
+///
+/// ## Safety
+///
+/// `data` must reference the original, writable HOB buffer: its `physical_start`
+/// field is overwritten in place with the internal copy address so the demoted
+/// user module observes it after demotion.
+unsafe fn init_user_comm_buffer(data: &[u8]) -> Result<(u64, u64, u64, u64), PolicyInitError> {
+    log::info!("Found MM Communication Buffer HOB");
+
+    // Copy the HOB fields once into an owned struct for safe access.
+    let (comm_buffer_hob, _) = MmCommonBufferHobData::read_from_prefix(data).map_err(|_| {
+        log::error!(
+            "MM Communication Buffer HOB data too small: {} < {}",
+            data.len(),
+            core::mem::size_of::<MmCommonBufferHobData>()
+        );
+        PolicyInitError::InvalidPolicyData
+    })?;
+    let user_comm_buffer = comm_buffer_hob.physical_start;
+    let user_comm_buffer_pages = comm_buffer_hob.number_of_pages;
+    let status_buffer = comm_buffer_hob.status_buffer;
+
+    let user_comm_buffer_size = user_comm_buffer_pages.checked_mul(UEFI_PAGE_SIZE as u64).unwrap_or_else(|| {
+        panic!(
+            "Invalid user common buffer size: {} pages * {} page size overflows",
+            user_comm_buffer_pages, UEFI_PAGE_SIZE
+        );
+    });
+
+    // Validate ownership if outside MMRAM
+    if !is_buffer_inside_mmram(user_comm_buffer, user_comm_buffer_size) {
+        match query_address_ownership(user_comm_buffer, user_comm_buffer_size) {
+            Some(PageOwnership::Supervisor) => { /* expected */ }
+            Some(PageOwnership::User) => {
+                panic!(
+                    "User common buffer at 0x{:016x}-0x{:016x} is not marked as user-owned",
+                    user_comm_buffer,
+                    user_comm_buffer + user_comm_buffer_size
+                );
+            }
+            None => {
+                panic!("Failed to query page ownership for user common buffer at 0x{:016x}", user_comm_buffer);
+            }
+        };
+    }
+
+    // Validate status buffer
+    if !is_buffer_inside_mmram(status_buffer, core::mem::size_of::<MmCommBufferStatus>() as u64) {
+        match query_address_ownership(status_buffer, core::mem::size_of::<MmCommBufferStatus>() as u64) {
+            Some(PageOwnership::Supervisor) => { /* expected */ }
+            Some(PageOwnership::User) => {
+                panic!("Status buffer at 0x{:016x} is not marked as supervisor-exposed", status_buffer);
+            }
+            None => {
+                panic!("Failed to query page ownership for status buffer at 0x{:016x}", status_buffer);
+            }
+        };
+    }
+
+    // Allocate internal copy
+    let user_comm_buffer_internal = security_state()
+        .page_allocator()
+        .allocate_pages_with_type(user_comm_buffer_pages as usize, AllocationType::User)
+        .map_err(|e| {
+            log::error!("Failed to allocate internal user common buffer: {:?}", e);
+            PolicyInitError::MemoryAllocationFailed
+        })?;
+
+    // TODO: Remove the logic that overwrites the HOB's physical_start with the internal buffer address
+    // so the user module sees it after demotion.
+    // SAFETY:
+    // - `data` aliases the original, writable HOB buffer (per this function's `## Safety` contract),
+    //   and the `read_from_prefix` above proved it is at least `size_of::<MmCommonBufferHobData>()`
+    //   bytes, so `physical_start` lies within the allocation. `addr_of_mut!` avoids forming a
+    //   reference to the (potentially unaligned) field, and `write_volatile` keeps the store from
+    //   being elided.
+    // - The HOB pages may be mapped read-only, so `disable_write_protection` clears `CR0.WP` to
+    //   permit the supervisor store. This runs in Ring 0 during single-threaded BSP init in the MM
+    //   (SMM) environment, where interrupts are masked, satisfying the privilege/atomicity
+    //   requirements of `disable_write_protection`. `enable_write_protection` is handed exactly the
+    //   value returned by `disable_write_protection`, restoring `CR0.WP` before this block returns
+    //   and bounding the unprotected window to the single field write.
+    unsafe {
+        let hob_ptr = data.as_ptr() as *mut MmCommonBufferHobData;
+        let original_cr0 = disable_write_protection();
+        core::ptr::write_volatile(core::ptr::addr_of_mut!((*hob_ptr).physical_start), user_comm_buffer_internal);
+        enable_write_protection(original_cr0);
+    }
+
+    Ok((user_comm_buffer, user_comm_buffer_size, user_comm_buffer_internal, status_buffer))
+}

--- a/patina_mm_supervisor/src/lib.rs
+++ b/patina_mm_supervisor/src/lib.rs
@@ -1,0 +1,600 @@
+//! MM Supervisor Core
+//!
+//! A pure Rust implementation of the MM Supervisor Core for standalone MM mode environments.
+//!
+//! This crate provides the core functionality for running a supervisor in MM (Management Mode)
+//! that orchestrates incoming requests on the BSP while APs wait in a holding pen.
+//!
+//! ## Architecture
+//!
+//! The entry point is executed on all cores:
+//! - **BSP**: Performs one-time initialization and enters the request serving loop
+//! - **APs**: Enter a holding pen and poll mailboxes for commands from BSP
+//!
+//! ## Memory Model
+//!
+//! This is a core component that manages its own memory. It does **not** use heap allocation.
+//! All structures use fixed-size arrays with compile-time constants provided via const generics.
+//!
+//! ## Examples
+//!
+//! ```rust,no_run
+//! # #[cfg(target_arch = "x86_64")]
+//! # mod example {
+//! use patina_mm_supervisor::*;
+//!
+//! struct MyPlatform;
+//!
+//! impl CpuInfo for MyPlatform {
+//!     fn ap_poll_timeout_us() -> u64 { 1000 }
+//! }
+//!
+//! impl PlatformInfo for MyPlatform {
+//!     type CpuInfo = Self;
+//! }
+//!
+//! // The const generic argument is the maximum CPU count used to size internal arrays.
+//! static SUPERVISOR: MmSupervisorCore<MyPlatform, 8> = MmSupervisorCore::new();
+//! # }
+//! ```
+//!
+//! ## License
+//!
+//! Copyright (c) Microsoft Corporation.
+//!
+//! SPDX-License-Identifier: Apache-2.0
+//!
+#![cfg_attr(all(not(feature = "std"), not(test)), no_std)]
+#![cfg(target_arch = "x86_64")]
+#![cfg_attr(coverage_nightly, feature(coverage_attribute))]
+
+mod cpu;
+mod init;
+mod mailbox;
+mod mem;
+mod mm_policy;
+mod perf_timer;
+mod privilege_mgmt;
+mod runtime;
+mod save_state;
+mod state;
+mod supervisor_handlers;
+
+use cpu::{CpuManager, get_current_cpu_id, is_bsp};
+use mailbox::MailboxManager;
+// Re-exported for use by descendant modules via `crate::` paths.
+use mem::{AllocationType, SharedPagingAllocator};
+
+use privilege_mgmt::{invoke_demoted_routine, syscall_setup::SyscallInterface};
+
+use spin::Mutex;
+
+use patina::management_mode::supervisor::UserCommandType;
+
+use core::{
+    ffi::c_void,
+    ptr::NonNull,
+    sync::atomic::{AtomicBool, Ordering},
+};
+
+use patina::{
+    base::{UEFI_PAGE_SIZE, align_range},
+    management_mode::MmCommBufferStatus,
+};
+use patina_paging::{MemoryAttributes, PageTable};
+
+use state::{init_state, security_state};
+
+// Public API: traits that platform binaries must implement.
+pub use cpu::CpuInfo;
+
+// Publicly re-export the handler types since platform-specific handlers will need to reference these for
+// their function signatures and return types.
+pub use init::PolicyInitError;
+pub use supervisor_handlers::SupervisorMmiHandler;
+
+// The entry-point shim references `rust_main`, which is provided by the platform binary, and is
+// only meaningful on the firmware (UEFI) target. Exclude it from host builds (tests, doctests)
+// so their harnesses can link.
+#[cfg(target_os = "uefi")]
+core::arch::global_asm!(include_str!("entry_point.asm"));
+
+/// GUID for `gMmCommonRegionHobGuid`.
+///
+/// `{ 0xd4ffc718, 0xfb82, 0x4274, { 0x9a, 0xfc, 0xaa, 0x8b, 0x1e, 0xef, 0x52, 0x93 } }`
+pub const MM_COMMON_REGION_HOB_GUID: patina::BinaryGuid =
+    patina::BinaryGuid::from_string("d4ffc718-fb82-4274-9afc-aa8b1eef5293");
+
+// GUID for gMmSupervisorPassDownHobGuid
+// { 0x3f2d2d1a, 0x7c6a, 0x4e2e, { 0x91, 0x2e, 0x5c, 0x4f, 0x5b, 0x8c, 0x2a, 0x9d } }
+/// GUID for the MM Supervisor PassDown HOB.
+pub const MM_SUPV_PASS_DOWN_HOB_GUID: patina::BinaryGuid =
+    patina::BinaryGuid::from_string("3f2d2d1a-7c6a-4e2e-912e-5c4f5b8c2a9d");
+
+// GUID for gMpInformationHobGuid (StandaloneMmPkg/Include/Guid/MpInformation.h)
+// { 0xba33f15d, 0x4000, 0x45c1, { 0x8e, 0x88, 0xf9, 0x16, 0x92, 0xd4, 0x57, 0xe3 } }
+/// GUID for the MP Information HOB, which carries the processor count and the
+/// `EFI_PROCESSOR_INFORMATION` array (APIC IDs) used by the save-state read path.
+pub const MP_INFORMATION_HOB_GUID: patina::BinaryGuid =
+    patina::BinaryGuid::from_string("ba33f15d-4000-45c1-8e88-f91692d457e3");
+
+/// MM Supervisor PassDown HOB Revision
+pub const MM_SUPV_PASS_DOWN_HOB_REVISION: u32 = 2;
+
+/// Timeout for waiting for APs to arrive in the holding pen (1 second).
+const AP_ARRIVAL_TIMEOUT_US: u64 = 1_000_000;
+
+/// Timeout for waiting for an AP to complete a dispatched procedure (10 seconds).
+const AP_TIMEOUT_US: u64 = 10_000_000;
+
+/// A trait to be implemented by the platform to provide configuration values and types to be used
+/// by the MM Supervisor Core.
+///
+/// ## Examples
+///
+/// ```rust,no_run
+/// # #[cfg(target_arch = "x86_64")]
+/// # mod example {
+/// use patina_mm_supervisor::*;
+///
+/// struct ExamplePlatform;
+///
+/// impl CpuInfo for ExamplePlatform {
+///     fn ap_poll_timeout_us() -> u64 { 1000 }
+/// }
+///
+/// impl PlatformInfo for ExamplePlatform {
+///     type CpuInfo = Self;
+/// }
+/// # }
+/// ```
+pub trait PlatformInfo: 'static {
+    /// The platform's CPU information and configuration.
+    type CpuInfo: CpuInfo;
+
+    /// Returns the platform-specific supervisor MMI handlers.
+    ///
+    /// The supervisor dispatch loop iterates the core's built-in handlers first and then
+    /// the handlers returned here, so platforms can register additional handlers (for
+    /// example platform-specific or test handlers) without modifying the core.
+    ///
+    /// The default implementation returns an empty slice.
+    fn mmi_handlers() -> &'static [SupervisorMmiHandler] {
+        &[]
+    }
+}
+
+/// Result of a page table ownership query.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum PageOwnership {
+    /// The page is user-accessible (U/S = 1, SpecialPurpose clear).
+    User,
+    /// The page is supervisor-only (U/S = 0, SpecialPurpose set).
+    Supervisor,
+}
+
+/// Queries the page table to determine the ownership (user vs supervisor) of an address.
+///
+/// The address and size are page-aligned before querying (rounded down / up respectively).
+///
+/// Checks the `Supervisor` attribute which maps to the U/S bit on X64:
+///   - `Supervisor` set  => `PageOwnership::Supervisor` (U/S = 0)
+///   - `Supervisor` clear => `PageOwnership::User` (U/S = 1)
+///
+/// Returns `None` if the page table is not initialized or the address is unmapped.
+pub(crate) fn query_address_ownership(address: u64, size: u64) -> Option<PageOwnership> {
+    let (aligned_addr, aligned_size) = align_range(address, size, UEFI_PAGE_SIZE as u64).ok()?;
+    let page_table = security_state().lock_page_table();
+    let pt = page_table.as_ref()?;
+    let attrs = pt.query_memory_region(aligned_addr, aligned_size).ok()?;
+    log::trace!(
+        "Queried page ownership for address range 0x{:016x}-0x{:016x}: attributes={:?}",
+        aligned_addr,
+        aligned_addr + aligned_size,
+        attrs
+    );
+    if attrs.contains(MemoryAttributes::Supervisor) {
+        Some(PageOwnership::Supervisor)
+    } else {
+        Some(PageOwnership::User)
+    }
+}
+
+/// Communication buffer configuration extracted from PassDown HOB.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct CommBufferConfig {
+    /// MM Supervisor communication buffer (external interface).
+    pub supv_comm_buffer: u64,
+    /// MM Supervisor internal communication buffer.
+    pub supv_comm_buffer_internal: u64,
+    /// Size of supervisor communication buffer.
+    pub supv_comm_buffer_size: u64,
+    /// MM User communication buffer (external interface).
+    pub user_comm_buffer: u64,
+    /// MM User internal communication buffer.
+    pub user_comm_buffer_internal: u64,
+    /// Size of user communication buffer.
+    pub user_comm_buffer_size: u64,
+    /// `MmCommBufferStatus` mailbox for user-targeted requests.
+    pub user_status_buffer: u64,
+    /// `MmCommBufferStatus` mailbox for supervisor-targeted requests.
+    pub supv_status_buffer: u64,
+    /// MM Supervisor to User buffer.
+    pub supv_to_user_buffer: u64,
+    /// Size of Supervisor to User buffer.
+    pub supv_to_user_buffer_size: u64,
+}
+
+/// Request target derived from the user and supervisor `MmCommBufferStatus`
+/// mailboxes.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RequestTarget {
+    /// No pending request (neither mailbox is valid).
+    None,
+    /// Request targets the Supervisor.
+    Supervisor,
+    /// Request targets the User module.
+    User,
+}
+
+impl RequestTarget {
+    /// Selects the dispatch target based on the two parallel status mailboxes.
+    ///
+    /// The user mailbox is checked first — if its `is_comm_buffer_valid` flag
+    /// is set, the request belongs to the user module. Otherwise the
+    /// supervisor mailbox is consulted. When neither mailbox is valid the
+    /// request is treated as an asynchronous MMI, which is still dispatched
+    /// through the user path so the user-core's async handler chain can run.
+    pub fn select(user_status: &MmCommBufferStatus, supv_status: &MmCommBufferStatus) -> Self {
+        if user_status.is_comm_buffer_valid != 0 {
+            RequestTarget::User
+        } else if supv_status.is_comm_buffer_valid != 0 {
+            RequestTarget::Supervisor
+        } else {
+            // Async MMI — user-core's async dispatcher runs unconditionally
+            // once we demote, so route through the user path.
+            RequestTarget::User
+        }
+    }
+}
+
+/// The MM Supervisor Core responsible for managing the standalone MM environment.
+///
+/// This struct is generic over the [`PlatformInfo`] trait, which provides platform-specific
+/// configuration including compile-time constants for array sizes.
+///
+/// The supervisor manages:
+/// - BSP initialization and request handling
+/// - AP management through the holding pen and mailbox system
+/// - Request dispatching and response handling
+///
+/// ## Memory Model
+///
+/// This struct does not perform heap allocation. All internal structures use fixed-size
+/// arrays sized by the `MAX_CPUS` const generic parameter.
+///
+/// ## Usage
+///
+/// Create a static instance of the supervisor and call `entry_point` from all cores:
+///
+/// ```rust,no_run
+/// # #[cfg(target_arch = "x86_64")]
+/// # mod example {
+/// use core::ffi::c_void;
+/// use patina_mm_supervisor::*;
+///
+/// struct MyPlatform;
+///
+/// impl CpuInfo for MyPlatform {
+///     fn ap_poll_timeout_us() -> u64 { 1000 }
+/// }
+///
+/// impl PlatformInfo for MyPlatform {
+///     type CpuInfo = Self;
+/// }
+///
+/// // The const generic argument is the maximum CPU count used to size internal arrays.
+/// static SUPERVISOR: MmSupervisorCore<MyPlatform, 8> = MmSupervisorCore::new();
+///
+/// // The MM IPL invokes this entry point on every core.
+/// pub extern "efiapi" fn mm_entry(cpu_index: usize, hob_list: *const c_void) {
+///     // SAFETY: invoked once per core by the MM environment with a valid HOB list.
+///     unsafe { SUPERVISOR.entry_point(cpu_index, hob_list) };
+/// }
+/// # }
+/// ```
+pub struct MmSupervisorCore<P: PlatformInfo, const MAX_CPUS: usize> {
+    /// Manager for CPU-related operations.
+    cpu_manager: CpuManager<MAX_CPUS>,
+    /// Manager for AP mailboxes.
+    mailbox_manager: MailboxManager<MAX_CPUS, P::CpuInfo>,
+    /// Syscall interface for privilege transitions.
+    syscall_interface: SyscallInterface<MAX_CPUS>,
+    /// Flag indicating if the core has been initialized.
+    initialized: AtomicBool,
+    /// TESTING: serializes per-core initialization so only one core runs it at a time.
+    init_lock: Mutex<()>,
+    /// Phantom data for the platform type.
+    _phantom: core::marker::PhantomData<fn() -> P>,
+}
+
+pub(crate) fn is_buffer_inside_mmram(base: u64, size: u64) -> bool {
+    // we will go over the page allocator to see if this region falls inside any of the MMRAM regions
+    security_state().page_allocator().is_region_inside_mmram(base, size)
+}
+
+/// Read CR3 register.
+pub(crate) fn read_cr3() -> u64 {
+    let mut _value = 0u64;
+
+    #[cfg(all(not(test), target_arch = "x86_64"))]
+    {
+        // SAFETY: inline asm is inherently unsafe because Rust can't reason about it.
+        // In this case we are reading the CR3 register, which is a safe operation.
+        unsafe {
+            core::arch::asm!("mov {}, cr3", out(reg) _value, options(nostack, preserves_flags));
+        }
+    }
+
+    _value
+}
+
+/// Checks if a specific core has completed initialization.
+///
+/// Reads the 1-byte slot at `mm_initialized_buffer + cpu_index`.
+/// A non-zero value indicates the core has completed initialization.
+fn is_core_initialized(cpu_index: usize) -> bool {
+    if let Some(buffer_base) = init_state().mm_initialized_buffer() {
+        if buffer_base == 0 {
+            return false;
+        }
+        let slot_ptr = (buffer_base as usize + cpu_index) as *const u8;
+        // SAFETY: The buffer is provided by the MM IPL and is guaranteed to be valid.
+        // Each core only reads its own slot or slots of other cores.
+        let value = unsafe { core::ptr::read_volatile(slot_ptr) };
+        value != 0
+    } else {
+        false
+    }
+}
+
+/// Marks a specific core as initialized.
+///
+/// Writes a non-zero value to the 1-byte slot at `mm_initialized_buffer + cpu_index`.
+fn mark_core_initialized(cpu_index: usize) {
+    if let Some(buffer_base) = init_state().mm_initialized_buffer() {
+        if buffer_base == 0 {
+            log::error!("MM initialized buffer is null, cannot mark core {} as initialized", cpu_index);
+            return;
+        }
+        let slot_ptr = (buffer_base as usize + cpu_index) as *mut u8;
+        // SAFETY: The buffer is provided by the MM IPL and is guaranteed to be valid.
+        // Each core writes only to its own slot.
+        unsafe { core::ptr::write_volatile(slot_ptr, 1) };
+        log::trace!("Core {} marked as initialized at 0x{:016x}", cpu_index, slot_ptr as u64);
+    } else {
+        log::error!("MM initialized buffer not set, cannot mark core {} as initialized", cpu_index);
+    }
+}
+
+impl<P: PlatformInfo, const MAX_CPUS: usize> MmSupervisorCore<P, MAX_CPUS> {
+    /// Creates a new instance of the MM Supervisor Core.
+    ///
+    /// This is a const fn that performs no heap allocation.
+    pub const fn new() -> Self {
+        Self {
+            cpu_manager: CpuManager::new(),
+            mailbox_manager: MailboxManager::new(),
+            syscall_interface: SyscallInterface::new(),
+            initialized: AtomicBool::new(false),
+            init_lock: Mutex::new(()),
+            _phantom: core::marker::PhantomData,
+        }
+    }
+
+    /// Sets the static supervisor instance for global access.
+    ///
+    /// Returns true if the address was successfully stored, false if already set.
+    /// Also registers the type-erased AP startup function pointer.
+    #[must_use]
+    fn set_instance(&'static self) -> bool {
+        let physical_address = NonNull::from_ref(self).expose_provenance();
+        let stored = init_state().set_supervisor(physical_address);
+        if stored {
+            // Register the conformed AP startup function for this platform
+            init_state().set_ap_startup_fn(Self::start_ap_procedure_trampoline);
+        }
+        stored
+    }
+
+    /// Gets the static MM Supervisor Core instance for global access.
+    #[allow(unused)]
+    pub(crate) fn instance<'a>() -> &'a Self {
+        // SAFETY: The pointer is guaranteed to be valid as set_instance ensures single initialization.
+        unsafe {
+            NonNull::<Self>::with_exposed_provenance(
+                init_state().supervisor().expect("MM Supervisor Core is not initialized."),
+            )
+            .as_ref()
+        }
+    }
+
+    /// The entry point for the MM Supervisor Core.
+    ///
+    /// This function is called on all cores (BSP and APs). The BSP performs initialization
+    /// and enters the request serving loop, while APs enter the holding pen.
+    ///
+    /// On the first call (initialization phase) this function returns after init is complete.
+    /// On subsequent calls neither path returns: the BSP enters the request loop and the APs
+    /// enter the holding pen.
+    ///
+    /// ## Panics
+    ///
+    /// Panics if:
+    /// - The supervisor instance was already set
+    /// - The HOB list pointer is null
+    ///
+    /// ## Safety
+    ///
+    /// This function is unsafe because it is called from the MM entry point and assumes the environment
+    /// is properly set up. The function will perform basic sanity checks against the incoming parameters
+    /// but does not validate the entire system state.
+    pub unsafe fn entry_point(&'static self, cpu_index: usize, hob_list: *const c_void) {
+        // Get the current CPU's APIC ID
+        let cpu_id = get_current_cpu_id();
+
+        // Determine if we're BSP by checking IA32_APIC_BASE MSR
+        let is_bsp = is_bsp();
+
+        log::trace!("CPU {} (index {}) entering MM Supervisor Core (BSP: {})", cpu_id, cpu_index, is_bsp);
+        // Check if this core has already completed initialization (per-core check)
+        if is_core_initialized(cpu_index) {
+            // Subsequent entry: go directly to request loop or holding pen (does not return)
+            log::trace!(
+                "CPU {} (index {}) re-entering MM Supervisor Core, skipping initialization.",
+                cpu_id,
+                cpu_index
+            );
+            self.enter_runtime(cpu_id);
+
+            return;
+        }
+
+        let _init_guard = self.init_lock.lock();
+
+        // First entry: initialization phase
+        if is_bsp {
+            // BSP path: Initialize the supervisor
+            assert!(self.set_instance(), "MM Supervisor Core instance was already set!");
+            assert!(!hob_list.is_null(), "MM Supervisor Core requires a non-null HOB list pointer.");
+
+            log::trace!("MM Supervisor Core v{}", env!("CARGO_PKG_VERSION"));
+            log::trace!("BSP (CPU {}, index {}) starting one-time initialization...", cpu_id, cpu_index);
+
+            // Register BSP with CPU manager
+            self.cpu_manager.register_cpu(cpu_id, cpu_index, true);
+
+            // Perform BSP-only one-time initialization (this sets up MM_INITIALIZED_BUFFER)
+            self.bsp_init(hob_list);
+
+            // Dispatch to the user level entry point discovered from the HOB list (if found)
+            let user_entry = match init_state().user_entry_point() {
+                Some(entry) if entry != 0 => entry,
+                _ => {
+                    log::error!("User entry point not configured, cannot demote");
+                    return;
+                }
+            };
+
+            let cpl3_stack = match self.syscall_interface.get_cpl3_stack(cpu_index) {
+                Ok(stack) => stack,
+                Err(e) => {
+                    log::error!("Failed to get CPL3 stack for CPU {}: {:?}", cpu_index, e);
+                    return;
+                }
+            };
+
+            // SAFETY: We are transitioning from the supervisor (CPL0) to the user module (CPL3) for the first time.
+            // The entry point and stack have been validated and set up during initialization, and the user module is
+            // will be responsible for validating any further inputs.
+            let ret = unsafe {
+                invoke_demoted_routine(
+                    cpu_index,
+                    user_entry,
+                    cpl3_stack,
+                    3,
+                    UserCommandType::StartUserCore as u64,
+                    hob_list as u64,
+                    0,
+                )
+            };
+            log::trace!("Returned from user entry point with value: 0x{:016x}", ret);
+
+            // Mark BSP init as complete so APs can proceed
+            self.initialized.store(true, Ordering::Release);
+            init_state().mark_bsp_init_complete();
+
+            log::trace!("BSP one-time initialization complete.");
+        } else {
+            // AP path: Wait for BSP to complete one-time initialization
+            log::trace!("AP (CPU {}, index {}) waiting for BSP initialization...", cpu_id, cpu_index);
+
+            // Spin until BSP completes initialization
+            while !init_state().is_bsp_init_complete() {
+                core::hint::spin_loop();
+            }
+
+            // Register this AP with the CPU manager
+            self.cpu_manager.register_cpu(cpu_id, cpu_index, false);
+        }
+
+        // All cores perform per-core initialization
+        self.per_core_init(cpu_id, is_bsp);
+
+        // Mark this core as initialized in the per-core buffer
+        mark_core_initialized(cpu_index);
+
+        // Track that this core has completed per-core init
+        let init_count = init_state().inc_per_core_init_count();
+        log::trace!("CPU {} (index {}) completed per-core init ({} cores initialized)", cpu_id, cpu_index, init_count);
+
+        // BSP waits for all registered CPUs to complete per-core init before returning
+        if is_bsp {
+            let expected_cpus = self.cpu_manager.registered_count();
+            while init_state().per_core_init_count() < expected_cpus as u32 {
+                core::hint::spin_loop();
+            }
+
+            log::trace!("All {} cores completed initialization, returning to caller.", expected_cpus);
+        }
+
+        // First entry returns to caller after init is complete
+        // (Each core has already marked itself as initialized via mark_core_initialized)
+    }
+
+    /// Get the CPU manager.
+    pub fn cpu_manager(&self) -> &CpuManager<MAX_CPUS> {
+        &self.cpu_manager
+    }
+
+    /// Get the mailbox manager.
+    pub fn mailbox_manager(&self) -> &MailboxManager<MAX_CPUS, P::CpuInfo> {
+        &self.mailbox_manager
+    }
+}
+
+impl<P: PlatformInfo, const MAX_CPUS: usize> Default for MmSupervisorCore<P, MAX_CPUS> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    struct TestPlatform;
+
+    impl CpuInfo for TestPlatform {}
+
+    impl PlatformInfo for TestPlatform {
+        type CpuInfo = Self;
+    }
+
+    #[test]
+    fn test_cpu_info_defaults() {
+        assert_eq!(<TestPlatform as CpuInfo>::ap_poll_timeout_us(), 1000);
+    }
+
+    #[test]
+    fn test_supervisor_creation() {
+        let _supervisor: MmSupervisorCore<TestPlatform, 4> = MmSupervisorCore::new();
+        // Just verify it compiles and creates without panic
+    }
+
+    #[test]
+    fn test_supervisor_is_const() {
+        // Verify we can create a static instance (no heap allocation)
+        static _SUPERVISOR: MmSupervisorCore<TestPlatform, 4> = MmSupervisorCore::new();
+    }
+}

--- a/patina_mm_supervisor/src/mailbox.rs
+++ b/patina_mm_supervisor/src/mailbox.rs
@@ -1,0 +1,425 @@
+//! Mailbox Module
+//!
+//! This module provides the mailbox infrastructure for BSP-AP communication.
+//! Each AP has a dedicated mailbox that the BSP uses to send commands and receive responses.
+//!
+//! ## Architecture
+//!
+//! The mailbox system uses a simple producer-consumer model:
+//! - BSP writes commands to AP mailboxes
+//! - APs poll their mailboxes for commands
+//! - APs write responses back
+//! - BSP reads responses when ready
+//!
+//! ## Memory Model
+//!
+//! This module does not perform heap allocation. All structures use fixed-size arrays
+//! with compile-time constants provided via const generics.
+//!
+//! ## License
+//!
+//! Copyright (c) Microsoft Corporation.
+//!
+//! SPDX-License-Identifier: Apache-2.0
+//!
+
+use core::sync::atomic::{AtomicU32, AtomicU64, Ordering};
+
+use crate::{CpuInfo, perf_timer};
+
+/// Commands that can be sent from BSP to APs via the mailbox.
+///
+/// APs sit in a holding pen polling for commands. When no command is pending
+/// the AP simply keeps spinning - there is no explicit "no-op" variant.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ApCommand {
+    /// Run a procedure on the AP, with potential demotion to user mode.
+    ///
+    /// The AP checks buffer ownership and demotes to Ring 3 if the procedure
+    /// lives in user-owned memory, otherwise calls it directly in Ring 0.
+    RunProcedure {
+        /// The procedure function pointer.
+        procedure: u64,
+        /// The argument to pass to the procedure.
+        argument: u64,
+    },
+}
+
+/// Responses from APs to the BSP.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ApResponse {
+    /// No response yet (mailbox empty).
+    None,
+    /// Command executed successfully.
+    Success,
+    /// Command failed with an error code.
+    Error(u32),
+    /// AP is busy and cannot accept commands.
+    Busy,
+}
+
+impl From<ApResponse> for u64 {
+    /// Converts the response to a u64 for atomic storage.
+    fn from(response: ApResponse) -> Self {
+        match response {
+            ApResponse::None => 0,
+            ApResponse::Success => 1,
+            ApResponse::Error(code) => 2 | ((code as u64) << 32),
+            ApResponse::Busy => 3,
+        }
+    }
+}
+
+impl From<u64> for ApResponse {
+    /// Converts a u64 back to a response.
+    fn from(value: u64) -> Self {
+        let resp_type = value & 0xFF;
+        match resp_type {
+            0 => ApResponse::None,
+            1 => ApResponse::Success,
+            2 => {
+                let code = (value >> 32) as u32;
+                ApResponse::Error(code)
+            }
+            3 => ApResponse::Busy,
+            _ => ApResponse::None,
+        }
+    }
+}
+
+/// Mailbox state flags.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u32)]
+enum MailboxState {
+    /// Mailbox is empty, no pending command.
+    Empty = 0,
+    /// Mailbox has a command waiting to be processed.
+    CommandPending = 1,
+    /// Command is being processed.
+    Processing = 2,
+    /// Response is ready for BSP to read.
+    ResponseReady = 3,
+}
+
+/// A single AP's mailbox for communication with the BSP.
+#[repr(align(64))] // Cache-line aligned to avoid false sharing
+pub struct ApMailbox {
+    /// Current state of the mailbox.
+    state: AtomicU32,
+    /// The procedure function pointer (for RunProcedure).
+    procedure: AtomicU64,
+    /// The argument to pass to the procedure (for RunProcedure).
+    argument: AtomicU64,
+    /// The response data (packed into u64).
+    response: AtomicU64,
+}
+
+impl ApMailbox {
+    /// Creates a new empty mailbox.
+    pub const fn new() -> Self {
+        Self {
+            state: AtomicU32::new(MailboxState::Empty as u32),
+            procedure: AtomicU64::new(0),
+            argument: AtomicU64::new(0),
+            response: AtomicU64::new(0),
+        }
+    }
+
+    /// Gets the pending command (called by AP).
+    ///
+    /// Returns `Some(command)` if a command is pending, `None` otherwise.
+    /// This also transitions the mailbox to the Processing state.
+    pub fn take_command(&self) -> Option<ApCommand> {
+        // Try to transition from CommandPending to Processing
+        let result = self.state.compare_exchange(
+            MailboxState::CommandPending as u32,
+            MailboxState::Processing as u32,
+            Ordering::AcqRel,
+            Ordering::Acquire,
+        );
+
+        if result.is_ok() {
+            let procedure = self.procedure.load(Ordering::Acquire);
+            let argument = self.argument.load(Ordering::Acquire);
+            Some(ApCommand::RunProcedure { procedure, argument })
+        } else {
+            None
+        }
+    }
+
+    /// Posts a response (called by AP).
+    pub fn post_response(&self, response: ApResponse) {
+        self.response.store(response.into(), Ordering::Release);
+        self.state.store(MailboxState::ResponseReady as u32, Ordering::Release);
+    }
+
+    /// Sends a command to this mailbox (called by BSP).
+    ///
+    /// Returns `true` if the command was successfully posted, `false` if the mailbox is busy.
+    ///
+    /// The payload (procedure and argument) is written first with `Relaxed`
+    /// ordering, then `state` is set to `CommandPending` with `Release` ordering.
+    /// The AP acquires `state`, which guarantees it sees the fully-written payload.
+    pub fn send_command(&self, command: ApCommand) -> bool {
+        // Only allow sending if mailbox is empty
+        let result = self.state.compare_exchange(
+            MailboxState::Empty as u32,
+            MailboxState::Empty as u32, // keep Empty while we fill the payload
+            Ordering::AcqRel,
+            Ordering::Acquire,
+        );
+
+        if result.is_ok() {
+            // Write all payload fields before publishing.
+            // Relaxed is fine here — the Release store to `state` below
+            // will fence all prior writes.
+            let ApCommand::RunProcedure { procedure, argument } = command;
+            self.procedure.store(procedure, Ordering::Relaxed);
+            self.argument.store(argument, Ordering::Relaxed);
+
+            // Publish: the AP polls on `state` with Acquire, so this
+            // Release ensures it sees the payload written above.
+            self.state.store(MailboxState::CommandPending as u32, Ordering::Release);
+            true
+        } else {
+            false
+        }
+    }
+
+    /// Gets the response from this mailbox (called by BSP).
+    ///
+    /// Returns the response and clears the mailbox if a response is ready.
+    pub fn get_response(&self) -> Option<ApResponse> {
+        // Only read if response is ready
+        let result = self.state.compare_exchange(
+            MailboxState::ResponseReady as u32,
+            MailboxState::Empty as u32,
+            Ordering::AcqRel,
+            Ordering::Acquire,
+        );
+
+        if result.is_ok() {
+            let resp = self.response.load(Ordering::Acquire);
+            Some(ApResponse::from(resp))
+        } else {
+            None
+        }
+    }
+
+    /// Forcibly resets the mailbox to the [`MailboxState::Empty`] state,
+    /// discarding any pending command, in-flight processing, or unread response.
+    ///
+    pub fn reset(&self) {
+        self.procedure.store(0, Ordering::Relaxed);
+        self.argument.store(0, Ordering::Relaxed);
+        self.response.store(ApResponse::None.into(), Ordering::Relaxed);
+        self.state.store(MailboxState::Empty as u32, Ordering::Release);
+    }
+}
+
+impl Default for ApMailbox {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Manager for all AP mailboxes.
+///
+/// Uses fixed-size arrays with const generic for maximum AP count.
+///
+/// ## Const Generic Parameters
+///
+/// * `MAX_APS` - The maximum number of APs that can be managed.
+pub struct MailboxManager<const MAX_APS: usize, C: CpuInfo> {
+    /// Mailboxes - fixed size array.
+    mailboxes: [ApMailbox; MAX_APS],
+    /// Phantom data for the CpuInfo type.
+    _cpu_info: core::marker::PhantomData<fn() -> C>,
+}
+
+impl<const MAX_APS: usize, C: CpuInfo> MailboxManager<MAX_APS, C> {
+    /// Creates a new mailbox manager.
+    ///
+    /// This is a const fn and performs no heap allocation.
+    pub const fn new() -> Self {
+        Self { mailboxes: [const { ApMailbox::new() }; MAX_APS], _cpu_info: core::marker::PhantomData }
+    }
+
+    /// Sends a command to a specific AP.
+    pub fn send_command(&self, cpu_index: usize, command: ApCommand) -> Result<(), ()> {
+        let mailbox = self.mailboxes.get(cpu_index).ok_or(())?;
+        if mailbox.send_command(command) { Ok(()) } else { Err(()) }
+    }
+
+    /// Checks for a pending command (called by AP).
+    pub fn check_mailbox(&self, cpu_index: usize) -> Option<ApCommand> {
+        self.mailboxes.get(cpu_index)?.take_command()
+    }
+
+    /// Posts a response (called by AP).
+    pub fn post_response(&self, cpu_index: usize, response: ApResponse) {
+        if let Some(mailbox) = self.mailboxes.get(cpu_index) {
+            mailbox.post_response(response);
+        }
+    }
+
+    /// Resets every assigned mailbox back to the empty state.
+    ///
+    pub fn reset_all(&self) {
+        for mailbox in &self.mailboxes {
+            mailbox.reset();
+        }
+    }
+
+    /// Waits for a response from an AP with timeout.
+    ///
+    /// Returns the response, or `None` if timeout.
+    pub fn wait_response(&self, cpu_index: usize, timeout_us: u64) -> Option<ApResponse> {
+        let mailbox = self.mailboxes.get(cpu_index)?;
+        let mut result = None;
+
+        perf_timer::spin_until::<C, _>(timeout_us, || {
+            if let Some(response) = mailbox.get_response() {
+                result = Some(response);
+                true
+            } else {
+                false
+            }
+        });
+
+        result
+    }
+}
+
+impl<const MAX_APS: usize, C: CpuInfo> Default for MailboxManager<MAX_APS, C> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Minimal `CpuInfo` implementation for tests (all methods use defaults).
+    struct TestCpuInfo;
+    impl CpuInfo for TestCpuInfo {}
+
+    #[test]
+    fn test_mailbox_creation() {
+        let mailbox = ApMailbox::new();
+        // A fresh mailbox has nothing to take or read back.
+        assert_eq!(mailbox.take_command(), None);
+        assert_eq!(mailbox.get_response(), None);
+    }
+
+    #[test]
+    fn test_mailbox_is_const() {
+        // Verify we can create a static mailbox
+        static _MAILBOX: ApMailbox = ApMailbox::new();
+    }
+
+    #[test]
+    fn test_command_send_receive() {
+        let mailbox = ApMailbox::new();
+        let cmd = ApCommand::RunProcedure { procedure: 0x1234, argument: 0x5678 };
+
+        // Send a command; a second send is rejected while one is pending.
+        assert!(mailbox.send_command(cmd));
+        assert!(!mailbox.send_command(cmd));
+
+        // Take the command, then post and read back the response.
+        assert_eq!(mailbox.take_command(), Some(cmd));
+        mailbox.post_response(ApResponse::Success);
+        assert_eq!(mailbox.get_response(), Some(ApResponse::Success));
+
+        // The mailbox is empty again: a fresh command can be sent.
+        assert!(mailbox.send_command(cmd));
+    }
+
+    #[test]
+    fn test_run_procedure_command() {
+        let mailbox = ApMailbox::new();
+
+        let cmd = ApCommand::RunProcedure { procedure: 0xDEAD_BEEF, argument: 0x12345678 };
+
+        assert!(mailbox.send_command(cmd));
+        let received = mailbox.take_command();
+        assert!(matches!(received, Some(ApCommand::RunProcedure { procedure: 0xDEAD_BEEF, argument: 0x12345678 })));
+    }
+
+    #[test]
+    fn test_mailbox_manager_is_const() {
+        // Verify we can create a static manager
+        static _MANAGER: MailboxManager<8, TestCpuInfo> = MailboxManager::new();
+    }
+
+    #[test]
+    fn test_mailbox_manager() {
+        let manager: MailboxManager<4, TestCpuInfo> = MailboxManager::new();
+
+        // Send a command to the AP occupying slot index 1.
+        let command = ApCommand::RunProcedure { procedure: 0x1000, argument: 0x2000 };
+        assert!(manager.send_command(1, command).is_ok());
+
+        // Check mailbox
+        let cmd = manager.check_mailbox(1);
+        assert_eq!(cmd, Some(command));
+
+        // Post response
+        manager.post_response(1, ApResponse::Success);
+
+        // Wait for response
+        let resp = manager.wait_response(1, 1000);
+        assert_eq!(resp, Some(ApResponse::Success));
+    }
+
+    #[test]
+    fn test_mailbox_reset_forces_empty() {
+        let mailbox = ApMailbox::new();
+
+        // Put the mailbox into a stuck, non-empty state: a command was sent and
+        // picked up for processing, but no response was ever posted (hung AP).
+        assert!(mailbox.send_command(ApCommand::RunProcedure { procedure: 0x1000, argument: 7 }));
+        let _ = mailbox.take_command();
+
+        // A fresh command cannot be sent while stuck.
+        assert!(!mailbox.send_command(ApCommand::RunProcedure { procedure: 0x2000, argument: 8 }));
+
+        // Reset forces the mailbox back to empty, so a new command now succeeds.
+        mailbox.reset();
+        assert!(mailbox.send_command(ApCommand::RunProcedure { procedure: 0x2000, argument: 8 }));
+    }
+
+    #[test]
+    fn test_manager_reset_all_scrubs_every_mailbox() {
+        let manager: MailboxManager<4, TestCpuInfo> = MailboxManager::new();
+
+        // Leave two different slots' mailboxes stuck in non-empty states.
+        assert!(manager.send_command(1, ApCommand::RunProcedure { procedure: 0x10, argument: 0 }).is_ok());
+        let _ = manager.check_mailbox(1); // -> Processing
+        assert!(manager.send_command(2, ApCommand::RunProcedure { procedure: 0x20, argument: 0 }).is_ok()); // -> CommandPending
+
+        // Neither can accept a new command while stuck.
+        assert!(manager.send_command(1, ApCommand::RunProcedure { procedure: 0x11, argument: 0 }).is_err());
+        assert!(manager.send_command(2, ApCommand::RunProcedure { procedure: 0x21, argument: 0 }).is_err());
+
+        // The BSP's leave-time sweep clears every mailbox at once.
+        manager.reset_all();
+
+        // Both slots are dispatchable again.
+        assert!(manager.send_command(1, ApCommand::RunProcedure { procedure: 0x11, argument: 0 }).is_ok());
+        assert!(manager.send_command(2, ApCommand::RunProcedure { procedure: 0x21, argument: 0 }).is_ok());
+    }
+
+    #[test]
+    fn test_response_encoding() {
+        let responses = [ApResponse::None, ApResponse::Success, ApResponse::Error(42), ApResponse::Busy];
+
+        for resp in responses {
+            let encoded = u64::from(resp);
+            let decoded = ApResponse::from(encoded);
+            assert_eq!(resp, decoded);
+        }
+    }
+}

--- a/patina_mm_supervisor/src/mem.rs
+++ b/patina_mm_supervisor/src/mem.rs
@@ -1,0 +1,17 @@
+//! Memory Management
+//!
+//! This module contains the memory allocators used by the MM Supervisor Core:
+//! - [`page_allocator`] — SMRAM page-granularity allocator for general use
+//! - [`paging_allocator`] — dedicated bump allocator for page table structures
+//!
+//! ## License
+//!
+//! Copyright (c) Microsoft Corporation.
+//!
+//! SPDX-License-Identifier: Apache-2.0
+
+pub mod page_allocator;
+pub mod paging_allocator;
+
+pub use page_allocator::{AllocationType, PageAllocator};
+pub use paging_allocator::{DEFAULT_PAGING_POOL_PAGES, PagingPoolAllocator, SharedPagingAllocator};

--- a/patina_mm_supervisor/src/mem/page_allocator.rs
+++ b/patina_mm_supervisor/src/mem/page_allocator.rs
@@ -1,0 +1,956 @@
+//! MM Supervisor Core Page and Pool Allocators
+//!
+//! Provides a page-granularity memory allocator and a pool allocator for the MM Supervisor Core.
+//!
+//! ## Page Allocator
+//!
+//! When the one-time initialization routine is called, it will mark the blocks reported under
+//! `gEfiSmmSmramMemoryGuid` or `gEfiMmPeiMmramMemoryReserveGuid` in the HOB list accordingly.
+//! Blocks that have the `EFI_ALLOCATED` bit set in the `RegionState` field will be marked as allocated,
+//! indicating they are in use. All other blocks will be marked as free.
+//!
+//! The page allocator is fully dynamic:
+//! - No fixed limit on number of SMRAM regions
+//! - No fixed limit on pages per region (supports up to 4GB per region)
+//! - Bookkeeping is stored in SMRAM itself
+//!
+//! The page allocator provides:
+//! - `allocate_pages(num_pages)` - Allocate contiguous pages
+//! - `free_pages(addr, num_pages)` - Free previously allocated pages
+//!
+//! ## Pool Allocator
+//!
+//! Built on top of the page allocator, the pool allocator provides smaller-granularity allocations.
+//! It allocates pages from the page allocator and subdivides them for pool allocations.
+//! When a pool page is exhausted, more pages are allocated as needed.
+//!
+//! The pool allocator implements the `GlobalAlloc` trait for use as a global allocator.
+//!
+//! ## License
+//!
+//! Copyright (c) Microsoft Corporation.
+//!
+//! SPDX-License-Identifier: Apache-2.0
+//!
+
+use core::{
+    ffi::c_void,
+    mem::size_of,
+    ptr, slice,
+    sync::atomic::{AtomicBool, Ordering},
+};
+
+use patina::{
+    base::UEFI_PAGE_SIZE,
+    pi::hob::{Hob, PhaseHandoffInformationTable},
+    uefi_pages_to_size, uefi_size_to_pages,
+};
+use patina_paging::{MemoryAttributes, PageTable};
+use r_efi::efi;
+use spin::{Mutex, MutexGuard, relax::Spin};
+
+/// Bits per byte.
+const BITS_PER_BYTE: usize = 8;
+
+/// EFI_ALLOCATED bit in RegionState.
+pub const EFI_ALLOCATED: u64 = 0x0000000000000010;
+
+// GUID for gEfiSmmSmramMemoryGuid
+// { 0x6dadf1d1, 0xd4cc, 0x4910, { 0xbb, 0x6e, 0x82, 0xb1, 0xfd, 0x80, 0xff, 0x3d }}
+pub const SMM_SMRAM_MEMORY_GUID: patina::BinaryGuid =
+    patina::BinaryGuid::from_string("6dadf1d1-d4cc-4910-bb6e-82b1fd80ff3d");
+
+// GUID for gEfiMmPeiMmramMemoryReserveGuid
+// { 0x0703f912, 0xbf8d, 0x4e2a, { 0xbe, 0x07, 0xab, 0x27, 0x25, 0x25, 0xc5, 0x92 }}
+pub const MM_PEI_MMRAM_MEMORY_RESERVE_GUID: patina::BinaryGuid =
+    patina::BinaryGuid::from_string("0703f912-bf8d-4e2a-be07-ab272525c592");
+
+/// Errors that can occur during page allocation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PageAllocError {
+    /// The allocator has not been initialized.
+    NotInitialized,
+    /// No free pages available to satisfy the request.
+    OutOfMemory,
+    /// The requested address is not aligned to page boundary.
+    NotAligned,
+    /// The address is not within any known SMRAM region.
+    InvalidAddress,
+    /// The address was not previously allocated.
+    NotAllocated,
+}
+
+/// Type of memory allocation - distinguishes supervisor-internal vs user/driver allocations.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u8)]
+pub enum AllocationType {
+    /// Supervisor-internal allocation (e.g., for core data structures).
+    /// These are typically never freed and may have stricter protections.
+    Supervisor = 0,
+    /// User/driver allocation (e.g., for MM driver requests).
+    /// These can be allocated and freed by external code.
+    User = 1,
+}
+
+/// SMRAM descriptor structure matching EFI_SMRAM_DESCRIPTOR.
+#[repr(C)]
+#[derive(Clone, Copy, Debug)]
+pub struct SmramDescriptor {
+    /// Physical start address of the SMRAM region.
+    pub physical_start: efi::PhysicalAddress,
+    /// CPU start address (may differ from physical for remapping).
+    pub cpu_start: efi::PhysicalAddress,
+    /// Size of the SMRAM region in bytes.
+    pub physical_size: u64,
+    /// Region state flags (EFI_ALLOCATED, etc.).
+    pub region_state: u64,
+}
+
+/// SMRAM reserve descriptor count structure.
+/// This is the data that immediately follows a GuidHob with SMM_SMRAM_MEMORY_GUID
+/// or MM_PEI_MMRAM_MEMORY_RESERVE_GUID.
+#[repr(C)]
+#[derive(Clone, Copy, Debug)]
+pub struct SmramReserveHobData {
+    /// Number of SMRAM descriptors that follow.
+    pub number_of_smram_regions: u32,
+    /// Reserved for alignment.
+    pub reserved: u32,
+    // SmramDescriptor array follows immediately after
+}
+
+/// Metadata for a single SMRAM region.
+/// This struct is stored in the bookkeeping pages, not statically.
+#[repr(C)]
+#[derive(Clone, Copy, Debug)]
+pub struct RegionInfo {
+    /// Base physical address of the region.
+    pub base: u64,
+    /// Total number of pages in this region.
+    pub total_pages: usize,
+    /// Starting bit index in the global allocation bitmap.
+    pub bitmap_start_bit: usize,
+}
+
+/// Internal state for the page allocator, stored in bookkeeping pages.
+#[repr(C)]
+struct AllocatorState {
+    /// Number of regions.
+    region_count: usize,
+    /// Total number of pages across all regions.
+    total_pages: usize,
+    /// Number of pages used for bookkeeping.
+    bookkeeping_pages: usize,
+    /// Base address of bookkeeping memory.
+    bookkeeping_base: u64,
+    // Followed by:
+    // - RegionInfo array (region_count entries)
+    // - Allocation bitmap (total_pages bits, rounded up to bytes)
+    // - Type bitmap (total_pages bits, rounded up to bytes)
+}
+
+/// Raw pointer to the allocator state living in SMRAM.
+struct StatePtr(*mut AllocatorState);
+
+// SAFETY: The content lives in SMRAM for the lifetime of the program and is only
+// ever dereferenced while the enclosing `Mutex<StatePtr>` is held, which
+// serializes all access to it.
+unsafe impl Send for StatePtr {}
+
+/// A lock-held view over the allocator state.
+///
+/// Obtaining a `LockedState` requires holding the state mutex (it owns the
+/// guard), so every method is guaranteed exclusive access to the SMRAM
+/// bookkeeping. Because the region/bitmap slices borrow from `&self` / `&mut
+/// self`, the borrow checker — not convention — prevents mutable and shared
+/// views from overlapping.
+struct LockedState<'a> {
+    /// State pointer copied out of the guard. Null until the allocator is initialized.
+    state: *mut AllocatorState,
+    /// Number of SMRAM regions, cached from the header at construction (0 if uninitialized).
+    region_count: usize,
+    /// Total pages across all regions, cached from the header at construction (0 if uninitialized).
+    total_pages: usize,
+    /// Held for the lifetime of this view to keep the lock acquired.
+    _guard: MutexGuard<'a, StatePtr, Spin>,
+}
+
+impl LockedState<'_> {
+    /// Number of SMRAM regions, or 0 if the allocator is uninitialized.
+    fn region_count(&self) -> usize {
+        self.region_count
+    }
+
+    /// Total number of pages across all regions, or 0 if uninitialized.
+    fn total_pages(&self) -> usize {
+        self.total_pages
+    }
+
+    /// Region metadata array.
+    fn regions(&self) -> &[RegionInfo] {
+        if self.state.is_null() {
+            return &[];
+        }
+
+        let regions_ptr = (self.state as *const u8).wrapping_add(size_of::<AllocatorState>()) as *const RegionInfo;
+        // SAFETY: `regions_ptr` points to the `RegionInfo` array of `region_count` entries that
+        // immediately follows the header within the bookkeeping allocation; we hold the lock so
+        // no other reference is live.
+        unsafe { slice::from_raw_parts(regions_ptr, self.region_count) }
+    }
+
+    /// Mutable region metadata array.
+    fn regions_mut(&mut self) -> &mut [RegionInfo] {
+        if self.state.is_null() {
+            return &mut [];
+        }
+
+        let regions_ptr = (self.state as *mut u8).wrapping_add(size_of::<AllocatorState>()) as *mut RegionInfo;
+        // SAFETY: as `regions`, plus we hold `&mut self` and the lock, so this is the only live
+        // reference to the array.
+        unsafe { slice::from_raw_parts_mut(regions_ptr, self.region_count) }
+    }
+
+    /// Byte offset of the allocation bitmap and its length in bytes.
+    fn bitmap_offset_len(&self) -> (usize, usize) {
+        let offset = size_of::<AllocatorState>() + self.region_count * size_of::<RegionInfo>();
+        let bitmap_bytes = self.total_pages.div_ceil(BITS_PER_BYTE);
+        (offset, bitmap_bytes)
+    }
+
+    /// Allocation bitmap (1 bit per page; set == allocated).
+    fn alloc_bitmap(&self) -> &[u8] {
+        if self.state.is_null() {
+            return &[];
+        }
+        let (offset, bitmap_bytes) = self.bitmap_offset_len();
+        let ptr = (self.state as *const u8).wrapping_add(offset);
+        // SAFETY: the allocation bitmap occupies `bitmap_bytes` bytes at `offset` within the
+        // bookkeeping allocation; we hold the lock.
+        unsafe { slice::from_raw_parts(ptr, bitmap_bytes) }
+    }
+
+    /// Type bitmap (1 bit per page; set == user, clear == supervisor).
+    fn type_bitmap(&self) -> &[u8] {
+        if self.state.is_null() {
+            return &[];
+        }
+        let (offset, bitmap_bytes) = self.bitmap_offset_len();
+        let ptr = (self.state as *const u8).wrapping_add(offset + bitmap_bytes);
+        // SAFETY: the type bitmap occupies `bitmap_bytes` bytes immediately after the allocation
+        // bitmap; we hold the lock.
+        unsafe { slice::from_raw_parts(ptr, bitmap_bytes) }
+    }
+
+    /// Mutable access to both bitmaps at once, returned as `(allocation, type)`.
+    fn bitmaps_mut(&mut self) -> (&mut [u8], &mut [u8]) {
+        if self.state.is_null() {
+            return (&mut [], &mut []);
+        }
+        let (offset, bitmap_bytes) = self.bitmap_offset_len();
+        let ptr = (self.state as *mut u8).wrapping_add(offset);
+        // SAFETY: the allocation and type bitmaps are two contiguous `bitmap_bytes`-sized ranges
+        // within the bookkeeping allocation. Materialize both as one slice; we hold `&mut self`
+        // and the lock, so no other reference exists.
+        let both = unsafe { slice::from_raw_parts_mut(ptr, bitmap_bytes * 2) };
+        // Safe split into the two disjoint halves.
+        both.split_at_mut(bitmap_bytes)
+    }
+
+    /// Returns whether the page at `bit_index` is allocated.
+    fn is_bit_allocated(&self, bit_index: usize) -> bool {
+        let bitmap = self.alloc_bitmap();
+        let byte_index = bit_index / BITS_PER_BYTE;
+        let bit_offset = bit_index % BITS_PER_BYTE;
+        // Out of bounds is treated as allocated.
+        match bitmap.get(byte_index) {
+            Some(byte) => (byte & (1 << bit_offset)) != 0,
+            None => panic!(
+                "{}: bit_index {} out of bounds (total_pages = {})",
+                patina::function!(),
+                bit_index,
+                self.total_pages
+            ),
+        }
+    }
+
+    /// Returns the allocation type recorded for `bit_index`.
+    fn bit_type(&self, bit_index: usize) -> AllocationType {
+        let bitmap = self.type_bitmap();
+        let byte_index = bit_index / BITS_PER_BYTE;
+        let bit_offset = bit_index % BITS_PER_BYTE;
+        // Out of bounds (or a clear bit) is treated as supervisor-owned.
+        match bitmap.get(byte_index) {
+            None => panic!(
+                "{}: bit_index {} out of bounds (total_pages = {})",
+                patina::function!(),
+                bit_index,
+                self.total_pages
+            ),
+            Some(byte) if (byte & (1 << bit_offset)) != 0 => AllocationType::User,
+            _ => AllocationType::Supervisor,
+        }
+    }
+
+    /// Marks `bit_index` as allocated with the given type.
+    fn set_bit_allocated(&mut self, bit_index: usize, alloc_type: AllocationType) {
+        let byte_index = bit_index / BITS_PER_BYTE;
+        let bit_offset = bit_index % BITS_PER_BYTE;
+        let (alloc_bitmap, type_bitmap) = self.bitmaps_mut();
+        // The two bitmaps are the same length, so a hit in one is a hit in the other.
+        if let (Some(alloc_byte), Some(type_byte)) = (alloc_bitmap.get_mut(byte_index), type_bitmap.get_mut(byte_index))
+        {
+            *alloc_byte |= 1 << bit_offset;
+            match alloc_type {
+                AllocationType::User => *type_byte |= 1 << bit_offset,
+                AllocationType::Supervisor => *type_byte &= !(1 << bit_offset),
+            }
+        }
+    }
+
+    /// Marks `bit_index` as free.
+    fn set_bit_free(&mut self, bit_index: usize) {
+        let byte_index = bit_index / BITS_PER_BYTE;
+        let bit_offset = bit_index % BITS_PER_BYTE;
+        let (alloc_bitmap, type_bitmap) = self.bitmaps_mut();
+        if let (Some(alloc_byte), Some(type_byte)) = (alloc_bitmap.get_mut(byte_index), type_bitmap.get_mut(byte_index))
+        {
+            *alloc_byte &= !(1 << bit_offset);
+            *type_byte &= !(1 << bit_offset);
+        }
+    }
+
+    /// Finds which region contains `addr`, returning `(region_index, page_in_region)`.
+    fn find_region_for_address(&self, addr: u64) -> Option<(usize, usize)> {
+        for (i, region) in self.regions().iter().enumerate() {
+            let region_end = region.base + uefi_pages_to_size!(region.total_pages) as u64;
+            if addr >= region.base && addr < region_end {
+                let page_in_region = uefi_size_to_pages!((addr - region.base) as usize);
+                return Some((i, page_in_region));
+            }
+        }
+        None
+    }
+
+    /// Converts a region index and page-in-region to a global bit index.
+    fn region_page_to_bit(&self, region_index: usize, page_in_region: usize) -> usize {
+        self.regions().get(region_index).map_or(0, |region| region.bitmap_start_bit + page_in_region)
+    }
+
+    /// First-fit search for `num_pages` contiguous free pages, marking them
+    /// allocated with `alloc_type`. Returns the base address on success.
+    fn allocate(&mut self, num_pages: usize, alloc_type: AllocationType) -> Option<u64> {
+        let mut found: Option<(u64, usize)> = None; // (addr, first global bit)
+        'outer: for region_index in 0..self.region_count() {
+            // `RegionInfo` is `Copy`, so this releases the `regions()` borrow immediately.
+            let Some(region) = self.regions().get(region_index).copied() else {
+                continue;
+            };
+
+            // First-fit search for contiguous pages within this region.
+            let mut run_start = 0usize;
+            let mut run_length = 0usize;
+            for page_in_region in 0..region.total_pages {
+                if self.is_bit_allocated(region.bitmap_start_bit + page_in_region) {
+                    run_start = page_in_region + 1;
+                    run_length = 0;
+                } else {
+                    run_length += 1;
+                    if run_length == num_pages {
+                        let addr = region.base + uefi_pages_to_size!(run_start) as u64;
+                        found = Some((addr, region.bitmap_start_bit + run_start));
+                        break 'outer;
+                    }
+                }
+            }
+        }
+
+        let (addr, first_bit) = found?;
+        for p in 0..num_pages {
+            self.set_bit_allocated(first_bit + p, alloc_type);
+        }
+        log::trace!("Allocated {} {:?} page(s) at 0x{:016x}", num_pages, alloc_type, addr);
+        Some(addr)
+    }
+
+    /// Frees `num_pages` starting at `addr`, verifying the pages are allocated.
+    fn free(&mut self, addr: u64, num_pages: usize) -> Result<(), PageAllocError> {
+        let (region_index, page_in_region) =
+            self.find_region_for_address(addr).ok_or(PageAllocError::InvalidAddress)?;
+        let base_bit =
+            self.regions().get(region_index).ok_or(PageAllocError::InvalidAddress)?.bitmap_start_bit + page_in_region;
+
+        // Verify all pages are allocated
+        for p in 0..num_pages {
+            if !self.is_bit_allocated(base_bit + p) {
+                return Err(PageAllocError::NotAllocated);
+            }
+        }
+        // Free the pages
+        for p in 0..num_pages {
+            self.set_bit_free(base_bit + p);
+        }
+        log::trace!("Freed {} page(s) at 0x{:016x}", num_pages, addr);
+        Ok(())
+    }
+
+    /// Frees `num_pages` starting at `addr`, verifying the allocation type matches.
+    fn free_checked(
+        &mut self,
+        addr: u64,
+        num_pages: usize,
+        expected_type: AllocationType,
+    ) -> Result<(), PageAllocError> {
+        let (region_index, page_in_region) =
+            self.find_region_for_address(addr).ok_or(PageAllocError::InvalidAddress)?;
+        let base_bit =
+            self.regions().get(region_index).ok_or(PageAllocError::InvalidAddress)?.bitmap_start_bit + page_in_region;
+
+        // Verify all pages are allocated with the expected type
+        for p in 0..num_pages {
+            let bit = base_bit + p;
+            if !self.is_bit_allocated(bit) {
+                return Err(PageAllocError::NotAllocated);
+            }
+            if self.bit_type(bit) != expected_type {
+                log::warn!(
+                    "Type mismatch at 0x{:016x}: expected {:?}, got {:?}",
+                    addr + uefi_pages_to_size!(p) as u64,
+                    expected_type,
+                    self.bit_type(bit)
+                );
+                return Err(PageAllocError::InvalidAddress);
+            }
+        }
+        // Free the pages
+        for p in 0..num_pages {
+            self.set_bit_free(base_bit + p);
+        }
+        log::trace!("Freed {} {:?} page(s) at 0x{:016x}", num_pages, expected_type, addr);
+        Ok(())
+    }
+
+    /// Counts free pages across all regions.
+    fn free_page_count(&self) -> usize {
+        (0..self.total_pages()).filter(|&bit| !self.is_bit_allocated(bit)).count()
+    }
+
+    /// Counts pages allocated with the given type.
+    fn allocated_page_count(&self, alloc_type: AllocationType) -> usize {
+        (0..self.total_pages()).filter(|&bit| self.is_bit_allocated(bit) && self.bit_type(bit) == alloc_type).count()
+    }
+
+    /// Returns the allocation type for `addr`, or `None` if not allocated.
+    fn allocation_type(&self, addr: u64) -> Option<AllocationType> {
+        let (region_index, page_in_region) = self.find_region_for_address(addr)?;
+        let bit = self.region_page_to_bit(region_index, page_in_region);
+        if self.is_bit_allocated(bit) { Some(self.bit_type(bit)) } else { None }
+    }
+
+    /// Returns whether `[addr, addr + size)` lies entirely within a single region.
+    fn is_region_inside_mmram(&self, addr: u64, size: u64) -> bool {
+        self.regions().iter().any(|region| {
+            let region_end = region.base + uefi_pages_to_size!(region.total_pages) as u64;
+            addr >= region.base && (addr + size) <= region_end
+        })
+    }
+
+    /// Populates freshly-zeroed bookkeeping with per-region metadata and marks
+    /// the pre-allocated regions and the bookkeeping pages themselves as
+    /// supervisor-allocated.
+    ///
+    /// The `AllocatorState` header (including `region_count`) must already be
+    /// written so that [`regions_mut`](Self::regions_mut) exposes the full array.
+    fn initialize(&mut self, scanned: &ScannedRegions, bookkeeping_base: u64, bookkeeping_pages: usize) {
+        // Fill in per-region metadata and assign each region its bitmap range.
+        let mut bitmap_start_bit = 0usize;
+        for (region, &(base, size, _)) in self.regions_mut().iter_mut().zip(scanned.regions.iter()) {
+            let pages = uefi_size_to_pages!(size as usize);
+            region.base = base;
+            region.total_pages = pages;
+            region.bitmap_start_bit = bitmap_start_bit;
+            bitmap_start_bit += pages;
+        }
+
+        // Mark pre-allocated regions and the bookkeeping pages as allocated (supervisor).
+        for i in 0..scanned.count {
+            let Some(&(base, size, pre_allocated)) = scanned.regions.get(i) else {
+                continue;
+            };
+            let pages = uefi_size_to_pages!(size as usize);
+            let Some(start_bit) = self.regions().get(i).map(|region| region.bitmap_start_bit) else {
+                continue;
+            };
+
+            if pre_allocated {
+                // Mark the entire region as allocated.
+                for p in 0..pages {
+                    self.set_bit_allocated(start_bit + p, AllocationType::Supervisor);
+                }
+            } else if base == bookkeeping_base {
+                // Mark just the bookkeeping pages at the start of this region.
+                for p in 0..bookkeeping_pages {
+                    self.set_bit_allocated(start_bit + p, AllocationType::Supervisor);
+                }
+            }
+        }
+    }
+}
+
+/// Maximum number of SMRAM regions collected on the stack while scanning the
+/// HOB list. The authoritative region metadata is stored in SMRAM afterwards.
+const MAX_TEMP_REGIONS: usize = 256;
+
+/// SMRAM regions discovered while scanning the HOB list, before they are copied
+/// into the SMRAM bookkeeping structures.
+struct ScannedRegions {
+    /// Discovered regions as `(base, size, pre_allocated)`.
+    regions: [(u64, u64, bool); MAX_TEMP_REGIONS],
+    /// Number of valid entries in `regions`.
+    count: usize,
+    /// Total pages across all discovered regions.
+    total_pages: usize,
+    /// Base of the first non-pre-allocated region (used to host bookkeeping).
+    first_free_base: Option<u64>,
+    /// Size in bytes of the first non-pre-allocated region.
+    first_free_size: u64,
+}
+
+impl ScannedRegions {
+    /// Creates an empty scan result.
+    fn new() -> Self {
+        Self {
+            regions: [(0, 0, false); MAX_TEMP_REGIONS],
+            count: 0,
+            total_pages: 0,
+            first_free_base: None,
+            first_free_size: 0,
+        }
+    }
+
+    /// Whether the temporary storage is full.
+    fn is_full(&self) -> bool {
+        self.count >= MAX_TEMP_REGIONS
+    }
+
+    /// Records one region. Precondition: `!self.is_full()`.
+    fn push(&mut self, base: u64, size: u64, pre_allocated: bool) {
+        if let Some(slot) = self.regions.get_mut(self.count) {
+            *slot = (base, size, pre_allocated);
+        }
+        if self.first_free_base.is_none() && !pre_allocated {
+            self.first_free_base = Some(base);
+            self.first_free_size = size;
+        }
+        self.total_pages += uefi_size_to_pages!(size as usize);
+        self.count += 1;
+    }
+}
+
+/// Page-granularity allocator for SMRAM memory.
+pub struct PageAllocator {
+    /// Allocator state pointer (into SMRAM), guarded by the lock.
+    ///
+    /// Holding the mutex is the single synchronization point for all access to
+    /// the SMRAM bookkeeping.
+    state: Mutex<StatePtr>,
+    /// Whether the allocator has been initialized.
+    initialized: AtomicBool,
+}
+
+impl PageAllocator {
+    /// Creates a new uninitialized page allocator.
+    pub const fn new() -> Self {
+        Self { state: Mutex::new(StatePtr(ptr::null_mut())), initialized: AtomicBool::new(false) }
+    }
+
+    /// Calculates the number of pages needed for bookkeeping.
+    fn calculate_bookkeeping_pages(region_count: usize, total_pages: usize) -> usize {
+        let header_size = size_of::<AllocatorState>();
+        let regions_size = region_count * size_of::<RegionInfo>();
+        let bitmap_bytes = total_pages.div_ceil(BITS_PER_BYTE);
+        let total_bytes = header_size + regions_size + bitmap_bytes * 2; // alloc + type bitmaps
+        uefi_size_to_pages!(total_bytes)
+    }
+
+    /// Scans the entire HOB list and collects every SMRAM/MMRAM region reported
+    /// under the supported GUIDs into `scanned`.
+    fn scan_smram_regions(handoff: &PhaseHandoffInformationTable, scanned: &mut ScannedRegions) {
+        let hob = Hob::Handoff(handoff);
+        for current_hob in &hob {
+            if let Hob::GuidHob(guid_hob, data) = current_hob
+                && (guid_hob.name == SMM_SMRAM_MEMORY_GUID || guid_hob.name == MM_PEI_MMRAM_MEMORY_RESERVE_GUID)
+            {
+                log::info!("Found SMRAM memory HOB with GUID {}", guid_hob.name.as_guid());
+                Self::collect_smram_regions(data, scanned);
+            }
+        }
+    }
+
+    /// Parses the `SmramReserveHobData` header and trailing `SmramDescriptor`
+    /// array from a single matching GUID HOB payload, appending each region to
+    /// `scanned`.
+    fn collect_smram_regions(data: &[u8], scanned: &mut ScannedRegions) {
+        let header_size = size_of::<SmramReserveHobData>();
+        if data.len() < header_size {
+            return;
+        }
+
+        // SAFETY: `data` is at least `header_size` bytes (checked above) and, per the
+        // `init_from_hob_list` contract, begins with a suitably aligned `SmramReserveHobData`
+        // header. Materialize it once; reading its fields below is then ordinary safe access.
+        let header = unsafe { &*(data.as_ptr() as *const SmramReserveHobData) };
+
+        // Clamp the declared count to what the payload can actually hold, so the descriptor
+        // bytes below are guaranteed in-bounds even if the HOB is malformed.
+        let max_fit = (data.len() - header_size) / size_of::<SmramDescriptor>();
+        let declared = header.number_of_smram_regions as usize;
+        if declared > max_fit {
+            log::warn!("SMRAM HOB declares {} descriptors but only {} fit in the payload", declared, max_fit);
+        }
+        let count = declared.min(max_fit);
+
+        // Take the descriptor region as a safe, bounds-checked sub-slice (this is where an
+        // out-of-range offset would be caught).
+        let end = header_size + count * size_of::<SmramDescriptor>();
+        let Some(descriptor_bytes) = data.get(header_size..end) else {
+            return;
+        };
+
+        // SAFETY: `descriptor_bytes` is exactly `count` `SmramDescriptor`s' worth of in-bounds
+        // bytes, and per the `init_from_hob_list` contract the payload is suitably aligned for
+        // `SmramDescriptor`. The loop below is then fully safe slice iteration.
+        let descriptors = unsafe { slice::from_raw_parts(descriptor_bytes.as_ptr() as *const SmramDescriptor, count) };
+
+        for descriptor in descriptors {
+            if scanned.is_full() {
+                log::warn!("Too many SMRAM regions for temp storage, increase MAX_TEMP_REGIONS");
+                break;
+            }
+
+            let pre_allocated = (descriptor.region_state & EFI_ALLOCATED) != 0;
+            let pages = uefi_size_to_pages!(descriptor.physical_size as usize);
+
+            log::info!(
+                "SMRAM Region {}: base=0x{:016x}, size=0x{:x}, pages={}, state=0x{:x}, allocated={}",
+                scanned.count,
+                descriptor.physical_start,
+                descriptor.physical_size,
+                pages,
+                descriptor.region_state,
+                pre_allocated
+            );
+
+            scanned.push(descriptor.physical_start, descriptor.physical_size, pre_allocated);
+        }
+    }
+
+    /// Acquires the state lock and returns a [`LockedState`] view over the SMRAM
+    /// bookkeeping. All access to the bookkeeping goes through this so the lock
+    /// is held for the full duration of the access.
+    fn lock_state(&self) -> LockedState<'_> {
+        let guard = self.state.lock();
+        let state = guard.0;
+
+        // Cache the header-derived sizes once so the view's length accessors stay safe.
+        let (region_count, total_pages) = if state.is_null() {
+            (0, 0)
+        } else {
+            // SAFETY: when non-null, `state` is a valid initialized header and we hold the lock.
+            unsafe { ((*state).region_count, (*state).total_pages) }
+        };
+        LockedState { state, region_count, total_pages, _guard: guard }
+    }
+
+    /// Initializes the page allocator from the HOB list.
+    ///
+    /// This function:
+    /// 1. Scans HOBs to count regions and total pages
+    /// 2. Finds the first non-allocated region for bookkeeping
+    /// 3. Reserves pages for bookkeeping structures
+    /// 4. Initializes the bitmaps
+    ///
+    /// ## Safety
+    ///
+    /// The caller must ensure that `hob_list` points to a valid HOB list. Only null pointer will be rejected.
+    pub unsafe fn init_from_hob_list(&self, hob_list: *const c_void) -> Result<(), PageAllocError> {
+        if hob_list.is_null() {
+            return Err(PageAllocError::NotInitialized);
+        }
+
+        let mut guard = self.state.lock();
+
+        // SAFETY: per this function's contract, a non-null `hob_list` points to a valid HOB
+        // list whose first entry is the Phase Handoff Information Table.
+        let hob_list_info = unsafe {
+            (hob_list as *const PhaseHandoffInformationTable).as_ref().ok_or(PageAllocError::NotInitialized)?
+        };
+
+        // First pass: scan the HOB list for every SMRAM region.
+        let mut scanned = ScannedRegions::new();
+        Self::scan_smram_regions(hob_list_info, &mut scanned);
+
+        if scanned.count == 0 {
+            log::error!("No SMRAM regions found in HOB list");
+            return Err(PageAllocError::NotInitialized);
+        }
+
+        // Reserve bookkeeping space in the first free region.
+        let bookkeeping_pages = Self::calculate_bookkeeping_pages(scanned.count, scanned.total_pages);
+
+        log::info!(
+            "Allocator needs {} pages for bookkeeping ({} regions, {} total pages)",
+            bookkeeping_pages,
+            scanned.count,
+            scanned.total_pages
+        );
+
+        let bookkeeping_base = scanned.first_free_base.ok_or_else(|| {
+            log::error!("No free SMRAM region available for bookkeeping");
+            PageAllocError::OutOfMemory
+        })?;
+
+        if uefi_pages_to_size!(bookkeeping_pages) as u64 > scanned.first_free_size {
+            log::error!("First free region too small for bookkeeping");
+            return Err(PageAllocError::OutOfMemory);
+        }
+
+        log::info!("Using 0x{:016x} for bookkeeping ({} pages)", bookkeeping_base, bookkeeping_pages);
+
+        // Zero the bookkeeping region, write the state header, and publish the pointer.
+        let state_ptr = bookkeeping_base as *mut AllocatorState;
+
+        // SAFETY: `bookkeeping_base` is a page-aligned region of `bookkeeping_pages` pages that
+        // we exclusively reserved for bookkeeping and hold the lock for. Zeroing it makes both
+        // the all-zero `AllocatorState` header and the trailing bitmaps valid, and we take the
+        // sole reference to the header at its start.
+        let state = unsafe {
+            ptr::write_bytes(bookkeeping_base as *mut u8, 0, uefi_pages_to_size!(bookkeeping_pages));
+            &mut *state_ptr
+        };
+        *state = AllocatorState {
+            region_count: scanned.count,
+            total_pages: scanned.total_pages,
+            bookkeeping_pages,
+            bookkeeping_base,
+        };
+
+        *guard = StatePtr(state_ptr);
+
+        // Populate region metadata and the allocation bitmaps under the held lock, then
+        // release the lock before the stats logging below re-acquires it.
+        let mut locked = LockedState {
+            state: state_ptr,
+            region_count: scanned.count,
+            total_pages: scanned.total_pages,
+            _guard: guard,
+        };
+        locked.initialize(&scanned, bookkeeping_base, bookkeeping_pages);
+        drop(locked);
+
+        self.initialized.store(true, Ordering::Release);
+
+        // print page allocator statistics after init
+        log::info!(
+            "Page allocator initialized: {} region(s), {} total pages, {} free pages, {} allocated supervisor pages, {} allocated user pages",
+            self.region_count(),
+            self.total_page_count(),
+            self.free_page_count(),
+            self.allocated_page_count(AllocationType::Supervisor),
+            self.allocated_page_count(AllocationType::User)
+        );
+
+        Ok(())
+    }
+
+    /// Allocates contiguous pages from SMRAM for supervisor use.
+    pub fn allocate_pages(&self, num_pages: usize) -> Result<u64, PageAllocError> {
+        self.allocate_pages_with_type(num_pages, AllocationType::Supervisor)
+    }
+
+    /// Allocates contiguous pages from SMRAM with the specified allocation type.
+    ///
+    /// For `Supervisor` allocations, the allocated region is marked as supervisor-owned
+    /// data pages (R/W, non-executable) in the page table.
+    pub fn allocate_pages_with_type(
+        &self,
+        num_pages: usize,
+        alloc_type: AllocationType,
+    ) -> Result<u64, PageAllocError> {
+        if !self.is_initialized() {
+            return Err(PageAllocError::NotInitialized);
+        }
+
+        if num_pages == 0 {
+            return Err(PageAllocError::OutOfMemory);
+        }
+
+        // Reserve pages under the state lock, then release it before touching the
+        // page table (which takes its own lock).
+        let addr = self.lock_state().allocate(num_pages, alloc_type).ok_or(PageAllocError::OutOfMemory)?;
+
+        // For supervisor allocations, update page table attributes to mark as
+        // supervisor-owned data pages (R/W/NX/S), otherwise they would
+        // default to user data (R/W/NX/U).
+        self.apply_data_page_attributes(addr, num_pages, alloc_type);
+
+        Ok(addr)
+    }
+
+    /// Applies supervisor page table attributes to a newly allocated region.
+    ///
+    /// Marks pages as supervisor-owned data pages: Read/Write + Non-Executable (NX).
+    /// This ensures supervisor data cannot be executed, providing W^X enforcement.
+    ///
+    /// If the global page table is not yet initialized (e.g., during early boot),
+    /// this is a no-op with a warning.
+    fn apply_data_page_attributes(&self, addr: u64, num_pages: usize, _alloc_type: AllocationType) {
+        let size = uefi_pages_to_size!(num_pages) as u64;
+        let mut pt_guard = crate::state::security_state().lock_page_table();
+        if let Some(ref mut pt) = *pt_guard {
+            // Data pages: R/W (no ReadOnly) + NX (ExecuteProtect)
+            let mut attributes = MemoryAttributes::ExecuteProtect;
+
+            if _alloc_type == AllocationType::Supervisor {
+                // For Supervisor allocations, we additionally want the U/S bit cleared (Supervisor-only).
+                attributes |= MemoryAttributes::Supervisor; // Ensure not writable by user code
+            }
+
+            if let Err(e) = pt.map_memory_region(addr, size, attributes) {
+                log::error!(
+                    "Failed to set supervisor page attributes for 0x{:016x} ({} pages): {:?}",
+                    addr,
+                    num_pages,
+                    e
+                );
+            } else {
+                log::trace!("Marked 0x{:016x} ({} pages) as supervisor R/W+NX", addr, num_pages,);
+            }
+        } else {
+            log::warn!("Page table not initialized, skipping attribute update for 0x{:016x}", addr);
+        }
+    }
+
+    /// Applies restrictive page table attributes to freed pages.
+    ///
+    /// Marks pages as completely inaccessible: Supervisor + ReadProtect + ExecuteProtect (NX).
+    /// This prevents any read, write, or execute access to freed memory, mitigating
+    /// use-after-free vulnerabilities.
+    ///
+    /// If the global page table is not yet initialized (e.g., during early boot),
+    /// this is a no-op with a warning.
+    fn apply_freed_page_attributes(&self, addr: u64, num_pages: usize) {
+        let size = uefi_pages_to_size!(num_pages) as u64;
+        let mut pt_guard = crate::state::security_state().lock_page_table();
+        if let Some(ref mut pt) = *pt_guard {
+            // Freed pages: ReadProtect (not present) + NX (no execute) + ReadOnly (no write)
+            // This makes the pages completely inaccessible.
+            if let Err(e) = pt.unmap_memory_region(addr, size) {
+                log::error!("Failed to set freed page attributes for 0x{:016x} ({} pages): {:?}", addr, num_pages, e);
+            } else {
+                log::trace!("Marked 0x{:016x} ({} pages) as inaccessible (RP+NX+RO+S)", addr, num_pages,);
+            }
+        } else {
+            log::warn!("Page table not initialized, skipping freed page attribute update for 0x{:016x}", addr);
+        }
+    }
+
+    /// Frees previously allocated pages.
+    ///
+    /// After freeing, the pages are marked as inaccessible in the page table
+    /// (Supervisor + ReadProtect + ExecuteProtect) to prevent use-after-free.
+    pub fn free_pages(&self, addr: u64, num_pages: usize) -> Result<(), PageAllocError> {
+        if !self.is_initialized() {
+            return Err(PageAllocError::NotInitialized);
+        }
+
+        if !addr.is_multiple_of(UEFI_PAGE_SIZE as u64) {
+            return Err(PageAllocError::NotAligned);
+        }
+
+        self.lock_state().free(addr, num_pages)?;
+
+        // Mark freed pages as inaccessible in the page table.
+        self.apply_freed_page_attributes(addr, num_pages);
+
+        Ok(())
+    }
+
+    /// Frees previously allocated pages, verifying the allocation type matches.
+    ///
+    /// After freeing, the pages are marked as inaccessible in the page table
+    /// (Supervisor + ReadProtect + ExecuteProtect) to prevent use-after-free.
+    pub fn free_pages_checked(
+        &self,
+        addr: u64,
+        num_pages: usize,
+        expected_type: AllocationType,
+    ) -> Result<(), PageAllocError> {
+        if !self.is_initialized() {
+            return Err(PageAllocError::NotInitialized);
+        }
+
+        if !addr.is_multiple_of(UEFI_PAGE_SIZE as u64) {
+            return Err(PageAllocError::NotAligned);
+        }
+
+        self.lock_state().free_checked(addr, num_pages, expected_type)?;
+
+        // Mark freed pages as inaccessible in the page table.
+        self.apply_freed_page_attributes(addr, num_pages);
+
+        Ok(())
+    }
+
+    /// Returns the total number of free pages across all regions.
+    pub fn free_page_count(&self) -> usize {
+        if !self.is_initialized() {
+            return 0;
+        }
+        self.lock_state().free_page_count()
+    }
+
+    /// Returns the number of pages allocated for a specific type.
+    pub fn allocated_page_count(&self, alloc_type: AllocationType) -> usize {
+        if !self.is_initialized() {
+            return 0;
+        }
+        self.lock_state().allocated_page_count(alloc_type)
+    }
+
+    /// Returns the allocation type for a given address.
+    pub fn get_allocation_type(&self, addr: u64) -> Option<AllocationType> {
+        if !self.is_initialized() {
+            return None;
+        }
+        self.lock_state().allocation_type(addr)
+    }
+
+    /// Returns whether the allocator has been initialized.
+    pub fn is_initialized(&self) -> bool {
+        self.initialized.load(Ordering::Acquire)
+    }
+
+    /// Returns the total number of pages across all regions.
+    pub fn total_page_count(&self) -> usize {
+        if !self.is_initialized() {
+            return 0;
+        }
+        self.lock_state().total_pages()
+    }
+
+    /// Returns the number of regions.
+    pub fn region_count(&self) -> usize {
+        if !self.is_initialized() {
+            return 0;
+        }
+        self.lock_state().region_count()
+    }
+
+    pub fn is_region_inside_mmram(&self, addr: u64, size: u64) -> bool {
+        if !self.is_initialized() {
+            return false;
+        }
+        self.lock_state().is_region_inside_mmram(addr, size)
+    }
+}

--- a/patina_mm_supervisor/src/mem/paging_allocator.rs
+++ b/patina_mm_supervisor/src/mem/paging_allocator.rs
@@ -1,0 +1,336 @@
+//! Paging Page Allocator
+//!
+//! A dedicated page allocator for the paging subsystem that allocates pages for
+//! page table structures (PML4, PDPT, PD, PT entries).
+//!
+//! ## Design
+//!
+//! This allocator is separate from the generic PageAllocator for two reasons:
+//!
+//! 1. **Bootstrap problem**: The paging subsystem needs to allocate pages for page
+//!    tables, but the generic PageAllocator wants to call into paging to set page
+//!    attributes for newly allocated pages. This creates a circular dependency.
+//!
+//! 2. **Security**: Page table pages require special attributes (Supervisor, RW,
+//!    non-executable) and should be tracked separately from general allocations.
+//!
+//! ## Initialization
+//!
+//! The paging allocator is initialized with a reserved memory region from SMRAM.
+//! This region is exclusively used for page table allocations.
+//!
+//! ## Integration with Paging
+//!
+//! After the paging subsystem is fully initialized, the generic PageAllocator can
+//! optionally register a callback to apply page table attributes to newly allocated
+//! pages via the paging instance.
+//!
+//! ## License
+//!
+//! Copyright (c) Microsoft Corporation.
+//!
+//! SPDX-License-Identifier: Apache-2.0
+//!
+
+use patina::{
+    base::{UEFI_PAGE_SIZE, align_up},
+    uefi_pages_to_size, uefi_size_to_pages,
+};
+use patina_paging::{PtError, page_allocator::PageAllocator as PagingPageAllocator};
+use spin::Mutex;
+
+/// Default number of pages to reserve for page table allocations.
+/// This should be sufficient for most MM environments (128 pages = 512KB).
+pub const DEFAULT_PAGING_POOL_PAGES: usize = 128;
+
+/// Errors that can occur during paging allocator operations.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PagingAllocError {
+    /// The allocator has not been initialized.
+    NotInitialized,
+    /// Already initialized.
+    AlreadyInitialized,
+    /// No free pages available to satisfy the request.
+    OutOfMemory,
+    /// Invalid alignment requested.
+    InvalidAlignment,
+    /// The pool region is too small.
+    PoolTooSmall,
+}
+
+/// A dedicated page allocator for the paging subsystem.
+///
+/// This allocator uses a simple bump allocator from a reserved pool of pages.
+/// It implements the `patina_paging::PageAllocator` trait to be used directly
+/// by the paging crate for allocating page table structures.
+///
+/// ## Thread Safety
+///
+/// This allocator is thread-safe and can be used from multiple CPUs.
+pub struct PagingPoolAllocator {
+    /// All mutable state, guarded by a single lock that serializes every operation.
+    state: Mutex<PagingPoolState>,
+}
+
+/// Mutable state of the paging pool allocator, guarded by [`PagingPoolAllocator`]'s lock.
+struct PagingPoolState {
+    /// Base address of the pool (0 until initialized).
+    pool_base: u64,
+    /// Total number of pages in the pool.
+    pool_pages: usize,
+    /// Current allocation offset (bump pointer) in bytes.
+    current_offset: usize,
+    /// Number of pages allocated.
+    allocated_pages: usize,
+    /// Whether the allocator has been initialized.
+    initialized: bool,
+}
+
+impl PagingPoolAllocator {
+    /// Creates a new uninitialized paging page allocator.
+    pub const fn new() -> Self {
+        Self {
+            state: Mutex::new(PagingPoolState {
+                pool_base: 0,
+                pool_pages: 0,
+                current_offset: 0,
+                allocated_pages: 0,
+                initialized: false,
+            }),
+        }
+    }
+
+    /// Initializes the paging allocator with a reserved memory region.
+    ///
+    /// `pool_base` must be page-aligned.
+    ///
+    /// ## Safety
+    ///
+    /// The caller must ensure that:
+    /// - `pool_base` points to a valid memory region in SMRAM
+    /// - The region is not used by any other allocator
+    /// - The region has at least `pool_pages * UEFI_PAGE_SIZE` bytes available
+    ///
+    /// ## Errors
+    ///
+    /// Returns an error if already initialized or if parameters are invalid.
+    pub unsafe fn init(&self, pool_base: u64, pool_pages: usize) -> Result<(), PagingAllocError> {
+        let mut state = self.state.lock();
+        if state.initialized {
+            return Err(PagingAllocError::AlreadyInitialized);
+        }
+
+        if pool_base == 0 || pool_pages == 0 {
+            return Err(PagingAllocError::PoolTooSmall);
+        }
+
+        if !pool_base.is_multiple_of(UEFI_PAGE_SIZE as u64) {
+            return Err(PagingAllocError::InvalidAlignment);
+        }
+
+        // SAFETY: `init` is an `unsafe fn` whose contract (see `# Safety` above) requires the
+        // caller to provide `pool_base`/`pool_pages` describing a valid, exclusively-owned region
+        // of at least `pool_pages * UEFI_PAGE_SIZE` bytes (typically reserved SMRAM untouched by
+        // other code). `pool_base` was validated non-zero and page-aligned above to mitigate the
+        // risk of undefined behavior.
+        unsafe {
+            core::ptr::write_bytes(pool_base as *mut u8, 0, uefi_pages_to_size!(pool_pages));
+        }
+
+        *state = PagingPoolState { pool_base, pool_pages, current_offset: 0, allocated_pages: 0, initialized: true };
+
+        log::info!("Paging allocator initialized: base=0x{:016x}, pages={}", pool_base, pool_pages);
+
+        Ok(())
+    }
+
+    /// Allocates a page for page table structures.
+    ///
+    /// `align` must be a power of 2 and at least `UEFI_PAGE_SIZE`, `size` must be
+    /// at least `UEFI_PAGE_SIZE`, and `is_root` indicates whether this is a root
+    /// page table (e.g., PML4).
+    pub fn allocate_page_internal(&self, align: u64, size: u64, _is_root: bool) -> Result<u64, PagingAllocError> {
+        let mut state = self.state.lock();
+        if !state.initialized {
+            return Err(PagingAllocError::NotInitialized);
+        }
+
+        let pages_needed = uefi_size_to_pages!(size as usize);
+
+        // Calculate the aligned address
+        let current_addr = state.pool_base + state.current_offset as u64;
+        let aligned_addr = align_up(current_addr, align).map_err(|_| PagingAllocError::InvalidAlignment)?;
+        let padding = (aligned_addr - current_addr) as usize;
+        let total_bytes = padding + uefi_pages_to_size!(pages_needed);
+
+        // Check if we have enough space
+        if state.current_offset + total_bytes > uefi_pages_to_size!(state.pool_pages) {
+            log::error!(
+                "Paging allocator out of memory: need {} bytes, have {} bytes remaining",
+                total_bytes,
+                uefi_pages_to_size!(state.pool_pages) - state.current_offset
+            );
+            return Err(PagingAllocError::OutOfMemory);
+        }
+
+        // Update the bump pointer and allocation count.
+        state.current_offset += total_bytes;
+        state.allocated_pages += pages_needed;
+
+        log::trace!(
+            "Paging allocator: allocated {} page(s) at 0x{:016x} (align=0x{:x})",
+            pages_needed,
+            aligned_addr,
+            align
+        );
+
+        Ok(aligned_addr)
+    }
+
+    /// Returns whether the allocator has been initialized.
+    #[cfg(test)]
+    pub fn is_initialized(&self) -> bool {
+        self.state.lock().initialized
+    }
+
+    /// Returns the number of pages still available in the pool.
+    #[cfg(test)]
+    pub fn free_page_count(&self) -> usize {
+        let state = self.state.lock();
+        state.pool_pages.saturating_sub(state.allocated_pages)
+    }
+
+    /// Returns the number of pages allocated so far.
+    #[cfg(test)]
+    pub fn allocated_page_count(&self) -> usize {
+        self.state.lock().allocated_pages
+    }
+}
+
+impl PagingPageAllocator for PagingPoolAllocator {
+    /// Allocates a page for page table structures.
+    ///
+    /// This implements the `patina_paging::PageAllocator` trait.
+    fn allocate_page(&mut self, align: u64, size: u64, is_root: bool) -> Result<u64, PtError> {
+        self.allocate_page_internal(align, size, is_root).map_err(|e| {
+            log::error!("Paging allocator error: {:?}", e);
+            match e {
+                PagingAllocError::NotInitialized => PtError::InvalidParameter,
+                PagingAllocError::AlreadyInitialized => PtError::InvalidParameter,
+                PagingAllocError::OutOfMemory => PtError::OutOfResources,
+                PagingAllocError::InvalidAlignment => PtError::InvalidParameter,
+                PagingAllocError::PoolTooSmall => PtError::InvalidParameter,
+            }
+        })
+    }
+}
+
+/// A wrapper around [`PagingPoolAllocator`] that implements the
+/// `patina_paging::PageAllocator` trait over a shared `&'static` reference.
+pub struct SharedPagingAllocator {
+    /// The underlying allocator.
+    inner: &'static PagingPoolAllocator,
+}
+
+impl SharedPagingAllocator {
+    /// Creates a new shared paging allocator wrapper.
+    pub const fn new(allocator: &'static PagingPoolAllocator) -> Self {
+        Self { inner: allocator }
+    }
+}
+
+impl PagingPageAllocator for SharedPagingAllocator {
+    fn allocate_page(&mut self, align: u64, size: u64, is_root: bool) -> Result<u64, PtError> {
+        let allocator = self.inner;
+        allocator.allocate_page_internal(align, size, is_root).map_err(|e| {
+            log::error!("Paging allocator error: {:?}", e);
+            match e {
+                PagingAllocError::NotInitialized => PtError::InvalidParameter,
+                PagingAllocError::AlreadyInitialized => PtError::InvalidParameter,
+                PagingAllocError::OutOfMemory => PtError::OutOfResources,
+                PagingAllocError::InvalidAlignment => PtError::InvalidParameter,
+                PagingAllocError::PoolTooSmall => PtError::InvalidParameter,
+            }
+        })
+    }
+}
+
+#[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_paging_allocator_not_initialized() {
+        let allocator = PagingPoolAllocator::new();
+        assert!(!allocator.is_initialized());
+        assert_eq!(allocator.free_page_count(), 0);
+        assert_eq!(allocator.allocated_page_count(), 0);
+    }
+
+    #[test]
+    fn test_paging_allocator_init() {
+        let allocator = PagingPoolAllocator::new();
+
+        // Create a test buffer
+        let mut buffer = vec![0u8; uefi_pages_to_size!(16)];
+        let base = buffer.as_mut_ptr() as u64;
+        // Align to page boundary
+        let aligned_base = align_up(base, UEFI_PAGE_SIZE as u64).unwrap();
+
+        // SAFETY: `aligned_base` is a page-aligned pointer into `buffer`, a live 16-page heap
+        // allocation, so it covers `init`'s required 8 valid pages.
+        unsafe {
+            assert!(allocator.init(aligned_base, 8).is_ok());
+        }
+
+        assert!(allocator.is_initialized());
+        assert_eq!(allocator.free_page_count(), 8);
+        assert_eq!(allocator.allocated_page_count(), 0);
+    }
+
+    #[test]
+    fn test_paging_allocator_double_init() {
+        let allocator = PagingPoolAllocator::new();
+
+        let mut buffer = vec![0u8; uefi_pages_to_size!(16)];
+        let base = buffer.as_mut_ptr() as u64;
+        let aligned_base = align_up(base, UEFI_PAGE_SIZE as u64).unwrap();
+
+        // SAFETY: `aligned_base` is a page-aligned pointer into `buffer`, a live 16-page heap
+        // allocation, so it covers `init`'s required 8 valid pages.
+        unsafe {
+            assert!(allocator.init(aligned_base, 8).is_ok());
+            assert_eq!(allocator.init(aligned_base, 8), Err(PagingAllocError::AlreadyInitialized));
+        }
+    }
+
+    #[test]
+    fn test_paging_allocator_allocate() {
+        let allocator = PagingPoolAllocator::new();
+
+        let mut buffer = vec![0u8; uefi_pages_to_size!(32)];
+        let base = buffer.as_mut_ptr() as u64;
+        let aligned_base = align_up(base, UEFI_PAGE_SIZE as u64).unwrap();
+
+        // SAFETY: `aligned_base` is a page-aligned pointer into `buffer`, a live 32-page heap
+        // allocation, so it covers `init`'s required 16 valid pages.
+        unsafe {
+            allocator.init(aligned_base, 16).unwrap();
+        }
+
+        // Allocate a page
+        let result = allocator.allocate_page_internal(UEFI_PAGE_SIZE as u64, UEFI_PAGE_SIZE as u64, false);
+        assert!(result.is_ok());
+        let addr = result.unwrap();
+        assert_eq!(addr, aligned_base);
+        assert_eq!(allocator.allocated_page_count(), 1);
+
+        // Allocate another page
+        let result2 = allocator.allocate_page_internal(UEFI_PAGE_SIZE as u64, UEFI_PAGE_SIZE as u64, false);
+        assert!(result2.is_ok());
+        let addr2 = result2.unwrap();
+        assert_eq!(addr2, aligned_base + UEFI_PAGE_SIZE as u64);
+        assert_eq!(allocator.allocated_page_count(), 2);
+    }
+}

--- a/patina_mm_supervisor/src/mm_policy.rs
+++ b/patina_mm_supervisor/src/mm_policy.rs
@@ -1,0 +1,389 @@
+//! MM Supervisor Secure Policy
+//!
+//! This module provides a comprehensive policy management library for the MM Supervisor,
+//! including policy data structures, access validation (policy gate), and helper utilities.
+//!
+//! ## Features
+//!
+//! ### Policy Gate
+//! Initialize with a policy buffer pointer, then query whether operations are allowed:
+//! - `is_io_allowed()` - Check I/O port access
+//! - `is_msr_allowed()` - Check MSR access
+//! - `is_instruction_allowed()` - Check privileged instruction execution
+//! - `is_save_state_read_allowed()` - Check save state read access
+//!
+//! ### Helper Functions
+//! - `dump_policy()` - Print policy contents for debugging
+//! - `compare_policies()` - Compare two policies (order-independent)
+//! - `populate_memory_policy_from_page_table()` - Walk page tables to generate memory policy
+//!
+//! ## License
+//!
+//! Copyright (c) Microsoft Corporation.
+//!
+//! SPDX-License-Identifier: Apache-2.0
+
+pub(crate) mod gate;
+pub(crate) mod helpers;
+
+pub(crate) use gate::{PolicyError, PolicyGate};
+pub(crate) use helpers::{dump_policy, walk_page_table};
+
+use core::slice;
+
+/// Memory policy descriptor type.
+pub const TYPE_MEM: u32 = 1;
+/// I/O policy descriptor type.
+pub const TYPE_IO: u32 = 2;
+/// MSR policy descriptor type.
+pub const TYPE_MSR: u32 = 3;
+/// Instruction policy descriptor type.
+pub const TYPE_INSTRUCTION: u32 = 4;
+/// Save state policy descriptor type.
+pub const TYPE_SAVE_STATE: u32 = 5;
+
+/// Access attribute: Allow access to resources described by this policy root.
+pub const ACCESS_ATTR_ALLOW: u8 = 0;
+/// Access attribute: Deny access to resources described by this policy root.
+pub const ACCESS_ATTR_DENY: u8 = 1;
+
+/// Resource attribute: Read access.
+pub const RESOURCE_ATTR_READ: u32 = 0x01;
+/// Resource attribute: Write access.
+pub const RESOURCE_ATTR_WRITE: u32 = 0x02;
+/// Resource attribute: Execute access.
+pub const RESOURCE_ATTR_EXECUTE: u32 = 0x04;
+/// Resource attribute: Strict width (for I/O - must match exact width).
+pub const RESOURCE_ATTR_STRICT_WIDTH: u32 = 0x08;
+/// Resource attribute: Conditional read access.
+pub const RESOURCE_ATTR_COND_READ: u32 = 0x10;
+/// Resource attribute: Conditional write access.
+pub const RESOURCE_ATTR_COND_WRITE: u32 = 0x20;
+
+/// Privileged instruction types.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u16)]
+pub enum Instruction {
+    /// CLI - Clear Interrupt Flag
+    Cli = 0,
+    /// WBINVD - Write Back and Invalidate Cache
+    Wbinvd = 1,
+    /// HLT - Halt
+    Hlt = 2,
+}
+
+impl Instruction {
+    /// Total count of privileged instructions tracked.
+    pub const COUNT: u16 = 3;
+
+    /// Convert to instruction index.
+    pub fn as_index(self) -> u16 {
+        self as u16
+    }
+}
+
+/// Save state map fields.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u32)]
+pub enum SaveStateField {
+    /// RAX register
+    Rax = 0,
+    /// I/O trap information
+    IoTrap = 1,
+}
+
+impl SaveStateField {
+    /// Convert to field index.
+    pub fn as_index(self) -> u32 {
+        self as u32
+    }
+}
+
+/// Save state access conditions.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u32)]
+pub enum SaveStateCondition {
+    /// Unconditional access
+    Unconditional = 0,
+    /// Conditional on I/O read trap
+    IoRead = 1,
+    /// Conditional on I/O write trap
+    IoWrite = 2,
+}
+
+/// Type of access being requested.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AccessType {
+    /// Read access
+    Read,
+    /// Write access
+    Write,
+    /// Execute access (for instructions)
+    Execute,
+}
+
+impl AccessType {
+    /// Convert to resource attribute mask.
+    pub fn as_attr_mask(self) -> u32 {
+        match self {
+            AccessType::Read => RESOURCE_ATTR_READ,
+            AccessType::Write => RESOURCE_ATTR_WRITE,
+            AccessType::Execute => RESOURCE_ATTR_EXECUTE,
+        }
+    }
+}
+
+/// I/O access width.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u32)]
+pub enum IoWidth {
+    /// 8-bit (1 byte) access
+    Byte = 1,
+    /// 16-bit (2 byte) access
+    Word = 2,
+    /// 32-bit (4 byte) access
+    Dword = 4,
+}
+
+impl IoWidth {
+    /// Get the size in bytes.
+    pub fn size(self) -> u32 {
+        self as u32
+    }
+}
+
+/// Memory policy descriptor (V1.0).
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct MemDescriptorV1_0 {
+    /// Base address of memory region.
+    pub base_address: u64,
+    /// Size of memory region in bytes.
+    pub size: u64,
+    /// Memory attributes (combination of `RESOURCE_ATTR_*`).
+    pub mem_attributes: u32,
+    /// Reserved, must be 0.
+    pub reserved: u32,
+}
+
+/// I/O policy descriptor (V1.0).
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct IoDescriptorV1_0 {
+    /// Base I/O port address.
+    pub io_address: u16,
+    /// Length or width of the I/O range.
+    pub length_or_width: u16,
+    /// I/O attributes (combination of `RESOURCE_ATTR_*`).
+    pub attributes: u16,
+    /// Reserved, must be 0.
+    pub reserved: u16,
+}
+
+/// MSR policy descriptor (V1.0).
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct MsrDescriptorV1_0 {
+    /// Base MSR address.
+    pub msr_address: u32,
+    /// Length of MSR range.
+    pub length: u16,
+    /// MSR attributes (combination of `RESOURCE_ATTR_*`).
+    pub attributes: u16,
+}
+
+/// Instruction policy descriptor (V1.0).
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct InstructionDescriptorV1_0 {
+    /// Instruction index (one of `INSTRUCTION_*` constants).
+    pub instruction_index: u16,
+    /// Instruction attributes (combination of `RESOURCE_ATTR_*`).
+    pub attributes: u16,
+    /// Reserved, must be 0.
+    pub reserved: u32,
+}
+
+/// Save state policy descriptor (V1.0).
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct SaveStateDescriptorV1_0 {
+    /// Save state map field (one of `SVST_*` constants).
+    pub map_field: u32,
+    /// Save state attributes (combination of `RESOURCE_ATTR_*`).
+    pub attributes: u32,
+    /// Access condition (one of `SVST_CONDITION_*` constants).
+    pub access_condition: u32,
+    /// Reserved, must be 0.
+    pub reserved: u32,
+}
+
+/// Policy root structure (V1).
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct PolicyRootV1 {
+    /// Version of this policy root structure.
+    pub version: u32,
+    /// Size of this policy root structure in bytes.
+    pub policy_root_size: u32,
+    /// Type of descriptors (one of `TYPE_*` constants).
+    pub policy_type: u32,
+    /// Offset in bytes from policy data start to the descriptors.
+    pub offset: u32,
+    /// Number of descriptor entries.
+    pub count: u32,
+    /// Access attribute (one of `ACCESS_ATTR_*` constants).
+    pub access_attr: u8,
+    /// Reserved, must be all zeros.
+    pub reserved: [u8; 3],
+}
+
+/// Secure policy data header (V1.0).
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct SecurePolicyDataV1_0 {
+    /// Minor version (should be 0x0000).
+    pub version_minor: u16,
+    /// Major version (should be 0x0001).
+    pub version_major: u16,
+    /// Total size in bytes of the entire policy block.
+    pub size: u32,
+    /// Offset to legacy memory policy (0 if not supported).
+    pub memory_policy_offset: u32,
+    /// Count of legacy memory policy entries (0 if not supported).
+    pub memory_policy_count: u32,
+    /// Flag field indicating supervisor status.
+    pub flags: u32,
+    /// Capability field indicating features supported by supervisor.
+    pub capabilities: u32,
+    /// Reserved, must be 0.
+    pub reserved: u64,
+    /// Offset from this structure to the policy root array.
+    pub policy_root_offset: u32,
+    /// Number of policy roots.
+    pub policy_root_count: u32,
+}
+
+impl SecurePolicyDataV1_0 {
+    /// Returns true if this is a valid V1.0 policy header.
+    pub fn is_valid_version(&self) -> bool {
+        self.version_major == 1 && self.version_minor == 0
+    }
+
+    /// Gets a pointer to the policy root array.
+    ///
+    /// ## Safety
+    ///
+    /// The caller must ensure that this structure is part of a valid policy buffer.
+    pub unsafe fn get_policy_roots_ptr(&self) -> *const PolicyRootV1 {
+        let base = self as *const Self as *const u8;
+        // SAFETY: per this function's contract `self` is part of a valid policy buffer, so
+        // `policy_root_offset` stays within that buffer. This only computes a pointer (no deref).
+        unsafe { base.add(self.policy_root_offset as usize) as *const PolicyRootV1 }
+    }
+
+    /// Gets a slice of policy roots.
+    ///
+    /// ## Safety
+    ///
+    /// The caller must ensure that this structure is part of a valid policy buffer.
+    pub unsafe fn get_policy_roots(&self) -> &[PolicyRootV1] {
+        // SAFETY: per this function's contract `self` is part of a valid policy buffer, so the
+        // roots pointer and `policy_root_count` describe an in-bounds, initialized array.
+        unsafe { slice::from_raw_parts(self.get_policy_roots_ptr(), self.policy_root_count as usize) }
+    }
+}
+
+impl PolicyRootV1 {
+    /// Returns true if the reserved fields are all zeros.
+    pub fn has_valid_reserved(&self) -> bool {
+        self.reserved == [0, 0, 0]
+    }
+
+    /// Gets a pointer to the descriptors for this policy root.
+    ///
+    /// ## Safety
+    ///
+    /// The caller must ensure that `policy_base` points to a valid policy buffer.
+    pub unsafe fn get_descriptors_ptr<T>(&self, policy_base: *const u8) -> *const T {
+        // SAFETY: per this function's contract `policy_base` points to a valid policy buffer, so
+        // `offset` stays within it. This only computes a pointer (no deref).
+        unsafe { policy_base.add(self.offset as usize) as *const T }
+    }
+
+    /// Gets memory descriptors from this policy root.
+    ///
+    /// ## Safety
+    ///
+    /// The caller must ensure that `policy_base` points to a valid policy buffer.
+    pub unsafe fn get_mem_descriptors(&self, policy_base: *const u8) -> &[MemDescriptorV1_0] {
+        // SAFETY: per this function's contract `policy_base` points to a valid policy buffer, so
+        // the descriptor pointer and `count` describe an in-bounds, initialized array.
+        unsafe {
+            slice::from_raw_parts(self.get_descriptors_ptr::<MemDescriptorV1_0>(policy_base), self.count as usize)
+        }
+    }
+
+    /// Gets I/O descriptors from this policy root.
+    ///
+    /// ## Safety
+    ///
+    /// The caller must ensure that `policy_base` points to a valid policy buffer.
+    pub unsafe fn get_io_descriptors(&self, policy_base: *const u8) -> &[IoDescriptorV1_0] {
+        // SAFETY: per this function's contract `policy_base` points to a valid policy buffer, so
+        // the descriptor pointer and `count` describe an in-bounds, initialized array.
+        unsafe { slice::from_raw_parts(self.get_descriptors_ptr::<IoDescriptorV1_0>(policy_base), self.count as usize) }
+    }
+
+    /// Gets MSR descriptors from this policy root.
+    ///
+    /// ## Safety
+    ///
+    /// The caller must ensure that `policy_base` points to a valid policy buffer.
+    pub unsafe fn get_msr_descriptors(&self, policy_base: *const u8) -> &[MsrDescriptorV1_0] {
+        // SAFETY: per this function's contract `policy_base` points to a valid policy buffer, so
+        // the descriptor pointer and `count` describe an in-bounds, initialized array.
+        unsafe {
+            slice::from_raw_parts(self.get_descriptors_ptr::<MsrDescriptorV1_0>(policy_base), self.count as usize)
+        }
+    }
+
+    /// Gets instruction descriptors from this policy root.
+    ///
+    /// ## Safety
+    ///
+    /// The caller must ensure that `policy_base` points to a valid policy buffer.
+    pub unsafe fn get_instruction_descriptors(&self, policy_base: *const u8) -> &[InstructionDescriptorV1_0] {
+        // SAFETY: per this function's contract `policy_base` points to a valid policy buffer, so
+        // the descriptor pointer and `count` describe an in-bounds, initialized array.
+        unsafe {
+            slice::from_raw_parts(
+                self.get_descriptors_ptr::<InstructionDescriptorV1_0>(policy_base),
+                self.count as usize,
+            )
+        }
+    }
+
+    /// Gets save state descriptors from this policy root.
+    ///
+    /// ## Safety
+    ///
+    /// The caller must ensure that `policy_base` points to a valid policy buffer.
+    pub unsafe fn get_save_state_descriptors(&self, policy_base: *const u8) -> &[SaveStateDescriptorV1_0] {
+        // SAFETY: per this function's contract `policy_base` points to a valid policy buffer, so
+        // the descriptor pointer and `count` describe an in-bounds, initialized array.
+        unsafe {
+            slice::from_raw_parts(self.get_descriptors_ptr::<SaveStateDescriptorV1_0>(policy_base), self.count as usize)
+        }
+    }
+}
+
+const _: () = {
+    assert!(core::mem::size_of::<MemDescriptorV1_0>() == 24);
+    assert!(core::mem::size_of::<IoDescriptorV1_0>() == 8);
+    assert!(core::mem::size_of::<MsrDescriptorV1_0>() == 8);
+    assert!(core::mem::size_of::<InstructionDescriptorV1_0>() == 8);
+    assert!(core::mem::size_of::<SaveStateDescriptorV1_0>() == 16);
+    assert!(core::mem::size_of::<PolicyRootV1>() == 24);
+    assert!(core::mem::size_of::<SecurePolicyDataV1_0>() == 40);
+};

--- a/patina_mm_supervisor/src/mm_policy/gate.rs
+++ b/patina_mm_supervisor/src/mm_policy/gate.rs
@@ -1,0 +1,662 @@
+//! Policy Gate - Runtime access validation
+//!
+//! This module provides the `PolicyGate` struct that wraps a policy buffer
+//! and provides methods to check if various operations are allowed.
+//!
+//! ## License
+//!
+//! Copyright (c) Microsoft Corporation.
+//!
+//! SPDX-License-Identifier: Apache-2.0
+//!
+use super::{
+    ACCESS_ATTR_ALLOW, ACCESS_ATTR_DENY, AccessType, Instruction, IoWidth, MemDescriptorV1_0, PolicyRootV1,
+    RESOURCE_ATTR_COND_READ, RESOURCE_ATTR_EXECUTE, RESOURCE_ATTR_READ, RESOURCE_ATTR_STRICT_WIDTH, SaveStateCondition,
+    SaveStateField, SecurePolicyDataV1_0, TYPE_INSTRUCTION, TYPE_IO, TYPE_MEM, TYPE_MSR, TYPE_SAVE_STATE,
+    helpers::{IsInsideMmramFn, walk_page_table},
+};
+use spin::Once;
+
+/// Errors that can occur during policy gate operations.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PolicyError {
+    /// The policy pointer is null.
+    NullPointer,
+    /// Invalid policy version.
+    InvalidVersion,
+    /// Invalid access mask specified.
+    InvalidAccessMask,
+    /// Invalid I/O address (out of 16-bit range).
+    InvalidIoAddress,
+    /// Invalid I/O address range (overflow).
+    InvalidIoRange,
+    /// Invalid instruction index.
+    InvalidInstructionIndex,
+    /// Policy root not found for the requested type.
+    PolicyRootNotFound,
+    /// Access denied by policy.
+    AccessDenied,
+    /// Internal error during policy evaluation.
+    InternalError,
+}
+
+/// Policy gate for runtime access validation.
+///
+/// This struct wraps a policy buffer and provides methods to check if
+/// various operations (I/O, MSR, instruction, save state) are allowed.
+pub struct PolicyGate {
+    /// Pointer to the firmware policy data (static, read-only).
+    policy_ptr: *const u8,
+    /// Memory policy buffer (written by `walk_page_table` during snapshot).
+    memory_policy_buffer: *mut MemDescriptorV1_0,
+    /// Maximum number of `MemDescriptorV1_0` entries the memory policy buffer can hold.
+    memory_policy_max_count: usize,
+    /// Number of descriptors stored in the snapshot buffer.
+    ///
+    /// `None` means the ready-to-lock event has **not** occurred.
+    /// `Some(count)` means a snapshot was taken with `count` entries.
+    snapshot_count: Once<usize>,
+}
+
+// SAFETY: PolicyGate only holds pointers into stable policy/snapshot memory; the snapshot buffer
+// is written only during the single ready-to-lock event, so moving it between MM cores is
+// race-free.
+unsafe impl Send for PolicyGate {}
+// SAFETY: see the `Send` impl above.
+unsafe impl Sync for PolicyGate {}
+
+impl PolicyGate {
+    /// Creates a new policy gate from a policy buffer pointer.
+    ///
+    /// ## Safety
+    ///
+    /// The caller must ensure that `policy_ptr` points to a valid policy buffer
+    /// that remains valid for the lifetime of this PolicyGate.
+    pub unsafe fn new(policy_ptr: *const u8) -> Result<Self, PolicyError> {
+        if policy_ptr.is_null() {
+            return Err(PolicyError::NullPointer);
+        }
+
+        // SAFETY: `policy_ptr` is non-null (checked above) and, per this function's contract,
+        // points to a valid policy buffer that outlives the gate, so reborrowing the header to
+        // read its version is sound.
+        let policy = unsafe { &*(policy_ptr as *const SecurePolicyDataV1_0) };
+        if !policy.is_valid_version() {
+            return Err(PolicyError::InvalidVersion);
+        }
+
+        Ok(Self {
+            policy_ptr,
+            memory_policy_buffer: core::ptr::null_mut(),
+            memory_policy_max_count: 0,
+            snapshot_count: Once::new(),
+        })
+    }
+
+    /// Sets the memory policy buffer for page-table-derived snapshots.
+    ///
+    /// Must be called before [`take_snapshot`](Self::take_snapshot). Typically
+    /// the buffer address and size come from the PassDown HOB.
+    ///
+    /// ## Safety
+    ///
+    /// ## Safety Contract (deferred)
+    ///
+    /// The caller must ensure that `buffer` points to a valid memory region
+    /// that can hold at least `max_count` `MemDescriptorV1_0` entries and that
+    /// this memory remains valid for the lifetime of the `PolicyGate`.
+    ///
+    /// Storing the pointer is safe; the contract is enforced when the buffer
+    /// is later dereferenced by [`take_snapshot`], [`verify_snapshot`], or
+    /// [`fetch_n_update_policy`].
+    pub fn set_memory_policy_buffer(&mut self, buffer: *mut MemDescriptorV1_0, max_count: usize) {
+        self.memory_policy_buffer = buffer;
+        self.memory_policy_max_count = max_count;
+    }
+
+    /// Gets a reference to the policy header.
+    fn policy(&self) -> &SecurePolicyDataV1_0 {
+        // SAFETY: Constructor validated the pointer
+        unsafe { &*(self.policy_ptr as *const SecurePolicyDataV1_0) }
+    }
+
+    /// Finds a policy root by type.
+    fn find_policy_root(&self, policy_type: u32) -> Option<&PolicyRootV1> {
+        let policy = self.policy();
+        // SAFETY: Constructor validated the policy
+        let roots = unsafe { policy.get_policy_roots() };
+        roots.iter().find(|r| r.policy_type == policy_type)
+    }
+
+    /// Checks if I/O access is allowed.
+    ///
+    /// `io_address` must be within the 16-bit I/O port space (`<= 0xFFFF`).
+    pub fn is_io_allowed(&self, io_address: u32, width: IoWidth, access_type: AccessType) -> Result<(), PolicyError> {
+        // Validate access type (must be read or write, not execute)
+        if access_type == AccessType::Execute {
+            return Err(PolicyError::InvalidAccessMask);
+        }
+
+        let io_size = width.size();
+
+        // Validate I/O address range (16-bit port space)
+        if io_address > u16::MAX as u32 {
+            return Err(PolicyError::InvalidIoAddress);
+        }
+
+        // Check for overflow (MAX_UINT16 + 1 is valid for end address)
+        if io_address.saturating_add(io_size) > (u16::MAX as u32) + 1 {
+            return Err(PolicyError::InvalidIoRange);
+        }
+
+        let policy_root = match self.find_policy_root(TYPE_IO) {
+            Some(root) => root,
+            None => {
+                log::warn!("Could not find IO policy root, denying access to be safe.");
+                return Err(PolicyError::PolicyRootNotFound);
+            }
+        };
+
+        // SAFETY: We validated the policy in the constructor
+        let descriptors = unsafe { policy_root.get_io_descriptors(self.policy_ptr) };
+        let access_mask = access_type.as_attr_mask();
+
+        let mut found_match = false;
+
+        for desc in descriptors {
+            let desc_start = desc.io_address as u32;
+            let desc_size = desc.length_or_width as u32;
+            let is_strict_width = (desc.attributes as u32 & RESOURCE_ATTR_STRICT_WIDTH) != 0;
+
+            if is_strict_width {
+                // Strict width: address and size must match exactly
+                if io_address == desc_start && io_size == desc_size {
+                    // Check if the access type matches
+                    if (desc.attributes as u32 & access_mask) != 0 {
+                        found_match = true;
+                        break;
+                    }
+                }
+            } else {
+                // Non-strict: check if our range is covered by this descriptor
+                let desc_end = desc_start.saturating_add(desc_size);
+                let our_end = io_address.saturating_add(io_size);
+
+                if io_address >= desc_start && our_end <= desc_end {
+                    // Check if the access type matches
+                    if (desc.attributes as u32 & access_mask) != 0 {
+                        found_match = true;
+                        break;
+                    }
+                }
+            }
+        }
+
+        // Evaluate based on allow/deny list semantics
+        let allowed = if policy_root.access_attr == ACCESS_ATTR_ALLOW {
+            found_match
+        } else if policy_root.access_attr == ACCESS_ATTR_DENY {
+            !found_match
+        } else {
+            log::error!(
+                "IO access: unrecognized policy access_attr 0x{:x}; denying (fail-closed).",
+                policy_root.access_attr
+            );
+            false
+        };
+
+        if !allowed {
+            log::debug!("Rejecting IO access: port=0x{:x}, width={}, type={:?}", io_address, io_size, access_type);
+            return Err(PolicyError::AccessDenied);
+        }
+
+        Ok(())
+    }
+
+    /// Checks if MSR access is allowed.
+    pub fn is_msr_allowed(&self, msr_address: u32, access_type: AccessType) -> Result<(), PolicyError> {
+        // Validate access type
+        if access_type == AccessType::Execute {
+            return Err(PolicyError::InvalidAccessMask);
+        }
+
+        let policy_root = match self.find_policy_root(TYPE_MSR) {
+            Some(root) => root,
+            None => {
+                log::warn!("Could not find MSR policy root, denying access to be safe.");
+                return Err(PolicyError::PolicyRootNotFound);
+            }
+        };
+
+        // SAFETY: We validated the policy in the constructor
+        let descriptors = unsafe { policy_root.get_msr_descriptors(self.policy_ptr) };
+        let access_mask = access_type.as_attr_mask();
+
+        let mut found_match = false;
+
+        for desc in descriptors {
+            let desc_start = desc.msr_address;
+            let desc_end = desc_start.saturating_add(desc.length as u32);
+
+            if msr_address >= desc_start && msr_address < desc_end && (desc.attributes as u32 & access_mask) != 0 {
+                found_match = true;
+                break;
+            }
+        }
+
+        // Evaluate based on allow/deny list semantics
+        let allowed = if policy_root.access_attr == ACCESS_ATTR_ALLOW {
+            found_match
+        } else if policy_root.access_attr == ACCESS_ATTR_DENY {
+            !found_match
+        } else {
+            log::error!(
+                "MSR access: unrecognized policy access_attr 0x{:x}; denying (fail-closed).",
+                policy_root.access_attr
+            );
+            false
+        };
+
+        if !allowed {
+            log::debug!("Rejecting MSR access: address=0x{:x}, type={:?}", msr_address, access_type);
+            return Err(PolicyError::AccessDenied);
+        }
+
+        Ok(())
+    }
+
+    /// Checks if instruction execution is allowed.
+    pub fn is_instruction_allowed(&self, instruction: Instruction) -> Result<(), PolicyError> {
+        let instruction_index = instruction.as_index();
+
+        if instruction_index >= Instruction::COUNT {
+            return Err(PolicyError::InvalidInstructionIndex);
+        }
+
+        let policy_root = match self.find_policy_root(TYPE_INSTRUCTION) {
+            Some(root) => root,
+            None => {
+                log::error!("Could not find Instruction policy root, denying access to be safe.");
+                return Err(PolicyError::PolicyRootNotFound);
+            }
+        };
+
+        // SAFETY: We validated the policy in the constructor
+        let descriptors = unsafe { policy_root.get_instruction_descriptors(self.policy_ptr) };
+
+        let mut found_match = false;
+
+        for desc in descriptors {
+            if instruction_index == desc.instruction_index && (desc.attributes as u32 & RESOURCE_ATTR_EXECUTE) != 0 {
+                found_match = true;
+                break;
+            }
+        }
+
+        // Evaluate based on allow/deny list semantics
+        let allowed = if policy_root.access_attr == ACCESS_ATTR_ALLOW {
+            found_match
+        } else if policy_root.access_attr == ACCESS_ATTR_DENY {
+            !found_match
+        } else {
+            log::error!(
+                "Instruction execution: unrecognized policy access_attr 0x{:x}; denying (fail-closed).",
+                policy_root.access_attr
+            );
+            false
+        };
+
+        if !allowed {
+            log::error!("Rejecting instruction execution: {:?}", instruction);
+            return Err(PolicyError::AccessDenied);
+        }
+
+        Ok(())
+    }
+
+    /// Checks if save state read access is allowed.
+    pub fn is_save_state_read_allowed(
+        &self,
+        field: SaveStateField,
+        width: usize,
+        current_condition: Option<SaveStateCondition>,
+    ) -> Result<(), PolicyError> {
+        let policy_root = match self.find_policy_root(TYPE_SAVE_STATE) {
+            Some(root) => root,
+            None => {
+                // No save state policy = level 20, allow all reads
+                log::error!("No save state policy root found, allowing read (level 20 policy).");
+                return Ok(());
+            }
+        };
+
+        // SAFETY: We validated the policy in the constructor
+        let descriptors = unsafe { policy_root.get_save_state_descriptors(self.policy_ptr) };
+
+        let mut found_match = false;
+
+        // Only RAX / IO_TRAP have a policy field; every other register has
+        // `field == None` and therefore matches no descriptor.
+        for desc in descriptors {
+            if desc.map_field == field.as_index() {
+                // Check if this is a read-allowed policy
+                let is_read = (desc.attributes & RESOURCE_ATTR_READ) != 0;
+                let is_cond_read = (desc.attributes & RESOURCE_ATTR_COND_READ) != 0;
+
+                if is_read || is_cond_read {
+                    // Check condition if this is conditional read
+                    if is_cond_read {
+                        if let Some(current) = current_condition
+                            && desc.access_condition == current as u32
+                        {
+                            found_match = true;
+                            break;
+                        }
+                        // Condition doesn't match, continue looking
+                    } else {
+                        // Unconditional read
+                        if desc.access_condition == SaveStateCondition::Unconditional as u32 {
+                            found_match = true;
+                            break;
+                        }
+                    }
+                }
+            }
+        }
+
+        // Evaluate based on allow/deny list semantics
+        let allowed = if policy_root.access_attr == ACCESS_ATTR_ALLOW {
+            // Allow-list: access is granted only if a matching descriptor was found.
+            found_match
+        } else if policy_root.access_attr == ACCESS_ATTR_DENY {
+            // Deny-list: access is granted only if no matching descriptor was found.
+            !found_match
+        } else {
+            log::error!(
+                "Save state read: unrecognized policy access_attr 0x{:x}; denying (fail-closed).",
+                policy_root.access_attr
+            );
+            false
+        };
+
+        if !allowed {
+            log::error!("Rejecting save state read: field={:?}, width={}", field, width);
+            return Err(PolicyError::AccessDenied);
+        }
+
+        Ok(())
+    }
+
+    /// Gets the raw policy pointer.
+    pub fn as_ptr(&self) -> *const u8 {
+        self.policy_ptr
+    }
+
+    /// Returns `true` if the ready-to-lock snapshot has been taken.
+    pub fn is_locked(&self) -> bool {
+        self.snapshot_count.get().is_some()
+    }
+
+    /// Returns the snapshot descriptor count, or `None` if not yet locked.
+    pub fn snapshot_count(&self) -> Option<usize> {
+        self.snapshot_count.get().copied()
+    }
+
+    /// Returns the firmware policy blob size (from `SecurePolicyDataV1_0::size`).
+    ///
+    /// Returns `0` if the policy pointer is null (should not happen after construction).
+    pub fn firmware_policy_size(&self) -> usize {
+        self.policy().size as usize
+    }
+
+    /// Takes a page-table memory policy snapshot and transitions to the locked
+    /// state.
+    ///
+    /// Walks the active page table, writes the resulting descriptors into the
+    /// memory policy buffer, and atomically saves the descriptor count. After
+    /// this call, [`is_locked`](Self::is_locked) returns `true`.
+    ///
+    /// If the gate is already locked, the snapshot is **not** re-taken and the
+    /// existing descriptor count is returned.
+    ///
+    /// ## Safety
+    ///
+    /// * `cr3` must point to a valid, stable PML4 table.
+    /// * The memory policy buffer (set via [`set_memory_policy_buffer`])
+    ///   must still be valid and large enough.
+    pub unsafe fn take_snapshot(&self, cr3: u64, is_inside_mmram: IsInsideMmramFn) -> Result<usize, PolicyError> {
+        // Idempotent: if already locked, return the saved count.
+        if let Some(&count) = self.snapshot_count.get() {
+            return Ok(count);
+        }
+
+        if self.memory_policy_buffer.is_null() || self.memory_policy_max_count == 0 {
+            log::error!("take_snapshot: memory policy buffer not configured");
+            return Err(PolicyError::InternalError);
+        }
+
+        // SAFETY: The caller guarantees that `cr3` points to a valid PML4 and
+        // that the memory policy buffer (set via `set_memory_policy_buffer`) is
+        // valid and can hold `memory_policy_max_count` descriptors.
+        let count =
+            unsafe { walk_page_table(cr3, self.memory_policy_buffer, self.memory_policy_max_count, is_inside_mmram) }
+                .map_err(|e| {
+                log::error!("take_snapshot: walk_page_table failed: {:?}", e);
+                PolicyError::InternalError
+            })?;
+
+        self.snapshot_count.call_once(|| count);
+        log::info!("Policy snapshot taken: {} descriptors, ready-to-lock is now TRUE", count);
+        Ok(count)
+    }
+
+    /// Verifies that the current page table still matches the saved snapshot.
+    ///
+    /// The caller must provide a scratch buffer (typically allocated from the
+    /// page allocator) large enough to hold the walk results. This avoids
+    /// overwriting the saved snapshot during comparison.
+    ///
+    /// Returns `Ok(())` if the tables match, or `Err(PolicyError::AccessDenied)`
+    /// if they differ ("security violation").
+    ///
+    /// ## Safety
+    ///
+    /// * `cr3` must point to a valid, stable PML4 table.
+    /// * `scratch` must point to a buffer of at least `scratch_max_count`
+    ///   `MemDescriptorV1_0` entries.
+    pub unsafe fn verify_snapshot(
+        &self,
+        cr3: u64,
+        is_inside_mmram: IsInsideMmramFn,
+        scratch: *mut MemDescriptorV1_0,
+        scratch_max_count: usize,
+    ) -> Result<(), PolicyError> {
+        let saved_count = match self.snapshot_count.get() {
+            Some(&c) => c,
+            None => {
+                log::warn!("verify_snapshot: no snapshot available, skipping verification");
+                return Ok(());
+            }
+        };
+
+        // SAFETY: The caller guarantees that `cr3` points to a valid PML4 and
+        // that `scratch` can hold `scratch_max_count` descriptors.
+        let fresh_count =
+            unsafe { walk_page_table(cr3, scratch, scratch_max_count, is_inside_mmram) }.map_err(|e| {
+                log::error!("verify_snapshot: walk_page_table failed: {:?}", e);
+                PolicyError::InternalError
+            })?;
+
+        if fresh_count != saved_count {
+            log::error!("verify_snapshot: descriptor count mismatch (saved={}, fresh={})", saved_count, fresh_count,);
+            return Err(PolicyError::AccessDenied);
+        }
+
+        // View both buffers as slices so the comparison runs in safe code.
+        let saved_ptr = self.memory_policy_buffer as *const MemDescriptorV1_0;
+        // SAFETY: `walk_page_table` populated `scratch` with `fresh_count` descriptors; the saved
+        // snapshot buffer was populated by a prior `take_snapshot` call with `saved_count`
+        // (== `fresh_count`) entries.
+        let (saved, fresh) = unsafe {
+            (
+                core::slice::from_raw_parts(saved_ptr, saved_count),
+                core::slice::from_raw_parts(scratch as *const MemDescriptorV1_0, fresh_count),
+            )
+        };
+
+        for (i, (saved, fresh)) in saved.iter().zip(fresh.iter()).enumerate() {
+            if saved != fresh {
+                log::error!(
+                    "verify_snapshot: descriptor {} mismatch - \
+                     saved=(base=0x{:x}, size=0x{:x}, attrs=0x{:x}) vs \
+                     fresh=(base=0x{:x}, size=0x{:x}, attrs=0x{:x})",
+                    i,
+                    saved.base_address,
+                    saved.size,
+                    saved.mem_attributes,
+                    fresh.base_address,
+                    fresh.size,
+                    fresh.mem_attributes,
+                );
+                return Err(PolicyError::AccessDenied);
+            }
+        }
+
+        log::info!("verify_snapshot: page table matches saved snapshot ({} descriptors)", saved_count,);
+        Ok(())
+    }
+
+    /// Writes the merged firmware + memory policy into `dest` and returns the total
+    /// number of bytes written.
+    ///
+    /// Mirrors the C `FetchNUpdateSecurityPolicy` function. The caller is
+    /// responsible for ensuring the snapshot has been taken first (via
+    /// [`take_snapshot`](Self::take_snapshot)).
+    ///
+    /// ## Layout written to `dest`
+    ///
+    /// ```text
+    /// |--------------------------------------|
+    /// | SecurePolicyDataV1_0 + payload       |  <- firmware policy blob (copied first)
+    /// |--------------------------------------|
+    /// | MemDescriptorV1_0[0..N]              |  <- memory policy snapshot (appended)
+    /// |--------------------------------------|
+    /// ```
+    ///
+    /// After the copy the function patches the header in-place:
+    ///
+    /// * The `TYPE_MEM` policy root's `offset` → `fw_size` and `count` → snapshot count
+    /// * The header's `size` → `fw_size + mem_policy_bytes`
+    /// * The legacy `memory_policy_count` field is zeroed (unused with root-based layout)
+    ///
+    /// Note: the caller is responsible for writing/reserving any request header
+    /// *before* the region pointed to by `dest`.
+    ///
+    /// ## Safety
+    ///
+    /// * `dest` must point to a writable buffer of at least `dest_size` bytes.
+    pub unsafe fn fetch_n_update_policy(&self, dest: *mut u8, dest_size: usize) -> Result<usize, PolicyError> {
+        let count = self.snapshot_count.get().copied().ok_or_else(|| {
+            log::error!("fetch_n_update_policy: no snapshot taken");
+            PolicyError::InternalError
+        })?;
+
+        let desc_size = core::mem::size_of::<MemDescriptorV1_0>();
+        let mem_policy_bytes = count.checked_mul(desc_size).ok_or_else(|| {
+            log::error!("fetch_n_update_policy: descriptor count overflow");
+            PolicyError::InternalError
+        })?;
+
+        let fw_size = self.firmware_policy_size();
+        if fw_size == 0 {
+            log::error!("fetch_n_update_policy: firmware policy size is 0");
+            return Err(PolicyError::InternalError);
+        }
+
+        let total_bytes = fw_size.checked_add(mem_policy_bytes).ok_or_else(|| {
+            log::error!("fetch_n_update_policy: total size overflow");
+            PolicyError::InternalError
+        })?;
+
+        if dest_size < total_bytes {
+            log::error!("fetch_n_update_policy: buffer too small ({} bytes, need {})", dest_size, total_bytes,);
+            return Err(PolicyError::InternalError);
+        }
+
+        // 1. Copy the firmware policy blob (header + payload), then append the
+        //    memory policy descriptors after it.
+        //
+        // SAFETY: The caller guarantees that `dest` is writable for at least
+        // `dest_size` bytes (verified >= `total_bytes` above). `self.policy_ptr`
+        // points to a valid firmware policy blob of `fw_size` bytes (validated at
+        // construction). The memory policy buffer holds `count` valid descriptors
+        // from a prior `take_snapshot` call.
+        unsafe {
+            core::ptr::copy_nonoverlapping(self.policy_ptr, dest, fw_size);
+            if mem_policy_bytes > 0 {
+                let src = self.memory_policy_buffer as *const u8;
+                core::ptr::copy_nonoverlapping(src, dest.add(fw_size), mem_policy_bytes);
+            }
+        }
+
+        // 2. Read the root table location from the freshly-copied header.
+        let (root_offset, root_count) = {
+            // SAFETY: `dest` now holds a valid `SecurePolicyDataV1_0` header copied from the
+            // validated firmware policy blob above.
+            let header = unsafe { &*(dest as *const SecurePolicyDataV1_0) };
+            (header.policy_root_offset as usize, header.policy_root_count as usize)
+        };
+
+        // 3. View the policy roots as a slice so the lookup/patch can be done in
+        //    safe code.
+        //
+        // SAFETY: The header reports `root_count` `PolicyRootV1` entries at
+        // `root_offset`, all within the `total_bytes` region copied above.
+        let roots = unsafe { core::slice::from_raw_parts_mut(dest.add(root_offset) as *mut PolicyRootV1, root_count) };
+
+        // Find the TYPE_MEM policy root and patch its offset/count.
+        let Some(mem_root) = roots.iter_mut().find(|r| r.policy_type == TYPE_MEM) else {
+            log::error!("fetch_n_update_policy: firmware policy has no TYPE_MEM policy root");
+            return Err(PolicyError::PolicyRootNotFound);
+        };
+        mem_root.access_attr = ACCESS_ATTR_ALLOW;
+        mem_root.offset = fw_size as u32;
+        mem_root.count = count as u32;
+
+        // 4. Update the total size and clear the legacy memory_policy_count.
+        //
+        // SAFETY: `dest` holds a valid `SecurePolicyDataV1_0` header (see above).
+        let header = unsafe { &mut *(dest as *mut SecurePolicyDataV1_0) };
+        header.size = total_bytes as u32;
+        header.memory_policy_count = 0;
+
+        log::info!(
+            "fetch_n_update_policy: wrote {} bytes (fw_policy={}, mem_policy={} ({} descs))",
+            total_bytes,
+            fw_size,
+            mem_policy_bytes,
+            count,
+        );
+        Ok(total_bytes)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_io_width() {
+        assert_eq!(IoWidth::Byte.size(), 1);
+        assert_eq!(IoWidth::Word.size(), 2);
+        assert_eq!(IoWidth::Dword.size(), 4);
+    }
+
+    #[test]
+    fn test_instruction_conversion() {
+        assert_eq!(Instruction::Cli.as_index(), 0);
+        assert_eq!(Instruction::Wbinvd.as_index(), 1);
+        assert_eq!(Instruction::Hlt.as_index(), 2);
+        assert_eq!(Instruction::COUNT, 3);
+    }
+}

--- a/patina_mm_supervisor/src/mm_policy/helpers.rs
+++ b/patina_mm_supervisor/src/mm_policy/helpers.rs
@@ -1,0 +1,636 @@
+//! Policy Helper Functions
+//!
+//! This module provides utility functions for policy manipulation:
+//! - Dump/print policy for debugging
+//! - Compare two policies (order-independent)
+//! - Page table walking to generate memory policy
+//!
+//! ## License
+//!
+//! Copyright (c) Microsoft Corporation.
+//!
+//! SPDX-License-Identifier: Apache-2.0
+//!
+use super::{
+    ACCESS_ATTR_ALLOW, InstructionDescriptorV1_0, IoDescriptorV1_0, MemDescriptorV1_0, MsrDescriptorV1_0, PolicyRootV1,
+    RESOURCE_ATTR_COND_READ, RESOURCE_ATTR_COND_WRITE, RESOURCE_ATTR_EXECUTE, RESOURCE_ATTR_READ, RESOURCE_ATTR_WRITE,
+    SaveStateCondition, SaveStateDescriptorV1_0, SecurePolicyDataV1_0, TYPE_INSTRUCTION, TYPE_IO, TYPE_MEM, TYPE_MSR,
+    TYPE_SAVE_STATE,
+};
+use core::mem::size_of;
+
+use patina_paging::{MemoryAttributes, PagingType, x64::X64PageTable};
+
+use crate::{SharedPagingAllocator, state::security_state};
+
+/// Dumps a single memory policy entry for debugging.
+pub fn dump_mem_policy_entry(desc: &MemDescriptorV1_0) {
+    let r = if (desc.mem_attributes & RESOURCE_ATTR_READ) != 0 { "R" } else { "." };
+    let w = if (desc.mem_attributes & RESOURCE_ATTR_WRITE) != 0 { "W" } else { "." };
+    let x = if (desc.mem_attributes & RESOURCE_ATTR_EXECUTE) != 0 { "X" } else { "." };
+
+    log::info!(
+        "  MEM: [0x{:016x}-0x{:016x}] {}{}{}",
+        desc.base_address,
+        desc.base_address.saturating_add(desc.size).saturating_sub(1),
+        r,
+        w,
+        x
+    );
+}
+
+/// Dumps policy data for debugging (like `DumpSmmPolicyData`).
+///
+/// ## Safety
+///
+/// The caller must ensure that `policy_ptr` points to a valid policy buffer.
+pub unsafe fn dump_policy(policy_ptr: *const u8) {
+    if policy_ptr.is_null() {
+        log::error!("dump_policy: null pointer");
+        return;
+    }
+
+    // SAFETY: `policy_ptr` is non-null (checked above) and, per this function's contract, points
+    // to a valid policy buffer, so the header can be reborrowed for reading.
+    let policy = unsafe { &*(policy_ptr as *const SecurePolicyDataV1_0) };
+
+    let len = policy.size as usize;
+    if len < size_of::<SecurePolicyDataV1_0>() {
+        log::error!("dump_policy: invalid policy size: 0x{:x}", len);
+        return;
+    }
+
+    log::info!("SMM_SUPV_SECURE_POLICY_DATA_V1_0:");
+    log::info!("  Version: {}.{}", policy.version_major, policy.version_minor);
+    log::info!("  Size: 0x{:x}", policy.size);
+    log::info!("  MemoryPolicyOffset: 0x{:x}", policy.memory_policy_offset);
+    log::info!("  MemoryPolicyCount: 0x{:x}", policy.memory_policy_count);
+    log::info!("  Flags: 0x{:x}", policy.flags);
+    log::info!("  Capabilities: 0x{:x}", policy.capabilities);
+    log::info!("  PolicyRootOffset: 0x{:x}", policy.policy_root_offset);
+    log::info!("  PolicyRootCount: 0x{:x}", policy.policy_root_count);
+
+    // SAFETY: `policy` is the validated header of a valid policy buffer, so its policy-root array
+    // (root pointer + count) is in-bounds.
+    let policy_roots = unsafe { policy.get_policy_roots() };
+
+    for (i, root) in policy_roots.iter().enumerate() {
+        log::info!("Policy Root {}:", i);
+        log::info!("  Version: {}", root.version);
+        log::info!("  PolicyRootSize: {}", root.policy_root_size);
+        log::info!("  Type: {}", root.policy_type);
+        log::info!("  Offset: 0x{:x}", root.offset);
+        log::info!("  Count: {}", root.count);
+        log::info!("  AccessAttr: {}", if root.access_attr == ACCESS_ATTR_ALLOW { "ALLOW" } else { "DENY" });
+
+        match root.policy_type {
+            TYPE_MEM => {
+                if root.offset as usize + root.count as usize * size_of::<MemDescriptorV1_0>() > len {
+                    panic!(
+                        "  Policy root {} out of bounds (offset=0x{:x}, count={}, total_size=0x{:x})",
+                        i, root.offset, root.count, len
+                    );
+                }
+                // SAFETY: `root` came from the validated policy buffer and `policy_ptr` points to
+                // that same buffer, so the descriptor array is in-bounds.
+                let descriptors = unsafe { root.get_mem_descriptors(policy_ptr) };
+                for desc in descriptors {
+                    dump_mem_policy_entry(desc);
+                }
+            }
+            TYPE_IO => {
+                if root.offset as usize + root.count as usize * size_of::<IoDescriptorV1_0>() > len {
+                    panic!(
+                        "  Policy root {} out of bounds (offset=0x{:x}, count={}, total_size=0x{:x})",
+                        i, root.offset, root.count, len
+                    );
+                }
+                // SAFETY: `root` came from the validated policy buffer and `policy_ptr` points to
+                // that same buffer, so the descriptor array is in-bounds.
+                let descriptors = unsafe { root.get_io_descriptors(policy_ptr) };
+                for desc in descriptors {
+                    let r = if (desc.attributes as u32 & RESOURCE_ATTR_READ) != 0 { "R" } else { "." };
+                    let w = if (desc.attributes as u32 & RESOURCE_ATTR_WRITE) != 0 { "W" } else { "." };
+                    log::info!(
+                        "  IO: [0x{:04x}-0x{:04x}] {}{}",
+                        desc.io_address,
+                        (desc.io_address as u32).saturating_add(desc.length_or_width as u32).saturating_sub(1),
+                        r,
+                        w
+                    );
+                }
+            }
+            TYPE_MSR => {
+                if root.offset as usize + root.count as usize * size_of::<MsrDescriptorV1_0>() > len {
+                    panic!(
+                        "  Policy root {} out of bounds (offset=0x{:x}, count={}, total_size=0x{:x})",
+                        i, root.offset, root.count, len
+                    );
+                }
+                // SAFETY: `root` came from the validated policy buffer and `policy_ptr` points to
+                // that same buffer, so the descriptor array is in-bounds.
+                let descriptors = unsafe { root.get_msr_descriptors(policy_ptr) };
+                for desc in descriptors {
+                    let r = if (desc.attributes as u32 & RESOURCE_ATTR_READ) != 0 { "R" } else { "." };
+                    let w = if (desc.attributes as u32 & RESOURCE_ATTR_WRITE) != 0 { "W" } else { "." };
+                    log::info!(
+                        "  MSR: [0x{:08x}-0x{:08x}] {}{}",
+                        desc.msr_address,
+                        desc.msr_address.saturating_add(desc.length as u32).saturating_sub(1),
+                        r,
+                        w
+                    );
+                }
+            }
+            TYPE_INSTRUCTION => {
+                if root.offset as usize + root.count as usize * size_of::<InstructionDescriptorV1_0>() > len {
+                    panic!(
+                        "  Policy root {} out of bounds (offset=0x{:x}, count={}, total_size=0x{:x})",
+                        i, root.offset, root.count, len
+                    );
+                }
+                // SAFETY: `root` came from the validated policy buffer and `policy_ptr` points to
+                // that same buffer, so the descriptor array is in-bounds.
+                let descriptors = unsafe { root.get_instruction_descriptors(policy_ptr) };
+                for desc in descriptors {
+                    let name = match desc.instruction_index {
+                        0 => "CLI",
+                        1 => "WBINVD",
+                        2 => "HLT",
+                        _ => "UNKNOWN",
+                    };
+                    let x = if (desc.attributes as u32 & RESOURCE_ATTR_EXECUTE) != 0 { "X" } else { "." };
+                    log::info!("  INSTRUCTION: {} {}", name, x);
+                }
+            }
+            TYPE_SAVE_STATE => {
+                if root.offset as usize + root.count as usize * size_of::<SaveStateDescriptorV1_0>() > len {
+                    panic!(
+                        "  Policy root {} out of bounds (offset=0x{:x}, count={}, total_size=0x{:x})",
+                        i, root.offset, root.count, len
+                    );
+                }
+                // SAFETY: `root` came from the validated policy buffer and `policy_ptr` points to
+                // that same buffer, so the descriptor array is in-bounds.
+                let descriptors = unsafe { root.get_save_state_descriptors(policy_ptr) };
+                for desc in descriptors {
+                    let field = match desc.map_field {
+                        0 => "RAX",
+                        1 => "IO_TRAP",
+                        _ => "UNKNOWN",
+                    };
+                    let condition = match desc.access_condition {
+                        0 => "Unconditional",
+                        1 => "IoRead",
+                        2 => "IoWrite",
+                        _ => "Unknown",
+                    };
+                    log::info!("  SAVESTATE: {} attr=0x{:x} cond={}", field, desc.attributes, condition);
+                }
+            }
+            _ => {
+                log::error!("  Unknown policy type: {}", root.policy_type);
+            }
+        }
+    }
+}
+
+/// Errors that can occur during policy validation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PolicyCheckError {
+    /// The policy pointer is null.
+    NullPointer,
+    /// Invalid policy version.
+    InvalidVersion { major: u16, minor: u16 },
+    /// A reserved field contains non-zero data.
+    InvalidReservedField { policy_type: u32, entry_index: usize },
+    /// The same policy type appears multiple times.
+    DuplicatePolicyType { policy_type: u32 },
+    /// Size mismatch.
+    SizeMismatch { expected: usize, declared: usize },
+    /// Unrecognized policy type.
+    UnrecognizedPolicyType { policy_type: u32 },
+    /// Unrecognized header bits.
+    UnrecognizedHeaderBits,
+    /// Unsupported attribute.
+    UnsupportedAttribute { policy_type: u32, entry_index: usize, attributes: u32 },
+    /// Conflicting condition.
+    ConflictingCondition { entry_index: usize },
+    /// Legacy memory policy detected.
+    LegacyMemoryPolicyDetected,
+}
+
+/// Performs comprehensive security policy validation.
+///
+/// ## Safety
+///
+/// The caller must ensure that `policy_ptr` points to a valid policy buffer.
+pub unsafe fn security_policy_check(policy_ptr: *const u8) -> Result<(), PolicyCheckError> {
+    if policy_ptr.is_null() {
+        return Err(PolicyCheckError::NullPointer);
+    }
+
+    // SAFETY: `policy_ptr` is non-null (checked above) and, per this function's contract, points
+    // to a valid policy buffer, so the header can be reborrowed for reading.
+    let policy = unsafe { &*(policy_ptr as *const SecurePolicyDataV1_0) };
+
+    let len = policy.size as usize;
+    if len < size_of::<SecurePolicyDataV1_0>() {
+        log::error!("security_policy_check: invalid policy size: 0x{:x}", len);
+        return Err(PolicyCheckError::SizeMismatch { expected: size_of::<SecurePolicyDataV1_0>(), declared: len });
+    }
+
+    log::info!("Security policy check entry...");
+
+    // Version check
+    if !policy.is_valid_version() {
+        return Err(PolicyCheckError::InvalidVersion { major: policy.version_major, minor: policy.version_minor });
+    }
+
+    // Check for unrecognized header bits
+    if policy.reserved != 0 || policy.flags != 0 || policy.capabilities != 0 {
+        return Err(PolicyCheckError::UnrecognizedHeaderBits);
+    }
+
+    let mut total_scanned_size = size_of::<SecurePolicyDataV1_0>();
+    let mut type_flags: u64 = 0;
+
+    // SAFETY: `policy` is the validated header of a valid policy buffer, so its policy-root array
+    // (root pointer + count) is in-bounds.
+    let policy_roots = unsafe { policy.get_policy_roots() };
+
+    for root in policy_roots.iter() {
+        let type_bit = 1u64 << root.policy_type;
+
+        if (type_flags & type_bit) != 0 {
+            return Err(PolicyCheckError::DuplicatePolicyType { policy_type: root.policy_type });
+        }
+        type_flags |= type_bit;
+
+        if !root.has_valid_reserved() {
+            return Err(PolicyCheckError::InvalidReservedField { policy_type: root.policy_type, entry_index: 0 });
+        }
+
+        match root.policy_type {
+            TYPE_IO => {
+                if root.offset as usize + root.count as usize * size_of::<IoDescriptorV1_0>() > len {
+                    panic!(
+                        "  Policy root {} out of bounds (offset=0x{:x}, count={}, total_size=0x{:x})",
+                        root.policy_type, root.offset, root.count, len
+                    );
+                }
+                // SAFETY: `policy_ptr` is a valid policy buffer (contract) and `root` was read from
+                // it, so the descriptors it references are in-bounds.
+                unsafe { validate_io_policy(policy_ptr, root)? };
+                total_scanned_size += (root.count as usize) * size_of::<IoDescriptorV1_0>();
+            }
+            TYPE_MEM => {
+                if root.offset as usize + root.count as usize * size_of::<MemDescriptorV1_0>() > len {
+                    panic!(
+                        "  Policy root {} out of bounds (offset=0x{:x}, count={}, total_size=0x{:x})",
+                        root.policy_type, root.offset, root.count, len
+                    );
+                }
+                // SAFETY: as above; `policy_ptr`/`root` describe an in-bounds descriptor array.
+                unsafe { validate_mem_policy(policy_ptr, root)? };
+                total_scanned_size += (root.count as usize) * size_of::<MemDescriptorV1_0>();
+            }
+            TYPE_MSR => {
+                if root.offset as usize + root.count as usize * size_of::<MsrDescriptorV1_0>() > len {
+                    panic!(
+                        "  Policy root {} out of bounds (offset=0x{:x}, count={}, total_size=0x{:x})",
+                        root.policy_type, root.offset, root.count, len
+                    );
+                }
+                // SAFETY: as above; `policy_ptr`/`root` describe an in-bounds descriptor array.
+                unsafe { validate_msr_policy(policy_ptr, root)? };
+                total_scanned_size += (root.count as usize) * size_of::<MsrDescriptorV1_0>();
+            }
+            TYPE_INSTRUCTION => {
+                if root.offset as usize + root.count as usize * size_of::<InstructionDescriptorV1_0>() > len {
+                    panic!(
+                        "  Policy root {} out of bounds (offset=0x{:x}, count={}, total_size=0x{:x})",
+                        root.policy_type, root.offset, root.count, len
+                    );
+                }
+                // SAFETY: as above; `policy_ptr`/`root` describe an in-bounds descriptor array.
+                unsafe { validate_instruction_policy(policy_ptr, root)? };
+                total_scanned_size += (root.count as usize) * size_of::<InstructionDescriptorV1_0>();
+            }
+            TYPE_SAVE_STATE => {
+                if root.offset as usize + root.count as usize * size_of::<SaveStateDescriptorV1_0>() > len {
+                    panic!(
+                        "  Policy root {} out of bounds (offset=0x{:x}, count={}, total_size=0x{:x})",
+                        root.policy_type, root.offset, root.count, len
+                    );
+                }
+                // SAFETY: as above; `policy_ptr`/`root` describe an in-bounds descriptor array.
+                unsafe { validate_save_state_policy(policy_ptr, root)? };
+                total_scanned_size += (root.count as usize) * size_of::<SaveStateDescriptorV1_0>();
+            }
+            _ => {
+                return Err(PolicyCheckError::UnrecognizedPolicyType { policy_type: root.policy_type });
+            }
+        }
+
+        total_scanned_size += size_of::<PolicyRootV1>();
+    }
+
+    if policy.memory_policy_count != 0 {
+        return Err(PolicyCheckError::LegacyMemoryPolicyDetected);
+    }
+
+    if total_scanned_size != policy.size as usize {
+        return Err(PolicyCheckError::SizeMismatch { expected: total_scanned_size, declared: policy.size as usize });
+    }
+
+    log::info!("Security policy check passed.");
+    Ok(())
+}
+
+// Validation helper functions
+
+/// Validates the I/O policy descriptors referenced by `root`.
+///
+/// ## Safety
+///
+/// The caller must ensure that `policy_base` points to a valid policy buffer
+/// and that `root` is a policy root from that same buffer, so its descriptor
+/// offset and count describe an in-bounds, properly aligned descriptor array.
+unsafe fn validate_io_policy(policy_base: *const u8, root: &PolicyRootV1) -> Result<(), PolicyCheckError> {
+    // SAFETY: The caller guarantees `policy_base` is a valid policy buffer and
+    // that `root` belongs to it, so the descriptor slice is in bounds.
+    let descriptors = unsafe { root.get_io_descriptors(policy_base) };
+
+    for (i, desc) in descriptors.iter().enumerate() {
+        if desc.reserved != 0 {
+            return Err(PolicyCheckError::InvalidReservedField { policy_type: TYPE_IO, entry_index: i });
+        }
+    }
+    Ok(())
+}
+
+/// Validates the memory policy descriptors referenced by `root`.
+///
+/// ## Safety
+///
+/// The caller must ensure that `policy_base` points to a valid policy buffer
+/// and that `root` is a policy root from that same buffer, so its descriptor
+/// offset and count describe an in-bounds, properly aligned descriptor array.
+unsafe fn validate_mem_policy(policy_base: *const u8, root: &PolicyRootV1) -> Result<(), PolicyCheckError> {
+    // SAFETY: The caller guarantees `policy_base` is a valid policy buffer and
+    // that `root` belongs to it, so the descriptor slice is in bounds.
+    let descriptors = unsafe { root.get_mem_descriptors(policy_base) };
+
+    for (i, desc) in descriptors.iter().enumerate() {
+        if desc.reserved != 0 {
+            return Err(PolicyCheckError::InvalidReservedField { policy_type: TYPE_MEM, entry_index: i });
+        }
+    }
+    Ok(())
+}
+
+/// Validates the MSR policy descriptors referenced by `root`.
+///
+/// ## Safety
+///
+/// The caller must ensure that `policy_base` points to a valid policy buffer.
+/// But MSR descriptors don't have reserved fields, so we don't need to validate
+/// any offsets/counts here.
+unsafe fn validate_msr_policy(_policy_base: *const u8, _root: &PolicyRootV1) -> Result<(), PolicyCheckError> {
+    // MSR descriptors don't have reserved fields
+    Ok(())
+}
+
+/// Validates the instruction policy descriptors referenced by `root`.
+///
+/// ## Safety
+///
+/// The caller must ensure that `policy_base` points to a valid policy buffer
+/// and that `root` is a policy root from that same buffer, so its descriptor
+/// offset and count describe an in-bounds, properly aligned descriptor array.
+unsafe fn validate_instruction_policy(policy_base: *const u8, root: &PolicyRootV1) -> Result<(), PolicyCheckError> {
+    // SAFETY: The caller guarantees `policy_base` is a valid policy buffer and
+    // that `root` belongs to it, so the descriptor slice is in bounds.
+    let descriptors = unsafe { root.get_instruction_descriptors(policy_base) };
+
+    for (i, desc) in descriptors.iter().enumerate() {
+        if desc.reserved != 0 {
+            return Err(PolicyCheckError::InvalidReservedField { policy_type: TYPE_INSTRUCTION, entry_index: i });
+        }
+    }
+    Ok(())
+}
+
+/// Validates the save state policy descriptors referenced by `root`.
+///
+/// ## Safety
+///
+/// The caller must ensure that `policy_base` points to a valid policy buffer
+/// and that `root` is a policy root from that same buffer, so its descriptor
+/// offset and count describe an in-bounds, properly aligned descriptor array.
+unsafe fn validate_save_state_policy(policy_base: *const u8, root: &PolicyRootV1) -> Result<(), PolicyCheckError> {
+    // SAFETY: The caller guarantees `policy_base` is a valid policy buffer and
+    // that `root` belongs to it, so the descriptor slice is in bounds.
+    let descriptors = unsafe { root.get_save_state_descriptors(policy_base) };
+
+    for (i, desc) in descriptors.iter().enumerate() {
+        // Check for unsupported write attributes
+        if (desc.attributes & (RESOURCE_ATTR_WRITE | RESOURCE_ATTR_COND_WRITE)) != 0 {
+            return Err(PolicyCheckError::UnsupportedAttribute {
+                policy_type: TYPE_SAVE_STATE,
+                entry_index: i,
+                attributes: desc.attributes,
+            });
+        }
+
+        // Check for conflicting conditions
+        if (desc.attributes & RESOURCE_ATTR_COND_READ) == 0
+            && desc.access_condition != SaveStateCondition::Unconditional as u32
+        {
+            return Err(PolicyCheckError::ConflictingCondition { entry_index: i });
+        }
+
+        if desc.reserved != 0 {
+            return Err(PolicyCheckError::InvalidReservedField { policy_type: TYPE_SAVE_STATE, entry_index: i });
+        }
+    }
+    Ok(())
+}
+
+/// Memory policy builder for collecting memory descriptors from page table walking.
+///
+/// This is used to generate memory policy from page table entries.
+pub struct MemoryPolicyBuilder {
+    /// Current descriptor being built
+    current: Option<MemDescriptorV1_0>,
+    /// Maximum number of descriptors we can store
+    max_count: usize,
+    /// Buffer for descriptors
+    buffer_ptr: *mut MemDescriptorV1_0,
+    /// Current count of descriptors
+    count: usize,
+}
+
+impl MemoryPolicyBuilder {
+    /// Creates a new memory policy builder.
+    ///
+    /// ## Safety
+    ///
+    /// The caller must ensure that `buffer_ptr` points to a valid buffer
+    /// with space for at least `max_count` descriptors.
+    pub unsafe fn new(buffer_ptr: *mut MemDescriptorV1_0, max_count: usize) -> Self {
+        Self { current: None, max_count, buffer_ptr, count: 0 }
+    }
+
+    /// Adds a memory region to the policy.
+    ///
+    /// Adjacent regions with the same attributes will be coalesced. Returns
+    /// `Err(())` if the descriptor buffer is full.
+    pub fn add_region(&mut self, base: u64, size: u64, attributes: u32) -> Result<(), ()> {
+        let new_desc = MemDescriptorV1_0 { base_address: base, size, mem_attributes: attributes, reserved: 0 };
+
+        if let Some(ref mut current) = self.current {
+            // Check if we can coalesce with current
+            let current_end = current.base_address.saturating_add(current.size);
+            if base == current_end && attributes == current.mem_attributes {
+                // Coalesce
+                current.size = current.size.saturating_add(size);
+                return Ok(());
+            } else {
+                // Flush current and start new
+                self.flush_current()?;
+            }
+        }
+
+        self.current = Some(new_desc);
+        Ok(())
+    }
+
+    /// Flushes the current descriptor to the buffer.
+    fn flush_current(&mut self) -> Result<(), ()> {
+        if let Some(desc) = self.current.take() {
+            if self.count >= self.max_count {
+                return Err(());
+            }
+
+            // SAFETY: We checked bounds
+            unsafe {
+                *self.buffer_ptr.add(self.count) = desc;
+            }
+            self.count += 1;
+        }
+        Ok(())
+    }
+
+    /// Finishes building and returns the count of descriptors.
+    pub fn finish(mut self) -> Result<usize, ()> {
+        self.flush_current()?;
+        Ok(self.count)
+    }
+}
+
+/// Converts effective page-table memory attributes to policy R/W/X attributes.
+///
+/// The iterator yields only present leaf mappings whose attributes already
+/// fold in restrictions inherited from parent table entries, so this is a
+/// direct translation: read is always granted, write unless read-only, and
+/// execute unless execute-protected.
+#[inline]
+fn mem_attrs_to_policy_attrs(attributes: MemoryAttributes) -> u32 {
+    let mut attrs = RESOURCE_ATTR_READ;
+
+    if !attributes.contains(MemoryAttributes::ReadOnly) {
+        attrs |= RESOURCE_ATTR_WRITE;
+    }
+
+    if !attributes.contains(MemoryAttributes::ExecuteProtect) {
+        attrs |= RESOURCE_ATTR_EXECUTE;
+    }
+
+    attrs
+}
+
+/// Errors that can occur during page table walking.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PageTableWalkError {
+    /// Buffer is full, cannot add more descriptors.
+    BufferFull,
+    /// The CR3 value is invalid (null).
+    InvalidCr3,
+}
+
+/// Callback type for checking if a buffer is inside MMRAM.
+///
+/// Returns `true` if the buffer `[base, base + size)` is fully inside MMRAM.
+pub type IsInsideMmramFn = fn(base: u64, size: u64) -> bool;
+
+/// Walks x86_64 4-level page tables and generates memory policy descriptors.
+///
+/// This function traverses the page table hierarchy starting from the PML4
+/// table (pointed to by CR3), and for each mapped page, generates a memory
+/// policy descriptor with the effective R/W/X attributes.
+///
+/// Adjacent pages with the same attributes are coalesced into single descriptors.
+/// Regions that lie fully inside MMRAM are skipped. Returns the number of memory
+/// policy descriptors generated.
+///
+/// ## Safety
+///
+/// The caller must ensure that:
+/// - `cr3` points to a valid PML4 table
+/// - `buffer` has space for at least `max_count` descriptors
+/// - The page table memory is accessible and won't change during the walk
+pub unsafe fn walk_page_table(
+    cr3: u64,
+    buffer: *mut MemDescriptorV1_0,
+    max_count: usize,
+    is_inside_mmram: IsInsideMmramFn,
+) -> Result<usize, PageTableWalkError> {
+    if cr3 == 0 || buffer.is_null() {
+        return Err(PageTableWalkError::InvalidCr3);
+    }
+
+    // Construct a read-only view of the active page table rooted at CR3. Clear
+    // the low 12 flag bits to obtain the page-aligned PML4 base. The iterator
+    // only reads entries, so the allocator is stored but never invoked.
+    let base = cr3 & !0xFFF;
+    let allocator = SharedPagingAllocator::new(security_state().paging_allocator());
+    // SAFETY: The caller guarantees `cr3` points to a valid PML4 table that
+    // remains stable for the duration of the walk.
+    let page_table = unsafe { X64PageTable::from_existing(base, allocator, PagingType::Paging4Level) }
+        .map_err(|_| PageTableWalkError::InvalidCr3)?;
+
+    // SAFETY: per this function's contract `buffer` has space for `max_count` `MemDescriptorV1_0`
+    // entries, satisfying `MemoryPolicyBuilder::new`'s requirement.
+    let mut builder = unsafe { MemoryPolicyBuilder::new(buffer, max_count) };
+
+    for region in page_table.iter_mapped_regions(None) {
+        // Skip regions that lie fully inside MMRAM.
+        if is_inside_mmram(region.pa, region.size) {
+            continue;
+        }
+
+        let attrs = mem_attrs_to_policy_attrs(region.attributes);
+        builder.add_region(region.pa, region.size, attrs).map_err(|()| PageTableWalkError::BufferFull)?;
+    }
+
+    builder.finish().map_err(|()| PageTableWalkError::BufferFull)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_dump_mem_policy_entry() {
+        // Just verify it doesn't panic
+        let desc = MemDescriptorV1_0 {
+            base_address: 0x1000,
+            size: 0x1000,
+            mem_attributes: RESOURCE_ATTR_READ | RESOURCE_ATTR_WRITE,
+            reserved: 0,
+        };
+        dump_mem_policy_entry(&desc);
+    }
+}

--- a/patina_mm_supervisor/src/perf_timer.rs
+++ b/patina_mm_supervisor/src/perf_timer.rs
@@ -1,0 +1,152 @@
+//! Performance Timer for the MM Supervisor Core
+//!
+//! Provides real-time, TSC-based timing helpers used by mailbox timeouts and
+//! AP-arrival polling.
+//!
+//! ## License
+//!
+//! Copyright (c) Microsoft Corporation.
+//!
+//! SPDX-License-Identifier: Apache-2.0
+//!
+
+use core::arch::x86_64;
+
+use crate::CpuInfo;
+
+// TODO: This is copied from perf_timer.rs in patina_dxe_core
+/// Returns the current CPU count using architecture-specific methods.
+///
+/// Skip coverage as any value could be valid, including 0.
+#[cfg_attr(coverage_nightly, coverage(off))]
+fn ticks() -> u64 {
+    // SAFETY: _rdtsc only reads the TSC on x86_64. No invariants are required for safety.
+    unsafe { x86_64::_rdtsc() }
+}
+
+/// Returns the frequency in Hz from the platform's CpuInfo, or `0` if
+/// not determinable.
+#[inline]
+pub fn frequency<C: CpuInfo>() -> u64 {
+    C::perf_timer_frequency().unwrap_or(0)
+}
+
+/// Converts a duration in microseconds to the equivalent tick count using
+/// the given CpuInfo's frequency.
+///
+/// Returns `None` if the frequency is unknown (0).
+#[inline]
+pub fn us_to_ticks<C: CpuInfo>(us: u64) -> Option<u64> {
+    let mut freq = frequency::<C>();
+    if freq == 0 {
+        freq = arch_perf_frequency();
+    }
+    Some(((freq as u128 * us as u128) / 1_000_000) as u64)
+}
+
+pub(crate) fn arch_perf_frequency() -> u64 {
+    // Try to get TSC frequency from CPUID (most Intel and AMD platforms).
+    #[cfg(target_arch = "x86_64")]
+    {
+        // `#[allow(unused_unsafe)]` is used here to simultaneously support Rust <= 1.93 toolchains
+        // that consider __cpuid unsafe and Rust >= 1.94 (or >= nightly-2025-12-27) toolchains that
+        // consider __cpuid safe.
+        #[allow(unused_unsafe)]
+        // SAFETY: Calling cpuid does not violate memory safety
+        let core::arch::x86_64::CpuidResult { eax, ebx, ecx, .. } = unsafe { core::arch::x86_64::__cpuid(0x15) };
+        if eax != 0 && ebx != 0 && ecx != 0 {
+            // CPUID 0x15 gives TSC_frequency = (ECX * EBX) / EAX.
+            // Most modern x86 platforms support this leaf.
+            return (ecx as u64 * ebx as u64) / eax as u64;
+        }
+
+        // CPUID 0x16 gives base frequency in MHz in EAX.
+        // This is supported on some older x86 platforms.
+        // This is a nominal frequency and is less accurate for reflecting actual operating conditions.
+        //
+        // `#[allow(unused_unsafe)]` is used here to simultaneously support Rust <= 1.93 toolchains
+        // that consider __cpuid unsafe and Rust >= 1.94 (or >= nightly-2025-12-27) toolchains that
+        // consider __cpuid safe.
+        #[allow(unused_unsafe)]
+        // SAFETY: Calling cpuid does not violate memory safety
+        let core::arch::x86_64::CpuidResult { eax, .. } = unsafe { core::arch::x86_64::__cpuid(0x16) };
+        if eax != 0 {
+            // CPUID 0x16 gives base frequency in MHz in EAX.
+            // This is supported on some older x86 platforms.
+            // This is a nominal frequency and is less accurate for reflecting actual operating conditions.
+            return (eax * 1_000_000) as u64;
+        }
+
+        0
+    }
+
+    #[cfg(not(any(target_arch = "x86_64", target_arch = "aarch64")))]
+    0
+}
+
+/// Spins until at least `timeout_us` microseconds have elapsed.
+///
+/// Returns `true` when the provided `condition` closure returns `true`
+/// before the deadline, or `false` on timeout.
+///
+/// If the performance frequency is unknown, falls back to a conservative
+/// iteration-count heuristic (`timeout_us * 10` loops).
+pub fn spin_until<C: CpuInfo, F>(timeout_us: u64, mut condition: F) -> bool
+where
+    F: FnMut() -> bool,
+{
+    if let Some(deadline_ticks) = us_to_ticks::<C>(timeout_us) {
+        let start = ticks();
+        loop {
+            if condition() {
+                return true;
+            }
+            if ticks().wrapping_sub(start) >= deadline_ticks {
+                return false;
+            }
+            core::hint::spin_loop();
+        }
+    } else {
+        // Fallback: iteration-count approximation.
+        let iterations = timeout_us.saturating_mul(10);
+        for _ in 0..iterations {
+            if condition() {
+                return true;
+            }
+            core::hint::spin_loop();
+        }
+        false
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    struct TestCpu;
+    impl CpuInfo for TestCpu {
+        fn perf_timer_frequency() -> Option<u64> {
+            None
+        }
+    }
+
+    /// A CPU to make timer test happy.
+    struct FixedFreqCpu;
+    impl CpuInfo for FixedFreqCpu {
+        fn perf_timer_frequency() -> Option<u64> {
+            Some(1_000_000)
+        }
+    }
+
+    #[test]
+    fn test_us_to_ticks_basic() {
+        // With a known 1 MHz frequency, 1000 us converts to exactly 1000 ticks.
+        assert_eq!(us_to_ticks::<FixedFreqCpu>(1000), Some(1000));
+    }
+
+    #[test]
+    fn test_spin_until_immediate_true() {
+        let result = spin_until::<TestCpu, _>(1_000, || true);
+        assert!(result);
+    }
+}

--- a/patina_mm_supervisor/src/privilege_mgmt.rs
+++ b/patina_mm_supervisor/src/privilege_mgmt.rs
@@ -1,0 +1,187 @@
+//! Privilege Management for MM Supervisor Core
+//!
+//! This module manages the privilege level transitions between Ring 0 (supervisor)
+//! and Ring 3 (user) in the MM environment. It provides:
+//!
+//! - One-time initialization of syscall/sysret MSRs
+//! - Demotion of code execution to Ring 3 via `InvokeDemotedRoutine`
+//! - Handling of syscall requests from Ring 3 code
+//! - Call gate and TSS descriptor management for privilege transitions
+//!
+//! ## Architecture
+//!
+//! The privilege management follows the x86_64 syscall/sysret model:
+//!
+//! 1. **Initialization**: Configure MSR_IA32_STAR, MSR_IA32_LSTAR, MSR_IA32_EFER
+//!    to set up syscall entry points and segment selectors.
+//!
+//! 2. **Demotion**: Use `InvokeDemotedRoutine` to transition from Ring 0 to Ring 3.
+//!    This sets up call gates for return and prepares the Ring 3 stack.
+//!
+//! 3. **Syscall Entry**: When Ring 3 code executes `syscall`, the CPU jumps to
+//!    the address in MSR_IA32_LSTAR (our `SyscallCenter`), which dispatches
+//!    to the appropriate handler.
+//!
+//! 4. **Return**: Ring 3 code returns via call gate or syscall dispatcher returns
+//!    via `sysret`.
+//!
+//! ## Segment Layout (from SmiException.nasm)
+//!
+//! ```text
+//! PROTECTED_DS      = 0x20
+//! LONG_CS_R0        = 0x38  (Ring 0 code segment)
+//! LONG_DS_R0        = 0x40  (Ring 0 data segment)
+//! LONG_CS_R3_PH     = 0x4B  (Ring 3 code segment placeholder)
+//! LONG_DS_R3        = 0x53  (Ring 3 data segment)
+//! LONG_CS_R3        = 0x5B  (Ring 3 code segment)
+//! CALL_GATE_OFFSET  = 0x60  (Call gate descriptor offset)
+//! TSS_SEL_OFFSET    = 0x70  (TSS selector offset)
+//! TSS_DESC_OFFSET   = 0x80  (TSS descriptor offset)
+//! ```
+//!
+//! ## License
+//!
+//! Copyright (c) Microsoft Corporation.
+//!
+//! SPDX-License-Identifier: Apache-2.0
+//!
+
+use r_efi::efi::Status;
+
+mod call_gate;
+mod syscall_dispatcher;
+pub(crate) mod syscall_setup;
+
+pub type SyscallResult = Result<u64, Status>; // Result of a syscall: Ok(value) or Err(EFI_STATUS)
+
+// FFI binding to the assembly `invoke_demoted_routine` routine (`call_gate_transfer.asm`).
+// Only linked for the firmware (UEFI) target; host builds (unit tests, doctests, `check`)
+// exclude the entry/transition assembly and use the wrapper's host paths below.
+#[cfg(target_os = "uefi")]
+unsafe extern "efiapi" {
+    #[link_name = "invoke_demoted_routine"]
+    fn invoke_demoted_routine_asm(cpu_index: usize, cpl3_routine: u64, cpl3_stack: u64, arg_count: usize, ...)
+    -> usize;
+}
+
+/// Invokes a specified routine in CPL 3 (Ring 3).
+///
+/// This function transitions from Ring 0 to Ring 3, executes the demoted routine, and
+/// returns back to Ring 0 through a call gate. The three trailing arguments are populated to
+/// registers and/or CPL3 stack areas per the EFIAPI calling convention. Returns `EFI_SUCCESS`
+/// if the demoted routine returned successfully, or other values for errors from ring
+/// transitioning or the demoted routine.
+///
+/// The assembly transition only exists on the firmware (UEFI) target. On host builds it cannot
+/// run, so test builds delegate to the controllable mock in the `mock` module (letting callers
+/// be exercised), and other host builds (e.g. doctests) use an inert stub.
+///
+/// ## Safety
+///
+/// This function modifies privilege levels and stack pointers. Callers must ensure:
+/// - Valid function pointer for `cpl3_routine`
+/// - Valid stack pointer for `cpl3_stack`
+/// - Correct `arg_count` matching the actual arguments
+pub(crate) unsafe fn invoke_demoted_routine(
+    cpu_index: usize,
+    cpl3_routine: u64,
+    cpl3_stack: u64,
+    arg_count: usize,
+    arg1: u64,
+    arg2: u64,
+    arg3: u64,
+) -> usize {
+    // Firmware (UEFI): perform the real Ring 0 -> Ring 3 transition via assembly.
+    #[cfg(target_os = "uefi")]
+    // SAFETY: forwards to the assembly transition; the documented preconditions are upheld by the caller.
+    let ret = unsafe { invoke_demoted_routine_asm(cpu_index, cpl3_routine, cpl3_stack, arg_count, arg1, arg2, arg3) };
+
+    // Host test builds: delegate to the controllable mock so callers can be exercised.
+    #[cfg(all(not(target_os = "uefi"), test))]
+    let ret = mock::invoke_demoted_routine(cpu_index, cpl3_routine, cpl3_stack, arg_count, arg1, arg2, arg3);
+
+    // Other host builds (e.g. doctests): inert; the transition never runs off the firmware target.
+    #[cfg(all(not(target_os = "uefi"), not(test)))]
+    let ret = {
+        let _ = (cpu_index, cpl3_routine, cpl3_stack, arg_count, arg1, arg2, arg3);
+        0
+    };
+
+    ret
+}
+
+/// Test-only mock backing [`invoke_demoted_routine`].
+///
+/// The assembly privilege transition cannot run on the host, so in test builds the wrapper
+/// delegates here. Install a handler with [`set_handler`] to observe calls and control the
+/// return value; with no handler installed, calls return `0` (EFI_SUCCESS).
+#[cfg(test)]
+pub(crate) mod mock {
+    use core::cell::RefCell;
+
+    /// Handler signature: receives the same arguments as the real routine and returns the value
+    /// the supervisor should observe.
+    type Handler = Box<dyn FnMut(usize, u64, u64, usize, u64, u64, u64) -> usize>;
+
+    thread_local! {
+        static HANDLER: RefCell<Option<Handler>> = const { RefCell::new(None) };
+    }
+
+    /// Installs a handler invoked in place of the real Ring 0 -> Ring 3 transition.
+    pub(crate) fn set_handler<F>(handler: F)
+    where
+        F: FnMut(usize, u64, u64, usize, u64, u64, u64) -> usize + 'static,
+    {
+        HANDLER.with(|h| *h.borrow_mut() = Some(Box::new(handler)));
+    }
+
+    /// Removes any installed handler; subsequent calls return `0`.
+    pub(crate) fn clear() {
+        HANDLER.with(|h| *h.borrow_mut() = None);
+    }
+
+    pub(super) fn invoke_demoted_routine(
+        cpu_index: usize,
+        cpl3_routine: u64,
+        cpl3_stack: u64,
+        arg_count: usize,
+        arg1: u64,
+        arg2: u64,
+        arg3: u64,
+    ) -> usize {
+        HANDLER.with(|h| match h.borrow_mut().as_mut() {
+            Some(handler) => handler(cpu_index, cpl3_routine, cpl3_stack, arg_count, arg1, arg2, arg3),
+            None => 0,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_invoke_demoted_routine_delegates_to_mock_handler() {
+        // With no handler installed, the wrapper returns 0 (EFI_SUCCESS).
+        mock::clear();
+        // SAFETY: under `test` the wrapper delegates to the mock; no real privilege transition occurs.
+        let ret = unsafe { invoke_demoted_routine(0, 0x1000, 0x2000, 3, 1, 2, 3) };
+        assert_eq!(ret, 0);
+
+        // An installed handler observes the arguments and controls the return value, so callers of
+        // `invoke_demoted_routine` can be exercised on the host.
+        mock::set_handler(|cpu_index, cpl3_routine, cpl3_stack, arg_count, arg1, arg2, arg3| {
+            assert_eq!(cpu_index, 7);
+            assert_eq!(cpl3_routine, 0xdead_beef);
+            assert_eq!(cpl3_stack, 0xcafe);
+            assert_eq!(arg_count, 3);
+            assert_eq!((arg1, arg2, arg3), (10, 20, 30));
+            0x1234
+        });
+        // SAFETY: see above.
+        let ret = unsafe { invoke_demoted_routine(7, 0xdead_beef, 0xcafe, 3, 10, 20, 30) };
+        assert_eq!(ret, 0x1234);
+
+        mock::clear();
+    }
+}

--- a/patina_mm_supervisor/src/privilege_mgmt/call_gate.rs
+++ b/patina_mm_supervisor/src/privilege_mgmt/call_gate.rs
@@ -1,0 +1,273 @@
+//! Call Gate and TSS Management
+//!
+//! This module manages call gates and Task State Segment (TSS) descriptors
+//! for privilege level transitions. Call gates provide an alternative mechanism
+//! (besides syscall/sysret) for Ring 3 code to transition back to Ring 0.
+//!
+//! ## Call Gate Usage
+//!
+//! 1. When invoking a demoted routine, the supervisor sets up a call gate
+//!    pointing to the return address.
+//!
+//! 2. The demoted routine in Ring 3 can return to Ring 0 by doing a far call
+//!    to the call gate selector.
+//!
+//! 3. The CPU automatically transitions to Ring 0 and jumps to the address
+//!    in the call gate descriptor.
+//!
+//! ## TSS Usage
+//!
+//! The TSS is used to specify the Ring 0 stack pointer (RSP0) that the CPU
+//! will load when transitioning from Ring 3 to Ring 0 via an interrupt or
+//! call gate.
+//!
+//! ## License
+//!
+//! Copyright (c) Microsoft Corporation.
+//!
+//! SPDX-License-Identifier: Apache-2.0
+//!
+use patina_paging::x64::{disable_write_protection, enable_write_protection};
+use zerocopy::{FromBytes, IntoBytes};
+
+// Firmware-only call-gate transfer assembly; included only for the UEFI target so host builds
+// (tests, doctests) can link.
+#[cfg(target_os = "uefi")]
+core::arch::global_asm!(include_str!("call_gate_transfer.asm"));
+
+/// Long mode Ring 0 code segment selector.
+pub const LONG_CS_R0: u16 = 0x38;
+
+/// Call gate descriptor offset in GDT.
+pub const CALL_GATE_OFFSET: u16 = 0x60;
+
+/// TSS selector offset in GDT.
+pub const TSS_SEL_OFFSET: u16 = 0x70;
+
+/// TSS descriptor offset in GDT.
+pub const TSS_DESC_OFFSET: u16 = 0x80;
+
+/// 64-bit Call Gate Descriptor.
+///
+/// A call gate allows privilege level transitions through a far call instruction.
+#[repr(C, packed)]
+#[derive(
+    Debug,
+    Clone,
+    Copy,
+    Default,
+    zerocopy_derive::FromBytes,
+    zerocopy_derive::IntoBytes,
+    zerocopy_derive::Immutable
+)]
+pub struct CallGateDescriptor {
+    /// Offset bits 15:0
+    pub offset_low: u16,
+    /// Target code segment selector
+    pub selector: u16,
+    /// Reserved (must be 0) and IST (bits 2:0)
+    pub ist: u8,
+    /// Type (0xC = 64-bit call gate) and DPL
+    pub type_attr: u8,
+    /// Offset bits 31:16
+    pub offset_mid: u16,
+    /// Offset bits 63:32
+    pub offset_high: u32,
+    /// Reserved (must be 0)
+    pub reserved: u32,
+}
+
+impl CallGateDescriptor {
+    /// Sets the target offset in the descriptor.
+    pub fn set_offset(&mut self, offset: u64) {
+        self.offset_low = (offset & 0xFFFF) as u16;
+        self.offset_mid = ((offset >> 16) & 0xFFFF) as u16;
+        self.offset_high = ((offset >> 32) & 0xFFFFFFFF) as u32;
+    }
+}
+
+/// 64-bit TSS Descriptor (16 bytes in 64-bit mode).
+#[repr(C, packed)]
+#[derive(
+    Debug,
+    Clone,
+    Copy,
+    Default,
+    zerocopy_derive::FromBytes,
+    zerocopy_derive::IntoBytes,
+    zerocopy_derive::Immutable
+)]
+pub struct TssDescriptor {
+    /// Limit bits 15:0
+    pub limit_low: u16,
+    /// Base bits 15:0
+    pub base_low: u16,
+    /// Base bits 23:16
+    pub base_mid_low: u8,
+    /// Type and attributes
+    pub type_attr: u8,
+    /// Limit bits 19:16 and flags
+    pub limit_flags: u8,
+    /// Base bits 31:24
+    pub base_mid_high: u8,
+    /// Base bits 63:32
+    pub base_high: u32,
+    /// Reserved
+    pub reserved: u32,
+}
+
+impl TssDescriptor {
+    /// Sets the base address in the descriptor.
+    pub fn set_base(&mut self, base: u64) {
+        self.base_low = (base & 0xFFFF) as u16;
+        self.base_mid_low = ((base >> 16) & 0xFF) as u8;
+        self.base_mid_high = ((base >> 24) & 0xFF) as u8;
+        self.base_high = ((base >> 32) & 0xFFFFFFFF) as u32;
+    }
+}
+
+/// GDTR (GDT Register) structure.
+#[repr(C, packed)]
+#[derive(Debug, Clone, Copy, Default)]
+pub struct GdtRegister {
+    /// Size of the GDT minus 1
+    pub limit: u16,
+    /// Linear address of the GDT
+    pub base: u64,
+}
+
+/// 64-bit Task State Segment.
+///
+/// In 64-bit mode the TSS holds information that is not directly related to the
+/// task-switch mechanism, but is used for stack switching when an interrupt or
+/// exception occurs. Layout matches the Intel SDM (total size 0x68 bytes).
+#[repr(C, packed(4))]
+#[derive(Debug, Clone, Copy, zerocopy_derive::FromBytes, zerocopy_derive::IntoBytes, zerocopy_derive::Immutable)]
+pub struct TaskStateSegment {
+    reserved_1: u32,
+    /// 64-bit canonical RSP values for privilege levels 0-2. Loaded on
+    /// privilege escalation from a lower to a higher privilege level.
+    pub privilege_stack_table: [u64; 3],
+    reserved_2: u64,
+    /// 64-bit canonical IST pointers. Loaded when an IDT entry has a non-zero
+    /// IST index.
+    pub interrupt_stack_table: [u64; 7],
+    reserved_3: u64,
+    reserved_4: u16,
+    /// 16-bit offset to the I/O permission bitmap from the TSS base.
+    pub io_map_base: u16,
+}
+
+/// Gets the current GDT base address by reading the GDTR register.
+/// ## Safety
+/// This function is safe to call as it only reads the GDTR register.
+#[cfg(target_arch = "x86_64")]
+pub unsafe fn get_current_gdt_base() -> u64 {
+    // Get current GDT base
+    let mut gdtr = GdtRegister::default();
+    // SAFETY: `sgdt` only stores the GDTR into the provided `gdtr` buffer and
+    // has no other side effects.
+    unsafe {
+        core::arch::asm!(
+            "sgdt [{}]",
+            in(reg) &mut gdtr,
+            options(nostack, preserves_flags)
+        );
+    }
+
+    gdtr.base
+}
+
+/// Sets up the call gate for returning from a demoted routine.
+/// This function is called from assembly code (InvokeDemotedRoutine).
+///
+/// ## Safety
+///
+/// This modifies the GDT.
+#[unsafe(no_mangle)]
+#[cfg(target_arch = "x86_64")]
+pub unsafe extern "efiapi" fn setup_call_gate(return_pointer: u64, cpl0_stack_ptr: u64) {
+    // Get current GDT base
+    // SAFETY: Reads the current GDTR register; see `get_current_gdt_base`.
+    let gdt_base = unsafe { get_current_gdt_base() };
+
+    let call_gate_addr = gdt_base + CALL_GATE_OFFSET as u64;
+
+    let tss_desc_addr = gdt_base + TSS_SEL_OFFSET as u64;
+    let tss_addr = gdt_base + TSS_DESC_OFFSET as u64;
+
+    // SAFETY: This is safe because we are temporarily disabling page protection
+    // on the GDT to update the call gate descriptor, which is necessary for the
+    // call gate setup. We will restore protections after updating.
+    let cr0 = unsafe { disable_write_protection() };
+
+    // Now program the call gate descriptor for the return address
+    let call_gate = call_gate_addr as *mut CallGateDescriptor;
+
+    // Update the call gate offset
+    // SAFETY: `call_gate` points to the call gate descriptor within the GDT,
+    // which is valid and readable while page protection is masked above.
+    let call_gate_bytes =
+        unsafe { core::ptr::read_volatile(call_gate.cast::<[u8; core::mem::size_of::<CallGateDescriptor>()]>()) };
+    let mut desc = CallGateDescriptor::read_from_bytes(&call_gate_bytes)
+        .expect("byte buffer is exactly the size of CallGateDescriptor");
+    desc.set_offset(return_pointer);
+    desc.selector = LONG_CS_R0;
+    // Type = 0xC (64-bit call gate), P = 1, DPL = 3 (Ring 3 can call)
+    desc.type_attr = 0xEC;
+    // SAFETY: `call_gate` points to the call gate descriptor within the GDT,
+    // which is valid and writable while page protection is masked above.
+    unsafe {
+        core::ptr::write_volatile(
+            call_gate.cast::<[u8; core::mem::size_of::<CallGateDescriptor>()]>(),
+            desc.as_bytes().try_into().expect("descriptor is exactly its byte size"),
+        )
+    };
+
+    // Then program the TSS descriptor to point to the TSS (which contains the stack pointer for Ring 0)
+    let tss_desc = tss_desc_addr as *mut TssDescriptor;
+    let tss = tss_addr as *mut TaskStateSegment;
+
+    // Read the raw TSS descriptor bytes, then reinterpret them as a
+    // `TssDescriptor` via zerocopy rather than a typed volatile read.
+    // SAFETY: `tss_desc` points to the TSS descriptor within the GDT, which is
+    // valid and readable while page protection is masked above.
+    let tss_desc_bytes =
+        unsafe { core::ptr::read_volatile(tss_desc.cast::<[u8; core::mem::size_of::<TssDescriptor>()]>()) };
+    let mut desc =
+        TssDescriptor::read_from_bytes(&tss_desc_bytes).expect("byte buffer is exactly the size of TssDescriptor");
+    desc.set_base(tss_addr);
+    // SAFETY: `tss_desc` points to the TSS descriptor within the GDT, which is
+    // valid and writable while page protection is masked above.
+    unsafe {
+        core::ptr::write_volatile(
+            tss_desc.cast::<[u8; core::mem::size_of::<TssDescriptor>()]>(),
+            desc.as_bytes().try_into().expect("descriptor is exactly its byte size"),
+        )
+    };
+
+    // Update RSP0 in the TSS
+    // SAFETY: `tss` points to the Task State Segment within the GDT region,
+    // which is valid and readable while page protection is masked above.
+    let tss_bytes = unsafe { core::ptr::read_volatile(tss.cast::<[u8; core::mem::size_of::<TaskStateSegment>()]>()) };
+    let mut tss_data =
+        TaskStateSegment::read_from_bytes(&tss_bytes).expect("byte buffer is exactly the size of TaskStateSegment");
+    tss_data.privilege_stack_table[0] = cpl0_stack_ptr;
+    // SAFETY: `tss` points to the Task State Segment within the GDT region,
+    // which is valid and writable while page protection is masked above.
+    unsafe {
+        core::ptr::write_volatile(
+            tss.cast::<[u8; core::mem::size_of::<TaskStateSegment>()]>(),
+            tss_data.as_bytes().try_into().expect("TSS is exactly its byte size"),
+        )
+    };
+
+    // Restore GDT read-only protection.
+    // SAFETY: `cr0` is the exact value returned by the paired `disable_write_protection` above, so
+    // this restores CR0.WP to its prior state, closing the write-enabled window. Runs in Ring 0.
+    unsafe {
+        enable_write_protection(cr0);
+    }
+
+    log::trace!("Call gate set to 0x{:016x}, CPL0 stack pointer set to 0x{:016x}", return_pointer, cpl0_stack_ptr);
+}

--- a/patina_mm_supervisor/src/privilege_mgmt/call_gate_transfer.asm
+++ b/patina_mm_supervisor/src/privilege_mgmt/call_gate_transfer.asm
@@ -1,0 +1,323 @@
+#------------------------------------------------------------------------------
+# Copyright 2008 - 2020 ADVANCED MICRO DEVICES, INC.  All Rights Reserved.
+# Copyright (c) Microsoft Corporation.
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+# Module Name:
+#
+#   WriteTr.nasm
+#
+# Abstract:
+#
+#   Write TR register
+#
+# Notes:
+#
+#------------------------------------------------------------------------------
+
+.section .data
+
+.global invoke_demoted_routine
+.global setup_call_gate
+.global syscall_center
+
+# .global SetupCpl0MsrStar
+# .global RestoreCpl0MsrStar
+
+.section .text
+.align 8
+
+# Segments defined in SmiException.nasm
+.equ PROTECTED_DS,                   0x20
+.equ LONG_CS_R0,                     0x38
+.equ LONG_DS_R0,                     0x40
+.equ LONG_CS_R3_PH,                  0x4B
+.equ LONG_DS_R3,                     0x53
+.equ LONG_CS_R3,                     0x5B
+.equ CALL_GATE_OFFSET,               0x63
+
+# MSR constants
+.equ MSR_IA32_EFER,                 0xC0000080
+.equ MSR_IA32_EFER_SCE_MASK,        0x00000001
+
+.equ MSR_IA32_STAR,                 0xC0000081
+.equ MSR_IA32_LSTAR,                0xC0000082
+.equ MSR_IA32_GS_BASE,              0xC0000101
+.equ MSR_IA32_KERNEL_GS_BASE,       0xC0000102
+
+
+.macro CHECK_RAX
+    cmp     rax, 0
+    jz      4f
+.endm
+
+#------------------------------------------------------------------------------
+# /**
+#   Invoke specified routine on specified core in CPL 3.
+#
+#   @param[in]      CpuIndex            CpuIndex value of intended core, cannot be
+#                                       greater than mNumberOfCpus.
+#   @param[in]      Cpl3Routine         Function pointer to demoted routine.
+#   @param[in]      ArgCount            Number of arguments needed by Cpl3Routine.
+#   @param          ...                 The variable argument list whose count is defined by
+#                                       ArgCount. Its contented will be accessed and populated
+#                                       to the registers and/or CPL3 stack areas per EFIAPI
+#                                       calling convention.
+#
+#   @retval EFI_SUCCESS                 The demoted routine returns successfully.
+#   @retval Others                      Errors caught by subroutines during ring transitioning
+#                                       or error code returned from demoted routine.
+# **/
+# EFI_STATUS
+# EFIAPI
+# InvokeDemotedRoutine (
+#   IN UINTN                 CpuIndex,
+#   IN EFI_PHYSICAL_ADDRESS  Cpl3Routine,
+#   IN EFI_PHYSICAL_ADDRESS  Cpl3Stack,
+#   IN UINTN                 ArgCount,
+#   ...
+#   );
+# Calling convention: Arg0 in RCX, Arg1 in RDX, Arg2 in R8, Arg3 in R9, more on the stack
+#------------------------------------------------------------------------------
+invoke_demoted_routine:
+    #Preserve input parameters onto reg parameter stack area for later usage
+    mov     [rsp + 0x20], r9
+    mov     [rsp + 0x18], r8
+    mov     [rsp + 0x10], rdx
+    mov     [rsp + 0x08], rcx
+
+    #Preserve nonvolatile registers, in case demoted routines mess with them
+    push    rbp
+    mov     rbp, rsp
+    #Clear the lowest 16 bit after saving rsp, to make sure the stack pointer 16byte aligned
+    and     rsp, -16
+
+    push    rbx
+    push    rdi
+    push    rsi
+    push    r12
+    push    r13
+    push    r14
+    push    r15
+
+    #Preserve the updated rbp as we need them on return
+    push    rbp
+
+    mov     r15, r8
+    and     r15, -16
+
+    # Set up the MSR STAR, LSTAR, EFER, GS_BASE and KERNEL_GS_BASE, in situ
+    mov     rcx, MSR_IA32_STAR
+    rdmsr
+    push    rdx
+    push    rax
+
+    mov     edx, LONG_CS_R3_PH
+    shl     edx, 16
+    add     edx, LONG_CS_R0
+    wrmsr
+
+    mov     rcx, MSR_IA32_LSTAR
+    rdmsr
+    push    rdx
+    push    rax
+
+    lea     rax, syscall_center
+    lea     rdx, syscall_center
+    shr     rdx, 32
+    wrmsr
+
+    mov     rcx, MSR_IA32_EFER
+    rdmsr
+    push    rdx
+    push    rax
+
+    or      rax, MSR_IA32_EFER_SCE_MASK
+    wrmsr
+
+    mov     rcx, MSR_IA32_GS_BASE
+    rdmsr
+    push    rdx
+    push    rax
+
+    xor     rdx, rdx
+    xor     rax, rax
+    wrmsr
+
+    mov     rcx, MSR_IA32_KERNEL_GS_BASE
+    rdmsr
+    push    rdx
+    push    rax
+
+    mov     eax, esp
+    sub     eax, 16
+    mov     rdx, rsp
+    sub     rdx, 16
+    shr     rdx, 32
+    wrmsr
+
+    # This is to do the GS trick upon syscall entry
+    sub     rsp, 8
+
+    # This is to do the GS trick upon syscall entry
+    mov     rdx, rsp
+    sub     rdx, 8
+    push    rdx
+
+    # Now the stack will look like
+    # Current RSP           <- Incoming calls will operate on top of this
+    # 0                     <- Will be used for user stack saving
+    # KERNEL_GS_BASE * 2    <- Will be restored on return
+    # GS_BASE * 2           <- Will be restored on return
+    # EFER                  <- Will be restored on return
+    # LSTAR * 2             <- Will be restored on return
+    # STAR * 2              <- Will be restored on return
+    # One version of RBP    <- Value after we pushed NV registers
+    # r15
+    # r14
+    # r13
+    # r12
+    # rsi
+    # rdi
+    # rbx
+    # ?                     <- Potential buffer for unaligned incoming caller
+    # Original RBP
+    # ---------------       <- RSP When the caller invokes this
+    # rcx
+    # rdx
+    # r8
+    # r9
+
+    #Setup call gate for return
+    lea     rcx, [rip + 5f]
+    mov     rdx, rsp
+    sub     rsp, 0x20
+    call    setup_call_gate
+    add     rsp, 0x20
+
+    #Same level far return to apply GDT change
+    xor     rcx, rcx
+    mov     rcx, cs
+    push    rcx                 #prepare cs on the stack
+    lea     rax, [rip + 2f]
+    push    rax                 #prepare return rip on the stack
+    retfq
+
+2:
+    #Prepare for ds, es, fs, gs
+    xor     rax, rax
+    mov     ax, LONG_DS_R3
+    mov     ds, ax
+    mov     es, ax
+    mov     fs, ax
+    mov     gs, ax
+
+    #Prepare input arguments
+    mov     rax, [rbp + 0x28]           #Get ArgCount from stack
+    CHECK_RAX
+    mov     rcx, [rbp + 0x30]           #First input argument for demoted routine
+    dec     rax
+    CHECK_RAX
+    mov     rdx, [rbp + 0x38]           #Second input argument for demoted routine
+    dec     rax
+    CHECK_RAX
+    mov     r8, [rbp + 0x40]            #Third input argument for demoted routine
+    dec     rax
+    CHECK_RAX
+    mov     r9, [rbp + 0x48]            #Forth input argument for demoted routine
+    dec     rax
+    CHECK_RAX
+    #For further input arguments, they will be put on the stack
+    xor     rbx, rbx                    #rbx=0
+    mov     r14, rax
+    shl     r14, 3                      #r14=8*rax
+    sub     r15, r14                    #r15-=r14, offset the stack for remainder of input arguments
+    sub     r15, 0x20                   #r15-=0x20, 4 stack parameters
+    and     r15, -16                    #finally we worry about the stack alignment in CPL3
+3:
+    mov     r14, [rbp + 0x48 + rbx]     #r14=*(rbp+0x48+rbx)
+    mov     [r15 + 0x20 + rbx], r14     #*(r15+0x20+rbx)=r14
+    add     rbx, 0x08                   #rbx+=0x08
+    dec     rax
+    CHECK_RAX
+    jmp     3b
+
+4:
+    #Demote to CPL3 by far return, it will take care of cs and ss
+    #Note: we did more pushes on the way, so need to compensate the calculation when grabbing earlier pushed values
+    sub     r15, 0x08                   #dummy r15 displacement, to mimic the return pointer on the stack
+    push    LONG_DS_R3                  #prepare ss on the stack
+    mov     rax, r15                    #grab Cpl3StackPtr from r15
+    push    rax                         #prepare CPL3 stack pointer on the stack
+    push    LONG_CS_R3                  #prepare cs on the stack
+    mov     rax, [rbp + 0x18]           #grab routine pointer from stack
+    push    rax                         #prepare routine pointer on the stack
+
+    mov     r15, CALL_GATE_OFFSET       #This is our way to come back, do not mess it up
+    shl     r15, 32                     #Call gate on call far stack should be CS:rIP
+
+    retfq
+
+    #2000 years later...
+
+5:
+    #First offset the return far related 4 pushes (we have 0 count of arguments):
+    #PUSH.v old_SS // #SS on this or next pushes use SS.sel as error code
+    #PUSH.v old_RSP
+    #PUSH.v old_CS
+    #PUSH.v next_RIP
+    add     rsp, 0x20
+
+    #Demoted routine is responsible for returning to this point by invoking call gate
+    #Return status should still be in rax, save it before calling other functions
+    push    rax
+
+    add     rsp, 24
+
+    pop     rax
+    pop     rdx
+    mov     rcx, MSR_IA32_KERNEL_GS_BASE
+    wrmsr
+
+    pop     rax
+    pop     rdx
+    mov     rcx, MSR_IA32_GS_BASE
+    wrmsr
+
+    pop     rax
+    pop     rdx
+    mov     rcx, MSR_IA32_EFER
+    wrmsr
+
+    pop     rax
+    pop     rdx
+    mov     rcx, MSR_IA32_LSTAR
+    wrmsr
+
+    pop     rax
+    pop     rdx
+    mov     rcx, MSR_IA32_STAR
+    wrmsr
+
+    mov     rax, [rsp - 13 * 8]
+
+    xor     rcx, rcx
+    mov     cx, LONG_DS_R0
+    mov     ds, cx
+    mov     es, cx
+    mov     fs, cx
+    mov     gs, cx
+
+    add     rsp, 0x08       #Unwind the rbp from the last net-push
+    #Unwind the rest of the pushes
+    pop     r15
+    pop     r14
+    pop     r13
+    pop     r12
+    pop     rsi
+    pop     rdi
+    pop     rbx
+    mov     rsp, rbp
+    pop     rbp
+
+    ret

--- a/patina_mm_supervisor/src/privilege_mgmt/syscall_dispatcher.rs
+++ b/patina_mm_supervisor/src/privilege_mgmt/syscall_dispatcher.rs
@@ -1,0 +1,823 @@
+//! Syscall Dispatcher
+//!
+//! This module handles syscall requests from Ring 3 code. When Ring 3 code
+//! executes the `syscall` instruction, the CPU jumps to the address in
+//! MSR_IA32_LSTAR (our SyscallCenter assembly stub), which then calls into
+//! this dispatcher.
+//!
+//! ## Syscall Interface
+//!
+//! The syscall uses a custom calling convention:
+//! - RAX: Call index (SyscallIndex)
+//! - RDX: Argument 1
+//! - R8:  Argument 2
+//! - R9:  Argument 3
+//! - RCX: Caller return address (set by syscall instruction)
+//! - R11: RFLAGS (set by syscall instruction)
+//!
+//! The dispatcher validates the request and dispatches to the appropriate handler.
+//!
+//! ## Security
+//!
+//! All syscall handlers must validate their arguments and check that any
+//! memory pointers are within valid user-accessible regions.
+//!
+//! ## License
+//!
+//! Copyright (c) Microsoft Corporation.
+//!
+//! SPDX-License-Identifier: Apache-2.0
+//!
+use core::arch::asm;
+use r_efi::efi::{ALLOCATE_ANY_PAGES, AllocateType, MemoryType, RUNTIME_SERVICES_DATA};
+
+use crate::mm_policy::{AccessType, Instruction, IoWidth};
+use patina::{base::UEFI_PAGE_SIZE, management_mode::supervisor::SyscallIndex};
+
+use crate::{
+    PageOwnership, query_address_ownership,
+    state::{init_state, security_state},
+};
+use r_efi::efi::Status;
+
+use super::SyscallResult;
+
+// Firmware-only syscall-entry assembly; included only for the UEFI target so host builds
+// (tests, doctests) can link.
+#[cfg(target_os = "uefi")]
+core::arch::global_asm!(include_str!("syscall_entry.asm"));
+
+/// MM_IO_UINT8 - 8-bit I/O access width.
+const MM_IO_UINT8: u64 = 0;
+/// MM_IO_UINT16 - 16-bit I/O access width.
+const MM_IO_UINT16: u64 = 1;
+/// MM_IO_UINT32 - 32-bit I/O access width.
+const MM_IO_UINT32: u64 = 2;
+
+/// Converts an EFI_MM_IO_WIDTH enum value to our [`IoWidth`] type.
+///
+/// The EFI spec defines: MM_IO_UINT8=0, MM_IO_UINT16=1, MM_IO_UINT32=2.
+fn efi_io_width_to_io_width(width: u64) -> Option<IoWidth> {
+    match width {
+        MM_IO_UINT8 => Some(IoWidth::Byte),
+        MM_IO_UINT16 => Some(IoWidth::Word),
+        MM_IO_UINT32 => Some(IoWidth::Dword),
+        _ => None,
+    }
+}
+
+/// Reads an 8-bit value from an I/O port.
+///
+/// ## Safety
+///
+/// IO port operation is unsafe and could have unexpected side effects.
+/// The caller must ensure the port address is valid.
+#[inline]
+unsafe fn io_read_u8(port: u16) -> u8 {
+    let value: u8;
+    // SAFETY: IO operation is genuinely unsafe.
+    // But `in al, dx` reads only the caller-specified I/O port (valid per this function's
+    // contract) and accesses no memory (nomem, nostack).
+    unsafe {
+        asm!("in al, dx", out("al") value, in("dx") port, options(nomem, nostack));
+    }
+    value
+}
+
+/// Reads a 16-bit value from an I/O port.
+///
+/// ## Safety
+///
+/// IO port operation is unsafe and could have unexpected side effects.
+/// The caller must ensure the port address is valid.
+#[inline]
+unsafe fn io_read_u16(port: u16) -> u16 {
+    let value: u16;
+    // SAFETY: IO operation is genuinely unsafe.
+    // `in ax, dx` reads only the caller-specified I/O port (valid per this function's
+    // contract) and accesses no memory (nomem, nostack).
+    unsafe {
+        asm!("in ax, dx", out("ax") value, in("dx") port, options(nomem, nostack));
+    }
+    value
+}
+
+/// Reads a 32-bit value from an I/O port.
+///
+/// ## Safety
+///
+/// IO port operation is unsafe and could have unexpected side effects.
+/// The caller must ensure the port address is valid.
+#[inline]
+unsafe fn io_read_u32(port: u16) -> u32 {
+    let value: u32;
+    // SAFETY: IO operation is genuinely unsafe.
+    // `in eax, dx` reads only the caller-specified I/O port (valid per this function's
+    // contract) and accesses no memory (nomem, nostack).
+    unsafe {
+        asm!("in eax, dx", out("eax") value, in("dx") port, options(nomem, nostack));
+    }
+    value
+}
+
+/// Writes an 8-bit value to an I/O port.
+///
+/// ## Safety
+///
+/// IO port operation is unsafe and could have unexpected side effects.
+/// The caller must ensure the port address is valid.
+#[inline]
+unsafe fn io_write_u8(port: u16, value: u8) {
+    // SAFETY: IO operation is genuinely unsafe.
+    // `out dx, al` writes only the caller-specified I/O port (valid per this function's
+    // contract) and accesses no memory (nomem, nostack).
+    unsafe {
+        asm!("out dx, al", in("dx") port, in("al") value, options(nomem, nostack));
+    }
+}
+
+/// Writes a 16-bit value to an I/O port.
+///
+/// ## Safety
+///
+/// IO port operation is unsafe and could have unexpected side effects.
+/// The caller must ensure the port address is valid.
+#[inline]
+unsafe fn io_write_u16(port: u16, value: u16) {
+    // SAFETY: IO operation is genuinely unsafe.
+    // `out dx, ax` writes only the caller-specified I/O port (valid per this function's
+    // contract) and accesses no memory (nomem, nostack).
+    unsafe {
+        asm!("out dx, ax", in("dx") port, in("ax") value, options(nomem, nostack));
+    }
+}
+
+/// Writes a 32-bit value to an I/O port.
+///
+/// ## Safety
+///
+/// IO port operation is unsafe and could have unexpected side effects.
+/// The caller must ensure the port address is valid.
+#[inline]
+unsafe fn io_write_u32(port: u16, value: u32) {
+    // SAFETY: IO operation is genuinely unsafe.
+    // `out dx, eax` writes only the caller-specified I/O port (valid per this function's
+    // contract) and accesses no memory (nomem, nostack).
+    unsafe {
+        asm!("out dx, eax", in("dx") port, in("eax") value, options(nomem, nostack));
+    }
+}
+
+/// Context for a syscall invocation.
+#[derive(Debug, Clone, Copy)]
+pub struct SyscallContext {
+    /// The syscall index (from RAX).
+    pub call_index: u64,
+    /// First argument (from RDX).
+    pub arg1: u64,
+    /// Second argument (from R8).
+    pub arg2: u64,
+    /// Third argument (from R9).
+    pub arg3: u64,
+    /// Caller return address (from RCX, set by syscall instruction).
+    pub caller_addr: u64,
+    /// Ring 3 stack pointer at syscall entry.
+    pub ring3_stack_ptr: u64,
+}
+
+/// The syscall dispatcher handles incoming syscalls from Ring 3.
+pub struct SyscallDispatcher;
+
+impl SyscallDispatcher {
+    /// Creates a new syscall dispatcher.
+    pub const fn new() -> Self {
+        Self
+    }
+
+    /// Dispatches a syscall.
+    ///
+    /// This is the main entry point called from the assembly syscall handler.
+    /// It validates the syscall index and dispatches to the appropriate handler. The result
+    /// is returned to Ring 3 in RAX.
+    pub fn dispatch(&self, ctx: &SyscallContext) -> SyscallResult {
+        // Parse the syscall index
+        let index = match SyscallIndex::from_u64(ctx.call_index) {
+            Some(idx) => idx,
+            None => {
+                log::error!("Unknown syscall index: 0x{:x}", ctx.call_index);
+                return Err(Status::UNSUPPORTED);
+            }
+        };
+
+        log::trace!(
+            "Syscall: {:?} (0x{:x}), args: 0x{:x}, 0x{:x}, 0x{:x}, caller: 0x{:x}, stack: 0x{:x}",
+            index,
+            ctx.call_index,
+            ctx.arg1,
+            ctx.arg2,
+            ctx.arg3,
+            ctx.caller_addr,
+            ctx.ring3_stack_ptr
+        );
+
+        // Dispatch to the appropriate handler
+        let result = match index {
+            SyscallIndex::RdMsr => self.handle_rdmsr(ctx),
+            SyscallIndex::WrMsr => self.handle_wrmsr(ctx),
+            SyscallIndex::Cli => self.handle_cli(ctx),
+            SyscallIndex::IoRead => self.handle_io_read(ctx),
+            SyscallIndex::IoWrite => self.handle_io_write(ctx),
+            SyscallIndex::Wbinvd => self.handle_wbinvd(ctx),
+            SyscallIndex::Hlt => self.handle_hlt(ctx),
+            SyscallIndex::SaveStateRead => self.handle_save_state_read(ctx),
+            SyscallIndex::LegacyMax => panic!("Invalid syscall index: LegacyMax is not a real syscall"),
+            SyscallIndex::AllocPage => self.handle_alloc_page(ctx),
+            SyscallIndex::FreePage => self.handle_free_page(ctx),
+            SyscallIndex::StartApProc => self.handle_start_ap_proc(ctx),
+            SyscallIndex::SaveStateRead2 => self.handle_save_state_read2(ctx),
+            SyscallIndex::MmMemoryUnblocked => self.handle_mm_memory_unblocked(ctx),
+            SyscallIndex::MmIsCommBuffer => self.handle_mm_is_comm_buffer(ctx),
+        };
+
+        match result {
+            Err(err) if index == SyscallIndex::SaveStateRead2 => {
+                log::error!("Syscall SaveStateRead2: {:?} returned value=0x{:x}", index, err.as_usize());
+                Ok(err.as_usize() as u64) // Return error code to caller for SaveStateRead2
+            }
+            Err(err) => {
+                panic!("Syscall: {:?} failed with error: {:?}", index, err); // Panic for other syscalls
+            }
+            _ => result,
+        }
+    }
+
+    /// Handles MSR read syscall.
+    ///
+    /// Validates the MSR read against firmware policy, then executes `rdmsr`.
+    /// - Arg1: MSR index
+    /// - Returns: MSR value in result.value
+    fn handle_rdmsr(&self, ctx: &SyscallContext) -> SyscallResult {
+        let msr_index = ctx.arg1 as u32;
+        log::trace!("RDMSR: msr=0x{:x}", msr_index);
+
+        // Validate against policy
+        let gate = match security_state().policy_gate() {
+            Some(g) => g,
+            None => {
+                log::error!("RDMSR: Policy gate not initialized");
+                return Err(Status::NOT_READY);
+            }
+        };
+
+        if let Err(e) = gate.is_msr_allowed(msr_index, AccessType::Read) {
+            log::error!("RDMSR: MSR 0x{:x} blocked by policy: {:?}", msr_index, e);
+            return Err(Status::ACCESS_DENIED);
+        }
+
+        // Policy allows - execute the MSR read
+        // SAFETY: the policy gate authorized reading this MSR above; `read_msr` only issues
+        // `rdmsr` for `msr_index` and returns its value.
+        let value = unsafe { crate::cpu::read_msr(msr_index) }.unwrap_or_else(|e| {
+            log::error!("RDMSR: rdmsr failed: {}", e);
+            0
+        });
+        log::debug!("RDMSR: MSR 0x{:x} = 0x{:x}", msr_index, value);
+        Ok(value)
+    }
+
+    /// Handles MSR write syscall.
+    ///
+    /// Validates the MSR write against firmware policy, then executes `wrmsr`.
+    /// - Arg1: MSR index
+    /// - Arg2: Value to write
+    fn handle_wrmsr(&self, ctx: &SyscallContext) -> SyscallResult {
+        let msr_index = ctx.arg1 as u32;
+        let value = ctx.arg2;
+        log::trace!("WRMSR: msr=0x{:x}, value=0x{:x}", msr_index, value);
+
+        // Validate against policy
+        let gate = match security_state().policy_gate() {
+            Some(g) => g,
+            None => {
+                log::error!("WRMSR: Policy gate not initialized");
+                return Err(Status::NOT_READY);
+            }
+        };
+
+        if let Err(e) = gate.is_msr_allowed(msr_index, AccessType::Write) {
+            log::error!("WRMSR: MSR 0x{:x} blocked by policy: {:?}", msr_index, e);
+            return Err(Status::ACCESS_DENIED);
+        }
+
+        // Policy allows - execute the MSR write
+        // SAFETY: the policy gate authorized writing this MSR above; `write_msr` only issues
+        // `wrmsr` for `msr_index` with the requested value.
+        if let Err(e) = unsafe { crate::cpu::write_msr(msr_index, value) } {
+            log::error!("WRMSR: wrmsr failed: {}", e);
+            return Err(Status::UNSUPPORTED);
+        }
+        log::debug!("WRMSR: MSR 0x{:x} written with 0x{:x}", msr_index, value);
+        Ok(0)
+    }
+
+    /// Handles CLI (clear interrupt flag) syscall.
+    ///
+    /// Validates the CLI instruction against firmware policy, then executes `cli`.
+    fn handle_cli(&self, _ctx: &SyscallContext) -> SyscallResult {
+        log::trace!("CLI");
+
+        // Validate against policy
+        let gate = match security_state().policy_gate() {
+            Some(g) => g,
+            None => {
+                log::error!("CLI: Policy gate not initialized");
+                return Err(Status::NOT_READY);
+            }
+        };
+
+        if let Err(e) = gate.is_instruction_allowed(Instruction::Cli) {
+            log::error!("CLI: Instruction blocked by policy: {:?}", e);
+            return Err(Status::ACCESS_DENIED);
+        }
+
+        // Policy allows - disable interrupts
+        // SAFETY: the policy gate authorized `CLI` above; the instruction only clears the interrupt
+        // flag and touches no memory (nomem, nostack).
+        unsafe { asm!("cli", options(nomem, nostack)) };
+        log::debug!("CLI: Interrupts disabled");
+        Ok(0)
+    }
+
+    /// Handles I/O port read syscall.
+    ///
+    /// Validates the I/O read against firmware policy, then executes the `in` instruction.
+    /// - Arg1: I/O port address
+    /// - Arg2: EFI_MM_IO_WIDTH (0=UINT8, 1=UINT16, 2=UINT32)
+    /// - Returns: Value read from the port in result.value
+    fn handle_io_read(&self, ctx: &SyscallContext) -> SyscallResult {
+        let port = ctx.arg1;
+        let efi_width = ctx.arg2;
+        log::trace!("IO_READ: port=0x{:x}, width={}", port, efi_width);
+
+        // Convert EFI_MM_IO_WIDTH to IoWidth
+        let io_width = match efi_io_width_to_io_width(efi_width) {
+            Some(w) => w,
+            None => {
+                log::error!("IO_READ: Invalid IO width: {}", efi_width);
+                return Err(Status::INVALID_PARAMETER);
+            }
+        };
+
+        // Validate against policy
+        let gate = match security_state().policy_gate() {
+            Some(g) => g,
+            None => {
+                log::error!("IO_READ: Policy gate not initialized");
+                return Err(Status::NOT_READY);
+            }
+        };
+
+        if let Err(e) = gate.is_io_allowed(port as u32, io_width, AccessType::Read) {
+            log::error!("IO_READ: Port 0x{:x} width {:?} blocked by policy: {:?}", port, io_width, e);
+            return Err(Status::ACCESS_DENIED);
+        }
+
+        // Policy allows - execute the I/O read
+        let port_addr = port as u16;
+        // SAFETY: the policy gate authorized reading this port/width above, and `efi_width` was
+        // validated to a supported width, so the matched `io_read_*` call targets a permitted port.
+        let value: u64 = unsafe {
+            match efi_width {
+                MM_IO_UINT8 => io_read_u8(port_addr) as u64,
+                MM_IO_UINT16 => io_read_u16(port_addr) as u64,
+                MM_IO_UINT32 => io_read_u32(port_addr) as u64,
+                _ => unreachable!(), // Already validated above
+            }
+        };
+
+        log::trace!("IO_READ: port=0x{:x} => 0x{:x}", port, value);
+        Ok(value)
+    }
+
+    /// Handles I/O port write syscall.
+    ///
+    /// Validates the I/O write against firmware policy, then executes the `out` instruction.
+    /// - Arg1: I/O port address
+    /// - Arg2: EFI_MM_IO_WIDTH (0=UINT8, 1=UINT16, 2=UINT32)
+    /// - Arg3: Value to write
+    fn handle_io_write(&self, ctx: &SyscallContext) -> SyscallResult {
+        let port = ctx.arg1;
+        let efi_width = ctx.arg2;
+        let value = ctx.arg3;
+        log::trace!("IO_WRITE: port=0x{:x}, width={}, value=0x{:x}", port, efi_width, value);
+
+        // Convert EFI_MM_IO_WIDTH to IoWidth
+        let io_width = match efi_io_width_to_io_width(efi_width) {
+            Some(w) => w,
+            None => {
+                log::error!("IO_WRITE: Invalid IO width: {}", efi_width);
+                return Err(Status::INVALID_PARAMETER);
+            }
+        };
+
+        // Validate against policy
+        let gate = match security_state().policy_gate() {
+            Some(g) => g,
+            None => {
+                log::error!("IO_WRITE: Policy gate not initialized");
+                return Err(Status::NOT_READY);
+            }
+        };
+
+        if let Err(e) = gate.is_io_allowed(port as u32, io_width, AccessType::Write) {
+            log::error!("IO_WRITE: Port 0x{:x} width {:?} blocked by policy: {:?}", port, io_width, e);
+            return Err(Status::ACCESS_DENIED);
+        }
+
+        // Policy allows - execute the I/O write
+        let port_addr = port as u16;
+        // SAFETY: the policy gate authorized writing this port/width above, and `efi_width` was
+        // validated to a supported width, so the matched `io_write_*` call targets a permitted port.
+        unsafe {
+            match efi_width {
+                MM_IO_UINT8 => io_write_u8(port_addr, value as u8),
+                MM_IO_UINT16 => io_write_u16(port_addr, value as u16),
+                MM_IO_UINT32 => io_write_u32(port_addr, value as u32),
+                _ => unreachable!(), // Already validated above
+            }
+        }
+
+        log::trace!("IO_WRITE: port=0x{:x} <= 0x{:x}", port, value);
+        Ok(0)
+    }
+
+    /// Handles WBINVD (write-back and invalidate cache) syscall.
+    ///
+    /// Validates the WBINVD instruction against firmware policy, then executes `wbinvd`.
+    fn handle_wbinvd(&self, _ctx: &SyscallContext) -> SyscallResult {
+        log::trace!("WBINVD");
+
+        // Validate against policy
+        let gate = match security_state().policy_gate() {
+            Some(g) => g,
+            None => {
+                log::error!("WBINVD: Policy gate not initialized");
+                return Err(Status::NOT_READY);
+            }
+        };
+
+        if let Err(e) = gate.is_instruction_allowed(Instruction::Wbinvd) {
+            log::error!("WBINVD: Instruction blocked by policy: {:?}", e);
+            return Err(Status::ACCESS_DENIED);
+        }
+
+        // Policy allows - write back and invalidate cache
+        // SAFETY: the policy gate authorized `WBINVD` above; the instruction only writes back and
+        // invalidates caches and touches no memory (nomem, nostack).
+        unsafe { asm!("wbinvd", options(nomem, nostack)) };
+        log::debug!("WBINVD: Cache written back and invalidated");
+        Ok(0)
+    }
+
+    /// Handles HLT (halt processor) syscall.
+    ///
+    /// Validates the HLT instruction against firmware policy, then executes `hlt`.
+    fn handle_hlt(&self, _ctx: &SyscallContext) -> SyscallResult {
+        log::trace!("HLT");
+
+        // Validate against policy
+        let gate = match security_state().policy_gate() {
+            Some(g) => g,
+            None => {
+                log::error!("HLT: Policy gate not initialized");
+                return Err(Status::NOT_READY);
+            }
+        };
+
+        if let Err(e) = gate.is_instruction_allowed(Instruction::Hlt) {
+            log::error!("HLT: Instruction blocked by policy: {:?}", e);
+            return Err(Status::ACCESS_DENIED);
+        }
+
+        // Policy allows - halt processor (sleep until next interrupt)
+        // SAFETY: the policy gate authorized `HLT` above; the instruction only halts until the next
+        // interrupt and touches no memory (nomem, nostack).
+        unsafe { asm!("hlt", options(nomem, nostack)) };
+        log::debug!("HLT: Processor halted and resumed");
+        Ok(0)
+    }
+
+    /// Handles save state read syscall (legacy).
+    ///
+    /// - Arg1: User MM CPU protocol pointer
+    /// - Arg2: Register to be read (`EFI_MM_SAVE_STATE_REGISTER`)
+    /// - Arg3: CPU index to read from
+    fn handle_save_state_read(&self, ctx: &SyscallContext) -> SyscallResult {
+        log::trace!("SAVE_STATE_READ: protocol=0x{:x}, register={}, cpu={}", ctx.arg1, ctx.arg2, ctx.arg3);
+
+        // Validate parameters
+        if ctx.arg1 == 0 {
+            log::error!("SAVE_STATE_READ: Null protocol pointer");
+            return Err(Status::INVALID_PARAMETER);
+        }
+
+        // Delegate to save state module Phase 1
+        crate::save_state::save_state_read_phase1(ctx.arg1, ctx.arg2, ctx.arg3)
+    }
+
+    /// Handles page allocation syscall.
+    ///
+    /// - Arg1: Allocate type (EFI_ALLOCATE_TYPE)
+    /// - Arg2: Memory type (must be EfiRuntimeServicesData)
+    /// - Arg3: Page count
+    /// - Returns: Allocated physical address in result.value
+    fn handle_alloc_page(&self, ctx: &SyscallContext) -> SyscallResult {
+        let alloc_type = ctx.arg1 as AllocateType;
+        let mem_type = ctx.arg2 as MemoryType;
+        let page_count = ctx.arg3;
+        log::trace!("ALLOC_PAGE: alloc_type={}, mem_type={}, count={}", alloc_type, mem_type, page_count);
+
+        // Only BSP can allocate pages (AP allocating involves page table updates)
+        if !crate::is_bsp() {
+            log::error!("ALLOC_PAGE: AP cannot allocate pages");
+            return Err(Status::ACCESS_DENIED);
+        }
+
+        if mem_type != RUNTIME_SERVICES_DATA {
+            log::error!("ALLOC_PAGE: Invalid memory type: {}", mem_type);
+            return Err(Status::INVALID_PARAMETER);
+        }
+
+        // Currently only AllocateAnyPages is supported by our page allocator
+        if alloc_type != ALLOCATE_ANY_PAGES {
+            log::error!("ALLOC_PAGE: Only AllocateAnyPages (0) is supported, got {}", alloc_type);
+            return Err(Status::UNSUPPORTED);
+        }
+
+        if page_count == 0 {
+            log::error!("ALLOC_PAGE: Zero page count");
+            return Err(Status::INVALID_PARAMETER);
+        }
+
+        // Allocate pages as User type (Ring 3 driver request)
+        match security_state()
+            .page_allocator()
+            .allocate_pages_with_type(page_count as usize, crate::mem::AllocationType::User)
+        {
+            Ok(addr) => {
+                log::trace!("ALLOC_PAGE: Allocated {} page(s) at 0x{:x}", page_count, addr);
+                Ok(addr)
+            }
+            Err(e) => {
+                log::error!("ALLOC_PAGE: Allocation failed: {:?}", e);
+                Err(Status::OUT_OF_RESOURCES)
+            }
+        }
+    }
+
+    /// Handles page free syscall.
+    ///
+    /// Mirrors the C implementation's `SMM_FREE_PAGE` case.
+    /// - Arg1: Physical address to free
+    /// - Arg2: Number of pages
+    fn handle_free_page(&self, ctx: &SyscallContext) -> SyscallResult {
+        let addr = ctx.arg1;
+        let page_count = ctx.arg2;
+        log::trace!("FREE_PAGE: addr=0x{:x}, count={}", addr, page_count);
+
+        if page_count == 0 {
+            log::error!("FREE_PAGE: Zero page count");
+            return Err(Status::INVALID_PARAMETER);
+        }
+
+        // Validate the address is page-aligned
+        if !addr.is_multiple_of(UEFI_PAGE_SIZE as u64) {
+            log::error!("FREE_PAGE: Address 0x{:x} is not page-aligned", addr);
+            return Err(Status::INVALID_PARAMETER);
+        }
+
+        // Verify the range was allocated as User type (Ring 3 code should only free its own memory)
+        // This prevents user code from freeing supervisor-internal allocations.
+        match security_state().page_allocator().get_allocation_type(addr) {
+            Some(crate::mem::AllocationType::User) => {
+                // Good - this is user-owned memory
+            }
+            Some(crate::mem::AllocationType::Supervisor) => {
+                log::error!("FREE_PAGE: Address 0x{:x} is a supervisor allocation - access denied", addr);
+                return Err(Status::SECURITY_VIOLATION);
+            }
+            None => {
+                log::error!("FREE_PAGE: Address 0x{:x} is not allocated", addr);
+                return Err(Status::INVALID_PARAMETER);
+            }
+        }
+
+        // Free the pages, verifying they are all User allocations
+        match security_state().page_allocator().free_pages_checked(
+            addr,
+            page_count as usize,
+            crate::mem::AllocationType::User,
+        ) {
+            Ok(()) => {
+                log::debug!("FREE_PAGE: Freed {} page(s) at 0x{:x}", page_count, addr);
+                Ok(0)
+            }
+            Err(e) => {
+                log::error!("FREE_PAGE: Free failed: {:?}", e);
+                Err(Status::SECURITY_VIOLATION)
+            }
+        }
+    }
+
+    /// Handles start AP procedure syscall.
+    ///
+    /// Validates the request and delegates to the platform-specific AP startup
+    /// function registered during [`MmSupervisorCore`] initialization.
+    ///
+    /// Checks performed before dispatch:
+    /// - Procedure pointer is non-null
+    /// - Procedure pointer is within user-accessible memory (unblocked region)
+    /// - Argument pointer (if non-null) is within user-accessible memory
+    ///
+    /// The remaining validation (CPU index range, BSP check, AP busy check) and
+    /// the actual dispatch are handled by the registered AP startup function,
+    /// which has access to the CPU manager and mailbox manager.
+    ///
+    /// - Arg1: Procedure function pointer
+    /// - Arg2: CPU index
+    /// - Arg3: Argument pointer
+    fn handle_start_ap_proc(&self, ctx: &SyscallContext) -> SyscallResult {
+        let procedure = ctx.arg1;
+        let cpu_index = ctx.arg2;
+        let argument = ctx.arg3;
+
+        log::info!("START_AP_PROC: proc=0x{:x}, cpu={}, arg=0x{:x}", procedure, cpu_index, argument);
+
+        // 1. Validate procedure pointer is non-null
+        if procedure == 0 {
+            log::error!("START_AP_PROC: Null procedure pointer");
+            return Err(Status::INVALID_PARAMETER);
+        }
+
+        // 2. Validate procedure pointer is within mapped memory via page table query
+        if crate::query_address_ownership(procedure, core::mem::size_of::<usize>() as u64).is_none() {
+            log::error!("START_AP_PROC: Procedure 0x{:x} not in mapped memory", procedure);
+            return Err(Status::INVALID_PARAMETER);
+        }
+
+        // 3. Validate argument pointer (if non-null) is within mapped memory
+        if argument != 0 && crate::query_address_ownership(argument, core::mem::size_of::<usize>() as u64).is_none() {
+            log::error!("START_AP_PROC: Argument 0x{:x} not in mapped memory", argument);
+            return Err(Status::INVALID_PARAMETER);
+        }
+
+        // 4. Delegate to the registered AP startup function
+        match init_state().ap_startup_fn() {
+            Some(start_fn) => {
+                log::info!(
+                    "START_AP_PROC: Dispatching to AP startup function at {:p} for CPU {}",
+                    start_fn as *const (),
+                    cpu_index
+                );
+                let status = start_fn(cpu_index, procedure, argument);
+                if status == 0 { Ok(0) } else { Err(Status::from_usize(status as usize)) }
+            }
+            None => {
+                log::error!("START_AP_PROC: AP startup not initialized");
+                Err(Status::NOT_READY)
+            }
+        }
+    }
+
+    /// Handles extended save state read syscall.
+    ///
+    /// - Arg1: User MM CPU protocol pointer
+    /// - Arg2: Width of buffer to read in bytes
+    /// - Arg3: User buffer to hold return data
+    fn handle_save_state_read2(&self, ctx: &SyscallContext) -> SyscallResult {
+        // Validate parameters
+        if ctx.arg1 == 0 {
+            log::error!("SAVE_STATE_READ2: Null protocol pointer");
+            return Err(Status::INVALID_PARAMETER);
+        }
+
+        // Delegate to save state module Phase 2
+        crate::save_state::save_state_read_phase2(ctx.arg1, ctx.arg2, ctx.arg3)
+    }
+
+    /// Handles MM memory unblocked check syscall.
+    ///
+    /// Checks if a memory range is outside MMRAM and valid (unblocked), AND
+    /// is within user-owned space.
+    /// - Arg1: Physical address
+    /// - Arg2: Size in bytes
+    /// - Returns: 1 (TRUE) if valid, 0 (FALSE) otherwise
+    fn handle_mm_memory_unblocked(&self, ctx: &SyscallContext) -> SyscallResult {
+        let addr = ctx.arg1;
+        let size = ctx.arg2;
+        log::trace!("MM_MEMORY_UNBLOCKED: addr=0x{:x}, size=0x{:x}", addr, size);
+
+        // Check if the buffer is within an unblocked memory region
+        let is_valid = security_state().unblocked_tracker().is_within_unblocked_region(addr, size);
+
+        if !is_valid {
+            log::trace!("MM_MEMORY_UNBLOCKED: addr=0x{:x} size=0x{:x} not in unblocked region", addr, size);
+            return Ok(0); // FALSE
+        }
+
+        // Additional check - verify buffer is in user-owned space
+        match query_address_ownership(addr, size) {
+            Some(owner) => {
+                if owner != PageOwnership::User {
+                    log::trace!(
+                        "MM_MEMORY_UNBLOCKED: addr=0x{:x} size=0x{:x} owned by {:?} - not valid",
+                        addr,
+                        size,
+                        owner
+                    );
+                    return Ok(0); // FALSE
+                }
+            }
+            None => {
+                log::trace!("MM_MEMORY_UNBLOCKED: addr=0x{:x} size=0x{:x} not in mapped memory", addr, size);
+                return Ok(0); // FALSE
+            }
+        }
+
+        log::trace!("MM_MEMORY_UNBLOCKED: addr=0x{:x} size=0x{:x} is valid", addr, size);
+        Ok(1) // TRUE
+    }
+
+    /// Handles MM is communication buffer check syscall.
+    ///
+    /// Verifies that a given memory range is a valid communication buffer.
+    /// - Arg1: Buffer address
+    /// - Arg2: Buffer size
+    /// - Returns: 1 (TRUE) if valid comm buffer, 0 (FALSE) otherwise
+    fn handle_mm_is_comm_buffer(&self, ctx: &SyscallContext) -> SyscallResult {
+        let address = ctx.arg1;
+        let size = ctx.arg2;
+        log::trace!("MM_IS_COMM_BUFFER: addr=0x{:x}, size=0x{:x}", address, size);
+
+        let config = match security_state().comm_buffer_config() {
+            Some(c) => c,
+            None => {
+                log::error!("MM_IS_COMM_BUFFER: Comm buffer config not initialized");
+                return Ok(0); // FALSE
+            }
+        };
+
+        let buf_start = config.user_comm_buffer_internal;
+        let buf_end = buf_start.saturating_add(config.user_comm_buffer_size);
+        let range_end = address.saturating_add(size);
+
+        // Check that the range is non-empty and falls entirely within the user comm buffer.
+        let is_valid = size > 0 && address >= buf_start && range_end <= buf_end;
+
+        log::debug!("MM_IS_COMM_BUFFER: addr=0x{:x} size=0x{:x} => {}", address, size, is_valid);
+        if is_valid { Ok(1) } else { Ok(0) }
+    }
+}
+
+/// C-compatible syscall dispatcher entry point.
+///
+/// This function is called from the assembly syscall entry stub (SyscallCenter). Its parameters
+/// carry the syscall registers described by the module-level calling convention, and its return
+/// value is the result placed in RAX for the Ring 3 caller.
+#[unsafe(no_mangle)]
+pub extern "efiapi" fn syscall_dispatcher(
+    call_index: u64,
+    arg1: u64,
+    arg2: u64,
+    arg3: u64,
+    caller_addr: u64,
+    ring3_stack_ptr: u64,
+) -> u64 {
+    let ctx = SyscallContext { call_index, arg1, arg2, arg3, caller_addr, ring3_stack_ptr };
+
+    // Unwrap is safe here because the dispatch() will always return a u64
+    // result, and panic on failure.
+    SyscallDispatcher::new().dispatch(&ctx).unwrap()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_syscall_index_roundtrip() {
+        for idx in
+            [SyscallIndex::RdMsr, SyscallIndex::WrMsr, SyscallIndex::Cli, SyscallIndex::IoRead, SyscallIndex::IoWrite]
+        {
+            assert_eq!(SyscallIndex::from_u64(idx.as_u64()), Some(idx));
+        }
+    }
+
+    #[test]
+    fn test_unknown_syscall_index() {
+        // Values that fall in the gaps between defined indices map to `None`.
+        assert_eq!(SyscallIndex::from_u64(0x0008), None);
+        assert_eq!(SyscallIndex::from_u64(0x10000), None);
+        assert_eq!(SyscallIndex::from_u64(0xDEAD_BEEF), None);
+    }
+}

--- a/patina_mm_supervisor/src/privilege_mgmt/syscall_entry.asm
+++ b/patina_mm_supervisor/src/privilege_mgmt/syscall_entry.asm
@@ -1,0 +1,159 @@
+#------------------------------------------------------------------------------
+# Copyright (c) 2020, AMD Incorporated. All rights reserved.<BR>
+# Copyright (c) 2017, Intel Corporation. All rights reserved.<BR>
+# Copyright (c) Microsoft Corporation.
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+# Module Name:
+#
+#   WriteTr.nasm
+#
+# Abstract:
+#
+#   Write TR register
+#
+# Notes:
+#
+#------------------------------------------------------------------------------
+
+.section .data
+.global syscall_center
+.global syscall_dispatcher
+
+.section .text
+.align 8
+
+# Segments defined in SmiException.nasm
+.equ LONG_DS_R0,                      0x40
+.equ LONG_DS_R3,                      0x53
+
+# This should be OFFSET_OF (MM_SUPV_SYSCALL_CACHE, MmSupvRsp)
+.equ MM_SUPV_RSP,                     0x00
+# This should be OFFSET_OF (MM_SUPV_SYSCALL_CACHE, SavedUserRsp)
+.equ SAVED_USER_RSP,                  0x08
+
+#------------------------------------------------------------------------------
+# Caller Interface:
+# UINT64
+# EFIAPI <SysV calling convention>
+# SysCall (
+#   UINTN CallIndex,
+#   UINTN Arg1,
+#   UINTN Arg2,
+#   UINTN Arg3
+#   );
+#
+# Backend Interface:
+# /// C-compatible syscall dispatcher entry point.
+# ///
+# /// This function is called from the assembly syscall entry stub (SyscallCenter).
+# ///
+# /// # Arguments
+# ///
+# /// * `call_index` - Syscall index (from RAX)
+# /// * `arg1` - First argument (from RDX)
+# /// * `arg2` - Second argument (from R8)
+# /// * `arg3` - Third argument (from R9)
+# /// * `caller_addr` - Caller return address (from RCX)
+# /// * `ring3_stack_ptr` - Ring 3 stack pointer
+# ///
+# /// # Returns
+# ///
+# /// The value to return in RAX.
+# #[unsafe(no_mangle)]
+# pub extern "efiapi" fn syscall_dispatcher(
+#     call_index: u64,
+#     arg1: u64,
+#     arg2: u64,
+#     arg3: u64,
+#     caller_addr: u64,
+#     ring3_stack_ptr: u64,
+# ) -> u64;
+#------------------------------------------------------------------------------
+syscall_center:
+# Calling convention: CallIndex in RAX, Arg1 in RDX, Arg2 in R8, Arg3 in R9 from SysCallLib
+# Architectural definition: CallerAddr in RCX, rFLAGs in R11 from x64 syscall instruction
+# push CallIndex stored at top of stack
+
+    swapgs  # get kernel pointer, save user GSbase
+    mov gs:[SAVED_USER_RSP], rsp # save user's stack pointer
+    mov rsp, gs:[MM_SUPV_RSP] # set up kernel stack
+
+    #Preserve all registers in CPL3
+    push    rax
+    push    rcx
+    push    rbp
+    push    rdx
+    push    r8
+    push    r9
+    push    rsi
+    push    r12
+    push    rdi
+    push    rbx
+    push    r11
+    push    r10
+    push    r13
+    push    r14
+    push    r15
+
+    mov     rbp, rsp
+    and     rsp, -16
+
+    ## FX_SAVE_STATE_X64 FxSaveState#
+    sub rsp, 512
+    mov rdi, rsp
+    .byte 0x0f, 0xae, 0x07 #fxsave [rdi]
+
+    #Prepare for ds, es, fs, gs
+    xor     rbx, rbx
+    mov     bx, LONG_DS_R0
+    mov     ds, bx
+    mov     es, bx
+    mov     fs, bx
+
+    mov     rsi, gs:[SAVED_USER_RSP]     # Save Ring 3 stack to RSI
+    push    rsi                          # Push Ring 3 stack as Ring3Stack for syscall_dispatcher
+    push    rcx                          # Push return address on stack as CallerAddr for syscall_dispatcher
+    mov     rcx, rax
+    sub     rsp, 0x20
+
+    call    syscall_dispatcher
+
+    add     rsp, 0x20
+    pop     rcx                          # Restore SP to avoid stack overflow
+    pop     rsi                          # Restore SI to avoid stack overflow
+
+    #Prepare for ds, es, fs, gs
+    xor     rbx, rbx
+    mov     bx, LONG_DS_R3
+    mov     ds, bx
+    mov     es, bx
+    mov     fs, bx
+
+    mov rsi, rsp
+    .byte 0x0f, 0xae, 0x0e # fxrstor [rsi]
+    add rsp, 512
+
+    mov     rsp, rbp
+
+    #restore registers from CPL3 stack
+    pop     r15
+    pop     r14
+    pop     r13
+    pop     r10
+    pop     r11
+    pop     rbx
+    pop     rdi
+    pop     r12
+    pop     rsi
+    pop     r9
+    pop     r8
+    pop     rdx
+    pop     rbp
+    pop     rcx           # return rcx from stack
+
+    add     rsp, 8        # return rsp to original position
+    mov     rsp, gs:[SAVED_USER_RSP]  # restore user RSP
+    swapgs  # restore user GS, save kernel pointer
+    .byte   0x48          # return to the long mode
+    sysret                # RAX contains return value

--- a/patina_mm_supervisor/src/privilege_mgmt/syscall_setup.rs
+++ b/patina_mm_supervisor/src/privilege_mgmt/syscall_setup.rs
@@ -1,0 +1,195 @@
+//! Syscall Interface Setup
+//!
+//! This module handles the initialization and configuration of syscall/sysret MSRs
+//! for privilege level transitions. It manages per-CPU storage for MSR values and
+//! the syscall cache structure used during ring transitions.
+//!
+//! ## MSR Configuration
+//!
+//! - **MSR_IA32_STAR**: Contains segment selectors for syscall/sysret
+//!   - Bits 47:32 = SYSRET CS and SS (LONG_CS_R3_PH << 16)
+//!   - Bits 31:16 = SYSCALL CS and SS (LONG_CS_R0)
+//!
+//! - **MSR_IA32_LSTAR**: Contains the 64-bit RIP for syscall entry (SyscallCenter)
+//!
+//! - **MSR_IA32_EFER**: Extended Feature Enable Register
+//!   - Bit 0 (SCE) must be set to enable syscall/sysret
+//!
+//! - **MSR_IA32_KERNEL_GS_BASE**: Used with swapgs to switch between user and kernel
+//!   GS base addresses, allowing access to per-CPU data in the syscall handler.
+//!
+//! ## License
+//!
+//! Copyright (c) Microsoft Corporation.
+//!
+//! SPDX-License-Identifier: Apache-2.0
+//!
+use core::sync::atomic::{AtomicBool, Ordering};
+use spin::Mutex;
+
+/// Errors specific to syscall setup operations.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SyscallSetupError {
+    /// The syscall interface has not been initialized.
+    NotInitialized,
+    /// Already initialized.
+    AlreadyInitialized,
+    /// Invalid CPU index (exceeds configured CPU count).
+    InvalidCpuIndex,
+}
+
+/// Internal state for the syscall interface.
+///
+/// ## Const Generic Parameters
+///
+/// * `MAX_CPUS` - The maximum number of CPUs that can be supported.
+struct SyscallInterfaceState<const MAX_CPUS: usize> {
+    /// Number of CPUs configured.
+    num_cpus: usize,
+    /// CPL3 stack array base address.
+    cpl3_stack_base: u64,
+    /// Per-CPU stack size.
+    stack_size: usize,
+}
+
+impl<const MAX_CPUS: usize> SyscallInterfaceState<MAX_CPUS> {
+    const fn new() -> Self {
+        Self { num_cpus: 0, cpl3_stack_base: 0, stack_size: 0 }
+    }
+}
+
+/// Syscall interface manager.
+///
+/// Manages the syscall/sysret MSR configuration for all CPUs and provides
+/// the infrastructure for Ring 0 ↔ Ring 3 transitions.
+///
+/// ## Const Generic Parameters
+///
+/// * `MAX_CPUS` - The maximum number of CPUs that can be supported.
+///   This should match the `MAX_CPUS` const generic of `MmSupervisorCore`.
+pub struct SyscallInterface<const MAX_CPUS: usize> {
+    /// Whether the interface has been initialized.
+    initialized: AtomicBool,
+    /// Internal state protected by mutex.
+    state: Mutex<SyscallInterfaceState<MAX_CPUS>>,
+}
+
+impl<const MAX_CPUS: usize> SyscallInterface<MAX_CPUS> {
+    /// Creates a new syscall interface.
+    pub const fn new() -> Self {
+        Self { initialized: AtomicBool::new(false), state: Mutex::new(SyscallInterfaceState::new()) }
+    }
+
+    /// Initializes the syscall interface.
+    ///
+    /// This should be called once during BSP initialization. `num_cpus` must be less than or
+    /// equal to `MAX_CPUS`.
+    pub fn init(&self, num_cpus: usize, cpl3_stack_base: u64, stack_size: usize) -> Result<(), SyscallSetupError> {
+        // Check if already initialized
+        if self.initialized.swap(true, Ordering::SeqCst) {
+            return Err(SyscallSetupError::AlreadyInitialized);
+        }
+
+        if num_cpus == 0 || num_cpus > MAX_CPUS {
+            self.initialized.store(false, Ordering::SeqCst);
+            return Err(SyscallSetupError::InvalidCpuIndex);
+        }
+
+        let mut state = self.state.lock();
+        state.num_cpus = num_cpus;
+        state.cpl3_stack_base = cpl3_stack_base;
+        state.stack_size = stack_size;
+
+        log::info!(
+            "SyscallInterface<{}> initialized: {} CPUs, cpl3_stack=0x{:016x}, stack_size=0x{:x}",
+            MAX_CPUS,
+            num_cpus,
+            cpl3_stack_base,
+            stack_size
+        );
+
+        Ok(())
+    }
+
+    /// Checks if the syscall interface is initialized.
+    pub fn is_initialized(&self) -> bool {
+        self.initialized.load(Ordering::Acquire)
+    }
+
+    /// Gets the CPL3 stack pointer for a specific CPU.
+    ///
+    /// The stack pointer is calculated as:
+    /// `cpl3_stack_base + stack_size * (cpu_index + 1) - sizeof(usize)`
+    ///
+    /// This gives the top of the stack for the CPU (stacks grow downward).
+    /// TODO: Might just want to allocate a page on the fly before demotion and free the pointer
+    /// upon returning instead of messing with the pre-allocated stack array.
+    pub fn get_cpl3_stack(&self, cpu_index: usize) -> Result<u64, SyscallSetupError> {
+        if !self.is_initialized() {
+            log::error!("SyscallInterface not initialized");
+            return Err(SyscallSetupError::NotInitialized);
+        }
+
+        let state = self.state.lock();
+        if cpu_index >= state.num_cpus {
+            log::error!("Invalid CPU index {}: exceeds configured CPU count {}", cpu_index, state.num_cpus);
+            return Err(SyscallSetupError::InvalidCpuIndex);
+        }
+
+        // Calculate stack top: base + size * (index + 1) - sizeof(usize)
+        let stack_top = state
+            .cpl3_stack_base
+            .wrapping_add((state.stack_size as u64) * ((cpu_index as u64) + 1))
+            .wrapping_sub(core::mem::size_of::<usize>() as u64);
+
+        Ok(stack_top)
+    }
+}
+
+impl<const MAX_CPUS: usize> Default for SyscallInterface<MAX_CPUS> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_cpl3_stack_calculation() {
+        let interface: SyscallInterface<8> = SyscallInterface::new();
+
+        // Initialize with known values: num_cpus=4, cpl3_stack_base=0x10000, stack_size=0x4000
+        interface.init(4, 0x10000, 0x4000).unwrap();
+
+        // CPU 0: base + 0x4000 * 1 - 8 = 0x10000 + 0x4000 - 8 = 0x13FF8
+        assert_eq!(interface.get_cpl3_stack(0).unwrap(), 0x13FF8);
+
+        // CPU 1: base + 0x4000 * 2 - 8 = 0x10000 + 0x8000 - 8 = 0x17FF8
+        assert_eq!(interface.get_cpl3_stack(1).unwrap(), 0x17FF8);
+    }
+
+    #[test]
+    fn test_init_twice_fails() {
+        let interface: SyscallInterface<8> = SyscallInterface::new();
+        assert!(interface.init(4, 0x10000, 0x4000).is_ok());
+        assert_eq!(interface.init(4, 0x10000, 0x4000), Err(SyscallSetupError::AlreadyInitialized));
+    }
+
+    #[test]
+    fn test_invalid_cpu_index() {
+        let interface: SyscallInterface<8> = SyscallInterface::new();
+        interface.init(4, 0x10000, 0x4000).unwrap();
+
+        assert_eq!(interface.get_cpl3_stack(4), Err(SyscallSetupError::InvalidCpuIndex));
+        assert_eq!(interface.get_cpl3_stack(100), Err(SyscallSetupError::InvalidCpuIndex));
+    }
+
+    #[test]
+    fn test_max_cpus_exceeded() {
+        let interface: SyscallInterface<4> = SyscallInterface::new();
+        // Try to init with more CPUs than the const generic allows
+        assert_eq!(interface.init(8, 0x10000, 0x4000), Err(SyscallSetupError::InvalidCpuIndex));
+    }
+}

--- a/patina_mm_supervisor/src/runtime.rs
+++ b/patina_mm_supervisor/src/runtime.rs
@@ -1,0 +1,777 @@
+//! MM Supervisor Core Runtime Dispatch
+//!
+//! This module contains the runtime request processing logic for the MM Supervisor Core,
+//! including the BSP request loop, user/supervisor request dispatch, AP holding pen,
+//! and AP procedure management.
+//!
+//! ## License
+//!
+//! Copyright (c) Microsoft Corporation.
+//!
+//! SPDX-License-Identifier: Apache-2.0
+//!
+
+use patina::{
+    management_mode::{MmCommBufferStatus, supervisor::UserCommandType},
+    pi::{mm_cis::EfiMmEntryContext, protocols::communication::EfiMmCommunicateHeader},
+};
+use r_efi::efi;
+
+use crate::{
+    AP_ARRIVAL_TIMEOUT_US, AP_TIMEOUT_US, CommBufferConfig, MmSupervisorCore, PageOwnership, PlatformInfo,
+    cpu::{ApState, is_bsp},
+    mailbox::{ApCommand, ApResponse},
+    privilege_mgmt::invoke_demoted_routine,
+    query_address_ownership,
+    state::{DEFAULT_SUPERVISOR_MMI_HANDLERS, init_state, security_state},
+};
+
+/// Helper function to disable the SMAP bit in EFLAGS to allow supervisor code to access user memory when needed.
+///
+/// ## Safety
+///
+/// Disabling SMAP removes the hardware barrier that stops the supervisor (Ring 0) from
+/// reading or writing user-owned (Ring 3) memory. The caller must re-enable SMAP via
+/// [`enable_smap`] once the user-memory access completes, and must ensure every access
+/// performed while SMAP is lifted targets valid, correctly-owned user memory. Prefer
+/// [`with_user_access`], which guarantees the disable/enable pair is balanced.
+unsafe fn disable_smap() {
+    // SAFETY: `stac` only sets the AC flag in EFLAGS; it touches no memory and clobbers
+    // no registers (hence `nostack, preserves_flags`). It is a privileged instruction that
+    // is valid in the Ring 0 supervisor context this code always runs in.
+    #[cfg(all(not(test), target_arch = "x86_64"))]
+    unsafe {
+        core::arch::asm!(
+            "stac", // Set AC flag to enable access to user memory
+            options(nostack, preserves_flags)
+        );
+    }
+}
+
+/// Helper function to re-enable the SMAP bit in EFLAGS after accessing user memory.
+///
+/// ## Safety
+///
+/// This mutates the privileged EFLAGS.AC state and must only be called to close a region
+/// opened by [`disable_smap`]. Callers must ensure no further user-memory access that
+/// relies on SMAP being lifted happens after this returns. Prefer [`with_user_access`],
+/// which guarantees the disable/enable pair is balanced.
+unsafe fn enable_smap() {
+    // SAFETY: `clac` only clears the AC flag in EFLAGS; it touches no memory and clobbers
+    // no registers (hence `nostack, preserves_flags`). It is a privileged instruction that
+    // is valid in the Ring 0 supervisor context this code always runs in.
+    #[cfg(all(not(test), target_arch = "x86_64"))]
+    unsafe {
+        core::arch::asm!(
+            "clac", // Clear AC flag to re-enable SMAP protections
+            options(nostack, preserves_flags)
+        );
+    }
+}
+
+/// Runs `access` with SMAP temporarily disabled so the supervisor can read or
+/// write user-owned memory, restoring SMAP protection when it returns.
+fn with_user_access<R>(access: impl FnOnce() -> R) -> R {
+    // SAFETY: `disable_smap`/`enable_smap` are called as a balanced pair around `access`,
+    // upholding the invariant that SMAP protection is always restored before returning. The
+    // caller of `with_user_access` is responsible for ensuring `access` only touches valid,
+    // correctly-owned user memory while SMAP is lifted.
+    unsafe {
+        disable_smap();
+        let result = access();
+        enable_smap();
+        result
+    }
+}
+
+impl<P: PlatformInfo, const MAX_CPUS: usize> MmSupervisorCore<P, MAX_CPUS> {
+    /// Enter runtime mode (called on subsequent entries after init is complete).
+    ///
+    /// Implements the MP synchronization protocol:
+    /// 1. APs check in by setting their state to `InHoldingPen` and entering the holding pen
+    /// 2. BSP waits for all registered APs, all cores must be in MM before servicing a request
+    /// 3. BSP processes the pending request via `bsp_request_loop`
+    /// 4. BSP releases every AP via the per-CPU rendezvous semaphore
+    /// 5. BSP waits indefinitely for every released AP to acknowledge it has left
+    /// 6. Each AP clears its `InHoldingPen` state and acknowledges the BSP
+    pub(crate) fn enter_runtime(&'static self, cpu_id: u32) {
+        let is_bsp = is_bsp();
+
+        if is_bsp {
+            log::info!("BSP (CPU {}) waiting for APs to arrive...", cpu_id);
+
+            // Wait for all registered APs to check in (set state to InHoldingPen).
+            let expected_aps = self.cpu_manager.registered_count().saturating_sub(1);
+            self.wait_for_ap_arrival(expected_aps);
+
+            // Every registered AP is now in MM - service the request.
+            log::trace!("BSP (CPU {}) entering request serving routine...", cpu_id);
+            self.bsp_request_loop(cpu_id as usize);
+
+            // Exit barrier: release every penned AP and wait for each to acknowledge it has left.
+            log::trace!("BSP (CPU {}) releasing all APs from the holding pen...", cpu_id);
+            self.cpu_manager.release_all_aps();
+            self.cpu_manager.wait_for_ap_exit_acks(expected_aps);
+
+            self.mailbox_manager.reset_all();
+        } else {
+            // AP: check in by marking state, then enter holding pen.
+            self.cpu_manager.set_ap_state(cpu_id, ApState::InHoldingPen);
+            log::info!("AP (CPU {}) checked in, entering holding pen...", cpu_id);
+            self.ap_holding_pen(cpu_id);
+
+            // Check out: clear the InHoldingPen state now that this AP has left the pen and let BSP know we are out.
+            self.cpu_manager.set_ap_state(cpu_id, ApState::NotPresent);
+            self.cpu_manager.ack_exit_to_bsp();
+        }
+    }
+
+    /// Waits for all registered APs to rendezvous in the holding pen, enforcing the
+    /// all APs arrival guarantee.
+    ///
+    /// TODO: A fully robust implementation would first re-assert the MMI via SMI IPI to
+    /// force delayed/blocked stragglers in before failing. That force-in needs Local APIC
+    /// IPI support the supervisor does not yet provide; until then a straggler that misses
+    /// the window halts the platform instead of being pulled in.
+    ///
+    /// ## Panics
+    ///
+    /// Panics (fail-secure halt) if not all registered APs arrive within
+    /// `AP_ARRIVAL_TIMEOUT_US`.
+    fn wait_for_ap_arrival(&self, expected_aps: usize) {
+        if expected_aps == 0 {
+            return;
+        }
+
+        let all_arrived = crate::perf_timer::spin_until::<P::CpuInfo, _>(AP_ARRIVAL_TIMEOUT_US, || {
+            self.cpu_manager.count_aps_in_state(ApState::InHoldingPen) >= expected_aps
+        });
+
+        if all_arrived {
+            log::trace!("All {} APs arrived", expected_aps);
+        } else {
+            // All cores have to rendezvous in the holding pen before the BSP services a request. If any core
+            // fails to arrive within the window, this is a security-fatal condition.
+            let arrived = self.cpu_manager.count_aps_in_state(ApState::InHoldingPen);
+            panic!(
+                "MM Supervisor fail-secure: only {}/{} APs rendezvoused within the arrival window; \
+                 refusing to service the request with a partial set of cores",
+                arrived, expected_aps
+            );
+        }
+    }
+
+    /// The main request serving loop for the BSP.
+    /// It manages other CPUs and processes pending requests from the communication buffer.
+    ///
+    /// Two parallel `MmCommBufferStatus` mailboxes are consulted — one for the
+    /// user channel and one for the supervisor channel. The user mailbox is
+    /// checked first; if neither mailbox is valid the request is treated as
+    /// an asynchronous MMI and dispatched through the user path so the
+    /// user-core's async handler chain still runs.
+    ///
+    /// - If targeting User: copies user comm buffer to internal, then demotes to user entry point
+    /// - If targeting Supervisor: dispatches to the request dispatcher
+    fn bsp_request_loop(&self, cpu_index: usize) {
+        // Get communication buffer configuration
+        let config = match security_state().comm_buffer_config() {
+            Some(c) => c,
+            None => {
+                // Not yet initialized, nothing to process
+                return;
+            }
+        };
+
+        // Bail out only if neither status mailbox is wired up yet.
+        if config.user_status_buffer == 0 && config.supv_status_buffer == 0 {
+            return;
+        }
+
+        // Read both status mailboxes. A buffer that hasn't been published yet
+        // is treated as an all-zero (idle) status.
+        let user_status = if config.user_status_buffer != 0 {
+            // SAFETY: `user_status_buffer` is non-zero here and, provided by the MM IPL, references
+            // an MMRAM-resident `MmCommBufferStatus`, so the volatile read is valid.
+            unsafe { core::ptr::read_volatile(config.user_status_buffer as *const MmCommBufferStatus) }
+        } else {
+            MmCommBufferStatus::new()
+        };
+        let supv_status = if config.supv_status_buffer != 0 {
+            // SAFETY: `supv_status_buffer` is non-zero here and, provided by the MM IPL, references
+            // an MMRAM-resident `MmCommBufferStatus`, so the volatile read is valid.
+            unsafe { core::ptr::read_volatile(config.supv_status_buffer as *const MmCommBufferStatus) }
+        } else {
+            MmCommBufferStatus::new()
+        };
+
+        let target = crate::RequestTarget::select(&user_status, &supv_status);
+
+        log::trace!(
+            "Processing request: user_valid={}, supv_valid={}, target={:?}",
+            user_status.is_comm_buffer_valid,
+            supv_status.is_comm_buffer_valid,
+            target
+        );
+
+        match target {
+            crate::RequestTarget::None => {
+                // No pending request
+            }
+            crate::RequestTarget::User => {
+                // Request targets the User module (sync user MMI or async dispatch)
+                self.process_user_request(config, &user_status, cpu_index);
+            }
+            crate::RequestTarget::Supervisor => {
+                // Request targets the Supervisor
+                self.process_supervisor_request(config, &supv_status, cpu_index);
+            }
+        }
+    }
+
+    /// Process a request targeting the User module.
+    ///
+    /// This function implements the user-mode MMI dispatch pathway:
+    /// 1. Builds a fresh `EfiMmEntryContext` with the current CPU index and CPU count
+    /// 2. Copies the `EfiMmEntryContext` into the supervisor-to-user data buffer
+    /// 3. Appends the `MmCommBufferStatus` immediately after the context
+    /// 4. For synchronous MMIs, copies the user comm buffer to the internal copy
+    /// 5. Demotes to the user entry point via `invoke_demoted_routine`
+    /// 6. On return, copies back the user comm buffer and reads the updated status
+    fn process_user_request(&self, config: &CommBufferConfig, status: &MmCommBufferStatus, cpu_index: usize) {
+        log::info!("Processing User request...");
+
+        // Validate buffers
+        if config.user_comm_buffer == 0 || config.user_comm_buffer_internal == 0 {
+            log::error!("User communication buffer not configured");
+            return;
+        }
+
+        if config.supv_to_user_buffer == 0 {
+            log::error!("Supervisor-to-user data buffer not configured");
+            return;
+        }
+
+        // Get user entry point
+        let user_entry = match init_state().user_entry_point() {
+            Some(entry) if entry != 0 => entry,
+            _ => {
+                log::error!("User entry point not configured, cannot demote");
+                return;
+            }
+        };
+
+        // Demote to user entry point to process the request
+        let cpl3_stack = match self.syscall_interface.get_cpl3_stack(cpu_index) {
+            Ok(stack) => stack,
+            Err(e) => {
+                log::error!("Failed to get CPL3 stack for CPU {}: {:?}", cpu_index, e);
+                return;
+            }
+        };
+
+        // Build a fresh EfiMmEntryContext with only the fields the user actually needs.
+        // The legacy C structure carried pointers (mm_startup_this_ap, cpu_save_state,
+        // cpu_save_state_size) that are meaningless in the Rust supervisor model — the
+        // user module accesses those services through syscalls instead.
+        let entry_context = EfiMmEntryContext {
+            mm_startup_this_ap: 0,
+            currently_executing_cpu: cpu_index as u64,
+            number_of_cpus: self.cpu_manager.registered_count() as u64,
+            cpu_save_state_size: 0,
+            cpu_save_state: 0,
+        };
+
+        // Copy the EfiMmEntryContext + MmCommBufferStatus into the supervisor-to-user
+        // data buffer so the user can read processor information after demotion.
+        let context_size = core::mem::size_of::<EfiMmEntryContext>();
+        let status_size = core::mem::size_of::<MmCommBufferStatus>();
+
+        // Validate the supervisor-to-user buffer is large enough for context + status
+        if (config.supv_to_user_buffer_size as usize) < context_size + status_size {
+            log::error!(
+                "Supervisor-to-user buffer too small: {} < {} (context) + {} (status)",
+                config.supv_to_user_buffer_size,
+                context_size,
+                status_size
+            );
+            return;
+        }
+
+        // Copy the context + status into the supervisor-to-user buffer with SMAP lifted.
+        // SAFETY: supv_to_user_buffer is valid and large enough, verified above.
+        with_user_access(|| unsafe {
+            // Copy the EfiMmEntryContext to the start of the supervisor-to-user buffer
+            core::ptr::copy_nonoverlapping(
+                &entry_context as *const EfiMmEntryContext as *const u8,
+                config.supv_to_user_buffer as *mut u8,
+                context_size,
+            );
+
+            // Copy the MmCommBufferStatus right after the context
+            core::ptr::copy_nonoverlapping(
+                status as *const MmCommBufferStatus as *const u8,
+                (config.supv_to_user_buffer as *mut u8).add(context_size),
+                status_size,
+            );
+        });
+
+        // Determine whether this is synchronous or asynchronous request
+        let sync_mmi = status.is_comm_buffer_valid;
+
+        if sync_mmi != 0 {
+            // Copy user buffer to user internal buffer for processing in Ring 3
+            // SAFETY: Buffers are provided by MM IPL and are guaranteed valid
+            with_user_access(|| unsafe {
+                core::ptr::copy_nonoverlapping(
+                    config.user_comm_buffer as *const u8,
+                    config.user_comm_buffer_internal as *mut u8,
+                    config.user_comm_buffer_size as usize,
+                );
+            });
+            log::trace!(
+                "Copied {} bytes from user buffer 0x{:x} to internal 0x{:x}",
+                config.user_comm_buffer_size,
+                config.user_comm_buffer,
+                config.user_comm_buffer_internal
+            );
+        }
+
+        log::info!("User request is synchronous: {}", sync_mmi != 0);
+
+        // Invoke the demoted user entry point with:
+        //   arg1: UserCommandType::UserRequest (command type)
+        //   arg2: supv_to_user_buffer (pointer to EfiMmEntryContext + MmCommBufferStatus)
+        //   arg3: sizeof(EfiMmEntryContext) (size of the context portion)
+        // SAFETY: `user_entry` was validated to be non-zero above and points to the user
+        // module entry published by MM IPL. `cpl3_stack` is the per-CPU Ring 3 stack returned
+        // by `get_cpl3_stack`. The arg count (3) matches the three argument values passed.
+        let ret = unsafe {
+            invoke_demoted_routine(
+                cpu_index,
+                user_entry,
+                cpl3_stack,
+                3,
+                UserCommandType::UserRequest as u64,
+                config.supv_to_user_buffer,
+                context_size as u64,
+            )
+        };
+        log::info!("Returned from user request with value: 0x{}", ret);
+
+        // Copy the response from the internal buffer back to the user buffer
+        if sync_mmi != 0 {
+            // SAFETY: Buffers are provided by MM IPL and are guaranteed valid.
+            with_user_access(|| unsafe {
+                core::ptr::copy_nonoverlapping(
+                    config.user_comm_buffer_internal as *const u8,
+                    config.user_comm_buffer as *mut u8,
+                    config.user_comm_buffer_size as usize,
+                );
+            });
+        }
+
+        // Read the updated MmCommBufferStatus back from the supervisor-to-user buffer
+        // (the user may have modified return_status and return_buffer_size)
+        // SAFETY: supv_to_user_buffer is valid and the status is at offset context_size
+        let returned_status = with_user_access(|| unsafe {
+            core::ptr::read((config.supv_to_user_buffer as *const u8).add(context_size) as *const MmCommBufferStatus)
+        });
+
+        // Write the returned status back to the user status mailbox, clearing
+        // is_comm_buffer_valid to indicate processing is complete
+        // SAFETY: user_status_buffer is valid and writable
+        unsafe {
+            let status_ptr = config.user_status_buffer as *mut MmCommBufferStatus;
+            let mut final_status = returned_status;
+            final_status.is_comm_buffer_valid = 0;
+            core::ptr::write_volatile(status_ptr, final_status);
+        }
+    }
+
+    /// Process a request targeting the Supervisor.
+    ///
+    /// Parses the [`EfiMmCommunicateHeader`] from the supervisor communication buffer,
+    /// matches the header GUID against the core's built-in handlers followed by the
+    /// platform handlers from [`PlatformInfo::mmi_handlers`], and invokes the first
+    /// matching handler. This lets platforms link in additional handlers without
+    /// modifying the core.
+    ///
+    /// ## Dispatch Flow
+    ///
+    /// 0. Reject the request with `ACCESS_DENIED` if ExitBootServices has already been signaled
+    /// 1. Zero the internal buffer and copy the external supervisor buffer into it
+    /// 2. Parse the `EfiMmCommunicateHeader` (GUID + message length) from the internal buffer
+    /// 3. Validate message length does not exceed the buffer size
+    /// 4. Iterate the default handlers then [`PlatformInfo::mmi_handlers`] to find a handler
+    ///    matching the header GUID
+    /// 5. Call the handler with a pointer to the data payload and mutable size
+    /// 6. Update the status buffer with return status and total response size
+    /// 7. Copy the internal buffer back to the external buffer
+    fn process_supervisor_request(&self, config: &CommBufferConfig, status: &MmCommBufferStatus, cpu_index: usize) {
+        log::trace!("Processing Supervisor request on CPU {}...", cpu_index);
+
+        // Deny any request here after ExitBootServices.
+        if init_state().is_at_runtime() {
+            log::error!("Supervisor buffer cannot be used for communication after ExitBootServices is signaled!!");
+            self.write_supv_status(config, status, efi::Status::ACCESS_DENIED, 0);
+            return;
+        }
+
+        // Validate buffers
+        if config.supv_comm_buffer == 0 || config.supv_comm_buffer_internal == 0 {
+            log::error!("Supervisor communication buffer not configured");
+            return;
+        }
+
+        let buffer_size = config.supv_comm_buffer_size as usize;
+
+        // Zero the internal buffer then copy the external supervisor buffer into it
+        // SAFETY: Buffers are provided by MM IPL and are guaranteed valid and non-overlapping
+        unsafe {
+            core::ptr::write_bytes(config.supv_comm_buffer_internal as *mut u8, 0, buffer_size);
+            core::ptr::copy_nonoverlapping(
+                config.supv_comm_buffer as *const u8,
+                config.supv_comm_buffer_internal as *mut u8,
+                buffer_size,
+            );
+        }
+
+        // Parse the EfiMmCommunicateHeader from the internal buffer
+        if buffer_size < EfiMmCommunicateHeader::size() {
+            log::error!(
+                "Supervisor buffer too small for communicate header: {} < {}",
+                buffer_size,
+                EfiMmCommunicateHeader::size()
+            );
+            self.write_supv_status(config, status, efi::Status::BAD_BUFFER_SIZE, 0);
+            return;
+        }
+
+        // SAFETY: We verified the buffer is large enough for the header.
+        // The header is packed so we use read_unaligned.
+        let header =
+            unsafe { core::ptr::read_unaligned(config.supv_comm_buffer_internal as *const EfiMmCommunicateHeader) };
+
+        let message_length = header.message_length();
+
+        // Validate message length doesn't exceed the buffer
+        if message_length > buffer_size.saturating_sub(EfiMmCommunicateHeader::size()) {
+            log::error!(
+                "Message length 0x{:x} exceeds available buffer space 0x{:x}",
+                message_length,
+                buffer_size - EfiMmCommunicateHeader::size()
+            );
+            self.write_supv_status(config, status, efi::Status::BAD_BUFFER_SIZE, 0);
+            return;
+        }
+
+        // Compute pointer to the data payload (after the header)
+        // SAFETY: `supv_comm_buffer_internal` is a valid buffer of `buffer_size` bytes, and we
+        // verified above that `buffer_size >= EfiMmCommunicateHeader::size()`, so offsetting by
+        // the header size stays within the same allocation.
+        let data_ptr = unsafe { (config.supv_comm_buffer_internal as *mut u8).add(EfiMmCommunicateHeader::size()) };
+        let mut data_size = message_length;
+
+        // Dispatch: iterate the default handlers followed by the platform handlers to find a match
+        let handler_guid = header.header_guid();
+        let mut dispatch_status = efi::Status::NOT_FOUND;
+
+        for handler in DEFAULT_SUPERVISOR_MMI_HANDLERS.iter().chain(P::mmi_handlers().iter()) {
+            if patina::Guid::from_ref(&handler.handler_guid) == handler_guid {
+                log::trace!(
+                    "Dispatching supervisor request to handler '{}' (GUID: {:?})",
+                    handler.name,
+                    handler.handler_guid
+                );
+                dispatch_status = (handler.handle)(data_ptr, &mut data_size);
+                break;
+            }
+        }
+
+        if dispatch_status == efi::Status::NOT_FOUND {
+            log::warn!("No handler found for supervisor request GUID: {:?}", handler_guid);
+        }
+
+        // Compute the total response size (header + data) for the copy-back
+        let total_response_size = data_size + EfiMmCommunicateHeader::size();
+
+        // Copy the (possibly modified) internal buffer back to the external buffer
+        if total_response_size <= buffer_size {
+            // SAFETY: Both buffers are valid and total_response_size is within bounds
+            unsafe {
+                core::ptr::copy_nonoverlapping(
+                    config.supv_comm_buffer_internal as *const u8,
+                    config.supv_comm_buffer as *mut u8,
+                    total_response_size,
+                );
+            }
+        } else {
+            log::error!("Response size 0x{:x} exceeds buffer capacity 0x{:x}", total_response_size, buffer_size);
+        }
+        log::trace!(
+            "Copied {} bytes from internal buffer 0x{:x} back to external 0x{:x}",
+            total_response_size,
+            config.supv_comm_buffer_internal,
+            config.supv_comm_buffer
+        );
+
+        // Update the status buffer with return status and response size
+        let return_status =
+            if dispatch_status == efi::Status::SUCCESS { efi::Status::SUCCESS } else { efi::Status::NOT_FOUND };
+        self.write_supv_status(config, status, return_status, total_response_size as u64);
+    }
+
+    /// Write the supervisor status buffer after processing a supervisor request.
+    ///
+    /// Clears `is_comm_buffer_valid`, sets return status and size on the
+    /// supervisor mailbox.
+    fn write_supv_status(
+        &self,
+        config: &CommBufferConfig,
+        _status: &MmCommBufferStatus,
+        return_status: efi::Status,
+        return_buffer_size: u64,
+    ) {
+        // SAFETY: supv_status_buffer is valid and writable, set up by MM IPL
+        unsafe {
+            let status_ptr = config.supv_status_buffer as *mut MmCommBufferStatus;
+            let updated = MmCommBufferStatus {
+                is_comm_buffer_valid: 0,
+                _padding: [0; 7],
+                return_status: return_status.as_usize() as u64,
+                return_buffer_size,
+            };
+            core::ptr::write_volatile(status_ptr, updated);
+        }
+    }
+
+    /// The holding pen for APs.
+    ///
+    /// APs wait here servicing RunProcedure commands from the BSP. The pen exits when
+    /// BSP releases this AP via its rendezvous semaphore.
+    fn ap_holding_pen(&'static self, cpu_id: u32) {
+        // Each CPU owns the mailbox at its dense slot index; resolve it once.
+        let cpu_index = match self.cpu_manager.find_cpu_index(cpu_id) {
+            Some(idx) => idx,
+            None => {
+                log::error!("AP (CPU {}) has no registered slot; skipping holding pen", cpu_id);
+                return;
+            }
+        };
+        log::trace!("AP (CPU {}) in holding pen, polling mailbox...", cpu_id);
+
+        loop {
+            // Service any pending point-to-point command for this AP.
+            if let Some(command) = self.mailbox_manager.check_mailbox(cpu_index) {
+                log::trace!("AP (CPU {}) received command: {:?}", cpu_id, command);
+
+                // Execute the command and post the response.
+                let response = self.execute_ap_command(cpu_id, &command);
+                self.mailbox_manager.post_response(cpu_index, response);
+            }
+
+            // Exit when the BSP releases us from the barrier.
+            if self.cpu_manager.take_release_by_index(cpu_index) {
+                break;
+            }
+            core::hint::spin_loop();
+        }
+
+        log::trace!("AP (CPU {}) exiting holding pen", cpu_id);
+    }
+
+    /// Execute a command received by an AP.
+    fn execute_ap_command(&self, cpu_id: u32, command: &ApCommand) -> ApResponse {
+        let ApCommand::RunProcedure { procedure, argument } = *command;
+        self.cpu_manager.set_ap_state(cpu_id, ApState::Busy);
+        let response = self.run_procedure_on_ap(cpu_id, procedure, argument);
+        self.cpu_manager.set_ap_state(cpu_id, ApState::InHoldingPen);
+        response
+    }
+
+    /// Run a procedure on an AP, demoting to user mode if the procedure is in user-owned range.
+    ///
+    /// This is the AP-side handler for `ApCommand::RunProcedure`. It mirrors the C
+    /// `ProcedureWrapper` logic: inspects the procedure pointer ownership and either
+    /// calls it directly (supervisor-owned) or demotes to Ring 3 (user-owned).
+    fn run_procedure_on_ap(&self, cpu_id: u32, procedure: u64, argument: u64) -> ApResponse {
+        log::trace!("AP (CPU {}) running procedure 0x{:x} with arg 0x{:x}", cpu_id, procedure, argument);
+
+        if procedure == 0 {
+            log::error!("AP (CPU {}) received null procedure pointer", cpu_id);
+            return ApResponse::Error(efi::Status::INVALID_PARAMETER.as_usize() as u32);
+        }
+
+        // Determine if the procedure is in user-owned (Ring 3) range by querying the
+        // page table via the centralized helper.
+        let is_user_range = match query_address_ownership(procedure, core::mem::size_of::<usize>() as u64) {
+            Some(PageOwnership::User) => true,
+            Some(PageOwnership::Supervisor) => false,
+            None => {
+                log::error!(
+                    "AP (CPU {}) failed to query ownership for 0x{:x} (unmapped or page table not ready)",
+                    cpu_id,
+                    procedure
+                );
+                return ApResponse::Error(efi::Status::DEVICE_ERROR.as_usize() as u32);
+            }
+        };
+
+        if is_user_range {
+            // Resolve the cpu_index (slot index) for this APIC ID
+            let cpu_index = match self.cpu_manager.find_cpu_index(cpu_id) {
+                Some(idx) => idx,
+                None => {
+                    log::error!("AP (CPU {}) has no registered slot, cannot demote", cpu_id);
+                    return ApResponse::Error(efi::Status::DEVICE_ERROR.as_usize() as u32);
+                }
+            };
+
+            // Get the CPL3 stack for this CPU
+            let cpl3_stack = match self.syscall_interface.get_cpl3_stack(cpu_index) {
+                Ok(stack) => stack,
+                Err(e) => {
+                    log::error!("AP (CPU {}) failed to get CPL3 stack: {:?}", cpu_id, e);
+                    return ApResponse::Error(efi::Status::DEVICE_ERROR.as_usize() as u32);
+                }
+            };
+
+            let user_entry = match init_state().user_entry_point() {
+                Some(entry) if entry != 0 => entry,
+                _ => {
+                    log::error!("User entry point not configured, cannot demote AP (CPU {})", cpu_id);
+                    return ApResponse::Error(efi::Status::DEVICE_ERROR.as_usize() as u32);
+                }
+            };
+
+            // Demote to user mode and call the procedure
+            // The procedure signature is: void (EFIAPI *)(void *ProcedureArgument)
+            log::trace!(
+                "AP (CPU {}) demoting to user: proc=0x{:x}, stack=0x{:x}, arg=0x{:x}",
+                cpu_id,
+                procedure,
+                cpl3_stack,
+                argument
+            );
+
+            // SAFETY: `user_entry` was validated to be non-zero above and points to the user
+            // module entry published by MM IPL. `cpl3_stack` is the per-CPU Ring 3 stack
+            // returned by `get_cpl3_stack`. The arg count (3) matches the three argument values
+            // passed.
+            let _ret = unsafe {
+                invoke_demoted_routine(
+                    cpu_index,
+                    user_entry,
+                    cpl3_stack,
+                    3,
+                    UserCommandType::UserApProcedure as u64,
+                    procedure,
+                    argument,
+                )
+            };
+
+            log::trace!("AP (CPU {}) returned from demoted procedure: 0x{:x}", cpu_id, _ret);
+            ApResponse::Success
+        } else {
+            // Supervisor-owned: call directly in Ring 0
+            log::trace!("AP (CPU {}) calling supervisor procedure directly at 0x{:x}", cpu_id, procedure);
+
+            type EfiApProcedure = unsafe extern "efiapi" fn(*mut core::ffi::c_void);
+            // SAFETY: The procedure pointer was validated to be non-null above and points to a
+            // supervisor-owned (Ring 0) function following the `EfiApProcedure` ABI.
+            let proc_fn: EfiApProcedure = unsafe { core::mem::transmute(procedure) };
+            // SAFETY: `procedure` is a supervisor-owned (Ring 0) address validated by the BSP and
+            // matching the `EfiApProcedure` ABI, so calling it with the provided argument is sound.
+            unsafe { proc_fn(argument as *mut core::ffi::c_void) };
+
+            ApResponse::Success
+        }
+    }
+
+    /// Type-erased trampoline for AP startup, called from the syscall dispatcher.
+    ///
+    /// This function is conformed for the concrete `P: PlatformInfo` type
+    /// and stored as a `fn(u64, u64, u64) -> u64` in [`AP_STARTUP_FN`].
+    pub(crate) fn start_ap_procedure_trampoline(cpu_index: u64, procedure: u64, argument: u64) -> u64 {
+        let core = Self::instance();
+        core.start_ap_procedure(cpu_index, procedure, argument)
+    }
+
+    /// Validate and dispatch a procedure to a specific AP.
+    ///
+    /// Performs validation checks similar to the C `InternalSmmStartupThisAp`:
+    /// 1. CPU index is within range of registered CPUs
+    /// 2. CPU at that index is present (registered)
+    /// 3. CPU is not the BSP
+    /// 4. Procedure pointer is non-null
+    /// 5. Sends the command via the mailbox (fails if AP is busy)
+    /// 6. Waits for the AP to complete (blocking)
+    fn start_ap_procedure(&self, cpu_index: u64, procedure: u64, argument: u64) -> u64 {
+        let cpu_index = cpu_index as usize;
+
+        // 1. Validate CPU index is within registered count
+        let registered = self.cpu_manager.registered_count();
+        if cpu_index >= registered {
+            log::error!("START_AP: CpuIndex({}) >= registered_count({})", cpu_index, registered);
+            return efi::Status::INVALID_PARAMETER.as_usize() as u64;
+        }
+
+        // 2. Look up the APIC ID for this index
+        let cpu_id = match self.cpu_manager.get_cpu_id_by_index(cpu_index) {
+            Some(id) => id,
+            None => {
+                log::error!("START_AP: CpuIndex({}) has no registered CPU", cpu_index);
+                return efi::Status::INVALID_PARAMETER.as_usize() as u64;
+            }
+        };
+
+        // 3. Check that the target is not the BSP
+        if self.cpu_manager.is_bsp(cpu_id) {
+            log::error!("START_AP: CpuIndex({}) is the BSP, cannot start as AP", cpu_index);
+            return efi::Status::INVALID_PARAMETER.as_usize() as u64;
+        }
+
+        // 4. Validate procedure pointer is non-null
+        if procedure == 0 {
+            log::error!("START_AP: Null procedure pointer");
+            return efi::Status::INVALID_PARAMETER.as_usize() as u64;
+        }
+
+        // 5. Send the RunProcedure command to the AP via mailbox
+        //    This will fail if the AP's mailbox is not empty (AP is busy).
+        let command = ApCommand::RunProcedure { procedure, argument };
+        if self.mailbox_manager.send_command(cpu_index, command).is_err() {
+            log::error!("START_AP: AP (CPU {}, index {}) is busy or mailbox unavailable", cpu_id, cpu_index);
+            return efi::Status::INVALID_PARAMETER.as_usize() as u64;
+        }
+
+        log::trace!(
+            "START_AP: Dispatched proc=0x{:x} arg=0x{:x} to CPU {} (index {})",
+            procedure,
+            argument,
+            cpu_id,
+            cpu_index
+        );
+
+        // 6. Wait for the AP to complete (blocking mode)
+        //    Use a generous timeout (10 seconds = 10_000_000 microseconds)
+        match self.mailbox_manager.wait_response(cpu_index, AP_TIMEOUT_US) {
+            Some(ApResponse::Success) => {
+                log::trace!("START_AP: AP (CPU {}) completed successfully", cpu_id);
+                efi::Status::SUCCESS.as_usize() as u64
+            }
+            Some(ApResponse::Error(code)) => {
+                log::error!("START_AP: AP (CPU {}) returned error: 0x{:x}", cpu_id, code);
+                code as u64
+            }
+            Some(ApResponse::Busy) => {
+                log::error!("START_AP: AP (CPU {}) reported busy", cpu_id);
+                efi::Status::NOT_READY.as_usize() as u64
+            }
+            Some(ApResponse::None) | None => {
+                log::error!("START_AP: AP (CPU {}) timed out or no response", cpu_id);
+                efi::Status::TIMEOUT.as_usize() as u64
+            }
+        }
+    }
+}

--- a/patina_mm_supervisor/src/save_state.rs
+++ b/patina_mm_supervisor/src/save_state.rs
@@ -1,0 +1,648 @@
+//! Save State Read Operations for the MM Supervisor Syscall Dispatcher
+//!
+//! Implements the two-phase save state read protocol used by the
+//! `EFI_MM_CPU_PROTOCOL.ReadSaveState()` user-space API.
+//!
+//! **Phase 1** (`SyscallIndex::SaveStateRead`): stores the requested register
+//! and CPU index in a per-BSP holder.
+//!
+//! **Phase 2** (`SyscallIndex::SaveStateRead2`): validates the request against
+//! the MM security policy, reads the register value from the CPU's SMRAM save
+//! state area, and copies the result into the caller-supplied buffer.
+//!
+//! ## Security Model
+//!
+//! - User buffer addresses are validated via page-table ownership queries.
+//! - Policy-gated registers (RAX, IO) are checked through
+//!   [`PolicyGate::is_save_state_read_allowed`](patina_mm_policy::PolicyGate::is_save_state_read_allowed).
+//! - `PROCESSOR_ID` is always allowed (informational, not security-sensitive).
+//! - Other architectural registers pass through without policy gating, matching
+//!   the C reference implementation's allow-list semantics.
+//!
+//! ## Vendor Selection
+//!
+//! The SMRAM save state layout (Intel vs AMD) is selected **at build time**
+//! via Cargo features on the `patina` crate (`save_state_intel` or
+//! `save_state_amd`).  All vendor-specific register offsets and I/O field
+//! parsing live in the SDK; this module is vendor-agnostic.
+//!
+//! ## License
+//!
+//! Copyright (c) Microsoft Corporation.
+//!
+//! SPDX-License-Identifier: Apache-2.0
+
+use crate::mm_policy::{SaveStateCondition, SaveStateField};
+use patina_internal_cpu::save_state::{
+    self, IA32_EFER_LMA, IO_INFO_SIZE, IO_TYPE_INPUT, IO_TYPE_OUTPUT, LMA_32BIT, LMA_64BIT, MmSaveStateIoInfo,
+    MmSaveStateRegister, PROCESSOR_INFO_ENTRY_SIZE,
+};
+use r_efi::efi::Status;
+
+use crate::{PageOwnership, privilege_mgmt::SyscallResult, query_address_ownership, state::security_state};
+
+/// Size in bytes of one `SMRAM_SAVE_STATE_MAP` region.
+///
+/// The relocation code sets every CPU's save-state size to
+/// `sizeof(SMRAM_SAVE_STATE_MAP)` — a fixed 0x400-byte region spanning
+/// SMBASE+0x7C00..SMBASE+0x8000 (Intel SDM Vol 3C, §34.4). Because it is
+/// identical for every CPU, it is a constant here rather than a per-CPU array
+/// passed through the HOB.
+const SMRAM_SAVE_STATE_MAP_SIZE: u64 = 0x400;
+
+/// Offset of the `SMRAM_SAVE_STATE_MAP` from a CPU's SMBASE.
+///
+/// A fixed architectural offset (Intel SDM Vol 3C, §34.4;
+/// `SMRAM_SAVE_STATE_MAP_OFFSET` in MdePkg). The per-CPU save-state region base
+/// is `sm_base[i] + SMRAM_SAVE_STATE_MAP_OFFSET`, derived here so the loader only
+/// has to pass the raw SMBASE array.
+const SMRAM_SAVE_STATE_MAP_OFFSET: u64 = 0xfc00;
+
+/// Per-CPU save-state metadata needed by the save-state read syscall.
+///
+/// Assembled at initialization from two public sources instead of the private
+/// `SMM_CPU_PRIVATE_DATA` layout:
+///
+/// - `number_of_cpus` and `processor_info` come from the MP Information HOB
+///   (`gMpInformationHobGuid`).
+/// - `sm_base` (the per-CPU SMBASE array) is passed through the MM Supervisor
+///   PassDown HOB. The save-state region base is derived as
+///   `sm_base[i] + SMRAM_SAVE_STATE_MAP_OFFSET` with the fixed
+///   [`SMRAM_SAVE_STATE_MAP_SIZE`].
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct SaveStateInfo {
+    /// Number of CPUs (from `MP_INFORMATION_HOB_DATA.NumberOfProcessors`).
+    pub(crate) number_of_cpus: u64,
+    /// Pointer to the `EFI_PROCESSOR_INFORMATION[]` array (from the MP Information HOB).
+    pub(crate) processor_info: u64,
+    /// Pointer to the per-CPU SMBASE array (`u64[number_of_cpus]`).
+    pub(crate) sm_base: u64,
+}
+
+/// Holds the parameters from Phase 1 until Phase 2 completes the read.
+pub(crate) struct SaveStateAccessHolder {
+    /// User protocol pointer (must match across both phases).
+    pub(crate) user_protocol: u64,
+    /// Register to read.
+    pub(crate) register: MmSaveStateRegister,
+    /// CPU index to read from.
+    pub(crate) cpu_index: u64,
+}
+
+/// Returns the ordered sequence of policy checks a read of `reg` must clear.
+///
+fn policy_checks_for_register(reg: MmSaveStateRegister) -> &'static [SaveStateField] {
+    match reg {
+        MmSaveStateRegister::Io => &[SaveStateField::IoTrap, SaveStateField::Rax],
+        MmSaveStateRegister::Rax => &[SaveStateField::Rax],
+        _ => &[],
+    }
+}
+
+/// Processes Phase 1 of the save state read syscall.
+///
+/// Validates and stores the register and CPU index for the subsequent Phase 2
+/// call. The `protocol` pointer is retained for a consistency check in Phase 2,
+/// and `register_raw` is the raw `EFI_MM_SAVE_STATE_REGISTER` value.
+pub fn save_state_read_phase1(protocol: u64, register_raw: u64, cpu_index: u64) -> SyscallResult {
+    // Validate register
+    let register = match MmSaveStateRegister::from_u64(register_raw) {
+        Some(r) => r,
+        None => {
+            log::error!("SAVE_STATE_READ: Unknown register value: {}", register_raw);
+            return Err(Status::INVALID_PARAMETER);
+        }
+    };
+
+    // Validate CPU index against NumberOfCpus
+    let num_cpus = match get_number_of_cpus() {
+        Ok(n) => n,
+        Err(status) => {
+            log::error!("SAVE_STATE_READ: Unable to get number of CPUs: {:?}", status);
+            return Err(status);
+        }
+    };
+
+    if cpu_index >= num_cpus {
+        log::error!("SAVE_STATE_READ: CPU index {} >= NumberOfCpus {}", cpu_index, num_cpus);
+        return Err(Status::INVALID_PARAMETER);
+    }
+
+    // Store for Phase 2
+    let mut access = security_state().lock_save_state_access();
+    *access = Some(SaveStateAccessHolder { user_protocol: protocol, register, cpu_index });
+
+    Ok(0)
+}
+
+/// Processes Phase 2 of the save state read syscall.
+///
+/// Validates the request against the MM security policy, reads the register
+/// from the CPU's SMRAM save state area, and copies the result into the user
+/// buffer. The `protocol` pointer must match the one supplied in Phase 1.
+pub fn save_state_read_phase2(protocol: u64, width: u64, buffer: u64) -> SyscallResult {
+    // Retrieve and consume the Phase 1 state
+    let holder = {
+        let mut access = security_state().lock_save_state_access();
+        match access.take() {
+            Some(h) => h,
+            None => {
+                log::error!("SAVE_STATE_READ2: Phase 1 not completed");
+                return Err(Status::INVALID_PARAMETER);
+            }
+        }
+    };
+
+    // Verify protocol matches Phase 1
+    if holder.user_protocol != protocol {
+        log::error!("SAVE_STATE_READ2: Protocol mismatch: expected 0x{:x}, got 0x{:x}", holder.user_protocol, protocol);
+        return Err(Status::INVALID_PARAMETER);
+    }
+
+    // Validate width and buffer
+    if width == 0 || buffer == 0 {
+        log::error!("SAVE_STATE_READ2: Invalid width ({}) or null buffer", width);
+        return Err(Status::INVALID_PARAMETER);
+    }
+
+    let register = holder.register;
+    let cpu_index = holder.cpu_index;
+
+    // Determine the actual number of bytes we'll write
+    let write_size = actual_write_size(register, width);
+    if write_size == 0 {
+        log::error!("SAVE_STATE_READ2: Unsupported width {} for register {:?}", width, register);
+        return Err(Status::UNSUPPORTED);
+    }
+
+    // Validate buffer is in user-owned memory
+    match query_address_ownership(buffer, write_size as u64) {
+        Some(PageOwnership::User) => {}
+        Some(owner) => {
+            log::error!("SAVE_STATE_READ2: Buffer 0x{:x} owned by {:?}, expected User", buffer, owner);
+            return Err(Status::ACCESS_DENIED);
+        }
+        None => {
+            log::error!("SAVE_STATE_READ2: Buffer 0x{:x} not in mapped memory", buffer);
+            return Err(Status::ACCESS_DENIED);
+        }
+    }
+
+    // Create a single mutable slice over the validated user output buffer so the
+    // individual read handlers write through safe slice operations.
+    //
+    // SAFETY: `buffer` was validated above as a user-owned, writable region of
+    // at least `write_size` bytes.  User code is not executing concurrently
+    // while the supervisor services this syscall, so there is no aliasing.
+    let out = unsafe { core::slice::from_raw_parts_mut(buffer as *mut u8, write_size) };
+
+    // Special case: PROCESSOR_ID — always allowed, no policy check
+    if register == MmSaveStateRegister::ProcessorId {
+        return read_processor_id(cpu_index, out);
+    }
+
+    // Build a safe view over this CPU's save state region.
+    let view = match get_save_state_view(cpu_index) {
+        Ok(v) => v,
+        Err(status) => {
+            log::error!("SAVE_STATE_READ2: Unable to get save state view for CPU {}: {:?}", cpu_index, status);
+            return Err(status);
+        }
+    };
+
+    let policy_checks = policy_checks_for_register(register);
+    let condition = if !policy_checks.is_empty() { inspect_io_condition(&view) } else { None };
+
+    // An IO read needs the trap condition; if it can't be determined the CPU did
+    // not trap an I/O instruction, which is NOT_FOUND rather than a policy denial.
+    if register == MmSaveStateRegister::Io && condition.is_none() {
+        log::error!("SAVE_STATE_READ2: Unable to determine I/O condition from save state");
+        return Err(Status::NOT_FOUND);
+    }
+
+    let gate = match security_state().policy_gate() {
+        Some(g) => g,
+        None => {
+            log::error!("SAVE_STATE_READ2: Policy gate not initialized");
+            return Err(Status::NOT_READY);
+        }
+    };
+
+    // Each required field must independently clear the policy under the same trap
+    // condition.
+    for &field in policy_checks {
+        if let Err(e) = gate.is_save_state_read_allowed(field, width as usize, condition) {
+            log::error!("SAVE_STATE_READ2: Policy denied read of {:?} (field {:?}): {:?}", register, field, e);
+            return Err(Status::ACCESS_DENIED);
+        }
+    }
+
+    // Dispatch to the appropriate read handler.  Each handler reads from the
+    // save state `view` and writes into the validated `out` buffer using only
+    // safe slice operations.
+    match register {
+        MmSaveStateRegister::Io => read_io_register(&view, out),
+        MmSaveStateRegister::Lma => read_lma_register(&view, width, out),
+        _ => read_architectural_register(&view, register, width, out),
+    }
+}
+
+/// Returns the per-CPU save-state metadata captured at initialization.
+fn save_state_info() -> Result<SaveStateInfo, Status> {
+    match security_state().save_state_info() {
+        Some(info) => Ok(info),
+        None => {
+            log::error!("Save-state metadata not initialized");
+            Err(Status::NOT_READY)
+        }
+    }
+}
+
+/// Returns the number of CPUs from the save-state metadata.
+fn get_number_of_cpus() -> Result<u64, Status> {
+    Ok(save_state_info()?.number_of_cpus)
+}
+
+/// A read-only byte view over a CPU's SMRAM save state region.
+struct SaveStateView {
+    bytes: &'static [u8],
+}
+
+impl SaveStateView {
+    /// Creates a view over `size` bytes of the save state region at `base`.
+    ///
+    /// ## Safety
+    ///
+    /// `base` must point to a readable SMRAM save state region of at least
+    /// `size` bytes that is not mutated for the lifetime of the view and lives
+    /// for the duration of the program.
+    unsafe fn new(base: *const u8, size: usize) -> Self {
+        // SAFETY: guaranteed by the caller's contract.
+        Self { bytes: unsafe { core::slice::from_raw_parts(base, size) } }
+    }
+
+    /// Reads the byte at `offset`. Panics if `offset` is out of range.
+    fn read_u8(&self, offset: usize) -> u8 {
+        *self.bytes.get(offset).expect("save state offset within region")
+    }
+
+    /// Reads a little-endian `u16` at `offset`. Panics on an out-of-range offset (see `read_u8`).
+    fn read_u16(&self, offset: usize) -> u16 {
+        let bytes = self.bytes.get(offset..offset + 2).expect("save state offset within region");
+        u16::from_le_bytes(bytes.try_into().expect("slice length is 2"))
+    }
+
+    /// Reads a little-endian `u32` at `offset`. Panics on an out-of-range offset (see `read_u8`).
+    fn read_u32(&self, offset: usize) -> u32 {
+        let bytes = self.bytes.get(offset..offset + 4).expect("save state offset within region");
+        u32::from_le_bytes(bytes.try_into().expect("slice length is 4"))
+    }
+
+    /// Reads a little-endian `u64` at `offset`. Panics on an out-of-range offset (see `read_u8`).
+    fn read_u64(&self, offset: usize) -> u64 {
+        let bytes = self.bytes.get(offset..offset + 8).expect("save state offset within region");
+        u64::from_le_bytes(bytes.try_into().expect("slice length is 8"))
+    }
+}
+
+/// Builds a [`SaveStateView`] for the given CPU index.
+///
+/// The region base is derived from the CPU's SMBASE as
+/// `sm_base[cpu_index] + SMRAM_SAVE_STATE_MAP_OFFSET`, with the SMBASE array
+/// passed through the MM Supervisor PassDown HOB. The region length is the fixed
+/// [`SMRAM_SAVE_STATE_MAP_SIZE`].
+fn get_save_state_view(cpu_index: u64) -> Result<SaveStateView, Status> {
+    let info = save_state_info()?;
+
+    let num_cpus = info.number_of_cpus;
+    if cpu_index >= num_cpus {
+        log::error!("Save state read: CPU index {} >= NumberOfCpus {}", cpu_index, num_cpus);
+        return Err(Status::INVALID_PARAMETER);
+    }
+
+    if info.sm_base == 0 {
+        log::error!("SmBase array pointer is null");
+        return Err(Status::NOT_READY);
+    }
+
+    // The SMBASE array holds `num_cpus` per-CPU SMBASE values set up by the
+    // relocation code. The save-state region base is `SmBase + 0xfc00` and every
+    // region is the fixed `SMRAM_SAVE_STATE_MAP_SIZE`.
+    //
+    // SAFETY: `sm_base` references a valid array of at least `num_cpus` `u64`
+    // entries in SMRAM (from the PassDown HOB), so the slice covers only valid,
+    // initialized memory.
+    let sm_bases = unsafe { core::slice::from_raw_parts(info.sm_base as *const u64, num_cpus as usize) };
+
+    let smbase = *sm_bases.get(cpu_index as usize).ok_or(Status::INVALID_PARAMETER)?;
+    if smbase == 0 {
+        log::error!("SmBase[{}] is null", cpu_index);
+        return Err(Status::INVALID_PARAMETER);
+    }
+    let base = smbase + SMRAM_SAVE_STATE_MAP_OFFSET;
+
+    // SAFETY: `base` points to a valid save state region of
+    // `SMRAM_SAVE_STATE_MAP_SIZE` bytes in SMRAM that is stable while this SMI
+    // is serviced and lives for the program's duration.
+    Ok(unsafe { SaveStateView::new(base as *const u8, SMRAM_SAVE_STATE_MAP_SIZE as usize) })
+}
+
+/// Determines the actual number of bytes that will be written to the user buffer.
+///
+/// Returns 0 if the width is not supported for the given register.
+fn actual_write_size(register: MmSaveStateRegister, width: u64) -> usize {
+    match register {
+        MmSaveStateRegister::Io => IO_INFO_SIZE,
+        MmSaveStateRegister::ProcessorId => 8,
+        MmSaveStateRegister::Lma => {
+            if width == 4 || width == 8 {
+                width as usize
+            } else {
+                0
+            }
+        }
+        _ => {
+            if let Some(info) = save_state::register_info(register) {
+                if width == 2 && info.native_width >= 2 {
+                    2
+                } else if width == 4 && info.native_width >= 4 {
+                    4
+                } else if width == 8 && info.native_width == 8 {
+                    8
+                } else {
+                    0
+                }
+            } else {
+                0
+            }
+        }
+    }
+}
+
+/// Reads the PROCESSOR_ID for a given CPU and writes it to the user buffer.
+///
+/// The ProcessorId (APIC ID) is read from the `EFI_PROCESSOR_INFORMATION` array
+/// carried by the MP Information HOB (`gMpInformationHobGuid`).
+fn read_processor_id(cpu_index: u64, out: &mut [u8]) -> SyscallResult {
+    let info = save_state_info()?;
+
+    if info.processor_info == 0 {
+        log::error!("PROCESSOR_ID: ProcessorInfo array is null");
+        return Err(Status::NOT_READY);
+    }
+
+    let num_cpus = info.number_of_cpus;
+
+    // View the processor information array as bytes so the per-CPU entry can be
+    // read through safe slice operations.
+    //
+    // SAFETY: `processor_info` points to a valid array of `num_cpus`
+    // `EFI_PROCESSOR_INFORMATION` entries (PROCESSOR_INFO_ENTRY_SIZE bytes
+    // each) in firmware memory, and `cpu_index` is < `num_cpus`.
+    let entries = unsafe {
+        core::slice::from_raw_parts(info.processor_info as *const u8, num_cpus as usize * PROCESSOR_INFO_ENTRY_SIZE)
+    };
+
+    // ProcessorId is the first field (u64) of EFI_PROCESSOR_INFORMATION.
+    let offset = cpu_index as usize * PROCESSOR_INFO_ENTRY_SIZE;
+    let processor_id = entries
+        .get(offset..offset + 8)
+        .and_then(|b| b.try_into().ok())
+        .map(u64::from_le_bytes)
+        .ok_or(Status::INVALID_PARAMETER)?;
+
+    // Write the 8-byte ProcessorId to the user buffer.
+    out.get_mut(..8).ok_or(Status::BUFFER_TOO_SMALL)?.copy_from_slice(&processor_id.to_le_bytes());
+
+    log::debug!("PROCESSOR_ID: CPU {} = 0x{:x}", cpu_index, processor_id);
+    Ok(0)
+}
+
+/// Inspects the I/O condition (IN vs OUT) from the save state for policy checking.
+///
+/// Reads the vendor-specific IO field from the CPU's save state and uses the
+/// SDK's [`save_state::parse_io_field`] to determine whether the I/O trap was
+/// caused by an IN or OUT instruction.
+fn inspect_io_condition(view: &SaveStateView) -> Option<SaveStateCondition> {
+    let vc = save_state::vendor_constants();
+
+    // Verify the save state revision supports IO info before reading the field.
+    let smm_rev_id = view.read_u32(vc.smmrevid_offset as usize);
+    if !save_state::io_info_supported(smm_rev_id) {
+        panic!("SMMRevId {:#x} does not expose I/O info; legacy hardware is not supported", smm_rev_id);
+    }
+
+    // Read the vendor-specific IO information field.
+    let io_field = view.read_u32(vc.io_info_offset as usize);
+    // Intentionally commented out to avoid info leakage.
+    // log::info!("Inspecting IO condition: IO field = 0x{:x}", io_field);
+
+    // Use the SDK's vendor-specific parser.
+    let parsed = save_state::parse_io_field(io_field)?;
+    match parsed.io_type {
+        IO_TYPE_INPUT => Some(SaveStateCondition::IoRead),
+        IO_TYPE_OUTPUT => Some(SaveStateCondition::IoWrite),
+        _ => Some(SaveStateCondition::IoWrite),
+    }
+}
+
+/// Reads an architectural register from the vendor save state map into `out`.
+fn read_architectural_register(
+    view: &SaveStateView,
+    register: MmSaveStateRegister,
+    width: u64,
+    out: &mut [u8],
+) -> SyscallResult {
+    let info = match save_state::register_info(register) {
+        Some(i) => i,
+        None => {
+            log::error!("Register {:?} not found in save state map", register);
+            return Err(Status::NOT_FOUND);
+        }
+    };
+
+    let lo = info.lo_offset as usize;
+    if width == 0 {
+        log::error!("Register {:?} does not support 0-byte read", register);
+        return Err(Status::NOT_FOUND);
+    } else if width == 2 {
+        if info.native_width < 2 {
+            log::error!("Register {:?} does not support 2-byte read", register);
+            return Err(Status::INVALID_PARAMETER);
+        }
+        // Read the low 2 bytes (AMD segment selectors, DT limits).
+        out.get_mut(..2).ok_or(Status::BUFFER_TOO_SMALL)?.copy_from_slice(&view.read_u16(lo).to_le_bytes());
+    } else if width == 4 {
+        if info.native_width < 4 {
+            log::error!("Register {:?} does not support 4-byte read", register);
+            return Err(Status::INVALID_PARAMETER);
+        }
+        // Read the low 4 bytes.
+        out.get_mut(..4).ok_or(Status::BUFFER_TOO_SMALL)?.copy_from_slice(&view.read_u32(lo).to_le_bytes());
+    } else if width == 8 {
+        if info.native_width != 8 {
+            log::error!("Register {:?} does not support 8-byte read", register);
+            return Err(Status::INVALID_PARAMETER);
+        }
+        // Read lo u32 then hi u32 (handles both contiguous and split
+        // layouts) and write them as two adjacent u32 (matching C
+        // split-register behaviour).
+        out.get_mut(..4).ok_or(Status::BUFFER_TOO_SMALL)?.copy_from_slice(&view.read_u32(lo).to_le_bytes());
+        out.get_mut(4..8)
+            .ok_or(Status::BUFFER_TOO_SMALL)?
+            .copy_from_slice(&view.read_u32(info.hi_offset as usize).to_le_bytes());
+    } else {
+        log::error!("Register {:?} does not support {}-byte read", register, width);
+        return Err(Status::INVALID_PARAMETER);
+    }
+
+    Ok(0)
+}
+
+/// Reads the IO pseudo-register and writes an `EFI_MM_SAVE_STATE_IO_INFO`
+/// structure to `out`.
+///
+/// The IO pseudo-register provides information about the I/O instruction that
+/// triggered the SMI, including the port, width, direction, and data value.
+fn read_io_register(view: &SaveStateView, out: &mut [u8]) -> SyscallResult {
+    let vc = save_state::vendor_constants();
+
+    // 1. Read SMMRevId to verify IO info is available.
+    let smm_rev_id = view.read_u32(vc.smmrevid_offset as usize);
+    if !save_state::io_info_supported(smm_rev_id) {
+        panic!("SMMRevId {:#x} does not expose I/O info; legacy hardware is not supported", smm_rev_id);
+    }
+
+    // 2. Read the vendor-specific IO information field and parse it.
+    let io_field = view.read_u32(vc.io_info_offset as usize);
+    let parsed = match save_state::parse_io_field(io_field) {
+        Some(p) => p,
+        None => {
+            log::error!("IO_READ: IO field 0x{:x} did not indicate a valid I/O trap", io_field);
+            return Err(Status::NOT_FOUND);
+        }
+    };
+
+    // 3. Read I/O data from RAX (only the significant bytes).
+    let rax = vc.rax_offset as usize;
+    let io_data: u64 = match parsed.byte_count {
+        1 => view.read_u8(rax) as u64,
+        2 => view.read_u16(rax) as u64,
+        4 => view.read_u32(rax) as u64,
+        _ => {
+            log::error!("IO_READ: Unsupported byte count: {}", parsed.byte_count);
+            0
+        }
+    };
+
+    // 4. Serialize the EFI_MM_SAVE_STATE_IO_INFO structure into the output
+    //    buffer by writing the whole #[repr(C)] struct at once.
+    let io_info =
+        MmSaveStateIoInfo { io_data, io_port: parsed.io_port, io_width: parsed.io_width, io_type: parsed.io_type };
+
+    // SAFETY: `out` was validated as a user owned, writable region of at least
+    // `IO_INFO_SIZE` bytes, which equals `size_of::<MmSaveStateIoInfo>()`.
+    // `write_unaligned` accounts for the buffer's unknown alignment.
+    unsafe {
+        core::ptr::write_unaligned(out.as_mut_ptr() as *mut MmSaveStateIoInfo, io_info);
+    }
+
+    Ok(0)
+}
+
+/// Reads the LMA pseudo-register (processor Long Mode Active state) into `out`.
+///
+/// Returns `LMA_32BIT` (32) or `LMA_64BIT` (64) depending on the IA32_EFER.LMA
+/// bit in the save state.
+fn read_lma_register(view: &SaveStateView, width: u64, out: &mut [u8]) -> SyscallResult {
+    let vc = save_state::vendor_constants();
+
+    // AMD64 always operates in 64-bit mode during SMM.
+    let lma_value = if vc.lma_always_64 {
+        LMA_64BIT
+    } else {
+        // Read IA32_EFER from the save state.
+        let efer = view.read_u64(vc.efer_offset as usize);
+        if (efer & IA32_EFER_LMA) != 0 { LMA_64BIT } else { LMA_32BIT }
+    };
+
+    if width == 4 {
+        out.get_mut(..4).ok_or(Status::BUFFER_TOO_SMALL)?.copy_from_slice(&(lma_value as u32).to_le_bytes());
+    } else if width == 8 {
+        out.get_mut(..8).ok_or(Status::BUFFER_TOO_SMALL)?.copy_from_slice(&lma_value.to_le_bytes());
+    } else {
+        return Err(Status::INVALID_PARAMETER);
+    }
+
+    Ok(0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_register_from_u64() {
+        assert_eq!(MmSaveStateRegister::from_u64(38), Some(MmSaveStateRegister::Rax));
+        assert_eq!(MmSaveStateRegister::from_u64(512), Some(MmSaveStateRegister::Io));
+        assert_eq!(MmSaveStateRegister::from_u64(514), Some(MmSaveStateRegister::ProcessorId));
+        assert_eq!(MmSaveStateRegister::from_u64(999), None);
+        assert_eq!(MmSaveStateRegister::from_u64(0), None);
+    }
+
+    #[test]
+    fn test_policy_checks_for_register() {
+        // RAX maps to a single RAX field check.
+        assert_eq!(policy_checks_for_register(MmSaveStateRegister::Rax), &[SaveStateField::Rax]);
+        // IO is composite: it discloses the IO trap field and RAX, so both are checked.
+        assert_eq!(policy_checks_for_register(MmSaveStateRegister::Io), &[SaveStateField::IoTrap, SaveStateField::Rax]);
+        // Non-gated registers still run a single `None` check (root allow/deny default).
+        assert_eq!(policy_checks_for_register(MmSaveStateRegister::Rbx), &[]);
+        assert_eq!(policy_checks_for_register(MmSaveStateRegister::ProcessorId), &[]);
+    }
+
+    #[test]
+    fn test_actual_write_size() {
+        // IO always writes IO_INFO_SIZE
+        assert_eq!(actual_write_size(MmSaveStateRegister::Io, 4), IO_INFO_SIZE);
+        assert_eq!(actual_write_size(MmSaveStateRegister::Io, 24), IO_INFO_SIZE);
+
+        // PROCESSOR_ID always writes 8
+        assert_eq!(actual_write_size(MmSaveStateRegister::ProcessorId, 8), 8);
+
+        // LMA supports 4 and 8
+        assert_eq!(actual_write_size(MmSaveStateRegister::Lma, 4), 4);
+        assert_eq!(actual_write_size(MmSaveStateRegister::Lma, 8), 8);
+        assert_eq!(actual_write_size(MmSaveStateRegister::Lma, 3), 0);
+
+        // RAX (native 8): supports Width=2, 4, and 8
+        assert_eq!(actual_write_size(MmSaveStateRegister::Rax, 2), 2);
+        assert_eq!(actual_write_size(MmSaveStateRegister::Rax, 4), 4);
+        assert_eq!(actual_write_size(MmSaveStateRegister::Rax, 8), 8);
+        assert_eq!(actual_write_size(MmSaveStateRegister::Rax, 16), 0);
+    }
+
+    #[test]
+    fn test_save_state_access_holder() {
+        // Test that the mutex works correctly for Phase 1/Phase 2.
+        {
+            let mut access = crate::state::security_state().lock_save_state_access();
+            assert!(access.is_none());
+            *access =
+                Some(SaveStateAccessHolder { user_protocol: 0xDEAD, register: MmSaveStateRegister::Rax, cpu_index: 0 });
+        }
+
+        {
+            let mut access = crate::state::security_state().lock_save_state_access();
+            let holder = access.take().unwrap();
+            assert_eq!(holder.user_protocol, 0xDEAD);
+            assert_eq!(holder.register, MmSaveStateRegister::Rax);
+            assert_eq!(holder.cpu_index, 0);
+        }
+
+        {
+            let access = crate::state::security_state().lock_save_state_access();
+            assert!(access.is_none());
+        }
+    }
+}

--- a/patina_mm_supervisor/src/state.rs
+++ b/patina_mm_supervisor/src/state.rs
@@ -1,0 +1,291 @@
+//! Consolidated global state for the MM Supervisor Core.
+//!
+//! This module collapses what used to be a dozen-plus free-standing `static`
+//! variables into two cohesive, non-generic structures:
+//!
+//! - [`InitState`] — boot/synchronization flags and the type-erased entry-point
+//!   handles used while bringing cores online.
+//! - [`SecurityState`] — the security-relevant state (policy gate, page table,
+//!   allocators, unblocked-memory tracker, communication-buffer configuration and
+//!   the save-state hand-off) that the syscall dispatcher and request handlers
+//!   validate against.
+//!
+//! ## License
+//!
+//! Copyright (c) Microsoft Corporation.
+//!
+//! SPDX-License-Identifier: Apache-2.0
+//!
+use core::{
+    num::NonZeroUsize,
+    sync::atomic::{AtomicBool, AtomicU32, Ordering},
+};
+
+use spin::{Mutex, MutexGuard, Once, relax::Spin};
+
+use patina::{
+    guids::EVENT_EXIT_BOOT_SERVICES,
+    management_mode::protocol::mm_supervisor_request::MM_SUPERVISOR_REQUEST_HANDLER_GUID,
+};
+use patina_paging::x64::X64PageTable;
+
+use crate::{
+    CommBufferConfig,
+    mem::{PageAllocator, PagingPoolAllocator, SharedPagingAllocator},
+    mm_policy::gate::PolicyGate,
+    save_state::{SaveStateAccessHolder, SaveStateInfo},
+    supervisor_handlers::{
+        EFI_DXE_MM_READY_TO_LOCK_PROTOCOL_GUID, SupervisorMmiHandler, UnblockedMemoryTracker,
+        mm_exit_boot_services_handler, mm_ready_to_lock_handler, mm_supv_request_handler,
+    },
+};
+
+/// Type alias for the global page table guarded by the [`SecurityState`].
+type SupervisorPageTable = X64PageTable<SharedPagingAllocator>;
+
+/// Boot-time and per-core synchronization state for the MM Supervisor Core.
+pub(crate) struct InitState {
+    /// Physical address of the global `MmSupervisorCore` instance.
+    supervisor: Once<NonZeroUsize>,
+    /// Set once BSP one-time initialization has completed.
+    bsp_init_complete: AtomicBool,
+    /// Pointer to the per-core initialized buffer from the PassDown HOB.
+    mm_initialized_buffer: Once<u64>,
+    /// Number of cores that have completed per-core initialization.
+    per_core_init_count: AtomicU32,
+    /// User module entry point discovered from the HOB list.
+    user_entry_point: Once<u64>,
+    /// Type-erased AP startup dispatch function (conformed for the platform).
+    ap_startup_fn: Once<fn(u64, u64, u64) -> u64>,
+    /// Set once ExitBootServices has been signaled.
+    at_runtime: Once<()>,
+}
+
+impl InitState {
+    /// Creates an empty, uninitialized [`InitState`].
+    pub(crate) const fn new() -> Self {
+        Self {
+            supervisor: Once::new(),
+            bsp_init_complete: AtomicBool::new(false),
+            mm_initialized_buffer: Once::new(),
+            per_core_init_count: AtomicU32::new(0),
+            user_entry_point: Once::new(),
+            ap_startup_fn: Once::new(),
+            at_runtime: Once::new(),
+        }
+    }
+
+    /// Records the supervisor instance address.
+    ///
+    /// Returns `true` if `addr` is the value now stored (i.e. this call won the
+    /// one-time initialization), matching the previous `call_once` comparison.
+    pub(crate) fn set_supervisor(&self, addr: NonZeroUsize) -> bool {
+        &addr == self.supervisor.call_once(|| addr)
+    }
+
+    /// Returns the stored supervisor instance address, if set.
+    pub(crate) fn supervisor(&self) -> Option<NonZeroUsize> {
+        self.supervisor.get().copied()
+    }
+
+    /// Marks BSP one-time initialization as complete (Release ordering).
+    pub(crate) fn mark_bsp_init_complete(&self) {
+        self.bsp_init_complete.store(true, Ordering::Release);
+    }
+
+    /// Returns whether BSP one-time initialization has completed (Acquire ordering).
+    pub(crate) fn is_bsp_init_complete(&self) -> bool {
+        self.bsp_init_complete.load(Ordering::Acquire)
+    }
+
+    /// Stores the per-core initialized buffer base address (one-time).
+    pub(crate) fn set_mm_initialized_buffer(&self, buffer_base: u64) {
+        self.mm_initialized_buffer.call_once(|| buffer_base);
+    }
+
+    /// Returns the per-core initialized buffer base address, if set.
+    pub(crate) fn mm_initialized_buffer(&self) -> Option<u64> {
+        self.mm_initialized_buffer.get().copied()
+    }
+
+    /// Increments the per-core init count and returns the new value (SeqCst).
+    pub(crate) fn inc_per_core_init_count(&self) -> u32 {
+        self.per_core_init_count.fetch_add(1, Ordering::SeqCst) + 1
+    }
+
+    /// Returns the number of cores that have completed per-core init (Acquire).
+    pub(crate) fn per_core_init_count(&self) -> u32 {
+        self.per_core_init_count.load(Ordering::Acquire)
+    }
+
+    /// Stores the user module entry point (one-time).
+    pub(crate) fn set_user_entry_point(&self, entry: u64) {
+        self.user_entry_point.call_once(|| entry);
+    }
+
+    /// Returns the user module entry point, if set.
+    pub(crate) fn user_entry_point(&self) -> Option<u64> {
+        self.user_entry_point.get().copied()
+    }
+
+    /// Stores the type-erased AP startup function (one-time).
+    pub(crate) fn set_ap_startup_fn(&self, func: fn(u64, u64, u64) -> u64) {
+        self.ap_startup_fn.call_once(|| func);
+    }
+
+    /// Returns the type-erased AP startup function, if set.
+    pub(crate) fn ap_startup_fn(&self) -> Option<fn(u64, u64, u64) -> u64> {
+        self.ap_startup_fn.get().copied()
+    }
+
+    /// Marks the supervisor as having entered runtime (ExitBootServices signaled).
+    pub(crate) fn mark_at_runtime(&self) -> bool {
+        let first = !self.at_runtime.is_completed();
+        self.at_runtime.call_once(|| ());
+        first
+    }
+
+    /// Returns whether ExitBootServices has been signaled.
+    pub(crate) fn is_at_runtime(&self) -> bool {
+        self.at_runtime.is_completed()
+    }
+}
+
+/// Security-relevant global state for the MM Supervisor Core.
+pub(crate) struct SecurityState {
+    /// Firmware security policy gate.
+    policy_gate: Once<PolicyGate>,
+    /// Global page table used for managing page attributes.
+    page_table: Mutex<Option<SupervisorPageTable>>,
+    /// SMRAM page-granularity allocator for general use.
+    page_allocator: PageAllocator,
+    /// Dedicated bump allocator for page-table structures.
+    paging_allocator: PagingPoolAllocator,
+    /// Tracker for all unblocked memory regions.
+    unblocked_memory_tracker: UnblockedMemoryTracker,
+    /// Communication buffer configuration from the PassDown HOB.
+    comm_buffer_config: Once<CommBufferConfig>,
+    /// Per-CPU save-state metadata for the save-state read syscall.
+    save_state_info: Once<SaveStateInfo>,
+    /// In-flight two-phase save-state read hand-off.
+    save_state_access: Mutex<Option<SaveStateAccessHolder>>,
+}
+
+impl SecurityState {
+    /// Creates an empty, uninitialized [`SecurityState`].
+    pub(crate) const fn new() -> Self {
+        Self {
+            policy_gate: Once::new(),
+            page_table: Mutex::new(None),
+            page_allocator: PageAllocator::new(),
+            paging_allocator: PagingPoolAllocator::new(),
+            unblocked_memory_tracker: UnblockedMemoryTracker::new(),
+            comm_buffer_config: Once::new(),
+            save_state_info: Once::new(),
+            save_state_access: Mutex::new(None),
+        }
+    }
+
+    /// Stores the firmware policy gate (one-time).
+    pub(crate) fn set_policy_gate(&self, gate: PolicyGate) {
+        self.policy_gate.call_once(|| gate);
+    }
+
+    /// Returns the firmware policy gate, if initialized.
+    pub(crate) fn policy_gate(&self) -> Option<&PolicyGate> {
+        self.policy_gate.get()
+    }
+
+    /// Locks the global page table for read or modification.
+    pub(crate) fn lock_page_table(&self) -> MutexGuard<'_, Option<SupervisorPageTable>, Spin> {
+        self.page_table.lock()
+    }
+
+    /// Returns the SMRAM page allocator.
+    pub(crate) fn page_allocator(&self) -> &PageAllocator {
+        &self.page_allocator
+    }
+
+    /// Returns the page-table-pool allocator.
+    pub(crate) fn paging_allocator(&self) -> &PagingPoolAllocator {
+        &self.paging_allocator
+    }
+
+    /// Returns the unblocked-memory tracker.
+    pub(crate) fn unblocked_tracker(&self) -> &UnblockedMemoryTracker {
+        &self.unblocked_memory_tracker
+    }
+
+    /// Stores the communication buffer configuration (one-time).
+    pub(crate) fn set_comm_buffer_config(&self, config: CommBufferConfig) {
+        self.comm_buffer_config.call_once(|| config);
+    }
+
+    /// Returns the communication buffer configuration, if set.
+    pub(crate) fn comm_buffer_config(&self) -> Option<&CommBufferConfig> {
+        self.comm_buffer_config.get()
+    }
+
+    /// Stores the per-CPU save-state metadata (one-time).
+    pub(crate) fn set_save_state_info(&self, info: SaveStateInfo) {
+        self.save_state_info.call_once(|| info);
+    }
+
+    /// Returns the per-CPU save-state metadata, if set.
+    pub(crate) fn save_state_info(&self) -> Option<SaveStateInfo> {
+        self.save_state_info.get().copied()
+    }
+
+    /// Locks the in-flight save-state hand-off slot.
+    pub(crate) fn lock_save_state_access(&self) -> MutexGuard<'_, Option<SaveStateAccessHolder>, Spin> {
+        self.save_state_access.lock()
+    }
+}
+
+/// Global boot/synchronization state instance.
+static INIT_STATE: InitState = InitState::new();
+
+/// Global security-relevant state instance.
+static SECURITY_STATE: SecurityState = SecurityState::new();
+
+/// Returns the global [`InitState`].
+#[inline]
+pub(crate) fn init_state() -> &'static InitState {
+    &INIT_STATE
+}
+
+/// Returns the global [`SecurityState`].
+#[inline]
+pub(crate) fn security_state() -> &'static SecurityState {
+    &SECURITY_STATE
+}
+
+/// The core's built-in supervisor MMI handlers.
+///
+/// - **MmReadyToLock**: Triggered from the non-MM environment upon DxeMmReadyToLock event.
+///   After this handler runs, certain features (e.g., unblock memory) are no longer available.
+/// - **MmSupvRequest**: Handles general supervisor requests such as unblock memory, fetch
+///   policy, version info, and communication buffer updates.
+/// - **MmExitBootServices**: Triggered from the non-MM environment upon ExitBootServices. After
+///   this handler runs, the supervisor communication channel is closed and supervisor-targeted
+///   requests are rejected.
+///
+/// This is an immutable, compile-time dispatch table with no runtime state. It is kept here
+/// alongside the other module-level globals purely for locality.
+pub(crate) static DEFAULT_SUPERVISOR_MMI_HANDLERS: &[SupervisorMmiHandler] = &[
+    SupervisorMmiHandler {
+        name: "MmReadyToLock",
+        handler_guid: EFI_DXE_MM_READY_TO_LOCK_PROTOCOL_GUID.into_inner(),
+        handle: mm_ready_to_lock_handler,
+    },
+    SupervisorMmiHandler {
+        name: "MmSupvRequest",
+        handler_guid: MM_SUPERVISOR_REQUEST_HANDLER_GUID.into_inner(),
+        handle: mm_supv_request_handler,
+    },
+    SupervisorMmiHandler {
+        name: "MmExitBootServices",
+        handler_guid: EVENT_EXIT_BOOT_SERVICES.into_inner(),
+        handle: mm_exit_boot_services_handler,
+    },
+];

--- a/patina_mm_supervisor/src/supervisor_handlers.rs
+++ b/patina_mm_supervisor/src/supervisor_handlers.rs
@@ -1,0 +1,106 @@
+//! Supervisor MMI Handler Registry
+//!
+//! This module provides the built-in supervisor MMI handlers for the MM Supervisor Core, along
+//! with the [`SupervisorMmiHandler`] type that platforms use to register their own handlers.
+//!
+//! ## Architecture
+//!
+//! The core's built-in handlers are collected in the [`DEFAULT_SUPERVISOR_MMI_HANDLERS`] slice.
+//! During supervisor request processing, the core iterates these handlers followed by any
+//! platform-provided handlers (see [`PlatformInfo::mmi_handlers`](crate::PlatformInfo::mmi_handlers))
+//! to find a handler matching the communicate header GUID.
+//!
+//! ## Adding Platform-Specific Handlers
+//!
+//! To register handlers from a platform crate, implement
+//! [`PlatformInfo::mmi_handlers`](crate::PlatformInfo::mmi_handlers) and return a static slice:
+//!
+//! ```rust,no_run
+//! # #[cfg(target_arch = "x86_64")]
+//! # mod example {
+//! use patina_mm_supervisor::{CpuInfo, PlatformInfo, SupervisorMmiHandler};
+//! use r_efi::efi;
+//!
+//! struct MyPlatform;
+//!
+//! fn my_handler(comm_buffer: *mut u8, comm_buffer_size: &mut usize) -> efi::Status {
+//!     // Handle the request...
+//!     efi::Status::SUCCESS
+//! }
+//!
+//! static MY_HANDLERS: &[SupervisorMmiHandler] = &[SupervisorMmiHandler {
+//!     name: "MyPlatformHandler",
+//!     handler_guid: patina::BinaryGuid::from_string("12345678-abcd-ef01-2345-6789abcdef01").into_inner(),
+//!     handle: my_handler,
+//! }];
+//!
+//! impl CpuInfo for MyPlatform {
+//!     fn ap_poll_timeout_us() -> u64 { 1000 }
+//! }
+//!
+//! impl PlatformInfo for MyPlatform {
+//!     type CpuInfo = Self;
+//!
+//!     fn mmi_handlers() -> &'static [SupervisorMmiHandler] {
+//!         MY_HANDLERS
+//!     }
+//! }
+//! # }
+//! ```
+//!
+//! ## License
+//!
+//! Copyright (c) Microsoft Corporation.
+//!
+//! SPDX-License-Identifier: Apache-2.0
+//!
+
+mod supv_request;
+mod system_handlers;
+
+pub use supv_request::unblock_memory::UnblockedMemoryTracker;
+
+pub(crate) use supv_request::mm_supv_request_handler;
+pub(crate) use system_handlers::{mm_exit_boot_services_handler, mm_ready_to_lock_handler};
+
+use r_efi::efi;
+
+// GUID for gEfiDxeMmReadyToLockProtocolGuid
+// { 0x60ff8964, 0xe906, 0x41d0, { 0xaf, 0xed, 0xf2, 0x41, 0xe9, 0x74, 0xe0, 0x8e } }
+/// GUID for the DXE MM Ready To Lock protocol.
+pub const EFI_DXE_MM_READY_TO_LOCK_PROTOCOL_GUID: patina::BinaryGuid =
+    patina::BinaryGuid::from_string("60ff8964-e906-41d0-afed-f241e974e08e");
+
+/// Supervisor version. Encodes major.minor as (major << 16) | minor.
+pub const VERSION: u32 = 0x00130008;
+
+/// Supervisor patch level.
+pub const PATCH_LEVEL: u32 = 0x00010001;
+
+/// A build-time registered supervisor MMI handler.
+///
+/// Each entry represents a handler that the supervisor core will consider when dispatching
+/// supervisor-channel requests. Handlers are matched by comparing the
+/// [`EfiMmCommunicateHeader::header_guid`](patina::pi::protocols::communication::EfiMmCommunicateHeader::header_guid)
+/// against [`handler_guid`](SupervisorMmiHandler::handler_guid).
+///
+/// ## Handler Function Signature
+///
+/// The [`handle`](SupervisorMmiHandler::handle) function receives:
+/// - `comm_buffer`: Pointer to the data portion of the communicate buffer (after the header).
+/// - `comm_buffer_size`: On input, the message length. On output, the response data length.
+///
+/// The handler should return an [`efi::Status`] code.
+#[derive(Debug)]
+pub struct SupervisorMmiHandler {
+    /// Human-readable name for logging and debugging.
+    pub name: &'static str,
+    /// GUID identifying the request type this handler processes.
+    pub handler_guid: efi::Guid,
+    /// The handler function.
+    pub handle: fn(comm_buffer: *mut u8, comm_buffer_size: &mut usize) -> efi::Status,
+}
+
+// SAFETY: SupervisorMmiHandler contains only a &'static str, a Guid (plain data), and a fn pointer.
+// All of these are inherently Sync.
+unsafe impl Sync for SupervisorMmiHandler {}

--- a/patina_mm_supervisor/src/supervisor_handlers/supv_request.rs
+++ b/patina_mm_supervisor/src/supervisor_handlers/supv_request.rs
@@ -1,0 +1,114 @@
+//! Supervisor Request Dispatcher
+//!
+//! Handles structured requests from the non-MM environment via the
+//! `MM_SUPERVISOR_REQUEST_HANDLER_GUID` protocol.
+//!
+//! Each request type is handled by a dedicated sub-module:
+//! - [`version_info`] — supervisor version query
+//! - [`fetch_policy`] — security policy retrieval
+//! - [`comm_update`] — communication buffer updates
+//! - [`unblock_mem`] — memory region unblocking
+//!
+//! ## License
+//!
+//! Copyright (c) Microsoft Corporation.
+//!
+//! SPDX-License-Identifier: Apache-2.0
+
+mod comm_update;
+mod fetch_policy;
+pub(crate) mod unblock_memory;
+mod version_info;
+
+use r_efi::efi;
+
+use patina::management_mode::protocol::mm_supervisor_request::{
+    MmSupervisorRequestHeader, REVISION, RequestType, SIGNATURE,
+};
+
+/// MM Supervisor request handler implementation.
+///
+/// Handles structured requests from the non-MM environment, such as:
+/// - [`RequestType::UnblockMem`]: Unblock memory regions
+/// - [`RequestType::FetchPolicy`]: Fetch security policy
+/// - [`RequestType::VersionInfo`]: Query supervisor version information
+/// - [`RequestType::CommUpdate`]: Update communication buffer configuration
+///
+/// The buffer is expected to contain an [`MmSupervisorRequestHeader`] at the start.
+/// On return, the header's `result` field is set and any response payload follows
+/// immediately after the header.
+pub(crate) fn mm_supv_request_handler(comm_buffer: *mut u8, comm_buffer_size: &mut usize) -> efi::Status {
+    log::info!("MmSupvRequestHandler invoked (buffer_size={})", *comm_buffer_size);
+
+    if comm_buffer.is_null() || *comm_buffer_size < MmSupervisorRequestHeader::SIZE {
+        log::error!(
+            "MmSupvRequestHandler: buffer too small ({} bytes, need at least {})",
+            *comm_buffer_size,
+            MmSupervisorRequestHeader::SIZE,
+        );
+        return efi::Status::INVALID_PARAMETER;
+    }
+
+    // SAFETY: We verified the buffer is non-null and large enough for the header.
+    let header = unsafe { &*(comm_buffer as *const MmSupervisorRequestHeader) };
+
+    // Validate signature
+    if header.signature != SIGNATURE {
+        log::error!("MmSupvRequestHandler: invalid signature 0x{:08X}, expected 0x{:08X}", header.signature, SIGNATURE,);
+        return efi::Status::INVALID_PARAMETER;
+    }
+
+    // Validate revision
+    if header.revision > REVISION {
+        log::error!("MmSupvRequestHandler: unsupported revision {}, max supported {}", header.revision, REVISION,);
+        return efi::Status::UNSUPPORTED;
+    }
+
+    // Dispatch by request type
+    let status = match RequestType::try_from(header.request) {
+        Ok(RequestType::VersionInfo) => {
+            log::info!("Processing VERSION_INFO request");
+            version_info::handle_version_info(comm_buffer, comm_buffer_size)
+        }
+        Ok(RequestType::FetchPolicy) => {
+            log::info!("Processing FETCH_POLICY request");
+            fetch_policy::handle_fetch_policy(comm_buffer, comm_buffer_size)
+        }
+        Ok(RequestType::CommUpdate) => {
+            log::info!("Processing COMM_UPDATE request");
+            comm_update::handle_comm_update(comm_buffer, comm_buffer_size)
+        }
+        Ok(RequestType::UnblockMem) => {
+            log::info!("Processing UNBLOCK_MEM request");
+            unblock_memory::handle_unblock_mem(comm_buffer, comm_buffer_size)
+        }
+        Err(unknown) => {
+            log::warn!("MmSupvRequestHandler: unsupported request type 0x{:08X}", unknown);
+            *comm_buffer_size = MmSupervisorRequestHeader::SIZE;
+            efi::Status::UNSUPPORTED
+        }
+    };
+
+    // Write the final status into the request header's result field.
+    write_request_result(comm_buffer, status);
+
+    // The handler's return value is only for indicating communication-level errors
+    // (e.g., interrupt is being handled or not), in this case we handled the request successfully.
+    efi::Status::SUCCESS
+}
+
+/// Write an [`efi::Status`] into the request header's `result` field.
+///
+/// The status is stored as its raw `usize` representation cast to `u64`,
+/// matching the C `MM_SUPERVISOR_REQUEST_HEADER.Result` convention.
+///
+/// ## Safety
+///
+/// `comm_buffer` must point to at least `MmSupervisorRequestHeader::SIZE` bytes of writable memory.
+fn write_request_result(comm_buffer: *mut u8, status: efi::Status) {
+    // SAFETY: caller guarantees buffer is large enough for the header.
+    unsafe {
+        let header = &mut *(comm_buffer as *mut MmSupervisorRequestHeader);
+        header.result = status.as_usize() as u64;
+    }
+}

--- a/patina_mm_supervisor/src/supervisor_handlers/supv_request/comm_update.rs
+++ b/patina_mm_supervisor/src/supervisor_handlers/supv_request/comm_update.rs
@@ -1,0 +1,24 @@
+//! COMM_UPDATE Request Handler
+//!
+//! ## License
+//!
+//! Copyright (c) Microsoft Corporation.
+//!
+//! SPDX-License-Identifier: Apache-2.0
+
+use r_efi::efi;
+
+use patina::management_mode::protocol::mm_supervisor_request::MmSupervisorRequestHeader;
+
+/// Handle a COMM_UPDATE request.
+///
+/// Updates the communication buffer address for future SMI entries.
+pub(super) fn handle_comm_update(_comm_buffer: *mut u8, comm_buffer_size: &mut usize) -> efi::Status {
+    log::info!("COMM_UPDATE request");
+
+    // We do not support dynamic communication buffer updates in this implementation, because
+    // we expect the runtime allocation will fall into PEI memory bin.
+    *comm_buffer_size = MmSupervisorRequestHeader::SIZE;
+
+    efi::Status::ACCESS_DENIED
+}

--- a/patina_mm_supervisor/src/supervisor_handlers/supv_request/fetch_policy.rs
+++ b/patina_mm_supervisor/src/supervisor_handlers/supv_request/fetch_policy.rs
@@ -1,0 +1,168 @@
+//! FETCH_POLICY Request Handler
+//!
+//! ## License
+//!
+//! Copyright (c) Microsoft Corporation.
+//!
+//! SPDX-License-Identifier: Apache-2.0
+
+use r_efi::efi;
+
+use patina::{
+    base::{UEFI_PAGE_SIZE, align_up},
+    management_mode::protocol::mm_supervisor_request::MmSupervisorRequestHeader,
+    uefi_size_to_pages,
+};
+
+use crate::{
+    is_buffer_inside_mmram,
+    mm_policy::{MemDescriptorV1_0, PolicyError, PolicyGate},
+    read_cr3,
+    state::security_state,
+};
+
+/// Handle a FETCH_POLICY request.
+///
+/// Returns the merged memory + firmware policy to the caller.
+///
+/// ## Behaviour
+///
+/// 1. **First-time call (before lock):** takes a memory policy snapshot, saves it,
+///    and sets the ready-to-lock flag (whichever of `MmReadyToLock` or `FETCH_POLICY`
+///    fires first performs this).
+/// 2. **Subsequent calls (after lock):** re-walks the page table and compares the
+///    fresh result against the saved snapshot. Any discrepancy is a security
+///    violation.
+/// 3. **Merges** the memory policy snapshot with the static firmware policy blob
+///    from `POLICY_GATE` and writes the combined result into `comm_buffer`.
+///
+/// ## Response layout
+///
+/// ```text
+/// |----------------------------------|
+/// | MmSupervisorRequestHeader (24 B) |
+/// |----------------------------------|
+/// | MemDescriptorV1_0[0..N]          |  <- memory policy snapshot
+/// |----------------------------------|
+/// | SecurePolicyDataV1_0 + payload   |  <- firmware policy blob (raw copy)
+/// |----------------------------------|
+/// ```
+pub(super) fn handle_fetch_policy(comm_buffer: *mut u8, comm_buffer_size: &mut usize) -> efi::Status {
+    log::info!("FETCH_POLICY request");
+
+    // -- 0. Obtain the PolicyGate -------------------------------------
+    let gate = match security_state().policy_gate() {
+        Some(g) => g,
+        None => {
+            log::error!("FETCH_POLICY: POLICY_GATE not initialized");
+            *comm_buffer_size = MmSupervisorRequestHeader::SIZE;
+            return efi::Status::NOT_READY;
+        }
+    };
+
+    let cr3 = read_cr3();
+
+    // -- 1. Ensure we have a snapshot (lock if not yet locked) ------------
+    if !gate.is_locked() {
+        // Policy requested prior to ready to lock - enforce lock now.
+        log::info!("FETCH_POLICY: not yet locked - taking snapshot and locking now");
+        // SAFETY: cr3 is valid and the memory policy buffer was configured during init.
+        if let Err(e) = unsafe { gate.take_snapshot(cr3, is_buffer_inside_mmram) } {
+            log::error!("FETCH_POLICY: take_snapshot failed: {:?}", e);
+            *comm_buffer_size = MmSupervisorRequestHeader::SIZE;
+            return efi::Status::DEVICE_ERROR;
+        }
+    } else {
+        // -- 2. Already locked - verify that current page table matches snapshot
+        if let Err(status) = verify_policy_snapshot(gate, cr3) {
+            *comm_buffer_size = MmSupervisorRequestHeader::SIZE;
+            return status;
+        }
+    }
+
+    // -- 3. Write the merged policy into the comm buffer (after the header) -
+    let payload_capacity = match comm_buffer_size.checked_sub(MmSupervisorRequestHeader::SIZE) {
+        Some(c) => c,
+        None => {
+            log::error!("FETCH_POLICY: comm_buffer_size too small for header");
+            *comm_buffer_size = MmSupervisorRequestHeader::SIZE;
+            return efi::Status::BUFFER_TOO_SMALL;
+        }
+    };
+
+    // SAFETY: comm_buffer + header offset is valid writable memory.
+    let dest = unsafe { comm_buffer.add(MmSupervisorRequestHeader::SIZE) };
+    // SAFETY: `dest` points to `payload_capacity` bytes of writable comm-buffer memory (computed
+    // above), satisfying `fetch_n_update_policy`'s requirement.
+    let payload_written = match unsafe { gate.fetch_n_update_policy(dest, payload_capacity) } {
+        Ok(n) => n,
+        Err(PolicyError::InternalError) => {
+            // Could be buffer-too-small, size overflow, or missing snapshot.
+            log::error!("FETCH_POLICY: fetch_n_update_policy failed");
+            *comm_buffer_size = MmSupervisorRequestHeader::SIZE;
+            return efi::Status::BUFFER_TOO_SMALL;
+        }
+        Err(e) => {
+            log::error!("FETCH_POLICY: fetch_n_update_policy unexpected error: {:?}", e);
+            *comm_buffer_size = MmSupervisorRequestHeader::SIZE;
+            return efi::Status::DEVICE_ERROR;
+        }
+    };
+
+    let total_response = MmSupervisorRequestHeader::SIZE + payload_written;
+    *comm_buffer_size = total_response;
+    log::info!(
+        "FETCH_POLICY: response {} bytes (header={}, payload={})",
+        total_response,
+        MmSupervisorRequestHeader::SIZE,
+        payload_written
+    );
+
+    efi::Status::SUCCESS
+}
+
+/// Walks the page table and compares the result against the saved snapshot
+/// inside `PolicyGate`. Allocates a temporary scratch buffer from the page
+/// allocator for the fresh walk.
+///
+/// Returns `Ok(())` if the tables match, or an `efi::Status` error on mismatch
+/// or allocation failure.
+fn verify_policy_snapshot(gate: &PolicyGate, cr3: u64) -> Result<(), efi::Status> {
+    let saved_count = match gate.snapshot_count() {
+        Some(c) => c,
+        None => {
+            log::warn!("verify_policy_snapshot: no snapshot available, skipping");
+            return Ok(());
+        }
+    };
+
+    let desc_size = core::mem::size_of::<MemDescriptorV1_0>();
+    let needed_bytes = saved_count.checked_mul(desc_size).ok_or_else(|| {
+        log::error!("verify_policy_snapshot: descriptor count overflow");
+        efi::Status::DEVICE_ERROR
+    })?;
+    let aligned_bytes = align_up(needed_bytes, UEFI_PAGE_SIZE).map_err(|e| {
+        log::error!("verify_policy_snapshot: failed to align scratch buffer size: {:?}", e);
+        efi::Status::DEVICE_ERROR
+    })?;
+    let needed_pages = uefi_size_to_pages!(aligned_bytes);
+
+    let scratch_base = security_state().page_allocator().allocate_pages(needed_pages).map_err(|e| {
+        log::error!("verify_policy_snapshot: failed to allocate scratch buffer: {:?}", e);
+        efi::Status::OUT_OF_RESOURCES
+    })?;
+
+    let scratch_ptr = scratch_base as *mut MemDescriptorV1_0;
+    let scratch_max_count = aligned_bytes / desc_size;
+
+    // SAFETY: scratch_ptr was just allocated and scratch_max_count is correct.
+    let result = unsafe { gate.verify_snapshot(cr3, is_buffer_inside_mmram, scratch_ptr, scratch_max_count) };
+
+    // Free the scratch buffer regardless of the result.
+    let _ = security_state().page_allocator().free_pages(scratch_base, needed_pages);
+
+    result.map_err(|e| {
+        log::error!("verify_policy_snapshot: snapshot verification failed: {:?}", e);
+        efi::Status::SECURITY_VIOLATION
+    })
+}

--- a/patina_mm_supervisor/src/supervisor_handlers/supv_request/unblock_memory.rs
+++ b/patina_mm_supervisor/src/supervisor_handlers/supv_request/unblock_memory.rs
@@ -1,0 +1,799 @@
+//! Unblocked Memory Region Management
+//!
+//! This module provides functionality to track and manage memory regions that have been
+//! unblocked for access in the MM (Management Mode) environment, similar to `UnblockMemory.c`.
+//!
+//! ## Overview
+//!
+//! The MM Supervisor maintains a list of memory regions that have been explicitly unblocked
+//! for access. By default, all memory outside MMRAM is blocked. Drivers and handlers can
+//! request specific regions to be unblocked via the `unblock_memory` interface.
+//!
+//! ## Design
+//!
+//! - The unblocked region tracker is initialized from memory policy descriptors
+//! - Regions can be dynamically added via `unblock_memory()`
+//! - Access checks use `is_memory_blocked()` to validate memory access requests
+//! - Duplicate unblock requests with identical attributes are allowed (idempotent)
+//! - Overlapping requests with different attributes are rejected
+//!
+//! ## License
+//!
+//! Copyright (c) Microsoft Corporation.
+//!
+//! SPDX-License-Identifier: Apache-2.0
+//!
+
+use core::sync::atomic::{AtomicBool, Ordering};
+use spin::Mutex;
+
+use r_efi::efi;
+
+use patina::base::UEFI_PAGE_SIZE;
+use patina_paging::{MemoryAttributes, PageTable, PtError};
+
+use patina::management_mode::protocol::mm_supervisor_request::{
+    MmSupervisorRequestHeader, MmSupervisorUnblockMemoryParams,
+};
+
+use crate::{
+    mm_policy,
+    mm_policy::{MemDescriptorV1_0, RESOURCE_ATTR_EXECUTE, RESOURCE_ATTR_READ, RESOURCE_ATTR_WRITE},
+    state::security_state,
+};
+
+/// Maximum number of unblocked memory regions that can be tracked.
+const MAX_UNBLOCKED_REGIONS: usize = 64;
+
+/// Errors that can occur during unblock memory operations.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum UnblockError {
+    /// Already initialized (cannot re-initialize).
+    AlreadyInitialized,
+    /// Too many regions to track (exceeded MAX_UNBLOCKED_REGIONS).
+    TooManyRegions,
+    /// The requested region overlaps with MMRAM.
+    OverlapsWithMmram,
+    /// The requested region overlaps with an existing unblocked region
+    /// but has different attributes.
+    ConflictingAttributes,
+    /// Invalid parameters (null pointer, zero length, etc.).
+    InvalidParameter,
+    /// The region's address + size would overflow.
+    AddressOverflow,
+}
+
+/// A single entry in the unblocked memory region list.
+#[derive(Clone, Copy, Debug, Default)]
+pub struct UnblockedMemoryEntry {
+    /// Base address of the unblocked region (page-aligned).
+    pub base_address: u64,
+    /// Size of the unblocked region in pages.
+    pub num_pages: u32,
+    /// Memory attributes (combination of `RESOURCE_ATTR_*`).
+    pub attributes: u32,
+}
+
+impl UnblockedMemoryEntry {
+    /// Creates a new empty entry.
+    pub const fn empty() -> Self {
+        Self { base_address: 0, num_pages: 0, attributes: 0 }
+    }
+
+    /// Creates a new entry from a base address, byte size, and attributes.
+    pub const fn new(base_address: u64, size: u64, attributes: u32) -> Self {
+        Self { base_address, num_pages: patina::uefi_size_to_pages!(size as usize) as u32, attributes }
+    }
+
+    /// Returns the size of this region in bytes.
+    pub fn size(&self) -> u64 {
+        self.num_pages as u64 * UEFI_PAGE_SIZE as u64
+    }
+
+    /// Returns the end address (exclusive) of this region.
+    pub fn end_address(&self) -> u64 {
+        self.base_address.saturating_add(self.size())
+    }
+
+    /// Checks if the given range [base, base + size) is fully contained within this entry.
+    pub fn contains(&self, base: u64, size: u64) -> bool {
+        if self.num_pages == 0 || size == 0 {
+            return false;
+        }
+        let query_end = base.saturating_add(size);
+        base >= self.base_address && query_end <= self.end_address()
+    }
+
+    /// Checks if the given range [base, base + size) overlaps with this entry.
+    pub fn overlaps(&self, base: u64, size: u64) -> bool {
+        if self.num_pages == 0 || size == 0 {
+            return false;
+        }
+        let query_end = base.saturating_add(size);
+        let entry_end = self.end_address();
+
+        // Two ranges overlap if: start1 < end2 && start2 < end1
+        base < entry_end && self.base_address < query_end
+    }
+}
+
+/// Internal state for the unblocked memory tracker.
+struct UnblockedMemoryState {
+    /// Array of unblocked memory entries.
+    entries: [UnblockedMemoryEntry; MAX_UNBLOCKED_REGIONS],
+    /// Number of valid entries in the array.
+    count: usize,
+}
+
+impl UnblockedMemoryState {
+    /// Creates a new empty state.
+    const fn new() -> Self {
+        Self { entries: [UnblockedMemoryEntry::empty(); MAX_UNBLOCKED_REGIONS], count: 0 }
+    }
+
+    /// Finds an entry that exactly matches the given base and size.
+    fn find_exact_match(&self, base: u64, size: u64) -> Option<&UnblockedMemoryEntry> {
+        self.entries.iter().take(self.count).find(|e| e.base_address == base && e.size() == size)
+    }
+
+    /// Adds a new entry if there's space.
+    fn add_entry(&mut self, base: u64, size: u64, attributes: u32) -> Result<(), UnblockError> {
+        let slot = self.entries.get_mut(self.count).ok_or(UnblockError::TooManyRegions)?;
+        *slot = UnblockedMemoryEntry::new(base, size, attributes);
+        self.count += 1;
+        Ok(())
+    }
+}
+
+/// Global unblocked memory region tracker.
+///
+/// This struct manages a list of memory regions that have been unblocked for
+/// access within the MM environment. It provides thread-safe access to the
+/// region list through internal locking.
+pub struct UnblockedMemoryTracker {
+    /// Whether the tracker has been initialized.
+    initialized: AtomicBool,
+    /// Flag indicating if core initialization is complete (after which we enforce checks).
+    core_init_complete: AtomicBool,
+    /// Internal state protected by a mutex.
+    state: Mutex<UnblockedMemoryState>,
+}
+
+impl UnblockedMemoryTracker {
+    /// Creates a new unblocked memory tracker.
+    pub const fn new() -> Self {
+        Self {
+            initialized: AtomicBool::new(false),
+            core_init_complete: AtomicBool::new(false),
+            state: Mutex::new(UnblockedMemoryState::new()),
+        }
+    }
+
+    /// Initializes the tracker from an array of memory policy descriptors, which represent the
+    /// initial "unblocked" regions.
+    ///
+    /// This should be called once during BSP initialization after the memory
+    /// policy has been generated from the page table walk. Returns an error if the tracker is
+    /// already initialized or if there are too many descriptors to track.
+    pub fn init_from_descriptors(&self, descriptors: &[MemDescriptorV1_0]) -> Result<(), UnblockError> {
+        // Check if already initialized
+        if self.initialized.swap(true, Ordering::SeqCst) {
+            return Err(UnblockError::AlreadyInitialized);
+        }
+
+        let mut state = self.state.lock();
+
+        // Add each descriptor as an unblocked region
+        for desc in descriptors {
+            if desc.size == 0 {
+                continue; // Skip zero-size entries
+            }
+
+            // Skip regions inside MMRAM - those are supervisor-controlled, not "unblocked"
+            if security_state().page_allocator().is_region_inside_mmram(desc.base_address, desc.size) {
+                log::trace!(
+                    "Skipping MMRAM region during unblock init: 0x{:016x} - 0x{:016x}",
+                    desc.base_address,
+                    desc.base_address.saturating_add(desc.size)
+                );
+                continue;
+            }
+
+            state.add_entry(desc.base_address, desc.size, desc.mem_attributes)?;
+        }
+
+        log::info!("UnblockedMemoryTracker initialized with {} regions", state.count);
+
+        Ok(())
+    }
+
+    /// Initializes the tracker from a raw buffer of memory policy descriptors.
+    ///
+    /// ## Safety
+    ///
+    /// The caller must ensure:
+    /// - `buffer` points to a valid array of `MemDescriptorV1_0` structures
+    /// - `count` is the number of valid entries in the buffer
+    pub unsafe fn init_from_buffer(&self, buffer: *const MemDescriptorV1_0, count: usize) -> Result<(), UnblockError> {
+        if buffer.is_null() || count == 0 {
+            // Empty initialization is valid
+            if self.initialized.swap(true, Ordering::SeqCst) {
+                return Err(UnblockError::AlreadyInitialized);
+            }
+            log::info!("UnblockedMemoryTracker initialized with 0 regions (empty)");
+            return Ok(());
+        }
+
+        // SAFETY: Caller guarantees buffer is valid for count entries
+        let descriptors = unsafe { core::slice::from_raw_parts(buffer, count) };
+        self.init_from_descriptors(descriptors)
+    }
+
+    /// Marks core initialization as complete.
+    ///
+    /// After this is called, memory access checks will be enforced.
+    /// Before this, all memory is considered accessible (for bootstrap).
+    pub fn set_core_init_complete(&self) {
+        self.core_init_complete.store(true, Ordering::Release);
+        log::info!("UnblockedMemoryTracker: Core initialization complete, enforcing checks");
+    }
+
+    /// Checks if core initialization is complete.
+    pub fn is_core_init_complete(&self) -> bool {
+        self.core_init_complete.load(Ordering::Acquire)
+    }
+
+    /// Unblocks a memory region for access.
+    ///
+    /// This adds a new region to the unblocked list after validating:
+    /// - The region does not overlap with MMRAM
+    /// - The region is not already unblocked with different attributes
+    /// - Identical unblock requests are allowed (idempotent)
+    pub fn unblock_memory(&self, base: u64, size: u64, attributes: u32) -> Result<(), UnblockError> {
+        // Validate parameters
+        if size == 0 {
+            return Err(UnblockError::InvalidParameter);
+        }
+
+        // Check for address overflow
+        if base.checked_add(size).is_none() {
+            return Err(UnblockError::AddressOverflow);
+        }
+
+        // Check if the region overlaps with MMRAM
+        if security_state().page_allocator().is_region_inside_mmram(base, size) {
+            log::error!(
+                "unblock_memory: Region 0x{:016x} - 0x{:016x} overlaps with MMRAM",
+                base,
+                base.saturating_add(size)
+            );
+            return Err(UnblockError::OverlapsWithMmram);
+        }
+
+        let mut state = self.state.lock();
+
+        // Check for existing entries that might conflict
+        // First, check for exact match (idempotent unblock)
+        if let Some(existing) = state.find_exact_match(base, size) {
+            if existing.attributes == attributes {
+                // Identical request - this is allowed (idempotent)
+                log::debug!(
+                    "unblock_memory: Region 0x{:016x} - 0x{:016x} already unblocked with same attributes",
+                    base,
+                    base.saturating_add(size)
+                );
+                return Ok(());
+            } else {
+                // Same base/size but different attributes - conflict
+                log::error!(
+                    "unblock_memory: Region 0x{:016x} - 0x{:016x} already unblocked with different attributes (existing: 0x{:x}, requested: 0x{:x})",
+                    base,
+                    base.saturating_add(size),
+                    existing.attributes,
+                    attributes
+                );
+                return Err(UnblockError::ConflictingAttributes);
+            }
+        }
+
+        // Check for partial overlaps (not allowed)
+        // We iterate directly without collecting to avoid heap allocation
+        let mut has_overlap = false;
+        for entry in state.entries.iter().take(state.count) {
+            if entry.overlaps(base, size) {
+                log::error!(
+                    "unblock_memory: Region 0x{:016x} - 0x{:016x} overlaps with existing region 0x{:016x} - 0x{:016x}",
+                    base,
+                    base.saturating_add(size),
+                    entry.base_address,
+                    entry.end_address()
+                );
+                has_overlap = true;
+                // Continue to log all overlaps for debugging
+            }
+        }
+
+        if has_overlap {
+            return Err(UnblockError::ConflictingAttributes);
+        }
+
+        // No conflicts - add the new entry
+        state.add_entry(base, size, attributes)?;
+
+        log::info!(
+            "unblock_memory: Unblocked region 0x{:016x} - 0x{:016x} with attributes 0x{:x}",
+            base,
+            base.saturating_add(size),
+            attributes
+        );
+
+        Ok(())
+    }
+
+    /// Checks if a memory region is blocked (i.e., NOT in the unblocked list).
+    ///
+    /// This is the inverse of checking if memory is accessible - a blocked region
+    /// should not be accessed by MM handlers.
+    ///
+    /// ## Note
+    ///
+    /// Before core initialization is complete, this always returns `false`
+    /// (everything is accessible during bootstrap).
+    pub fn is_memory_blocked(&self, base: u64, size: u64) -> bool {
+        // During initialization, everything is accessible
+        if !self.core_init_complete.load(Ordering::Acquire) {
+            return false;
+        }
+
+        // Zero-size queries are invalid
+        if size == 0 {
+            log::warn!("is_memory_blocked: Zero-size query for address 0x{:016x}", base);
+            return true; // Invalid query = blocked
+        }
+
+        // Check for address overflow
+        if base.checked_add(size).is_none() {
+            log::warn!("is_memory_blocked: Address overflow for 0x{:016x} + 0x{:x}", base, size);
+            return true; // Invalid query = blocked
+        }
+
+        let state = self.state.lock();
+
+        // Check if the queried region is fully contained within any unblocked entry
+        for entry in state.entries.iter().take(state.count) {
+            if entry.contains(base, size) {
+                log::trace!(
+                    "is_memory_blocked: Region 0x{:016x} - 0x{:016x} is within unblocked region 0x{:016x} - 0x{:016x}",
+                    base,
+                    base.saturating_add(size),
+                    entry.base_address,
+                    entry.end_address()
+                );
+                return false; // Found within unblocked region
+            }
+        }
+
+        log::trace!(
+            "is_memory_blocked: Region 0x{:016x} - 0x{:016x} is NOT within any unblocked region",
+            base,
+            base.saturating_add(size)
+        );
+
+        true // Not found in any unblocked region = blocked
+    }
+
+    /// Checks if a memory region is within unblocked regions (the inverse of `is_memory_blocked`).
+    ///
+    /// This is a convenience method that returns `true` if the region is accessible.
+    #[inline]
+    pub fn is_within_unblocked_region(&self, base: u64, size: u64) -> bool {
+        !self.is_memory_blocked(base, size)
+    }
+
+    /// Gets the current count of unblocked regions.
+    pub fn region_count(&self) -> usize {
+        self.state.lock().count
+    }
+
+    /// Dumps the unblocked regions for debugging.
+    pub fn dump_regions(&self) {
+        let state = self.state.lock();
+
+        log::info!("UnblockedMemoryTracker: {} regions", state.count);
+        for (i, entry) in state.entries.iter().take(state.count).enumerate() {
+            let r = if (entry.attributes & RESOURCE_ATTR_READ) != 0 { "R" } else { "." };
+            let w = if (entry.attributes & RESOURCE_ATTR_WRITE) != 0 { "W" } else { "." };
+            let x = if (entry.attributes & RESOURCE_ATTR_EXECUTE) != 0 { "X" } else { "." };
+            log::info!("  [{}] 0x{:016x} - 0x{:016x} {}{}{}", i, entry.base_address, entry.end_address(), r, w, x);
+        }
+    }
+}
+
+/// Handle an UNBLOCK_MEM request.
+///
+/// Unblocks a memory region so that user-mode MM drivers can access it.
+///
+/// ## Validation (stricter than the C `ProcessUnblockPages` implementation)
+///
+/// 1. **Ready-to-lock check** - reject if core init is complete (post-lock state).
+/// 2. **Buffer size** - must hold header + [`MmSupervisorUnblockMemoryParams`].
+/// 3. **Zero-GUID** - the identifier GUID must be non-zero.
+/// 4. **Page alignment** - `PhysicalStart` must be 4 KiB aligned.
+/// 5. **Non-zero page count** - `NumberOfPages` must be > 0.
+/// 6. **Overflow** - `NumberOfPages * UEFI_PAGE_SIZE` and `PhysicalStart + size` must not overflow.
+/// 7. **MMRAM overlap** - region must not overlap supervisor RAM.
+/// 8. **Duplicate / conflict** - checked by the [`UNBLOCKED_MEMORY_TRACKER`].
+/// 9. **Page attributes** - pages must be not-present (RP set) and not read-only.
+/// 10. **Page table update** - make pages present, R/W, NX; optionally supervisor-only (SP).
+pub(crate) fn handle_unblock_mem(comm_buffer: *mut u8, comm_buffer_size: &mut usize) -> efi::Status {
+    log::info!("UNBLOCK_MEM request");
+
+    // 1. Ready-to-lock check
+    // After core initialization is complete, unblock requests are rejected.
+    // This mirrors the C `mMmReadyToLockDone` guard.
+    if crate::state::security_state().unblocked_tracker().is_core_init_complete() {
+        log::error!("UNBLOCK_MEM: rejected - core initialization already complete (post ready-to-lock)");
+        *comm_buffer_size = MmSupervisorRequestHeader::SIZE;
+        return efi::Status::ACCESS_DENIED;
+    }
+
+    // 2. Buffer size check
+    let min_size = MmSupervisorRequestHeader::SIZE + MmSupervisorUnblockMemoryParams::SIZE;
+    if *comm_buffer_size < min_size {
+        log::error!("UNBLOCK_MEM: buffer too small ({} bytes, need at least {})", *comm_buffer_size, min_size,);
+        *comm_buffer_size = MmSupervisorRequestHeader::SIZE;
+        return efi::Status::BUFFER_TOO_SMALL;
+    }
+
+    // 3. Parse the payload
+    // SAFETY: We verified the buffer is large enough for header + params.
+    let params =
+        unsafe { &*(comm_buffer.add(MmSupervisorRequestHeader::SIZE) as *const MmSupervisorUnblockMemoryParams) };
+
+    let physical_start = params.memory_descriptor.physical_start;
+    let number_of_pages = params.memory_descriptor.number_of_pages;
+    let attribute = params.memory_descriptor.attribute;
+    let identifier_guid = params.identifier_guid;
+
+    log::info!(
+        "UNBLOCK_MEM: request from {} - PhysicalStart=0x{:016x}, Pages={}, Attr=0x{:x}",
+        identifier_guid.as_guid(),
+        physical_start,
+        number_of_pages,
+        attribute,
+    );
+
+    // 4. Zero-GUID check
+    if *identifier_guid.as_bytes() == [0u8; 16] {
+        log::error!("UNBLOCK_MEM: identifier GUID is zero");
+        *comm_buffer_size = MmSupervisorRequestHeader::SIZE;
+        return efi::Status::INVALID_PARAMETER;
+    }
+
+    // 5. Page alignment check (stricter than C)
+    if !physical_start.is_multiple_of(UEFI_PAGE_SIZE as u64) {
+        log::error!("UNBLOCK_MEM: PhysicalStart 0x{:016x} is not page-aligned", physical_start,);
+        *comm_buffer_size = MmSupervisorRequestHeader::SIZE;
+        return efi::Status::INVALID_PARAMETER;
+    }
+
+    // 6. Non-zero page count
+    if number_of_pages == 0 {
+        log::error!("UNBLOCK_MEM: NumberOfPages is 0");
+        *comm_buffer_size = MmSupervisorRequestHeader::SIZE;
+        return efi::Status::INVALID_PARAMETER;
+    }
+
+    // 7. Overflow checks
+    let region_size = match number_of_pages.checked_mul(UEFI_PAGE_SIZE as u64) {
+        Some(s) => s,
+        None => {
+            log::error!("UNBLOCK_MEM: NumberOfPages ({}) * UEFI_PAGE_SIZE overflows u64", number_of_pages,);
+            *comm_buffer_size = MmSupervisorRequestHeader::SIZE;
+            return efi::Status::INVALID_PARAMETER;
+        }
+    };
+
+    if physical_start.checked_add(region_size).is_none() {
+        log::error!("UNBLOCK_MEM: address range 0x{:016x} + 0x{:x} overflows", physical_start, region_size,);
+        *comm_buffer_size = MmSupervisorRequestHeader::SIZE;
+        return efi::Status::INVALID_PARAMETER;
+    }
+
+    // 8. MMRAM overlap check
+    if security_state().page_allocator().is_region_inside_mmram(physical_start, region_size) {
+        log::error!(
+            "UNBLOCK_MEM: region 0x{:016x}-0x{:016x} overlaps with MMRAM",
+            physical_start,
+            physical_start + region_size,
+        );
+        *comm_buffer_size = MmSupervisorRequestHeader::SIZE;
+        return efi::Status::SECURITY_VIOLATION;
+    }
+
+    // 9. Duplicate / conflict check via tracker
+    // We use the tracker's region count to distinguish newly-added vs idempotent.
+    // For newly-added regions we must additionally verify page attributes and
+    // apply page table changes. For idempotent (exact duplicate) requests we
+    // can short-circuit with SUCCESS.
+    let is_supervisor_page = (attribute & efi::MEMORY_SP) != 0;
+    let track_attributes: u32 = if is_supervisor_page {
+        mm_policy::RESOURCE_ATTR_READ | mm_policy::RESOURCE_ATTR_WRITE | 0x80000000 // high bit tag for supervisor-only tracking
+    } else {
+        mm_policy::RESOURCE_ATTR_READ | mm_policy::RESOURCE_ATTR_WRITE
+    };
+
+    let count_before = security_state().unblocked_tracker().region_count();
+    match security_state().unblocked_tracker().unblock_memory(physical_start, region_size, track_attributes) {
+        Ok(()) => {
+            let count_after = security_state().unblocked_tracker().region_count();
+            if count_after == count_before {
+                // Idempotent - already tracked with same attributes, nothing more to do.
+                log::info!(
+                    "UNBLOCK_MEM: region 0x{:016x}-0x{:016x} already unblocked (idempotent)",
+                    physical_start,
+                    physical_start + region_size,
+                );
+                *comm_buffer_size = MmSupervisorRequestHeader::SIZE;
+                return efi::Status::SUCCESS;
+            }
+            // Newly added - continue to verify page attributes and update page table.
+        }
+        Err(UnblockError::ConflictingAttributes) => {
+            log::error!(
+                "UNBLOCK_MEM: region 0x{:016x}-0x{:016x} conflicts with existing entry",
+                physical_start,
+                physical_start + region_size,
+            );
+            *comm_buffer_size = MmSupervisorRequestHeader::SIZE;
+            return efi::Status::SECURITY_VIOLATION;
+        }
+        Err(e) => {
+            log::error!(
+                "UNBLOCK_MEM: tracker rejected request for 0x{:016x}-0x{:016x}: {:?}",
+                physical_start,
+                physical_start + region_size,
+                e,
+            );
+            *comm_buffer_size = MmSupervisorRequestHeader::SIZE;
+            return efi::Status::INVALID_PARAMETER;
+        }
+    }
+
+    // 10. Verify current page attributes and apply page table changes.
+    //
+    // Acquire the page table lock once and hold it across both the read
+    // (verification) and the write (update). The page table mutex is not
+    // reentrant, so acquiring it a second time while the first guard is still
+    // alive would deadlock.
+    let mut pt_guard = security_state().lock_page_table();
+    let Some(pt) = pt_guard.as_mut() else {
+        log::error!("UNBLOCK_MEM: page table not initialized");
+        *comm_buffer_size = MmSupervisorRequestHeader::SIZE;
+        return efi::Status::NOT_READY;
+    };
+
+    // 10. Verify current page attributes
+    // Pages must be not-present (ReadProtect) and NOT read-only. This ensures
+    // we only unblock pages that were explicitly guarded, matching the C
+    // `VerifyUnblockRequest` logic with an additional RO check.
+    match pt.query_memory_region(physical_start, region_size) {
+        Ok(current_attrs) => {
+            log::error!(
+                "UNBLOCK_MEM: pages at 0x{:016x} are already present (attrs: {:?}). \
+                    Only not-present pages may be unblocked.",
+                physical_start,
+                current_attrs,
+            );
+            *comm_buffer_size = MmSupervisorRequestHeader::SIZE;
+            return efi::Status::SECURITY_VIOLATION;
+        }
+        Err(PtError::NoMapping) => {
+            // Expected case - pages are currently not present, so we can unblock them.
+        }
+        Err(e) => {
+            log::error!(
+                "UNBLOCK_MEM: failed to query page attributes for 0x{:016x}-0x{:016x}: {:?}",
+                physical_start,
+                physical_start + region_size,
+                e,
+            );
+            *comm_buffer_size = MmSupervisorRequestHeader::SIZE;
+            return efi::Status::DEVICE_ERROR;
+        }
+    }
+
+    // 11. Apply page table changes
+    // Make the region:
+    //   - Present (clear ReadProtect)
+    //   - Read/Write (clear ReadOnly)
+    //   - Non-executable (set ExecuteProtect) - data pages must be W^X
+    //   - Optionally Supervisor-only (set Supervisor) if EFI_MEMORY_SP requested
+    let mut new_attrs = MemoryAttributes::ExecuteProtect; // NX - data pages are non-executable
+    if is_supervisor_page {
+        new_attrs |= MemoryAttributes::Supervisor; // Supervisor-only (U/S=0)
+    }
+
+    if let Err(e) = pt.map_memory_region(physical_start, region_size, new_attrs) {
+        log::error!(
+            "UNBLOCK_MEM: failed to update page table for 0x{:016x}-0x{:016x}: {:?}",
+            physical_start,
+            physical_start + region_size,
+            e,
+        );
+        *comm_buffer_size = MmSupervisorRequestHeader::SIZE;
+        return efi::Status::DEVICE_ERROR;
+    }
+
+    log::info!(
+        "UNBLOCK_MEM: SUCCESS - unblocked 0x{:016x}-0x{:016x} ({} pages, {})",
+        physical_start,
+        physical_start + region_size,
+        number_of_pages,
+        if is_supervisor_page { "supervisor-only" } else { "user-accessible" },
+    );
+
+    *comm_buffer_size = MmSupervisorRequestHeader::SIZE;
+    efi::Status::SUCCESS
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn create_test_tracker() -> UnblockedMemoryTracker {
+        UnblockedMemoryTracker::new()
+    }
+
+    #[test]
+    fn test_empty_entry() {
+        let entry = UnblockedMemoryEntry::empty();
+        assert_eq!(entry.num_pages, 0);
+        assert_eq!(entry.base_address, 0);
+        assert_eq!(entry.size(), 0);
+    }
+
+    #[test]
+    fn test_entry_is_compact() {
+        // The tracker is a SEA-audited static, so guard against the per-entry
+        // footprint regressing: base (u64) + num_pages (u32) + attributes (u32).
+        assert_eq!(core::mem::size_of::<UnblockedMemoryEntry>(), 16);
+    }
+
+    #[test]
+    fn test_entry_size_round_trips_pages() {
+        let entry = UnblockedMemoryEntry::new(0x2000, 4 * UEFI_PAGE_SIZE as u64, RESOURCE_ATTR_READ);
+        assert_eq!(entry.num_pages, 4);
+        assert_eq!(entry.size(), 4 * UEFI_PAGE_SIZE as u64);
+        assert_eq!(entry.end_address(), 0x2000 + 4 * UEFI_PAGE_SIZE as u64);
+
+        // A sub-page size rounds up to a whole page (matching the page-granular mapping).
+        let partial = UnblockedMemoryEntry::new(0x1000, 1, RESOURCE_ATTR_READ);
+        assert_eq!(partial.num_pages, 1);
+        assert_eq!(partial.size(), UEFI_PAGE_SIZE as u64);
+    }
+
+    #[test]
+    fn test_entry_contains() {
+        let entry = UnblockedMemoryEntry::new(0x1000, 0x1000, RESOURCE_ATTR_READ);
+
+        // Fully contained
+        assert!(entry.contains(0x1000, 0x1000));
+        assert!(entry.contains(0x1000, 0x800));
+        assert!(entry.contains(0x1800, 0x800));
+
+        // Partially outside
+        assert!(!entry.contains(0x0800, 0x1000)); // Starts before
+        assert!(!entry.contains(0x1800, 0x1000)); // Ends after
+
+        // Completely outside
+        assert!(!entry.contains(0x3000, 0x1000));
+    }
+
+    #[test]
+    fn test_entry_overlaps() {
+        let entry = UnblockedMemoryEntry::new(0x1000, 0x1000, RESOURCE_ATTR_READ);
+
+        // Overlapping cases
+        assert!(entry.overlaps(0x1000, 0x1000)); // Exact match
+        assert!(entry.overlaps(0x0800, 0x1000)); // Starts before, ends inside
+        assert!(entry.overlaps(0x1800, 0x1000)); // Starts inside, ends after
+        assert!(entry.overlaps(0x0800, 0x2000)); // Completely contains entry
+
+        // Non-overlapping
+        assert!(!entry.overlaps(0x2000, 0x1000)); // Immediately after
+        assert!(!entry.overlaps(0x0000, 0x1000)); // Immediately before
+        assert!(!entry.overlaps(0x3000, 0x1000)); // Far after
+    }
+
+    #[test]
+    fn test_tracker_before_init_complete() {
+        let tracker = create_test_tracker();
+
+        // Before core init complete, nothing is blocked
+        assert!(!tracker.is_memory_blocked(0x1000, 0x1000));
+        assert!(!tracker.is_memory_blocked(0x0, 0x100000));
+    }
+
+    #[test]
+    fn test_tracker_after_init_complete_empty() {
+        let tracker = create_test_tracker();
+        tracker.set_core_init_complete();
+
+        // After init complete with no regions, everything is blocked
+        assert!(tracker.is_memory_blocked(0x1000, 0x1000));
+    }
+
+    #[test]
+    fn test_unblock_memory() {
+        let tracker = create_test_tracker();
+
+        // Unblock a region
+        assert!(tracker.unblock_memory(0x1000, 0x1000, RESOURCE_ATTR_READ | RESOURCE_ATTR_WRITE).is_ok());
+
+        tracker.set_core_init_complete();
+
+        // Region should be accessible
+        assert!(!tracker.is_memory_blocked(0x1000, 0x1000));
+        assert!(!tracker.is_memory_blocked(0x1000, 0x800));
+
+        // Outside region should be blocked
+        assert!(tracker.is_memory_blocked(0x3000, 0x1000));
+    }
+
+    #[test]
+    fn test_idempotent_unblock() {
+        let tracker = create_test_tracker();
+
+        // First unblock
+        assert!(tracker.unblock_memory(0x1000, 0x1000, RESOURCE_ATTR_READ).is_ok());
+
+        // Identical unblock should succeed
+        assert!(tracker.unblock_memory(0x1000, 0x1000, RESOURCE_ATTR_READ).is_ok());
+
+        // Same region with different attributes should fail
+        assert_eq!(
+            tracker.unblock_memory(0x1000, 0x1000, RESOURCE_ATTR_READ | RESOURCE_ATTR_WRITE),
+            Err(UnblockError::ConflictingAttributes)
+        );
+    }
+
+    #[test]
+    fn test_overlapping_unblock_fails() {
+        let tracker = create_test_tracker();
+
+        // First unblock
+        assert!(tracker.unblock_memory(0x1000, 0x1000, RESOURCE_ATTR_READ).is_ok());
+
+        // Overlapping unblock should fail
+        assert_eq!(
+            tracker.unblock_memory(0x1800, 0x1000, RESOURCE_ATTR_READ),
+            Err(UnblockError::ConflictingAttributes)
+        );
+    }
+
+    #[test]
+    fn test_invalid_parameters() {
+        let tracker = create_test_tracker();
+        tracker.set_core_init_complete();
+
+        // Zero size
+        assert_eq!(tracker.unblock_memory(0x1000, 0, RESOURCE_ATTR_READ), Err(UnblockError::InvalidParameter));
+
+        // Overflow
+        assert_eq!(tracker.unblock_memory(u64::MAX, 0x1000, RESOURCE_ATTR_READ), Err(UnblockError::AddressOverflow));
+    }
+
+    #[test]
+    fn test_region_count() {
+        let tracker = create_test_tracker();
+
+        assert_eq!(tracker.region_count(), 0);
+
+        tracker.unblock_memory(0x1000, 0x1000, RESOURCE_ATTR_READ).unwrap();
+        assert_eq!(tracker.region_count(), 1);
+
+        tracker.unblock_memory(0x3000, 0x1000, RESOURCE_ATTR_WRITE).unwrap();
+        assert_eq!(tracker.region_count(), 2);
+    }
+}

--- a/patina_mm_supervisor/src/supervisor_handlers/supv_request/version_info.rs
+++ b/patina_mm_supervisor/src/supervisor_handlers/supv_request/version_info.rs
@@ -1,0 +1,55 @@
+//! VERSION_INFO Request Handler
+//!
+//! ## License
+//!
+//! Copyright (c) Microsoft Corporation.
+//!
+//! SPDX-License-Identifier: Apache-2.0
+
+use r_efi::efi;
+
+use patina::management_mode::protocol::mm_supervisor_request::{
+    MmSupervisorRequestHeader, MmSupervisorVersionInfo, RequestType,
+};
+
+use crate::supervisor_handlers::{PATCH_LEVEL, VERSION};
+
+/// Handle a VERSION_INFO request.
+///
+/// Writes back the response header followed by [`MmSupervisorVersionInfo`].
+pub(super) fn handle_version_info(comm_buffer: *mut u8, comm_buffer_size: &mut usize) -> efi::Status {
+    let response_size = MmSupervisorRequestHeader::SIZE + MmSupervisorVersionInfo::SIZE;
+
+    if *comm_buffer_size < response_size {
+        log::error!(
+            "VERSION_INFO: buffer too small for response ({} bytes, need {})",
+            *comm_buffer_size,
+            response_size,
+        );
+        *comm_buffer_size = MmSupervisorRequestHeader::SIZE;
+        return efi::Status::BUFFER_TOO_SMALL;
+    }
+
+    // Write version info payload after the header
+    let version_info = MmSupervisorVersionInfo {
+        version: VERSION,
+        patch_level: PATCH_LEVEL,
+        max_supervisor_request_level: RequestType::MAX_REQUEST_TYPE,
+    };
+
+    // SAFETY: We verified the buffer is large enough for header + version info.
+    unsafe {
+        let payload_ptr = comm_buffer.add(MmSupervisorRequestHeader::SIZE) as *mut MmSupervisorVersionInfo;
+        core::ptr::write(payload_ptr, version_info);
+    }
+
+    *comm_buffer_size = response_size;
+    log::info!(
+        "VERSION_INFO response: version=0x{:08X}, patch=0x{:08X}, max_level={}",
+        VERSION,
+        PATCH_LEVEL,
+        RequestType::MAX_REQUEST_TYPE,
+    );
+
+    efi::Status::SUCCESS
+}

--- a/patina_mm_supervisor/src/supervisor_handlers/system_handlers.rs
+++ b/patina_mm_supervisor/src/supervisor_handlers/system_handlers.rs
@@ -1,0 +1,72 @@
+//! System-level MMI Handlers
+//!
+//! Contains handlers for system events such as the DXE MM Ready-to-Lock transition
+//! and the ExitBootServices hand-off to the OS.
+//!
+//! ## License
+//!
+//! Copyright (c) Microsoft Corporation.
+//!
+//! SPDX-License-Identifier: Apache-2.0
+
+use r_efi::efi;
+
+use crate::{
+    is_buffer_inside_mmram, read_cr3,
+    state::{init_state, security_state},
+};
+
+/// MmReadyToLock handler implementation.
+///
+/// Called when the DXE phase signals that MM should transition to a locked state.
+/// After this runs, no new memory regions can be unblocked and the memory policy
+/// snapshot stored inside `PolicyGate` is considered the reference baseline.
+pub(crate) fn mm_ready_to_lock_handler(_comm_buffer: *mut u8, _comm_buffer_size: &mut usize) -> efi::Status {
+    log::info!("MmReadyToLockHandler invoked");
+
+    let gate = match security_state().policy_gate() {
+        Some(g) => g,
+        None => {
+            log::error!("MmReadyToLock: POLICY_GATE not initialized");
+            return efi::Status::NOT_READY;
+        }
+    };
+
+    // If already locked, this is a no-op (idempotent).
+    if gate.is_locked() {
+        log::warn!("MmReadyToLock: already locked, ignoring duplicate");
+        return efi::Status::SUCCESS;
+    }
+
+    // Take a snapshot and mark as locked.
+    let cr3 = read_cr3();
+    // SAFETY: cr3 points to the active PML4 table inside SMM,
+    // and the memory policy buffer was configured during init.
+    if let Err(e) = unsafe { gate.take_snapshot(cr3, is_buffer_inside_mmram) } {
+        log::error!("MmReadyToLock: take_snapshot failed: {:?}", e);
+        return efi::Status::DEVICE_ERROR;
+    }
+
+    // And mark the unblock memory tracker as locked as well since unblock memory is no longer allowed after this point.
+    security_state().unblocked_tracker().set_core_init_complete();
+
+    efi::Status::SUCCESS
+}
+
+/// ExitBootServices handler implementation.
+///
+/// Called when the non-MM environment signals ExitBootServices. This marks the
+/// supervisor as being at runtime, after which the supervisor communication
+/// channel is closed and supervisor-targeted requests are rejected (the runtime
+/// gate in the dispatch loop denies them).
+pub(crate) fn mm_exit_boot_services_handler(_comm_buffer: *mut u8, _comm_buffer_size: &mut usize) -> efi::Status {
+    log::info!("MmExitBootServicesHandler invoked");
+
+    // Idempotent: if ExitBootServices was already signaled, warn and succeed
+    // without re-arming so duplicate notifications are tolerated.
+    if !init_state().mark_at_runtime() {
+        log::warn!("MmExitBootServices: ExitBootServices event is signaled more than once??");
+    }
+
+    efi::Status::SUCCESS
+}

--- a/patina_mm_user_core/Cargo.toml
+++ b/patina_mm_user_core/Cargo.toml
@@ -1,0 +1,31 @@
+[package]
+name = "patina_mm_user_core"
+version.workspace = true
+repository.workspace = true
+license.workspace = true
+edition.workspace = true
+readme = "README.md"
+description = "A pure Rust implementation of the MM User Core for standalone MM mode environments."
+
+# Metadata to tell docs.rs how to build the documentation when uploading
+[package.metadata.docs.rs]
+features = ["doc"]
+
+[dependencies]
+goblin = { workspace = true, features = ["pe32", "pe64"] }
+log = { workspace = true }
+patina = { workspace = true, features = ["core"] }
+patina_internal_core = { workspace = true }
+r-efi = { workspace = true }
+spin = { workspace = true }
+uuid = { workspace = true }
+zerocopy = { workspace = true }
+
+[dev-dependencies]
+mockall = { workspace = true }
+serial_test = { workspace = true }
+
+[features]
+default = []
+std = []
+doc = []

--- a/patina_mm_user_core/README.md
+++ b/patina_mm_user_core/README.md
@@ -1,0 +1,121 @@
+# Patina MM Supervisor Core
+
+A pure Rust implementation of the MM Supervisor Core for standalone MM mode environments.
+
+## Overview
+
+This crate provides the core functionality at user level in a standalone MM environment. It is designed to run on x64
+systems where:
+
+- Execution environment is demoted to user mode (Ring 3) after the supervisor is initialized
+- Page tables are managed by the supervisor module
+- All images are loaded and ready to execute
+- Syscall interface is provided for user modules to request services from the supervisor
+
+## Memory Model
+
+The supervisor module is in control of the final memory model, in terms of page tables and memory attributes, as well as
+page allocation and freeing.
+
+The user module controls a pool management system for small allocations, and can request larger pages from the
+supervisor module.
+
+For simplicity, only runtime data is allowed from the user level.
+
+## Building a PE/COFF Binary
+
+### Prerequisites
+
+1. Install the Rust UEFI target:
+
+   ```bash
+   rustup target add x86_64-unknown-uefi
+   ```
+
+2. Ensure you have the nightly toolchain (required for `#![feature(...)]`):
+
+   ```bash
+   rustup override set nightly
+   ```
+
+### Build Command
+
+Build the example MM Supervisor binary:
+
+```bash
+cargo build --target x86_64-unknown-uefi --bin example_mm_user_core --features="x64 user_core"
+```
+
+The output PE/COFF binary will be at:
+
+```text
+target/x86_64-unknown-uefi/debug/example_mm_user_core.efi
+```
+
+### Entry Point
+
+The MM Supervisor exports `user_core_main` as its entry point, matching the EDK2 convention:
+
+```rust
+#[cfg_attr(target_os = "uefi", unsafe(export_name = "user_core_main"))]
+pub extern "efiapi" fn mm_user_main(op_code: u64, arg1: u64, arg2: u64) -> u64 {
+    USER_CORE.entry_point_worker(op_code, arg1, arg2)
+}
+```
+
+The MM Supervisor calls this entry point through a call gate after:
+
+1. Setting up the MM environment, including page tables and memory attributes
+2. Setting up the secure policy gate
+
+## Architecture
+
+### Entry Point Model
+
+The entry point supports 3 operation codes:
+
+1. **Start User Core**:
+   - Executed on BSP only
+   - Initializes the user core and sets up the environment (pool mananger, protocol database, MMI handler database,
+   etc.)
+   - Dispatches all preloaded user drivers
+
+2. **User Request**:
+   - Executed on BSP only
+   - Iterate through the registered user level handlers and dispatch the request to the appropriate handler
+
+3. **User AP Procedure**:
+   - Executed on APs
+   - This function should not access global state or shared data structures, as it is executed in parallel on all APs.
+   It is intended for user-level AP procedures that do not require synchronization with the BSP.
+
+## Usage
+
+### Basic Platform Implementation
+
+```rust
+#![no_std]
+#![no_main]
+
+use core::{ffi::c_void, panic::PanicInfo};
+use patina_mm_user_core::MmUserCore;
+
+// Static instance - no heap allocation required
+static USER_CORE: MmUserCore = MmUserCore::new();
+
+#[panic_handler]
+fn panic(_info: &PanicInfo) -> ! {
+    loop { core::hint::spin_loop(); }
+}
+
+#[unsafe(export_name = "MmUserCoreMain")]
+pub extern "efiapi" fn mm_user_main(op_code: u64, arg1: u64, arg2: u64) -> u64 {
+    USER_CORE.entry_point_worker(op_code, arg1, arg2)
+}
+```
+
+## License
+
+Copyright (c) Microsoft Corporation.
+
+SPDX-License-Identifier: Apache-2.0

--- a/patina_mm_user_core/src/component_dispatcher.rs
+++ b/patina_mm_user_core/src/component_dispatcher.rs
@@ -1,0 +1,253 @@
+//! MM User Core subsystem for the Patina component dispatcher.
+//!
+//! This subsystem brings the Patina component model (dependency-injected
+//! `#[component]` entry points) into the MM User Core, mirroring the DXE Core's
+//! `component_dispatcher` module. It lets a platform register components,
+//! configurations, and services that are then dispatched in dependency order
+//! during MM User Core startup.
+//!
+//! The component [`Storage`], [`Component`], and parameter types are reused
+//! directly from the Patina SDK ([`patina::component`]); only the dispatcher and
+//! the platform-facing [`MmComponentInfo`] registration trait live here.
+//!
+//! ## Relationship to MM driver dispatch
+//!
+//! This is distinct from the FFS/HOB-based MM driver dispatch performed by
+//! [`MmDispatcher`](crate::mm_dispatcher::MmDispatcher). Both can coexist:
+//! components are Rust objects registered by the platform binary, while MM
+//! drivers are separate modules discovered from HOBs.
+//!
+//! ## License
+//!
+//! Copyright (c) Microsoft Corporation.
+//!
+//! SPDX-License-Identifier: Apache-2.0
+//!
+
+extern crate alloc;
+
+use alloc::{borrow::Cow, boxed::Box, vec::Vec};
+
+use patina::{
+    component::{IntoComponent, Storage, service::IntoService},
+    pi::hob::Hob,
+};
+
+/// A trait implemented by the platform to register components, configurations,
+/// and services with the MM User Core.
+///
+/// This is the MM analogue of the DXE Core's `ComponentInfo` trait. The platform
+/// MM binary implements it and passes the implementing type to
+/// [`MmUserCore::entry_point_worker`](crate::MmUserCore::entry_point_worker),
+/// which applies it during `StartUserCore`.
+///
+/// Allocations are available when these callbacks are invoked.
+///
+/// ## Example
+///
+/// ```rust,ignore
+/// use patina_mm_user_core::component_dispatcher::{Add, Component, MmComponentInfo};
+///
+/// struct MyMmPlatform;
+///
+/// impl MmComponentInfo for MyMmPlatform {
+///     fn components(mut add: Add<Component>) {
+///         add.component(my_mm_component::MyComponent::default());
+///     }
+/// }
+/// ```
+pub trait MmComponentInfo: Sized {
+    /// A platform callback to register components with the MM User Core.
+    #[inline(always)]
+    fn components(_add: Add<'_, Component>) {}
+
+    /// A platform callback to register configurations with the MM User Core.
+    #[inline(always)]
+    fn configs(_add: Add<'_, Config>) {}
+
+    /// A platform callback to register services with the MM User Core.
+    #[inline(always)]
+    fn services(_add: Add<'_, Service>) {}
+}
+
+/// A marker to limit [`Add`] methods to only adding [`Component`](patina::component::Component)s.
+pub struct Component;
+/// A marker to limit [`Add`] methods to only adding configurations.
+pub struct Config;
+/// A marker to limit [`Add`] methods to only adding [`Service`](patina::component::service::Service)s.
+pub struct Service;
+
+/// A struct used to allow controlled access to the MM User Core's component storage.
+///
+/// The type parameter `L` limits which `add` methods are available, matching the
+/// callback in [`MmComponentInfo`] that produced it.
+pub struct Add<'a, L> {
+    /// The component dispatcher to add to.
+    dispatcher: &'a mut MmComponentDispatcher,
+    /// Marker to limit what methods are available on this struct.
+    _limiter: core::marker::PhantomData<L>,
+}
+
+impl<L> Add<'_, L> {
+    /// Creates a new [`Add`] struct.
+    #[inline(always)]
+    pub(crate) fn new(dispatcher: &mut MmComponentDispatcher) -> Add<'_, L> {
+        Add { dispatcher, _limiter: core::marker::PhantomData }
+    }
+}
+
+impl Add<'_, Component> {
+    /// Adds a component to the MM User Core's component list.
+    pub fn component<I>(&mut self, component: impl IntoComponent<I>) {
+        let component = component.into_component();
+        let idx = self.dispatcher.components.len();
+        self.dispatcher.insert_component(idx, component);
+    }
+}
+
+impl Add<'_, Config> {
+    /// Adds a configuration value to the MM User Core's storage.
+    #[inline(always)]
+    pub fn config<C: Default + 'static>(&mut self, config: C) {
+        self.dispatcher.storage.add_config::<C>(config);
+    }
+}
+
+impl Add<'_, Service> {
+    /// Adds a service to the MM User Core's storage.
+    #[inline(always)]
+    pub fn service(&mut self, service: impl IntoService + 'static) {
+        self.dispatcher.storage.add_service(service);
+    }
+}
+
+/// The MM User Core component dispatcher.
+///
+/// Owns the registered components and the component [`Storage`] used for
+/// dependency injection, and drives dispatch to a fixed point.
+pub struct MmComponentDispatcher {
+    /// Components that successfully initialized and are ready for dispatch attempts.
+    components: Vec<Box<dyn patina::component::Component>>,
+    /// Components that failed to initialize and are not ready for dispatch attempts.
+    rejected: Vec<Box<dyn patina::component::Component>>,
+    /// Storage for components to use during execution.
+    storage: Storage,
+}
+
+impl Default for MmComponentDispatcher {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+// SAFETY: The MmComponentDispatcher owns all data stored within it and does not
+// share it. It is only accessed by the BSP during single-threaded MM User Core
+// startup, guarded by the containing `spin::Mutex`.
+unsafe impl Send for MmComponentDispatcher {}
+
+impl MmComponentDispatcher {
+    /// Creates a new, empty `MmComponentDispatcher`.
+    #[inline(always)]
+    pub const fn new() -> Self {
+        Self { components: Vec::new(), rejected: Vec::new(), storage: Storage::new() }
+    }
+
+    /// Applies the component information provided by the given type implementing
+    /// [`MmComponentInfo`].
+    pub fn apply_component_info<C: MmComponentInfo>(&mut self) {
+        C::configs(Add::new(self));
+        C::services(Add::new(self));
+        C::components(Add::new(self));
+    }
+
+    /// Inserts a component at the given index, initializing it against storage.
+    ///
+    /// Components that fail initialization are moved to the rejected list and
+    /// will not be dispatched.
+    pub fn insert_component(&mut self, idx: usize, mut component: Box<dyn patina::component::Component>) {
+        match component.initialize(&mut self.storage) {
+            true => self.components.insert(idx, component),
+            false => self.rejected.push(component),
+        }
+    }
+
+    /// Adds a service to storage.
+    #[inline(always)]
+    pub fn add_service<S: IntoService + 'static>(&mut self, service: S) {
+        self.storage.add_service(service);
+    }
+
+    /// Adds a configuration value to storage.
+    #[inline(always)]
+    pub fn add_config<C: Default + 'static>(&mut self, config: C) {
+        self.storage.add_config::<C>(config);
+    }
+
+    /// Locks the configurations in storage, preventing further modifications.
+    ///
+    /// This enables components that request an immutable `Config<T>` to be
+    /// dispatched, and prevents further `ConfigMut<T>` components from running.
+    #[inline(always)]
+    pub fn lock_configs(&mut self) {
+        self.storage.lock_configs();
+    }
+
+    /// Parses the HOB list, producing a `Hob<T>` datum for each guided HOB that
+    /// has a registered parser.
+    pub fn insert_hobs(&mut self, hob: &Hob<'_>) {
+        for entry in hob.into_iter() {
+            if let Hob::GuidHob(guid, data) = entry {
+                let parser_funcs = self.storage.get_hob_parsers(&guid.name);
+                if parser_funcs.is_empty() {
+                    continue;
+                }
+                for parser_func in parser_funcs {
+                    parser_func(data, &mut self.storage);
+                }
+            }
+        }
+    }
+
+    /// Attempts to dispatch all pending components in a single pass.
+    ///
+    /// Returns `true` if at least one component was dispatched (successfully or
+    /// with an error), indicating progress and that another pass may dispatch
+    /// more.
+    pub fn dispatch(&mut self) -> bool {
+        let len = self.components.len();
+        self.components.retain_mut(|component| {
+            let name = component.metadata().name();
+            log::trace!("MM Dispatch Start: Id = [{name:?}]");
+            // Ok(true):  dispatchable and dispatched successfully -> remove.
+            // Ok(false): not dispatchable at this time -> retain.
+            // Err(e):    dispatchable and dispatched with failure -> remove.
+            !match component.run(&mut self.storage) {
+                Ok(true) => true,
+                Ok(false) => false,
+                Err(err) => {
+                    log::error!("MM Component dispatched: Id = [{name:?}] Status = [Failed] Error = [{err:?}]");
+                    true
+                }
+            }
+        });
+        len != self.components.len()
+    }
+
+    /// Repeatedly dispatches components until no further progress is made.
+    pub fn dispatch_to_completion(&mut self) {
+        while self.dispatch() {}
+    }
+
+    /// Logs all components that were not dispatched and why.
+    pub fn display_not_dispatched(&self) {
+        if self.components.is_empty() && self.rejected.is_empty() {
+            return;
+        }
+
+        log::warn!("MM components not dispatched:");
+        for component in self.components.iter().chain(&self.rejected) {
+            let metadata = component.metadata();
+            log::warn!("  {} — {}", metadata.name(), metadata.error_message().unwrap_or(Cow::from("")));
+        }
+    }
+}

--- a/patina_mm_user_core/src/config_table.rs
+++ b/patina_mm_user_core/src/config_table.rs
@@ -1,0 +1,194 @@
+//! Configuration Table Management for MM System Table
+//!
+//! Implements `MmInstallConfigurationTable` — the ability to add, modify, or
+//! delete (GUID, pointer) pairs stored in the MM System Table's configuration
+//! table array.
+//!
+//! ## Semantics
+//!
+//! The configuration table is an array of `EFI_CONFIGURATION_TABLE` entries
+//! exposed through `EfiMmSystemTable.mm_configuration_table`. Drivers use
+//! this to publish well-known data (e.g. the HOB list) that other drivers
+//! can discover by iterating the table.
+//!
+//! Operations:
+//! - **Add**: GUID not present, table pointer non-null.
+//! - **Modify**: GUID already present, table pointer non-null → update pointer.
+//! - **Delete**: GUID already present, table pointer null → remove entry.
+//! - **Error**: GUID not present, table pointer null → `NOT_FOUND`.
+//!
+//! After every modification the MM System Table's `mm_configuration_table`
+//! pointer and `number_of_table_entries` count are updated so the change is
+//! immediately visible to all consumers.
+//!
+//! ## Thread Safety
+//!
+//! All access is serialized through a `spin::Mutex`. The configuration table
+//! array pointer stored in the system table is replaced atomically (pointer-
+//! sized write) so readers always see a consistent snapshot even without
+//! holding the lock.
+//!
+//! ## License
+//!
+//! Copyright (c) Microsoft Corporation.
+//!
+//! SPDX-License-Identifier: Apache-2.0
+//!
+
+extern crate alloc;
+
+use alloc::{boxed::Box, vec::Vec};
+use core::ffi::c_void;
+
+use r_efi::efi;
+use spin::Mutex;
+
+use patina::pi::mm_cis::EfiMmSystemTable;
+
+/// Configuration table database for the MM System Table.
+///
+/// Maintains the canonical list of `(GUID, Pointer)` pairs. After each
+/// mutation the MM System Table's pointer and count are updated so all
+/// consumers see the change immediately.
+pub struct MmConfigurationTableDb {
+    inner: Mutex<ConfigTableInner>,
+}
+
+struct ConfigTableInner {
+    /// The authoritative list of entries.
+    entries: Vec<efi::ConfigurationTable>,
+    /// Raw pointer to the most recently leaked boxed‐slice that the system
+    /// table currently points to. `null` when no allocation exists.
+    leaked_ptr: *mut efi::ConfigurationTable,
+    /// Length of the leaked allocation (for reclaim).
+    leaked_len: usize,
+}
+
+// SAFETY: All access is synchronized by the Mutex.
+unsafe impl Send for MmConfigurationTableDb {}
+unsafe impl Sync for MmConfigurationTableDb {}
+
+impl Default for MmConfigurationTableDb {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl MmConfigurationTableDb {
+    /// Create a new, empty configuration table database.
+    pub const fn new() -> Self {
+        Self {
+            inner: Mutex::new(ConfigTableInner {
+                entries: Vec::new(),
+                leaked_ptr: core::ptr::null_mut(),
+                leaked_len: 0,
+            }),
+        }
+    }
+
+    /// Install, modify, or delete a configuration table entry.
+    ///
+    /// Semantics match the PI Specification `EFI_MM_INSTALL_CONFIGURATION_TABLE`:
+    ///
+    /// | Existing? | `table` | Action   |
+    /// |-----------|---------|----------|
+    /// | Yes       | non-null| Modify   |
+    /// | Yes       | null    | Delete   |
+    /// | No        | non-null| Add      |
+    /// | No        | null    | NOT_FOUND|
+    pub fn install_configuration_table(
+        &self,
+        mmst: *mut EfiMmSystemTable,
+        guid: &efi::Guid,
+        table: *mut c_void,
+    ) -> efi::Status {
+        let mut inner = self.inner.lock();
+
+        // Search for an existing entry with the same GUID.
+        let existing_idx = inner.entries.iter().position(|e| e.vendor_guid == *guid);
+
+        match (existing_idx, table.is_null()) {
+            // Match found, table non-null → modify
+            (Some(idx), false) => {
+                inner.entries[idx].vendor_table = table;
+                log::debug!("MmInstallConfigurationTable: modified {:?}", guid);
+            }
+            // Match found, table null → delete
+            (Some(idx), true) => {
+                inner.entries.remove(idx);
+                log::debug!("MmInstallConfigurationTable: deleted {:?}", guid);
+            }
+            // No match, table non-null → add
+            (None, false) => {
+                inner.entries.push(efi::ConfigurationTable { vendor_guid: *guid, vendor_table: table });
+                log::debug!("MmInstallConfigurationTable: added {:?}", guid);
+            }
+            // No match, table null → error
+            (None, true) => {
+                return efi::Status::NOT_FOUND;
+            }
+        }
+
+        // Publish the updated table to the MM System Table.
+        Self::publish_to_system_table(&mut inner, mmst);
+
+        efi::Status::SUCCESS
+    }
+
+    /// Look up a configuration table entry by GUID.
+    ///
+    /// Returns the `vendor_table` pointer if found, or `None`.
+    #[allow(dead_code)]
+    pub fn get_configuration_table(&self, guid: &efi::Guid) -> Option<*mut c_void> {
+        let inner = self.inner.lock();
+        inner.entries.iter().find(|e| e.vendor_guid == *guid).map(|e| e.vendor_table)
+    }
+
+    // -------------------------------------------------------------------------
+    // Internal helpers
+    // -------------------------------------------------------------------------
+
+    /// Re‐publish the current entry list to the MM System Table.
+    ///
+    /// Allocates a new boxed slice, updates the system table pointer, then
+    /// reclaims the previous allocation.
+    fn publish_to_system_table(inner: &mut ConfigTableInner, mmst: *mut EfiMmSystemTable) {
+        if mmst.is_null() {
+            return;
+        }
+
+        // --- Reclaim the previous allocation ---------------------------------
+        if !inner.leaked_ptr.is_null() {
+            // SAFETY: `leaked_ptr` / `leaked_len` were produced by
+            // `Box::into_raw` in a prior call to this function.
+            unsafe {
+                let _ = Box::from_raw(core::ptr::slice_from_raw_parts_mut(inner.leaked_ptr, inner.leaked_len));
+            }
+            inner.leaked_ptr = core::ptr::null_mut();
+            inner.leaked_len = 0;
+        }
+
+        // --- Produce the new allocation and patch the MMST -------------------
+        if inner.entries.is_empty() {
+            // SAFETY: We hold the Mutex, and `mmst` was initialized by
+            // `init_mm_system_table`.
+            unsafe {
+                (*mmst).number_of_table_entries = 0;
+                (*mmst).mm_configuration_table = core::ptr::null_mut();
+            }
+        } else {
+            let boxed: Box<[efi::ConfigurationTable]> = inner.entries.clone().into_boxed_slice();
+            let len = boxed.len();
+            let ptr = Box::into_raw(boxed) as *mut efi::ConfigurationTable;
+
+            inner.leaked_ptr = ptr;
+            inner.leaked_len = len;
+
+            // SAFETY: Same as above.
+            unsafe {
+                (*mmst).number_of_table_entries = len;
+                (*mmst).mm_configuration_table = ptr;
+            }
+        }
+    }
+}

--- a/patina_mm_user_core/src/core_handlers.rs
+++ b/patina_mm_user_core/src/core_handlers.rs
@@ -1,0 +1,274 @@
+//! MM Core Internal MMI Handlers
+//!
+//! These are the MMI handlers registered by the MM Core itself to handle
+//! lifecycle events forwarded from the DXE phase. They mirror the C
+//! `mMmCoreMmiHandlers[]` table in `StandaloneMmCore.c`.
+//!
+//! Each handler is registered with [`MmiDatabase::register_internal_handler`](crate::mmi::MmiDatabase::register_internal_handler)
+//! during startup and dispatched when the supervisor forwards the corresponding
+//! GUID-tagged MMI through the communication buffer.
+//!
+//! ## Lifecycle Events
+//!
+//! | GUID | Handler | Description |
+//! |------|---------|-------------|
+//! | `MM_DISPATCH_EVENT` | `mm_driver_dispatch_handler` | Dispatches discovered MM drivers |
+//! | `MM_DXE_READY_TO_LOCK_PROTOCOL` | `mm_ready_to_lock_handler` | Unregisters one-shot handlers, installs lock protocol |
+//! | `MM_END_OF_PEI_PROTOCOL` | `mm_end_of_pei_handler` | Installs end-of-PEI protocol |
+//! | `EVENT_GROUP_END_OF_DXE` | `mm_end_of_dxe_handler` | Installs end-of-DXE protocol |
+//! | `EVENT_EXIT_BOOT_SERVICES` | `mm_exit_boot_service_handler` | Installs exit-boot-services protocol |
+//! | `EVENT_READY_TO_BOOT` | `mm_ready_to_boot_handler` | Installs ready-to-boot protocol |
+//!
+//! ## License
+//!
+//! Copyright (c) Microsoft Corporation.
+//!
+//! SPDX-License-Identifier: Apache-2.0
+//!
+
+use core::ffi::c_void;
+
+use r_efi::efi;
+use spin::Mutex;
+
+use crate::{MmUserCore, mmi::InternalMmiHandler};
+use patina::{BinaryGuid, Guid, guids, mm_services::MmServices};
+
+/// Table of MMI handlers registered by the MM Core, mirroring the C `mMmCoreMmiHandlers[]`.
+static CORE_MMI_HANDLERS: &[CoreMmiHandler] = &[
+    CoreMmiHandler {
+        handler: mm_driver_dispatch_handler,
+        handler_type: &guids::MM_DISPATCH_EVENT,
+        unregister_on_lock: true,
+    },
+    CoreMmiHandler {
+        handler: mm_ready_to_lock_handler,
+        handler_type: &guids::MM_DXE_READY_TO_LOCK_PROTOCOL,
+        unregister_on_lock: true,
+    },
+    CoreMmiHandler {
+        handler: mm_end_of_pei_handler,
+        handler_type: &guids::MM_END_OF_PEI_PROTOCOL,
+        unregister_on_lock: true,
+    },
+    CoreMmiHandler {
+        handler: mm_end_of_dxe_handler,
+        handler_type: &guids::EVENT_GROUP_END_OF_DXE,
+        unregister_on_lock: false,
+    },
+    CoreMmiHandler {
+        handler: mm_exit_boot_service_handler,
+        handler_type: &guids::EVENT_EXIT_BOOT_SERVICES,
+        unregister_on_lock: false,
+    },
+    CoreMmiHandler {
+        handler: mm_ready_to_boot_handler,
+        handler_type: &guids::EVENT_READY_TO_BOOT,
+        unregister_on_lock: false,
+    },
+];
+
+/// Dispatch handles returned from `register_internal_handler` for each core handler.
+///
+/// Index matches the `CORE_MMI_HANDLERS` table. Populated by [`register_core_mmi_handlers`].
+static DISPATCH_HANDLES: Mutex<[SendHandle; 6]> = Mutex::new([SendHandle::NULL; 6]);
+
+/// Description of a core MMI handler to be registered at startup.
+struct CoreMmiHandler {
+    /// The handler function (native Rust signature).
+    handler: InternalMmiHandler,
+    /// The GUID that triggers this handler.
+    handler_type: &'static BinaryGuid,
+    /// Whether this handler should be unregistered during ready-to-lock.
+    unregister_on_lock: bool,
+}
+
+/// Newtype wrapper around `efi::Handle` so it can be stored in a `static Mutex`.
+///
+/// `efi::Handle` is `*mut c_void` which is `!Send`.  The dispatch handles are only
+/// written by the BSP during single-threaded init and read during the ready-to-lock
+/// handler (also on the BSP), so it is safe to share them.
+#[derive(Clone, Copy)]
+struct SendHandle(efi::Handle);
+unsafe impl Send for SendHandle {}
+unsafe impl Sync for SendHandle {}
+
+impl SendHandle {
+    const NULL: Self = Self(core::ptr::null_mut());
+}
+
+/// Register all core MMI handlers with the global MMI database.
+///
+/// Registration installs the `MM_DISPATCH_EVENT` handler that performs the
+/// deferred driver dispatch, so this runs before any drivers are dispatched.
+pub fn register_core_mmi_handlers() {
+    let mut handles = DISPATCH_HANDLES.lock();
+
+    for (i, entry) in CORE_MMI_HANDLERS.iter().enumerate() {
+        match MmUserCore::instance().mmi_db.register_internal_handler(entry.handler, Some(entry.handler_type)) {
+            Ok(handle) => {
+                handles[i] = SendHandle(handle);
+                log::info!("Registered core MMI handler [{}] for {}", i, entry.handler_type);
+            }
+            Err(status) => {
+                log::error!("Failed to register core MMI handler [{}] for {}: {:?}", i, entry.handler_type, status);
+            }
+        }
+    }
+}
+
+/// Install a protocol with a NULL interface on a new handle.
+///
+/// This mirrors the C pattern used in lifecycle handlers:
+/// ```c
+/// MmHandle = NULL;
+/// Status = MmInstallProtocolInterface(&MmHandle, &guid, EFI_NATIVE_INTERFACE, NULL);
+/// ```
+fn install_lifecycle_protocol(guid: &efi::Guid) -> efi::Status {
+    // SAFETY: installs a marker protocol (null interface) on a freshly allocated handle.
+    match unsafe { MmUserCore::instance().install_protocol_interface(None, guid, core::ptr::null_mut()) } {
+        Ok(handle) => {
+            log::info!("Installed lifecycle protocol {} on handle {:p}", Guid::from_ref(guid), handle);
+            efi::Status::SUCCESS
+        }
+        Err(status) => status,
+    }
+}
+
+/// MM Driver Dispatch Handler.
+///
+/// Re-triggers driver dispatch for any previously discovered but not-yet-dispatched
+/// drivers. Once dispatch completes, the handler unregisters itself (it is a
+/// one-shot handler).
+///
+/// Corresponds to the C `MmDriverDispatchHandler`.
+fn mm_driver_dispatch_handler(
+    _handler_type: &efi::Guid,
+    _comm_buffer: *mut c_void,
+    _comm_buffer_size: *mut usize,
+) -> efi::Status {
+    log::info!("MmDriverDispatchHandler");
+
+    // Dispatch the MM drivers discovered during StartUserCore (single dependency-ordered pass).
+    match MmUserCore::instance().dispatch_drivers() {
+        Ok(count) => log::info!("Successfully dispatched {} MM driver(s).", count),
+        Err(status) => log::error!("Driver dispatch failed: {:?}", status),
+    }
+
+    // Self-unregister (one-shot).
+    let handles = DISPATCH_HANDLES.lock();
+    let dispatch_handle = handles[0].0;
+    drop(handles);
+
+    if !dispatch_handle.is_null() {
+        // SAFETY: unregistering by handle is safe even if the handle is already gone.
+        let _ = unsafe { MmUserCore::instance().mmi_handler_unregister(dispatch_handle) };
+    }
+
+    log::info!("MmDriverDispatchHandler done");
+
+    efi::Status::SUCCESS
+}
+
+/// MM Ready To Lock Handler.
+///
+/// Called when `gEfiDxeMmReadyToLockProtocolGuid` MMI is received. This:
+/// 1. Unregisters handlers marked with `unregister_on_lock` (including itself).
+/// 2. Installs the `gEfiMmReadyToLockProtocolGuid` protocol to notify MM drivers.
+///
+/// Corresponds to the C `MmReadyToLockHandler`.
+fn mm_ready_to_lock_handler(
+    _handler_type: &efi::Guid,
+    _comm_buffer: *mut c_void,
+    _comm_buffer_size: *mut usize,
+) -> efi::Status {
+    log::info!("MmReadyToLockHandler");
+
+    // Unregister handlers that are no longer needed after MM lock.
+    let handles = DISPATCH_HANDLES.lock();
+    for (i, entry) in CORE_MMI_HANDLERS.iter().enumerate() {
+        if entry.unregister_on_lock && !handles[i].0.is_null() {
+            // SAFETY: unregistering by handle is safe even if the handle is already gone.
+            let _ = unsafe { MmUserCore::instance().mmi_handler_unregister(handles[i].0) };
+        }
+    }
+    drop(handles);
+
+    // Install the MM Ready To Lock Protocol.
+    let status = install_lifecycle_protocol(&guids::MM_READY_TO_LOCK_PROTOCOL);
+    if status != efi::Status::SUCCESS {
+        log::error!("Failed to install MM Ready To Lock Protocol: {:?}", status);
+    }
+
+    status
+}
+
+/// MM End of PEI Handler.
+///
+/// Installs the `gEfiMmEndOfPeiProtocol` protocol.
+///
+/// Corresponds to the C `MmEndOfPeiHandler`.
+fn mm_end_of_pei_handler(
+    _handler_type: &efi::Guid,
+    _comm_buffer: *mut c_void,
+    _comm_buffer_size: *mut usize,
+) -> efi::Status {
+    log::info!("MmEndOfPeiHandler");
+
+    install_lifecycle_protocol(&guids::MM_END_OF_PEI_PROTOCOL)
+}
+
+/// MM End of DXE Handler.
+///
+/// Installs the `gEfiMmEndOfDxeProtocolGuid` protocol.
+///
+/// Corresponds to the C `MmEndOfDxeHandler`.
+fn mm_end_of_dxe_handler(
+    _handler_type: &efi::Guid,
+    _comm_buffer: *mut c_void,
+    _comm_buffer_size: *mut usize,
+) -> efi::Status {
+    log::info!("MmEndOfDxeHandler");
+
+    install_lifecycle_protocol(&guids::MM_END_OF_DXE_PROTOCOL)
+}
+
+/// MM Exit Boot Service Handler.
+///
+/// Installs the `gEfiEventExitBootServicesGuid` protocol (once).
+///
+/// Corresponds to the C `MmExitBootServiceHandler`.
+fn mm_exit_boot_service_handler(
+    _handler_type: &efi::Guid,
+    _comm_buffer: *mut c_void,
+    _comm_buffer_size: *mut usize,
+) -> efi::Status {
+    static FIRED: spin::Once<()> = spin::Once::new();
+    let mut status = efi::Status::SUCCESS;
+
+    FIRED.call_once(|| {
+        status = install_lifecycle_protocol(&guids::EVENT_EXIT_BOOT_SERVICES);
+    });
+
+    status
+}
+
+/// MM Ready To Boot Handler.
+///
+/// Installs the `gEfiEventReadyToBootGuid` protocol (once).
+///
+/// Corresponds to the C `MmReadyToBootHandler`.
+fn mm_ready_to_boot_handler(
+    _handler_type: &efi::Guid,
+    _comm_buffer: *mut c_void,
+    _comm_buffer_size: *mut usize,
+) -> efi::Status {
+    static FIRED: spin::Once<()> = spin::Once::new();
+    let mut status = efi::Status::SUCCESS;
+
+    FIRED.call_once(|| {
+        status = install_lifecycle_protocol(&guids::EVENT_READY_TO_BOOT);
+    });
+
+    status
+}

--- a/patina_mm_user_core/src/entry_point.asm
+++ b/patina_mm_user_core/src/entry_point.asm
@@ -1,0 +1,33 @@
+#
+# Entry point to a Standalone MM driver.
+#
+# Copyright (c), Microsoft Corporation.
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+
+.section .data
+
+.section .text
+.global user_core_main
+.global efi_main
+
+
+.align 8
+# Shim layer that redefines the contract between runtime module and init.
+efi_main:
+
+    #By the time we are here, it should be everything CPL3 already
+    sub     rsp, 0x28
+
+    #To boot strap this driver, we directly call the entry point worker
+    call    user_core_main
+
+    #Restore the stack pointer
+    add     rsp, 0x28
+
+    # Once returned, we will get returned status in rax, don't touch it, if you can help
+    # r15 contains call gate selector that was planned ahead
+    push    r15                         # New selector to be used, which is set to call gate by the supervisor
+    .byte   0xff, 0x1c, 0x24            # call    far qword [rsp]# return to ring 0 via call gate m16:32
+1:
+    jmp     1b                           # Code should not reach here

--- a/patina_mm_user_core/src/lib.rs
+++ b/patina_mm_user_core/src/lib.rs
@@ -1,0 +1,622 @@
+//! MM User Core
+//!
+//! A pure Rust implementation of the MM User Core for standalone MM mode environments.
+//!
+//! This crate provides the core functionality for a user-mode (Ring 3) MM module that is
+//! invoked by the MM Supervisor Core via privilege demotion. It implements the equivalent
+//! functionality of the C `StandaloneMmCore` — discovering drivers from HOBs, evaluating
+//! dependency expressions, dispatching drivers, and managing MMI handlers.
+//!
+//! ## Architecture
+//!
+//! The user core is invoked by the supervisor with three command types:
+//! - **StartUserCore**: One-time initialization. Walk HOBs to discover drivers and dispatch them.
+//! - **UserRequest**: Runtime MMI dispatch. Parse the communication buffer and invoke registered handlers.
+//! - **UserApProcedure**: Execute a procedure on behalf of an AP.
+//!
+//! ## Entry Protocol
+//!
+//! The supervisor calls the user core entry point with three arguments:
+//! - `arg1` (`u64`): Command type (0 = StartUserCore, 1 = UserRequest, 2 = UserApProcedure)
+//! - `arg2` (`u64`): Command-specific data pointer
+//! - `arg3` (`u64`): Command-specific size or auxiliary data
+//!
+//! ## Memory Model
+//!
+//! This crate runs in Ring 3 (user mode). It does not have direct access to supervisor
+//! resources. All supervisor services are accessed through syscalls.
+//!
+//! ## Example
+//!
+//! ```rust,ignore
+//! use patina_mm_user_core::*;
+//!
+//! static USER_CORE: MmUserCore = MmUserCore::new();
+//! ```
+//!
+//! ## License
+//!
+//! Copyright (c) Microsoft Corporation.
+//!
+//! SPDX-License-Identifier: Apache-2.0
+//!
+#![cfg_attr(all(not(feature = "std"), not(test)), no_std)]
+#![cfg(target_arch = "x86_64")]
+
+extern crate alloc;
+
+pub mod component_dispatcher;
+pub mod config_table;
+pub mod core_handlers;
+pub mod mm_dispatcher;
+pub mod mm_mem;
+pub mod mm_services;
+pub mod mmi;
+pub mod pool_allocator;
+pub mod protocol_db;
+
+use core::{
+    ffi::c_void,
+    mem,
+    num::NonZeroUsize,
+    ptr::NonNull,
+    sync::atomic::{AtomicBool, AtomicU64, Ordering},
+};
+
+use alloc::boxed::Box;
+use patina::{
+    mm_services::MmServices,
+    pi::hob::{Hob, PhaseHandoffInformationTable},
+};
+use r_efi::efi;
+use spin::{Mutex, Once};
+
+use crate::{
+    component_dispatcher::{MmComponentDispatcher, MmComponentInfo},
+    config_table::MmConfigurationTableDb,
+    mm_dispatcher::MmDispatcher,
+    mmi::MmiDatabase,
+    protocol_db::ProtocolDatabase,
+};
+
+use patina::{
+    management_mode::{
+        MmCommBufferStatus,
+        comm_buffer_hob::{MM_COMM_BUFFER_HOB_GUID, MmCommonBufferHobData},
+        supervisor::UserCommandType,
+    },
+    pi::{
+        mm_cis::{EfiMmEntryContext, EfiMmSystemTable},
+        protocols::communication::EfiMmCommunicateHeader,
+    },
+};
+use zerocopy::FromBytes;
+
+// The entry-point shim references `user_core_main`, which is provided by the platform binary, and
+// is only meaningful on the firmware (UEFI) target. Exclude it from host builds (tests, doctests)
+// so their harnesses can link.
+#[cfg(target_os = "uefi")]
+core::arch::global_asm!(include_str!("entry_point.asm"));
+
+/// GUID identifying the MM Supervisor Core module (to be skipped during driver discovery).
+///
+/// `gMmSupervisorCoreGuid`
+pub const MM_SUPERVISOR_CORE_GUID: patina::BinaryGuid =
+    patina::BinaryGuid::from_string("4e4c89dc-a452-4b6b-b183-f16a2a223733");
+
+/// GUID for depex data HOBs paired with driver `MemoryAllocationModule` HOBs.
+///
+/// `gMmSupervisorDepexHobGuid`
+pub const MM_SUPERVISOR_DEPEX_HOB_GUID: patina::BinaryGuid =
+    patina::BinaryGuid::from_string("b17f0049-affd-4530-acd6-e245e19deaf1");
+
+/// Mirrors the MM_SUPV_DEPEX_HOB_DATA structure defined in the supervisor.
+#[repr(C)]
+#[derive(Debug, Clone, Copy)]
+pub struct DepexHobData {
+    /// Protocol GUID the dependency expression applies to.
+    pub name: patina::BinaryGuid,
+    /// Size in bytes of the dependency expression that follows.
+    pub depex_expression_size: u64,
+    /// Variable-length dependency expression bytes (flexible array member).
+    pub depex_expression: [u8; 0],
+}
+
+/// Base address of the user communication buffer (discovered from HOBs).
+///
+/// The supervisor rewrites the HOB's `physical_start` to point to the internal
+/// (MMRAM-resident, user-accessible) copy of the communication buffer before
+/// invoking `StartUserCore`.
+static COMM_BUFFER_BASE: AtomicU64 = AtomicU64::new(0);
+
+/// Size in bytes of the user communication buffer.
+static COMM_BUFFER_SIZE: AtomicU64 = AtomicU64::new(0);
+
+/// Static reference to the user core instance.
+static __USER_CORE: Once<NonZeroUsize> = Once::new();
+
+/// Useful for offline inspection (like debugging) to determine core version.
+#[used]
+static MM_USER_CORE_VERSION: &str = env!("CARGO_PKG_VERSION");
+
+/// The MM User Core responsible for driver dispatch and MMI handling in user mode.
+///
+/// Create a static instance and call [`entry_point_worker`](MmUserCore::entry_point_worker)
+/// from the binary entry point.
+///
+/// ## Examples
+///
+/// ```rust,ignore
+/// use patina_mm_user_core::component_dispatcher::{Add, Component, MmComponentInfo};
+///
+/// static USER_CORE: MmUserCore = MmUserCore::new();
+///
+/// // The platform provides its components via an `MmComponentInfo` type.
+/// struct MyMmPlatform;
+/// impl MmComponentInfo for MyMmPlatform {
+///     fn components(mut add: Add<Component>) {
+///         // add.component(...);
+///     }
+/// }
+///
+/// #[unsafe(export_name = "user_core_main")]
+/// pub extern "efiapi" fn _start(op_code: u64, arg1: u64, arg2: u64) -> u64 {
+///     USER_CORE.entry_point_worker::<MyMmPlatform>(op_code, arg1, arg2)
+/// }
+/// ```
+pub struct MmUserCore {
+    /// The MMI handler database.
+    pub mmi_db: MmiDatabase,
+    /// The protocol/handle database (for depex evaluation and driver services).
+    pub protocol_db: ProtocolDatabase,
+    /// The configuration-table database backing `MmInstallConfigurationTable`.
+    pub config_table_db: MmConfigurationTableDb,
+    /// The driver dispatcher.
+    pub dispatcher: MmDispatcher,
+    /// The Patina component dispatcher (dependency-injected `#[component]` entry points).
+    pub component_dispatcher: Mutex<MmComponentDispatcher>,
+    /// Address of the heap-allocated MM System Table, set once it is built.
+    mm_system_table: Once<usize>,
+    /// Whether the core has completed initialization.
+    initialized: AtomicBool,
+}
+
+impl Default for MmUserCore {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl MmUserCore {
+    /// Creates a new instance of the MM User Core.
+    pub const fn new() -> Self {
+        Self {
+            mmi_db: MmiDatabase::new(),
+            protocol_db: ProtocolDatabase::new(),
+            config_table_db: MmConfigurationTableDb::new(),
+            dispatcher: MmDispatcher::new(),
+            component_dispatcher: Mutex::new(MmComponentDispatcher::new()),
+            mm_system_table: Once::new(),
+            initialized: AtomicBool::new(false),
+        }
+    }
+
+    /// Sets the static user core instance for global access.
+    ///
+    /// Returns true if the address was successfully stored, false if already set.
+    #[must_use]
+    fn set_instance(&'static self) -> bool {
+        let physical_address = NonNull::from_ref(self).expose_provenance();
+        &physical_address == __USER_CORE.call_once(|| physical_address)
+    }
+
+    /// Gets the static MM User Core instance for global access.
+    pub fn instance<'a>() -> &'a Self {
+        // SAFETY: The pointer is guaranteed to be valid as set_instance ensures single initialization.
+        unsafe {
+            NonNull::<Self>::with_exposed_provenance(*__USER_CORE.get().expect("MM User Core is not initialized."))
+                .as_ref()
+        }
+    }
+
+    /// Gets the static MM User Core instance if it has been initialized.
+    ///
+    /// Unlike [`instance`](Self::instance), this returns `None` instead of
+    /// panicking when the instance has not yet been set via `set_instance`.
+    pub fn try_instance<'a>() -> Option<&'a Self> {
+        // SAFETY: The pointer, if present, was stored by `set_instance` from a
+        // `&'static Self` and remains valid for the lifetime of the program.
+        __USER_CORE.get().map(|&addr| unsafe { NonNull::<Self>::with_exposed_provenance(addr).as_ref() })
+    }
+
+    /// Build (once) and return the heap-allocated MM System Table.
+    ///
+    /// The table's function pointers are thin thunks that forward to this
+    /// instance's databases (see [`crate::mm_services`]). Must be called after
+    /// [`set_instance`](Self::set_instance) and after the heap is available.
+    fn init_mm_system_table(&'static self) -> *mut EfiMmSystemTable {
+        let addr = *self.mm_system_table.call_once(|| {
+            let ptr = Box::into_raw(Box::new(mm_services::build_mm_system_table()));
+            log::info!("MM System Table allocated at {:p}", ptr);
+            ptr.expose_provenance()
+        });
+        core::ptr::with_exposed_provenance_mut(addr)
+    }
+
+    /// Returns the MM System Table pointer, or null if it has not been built yet.
+    pub(crate) fn mm_system_table_ptr(&self) -> *mut EfiMmSystemTable {
+        self.mm_system_table.get().map_or(core::ptr::null_mut(), |&addr| core::ptr::with_exposed_provenance_mut(addr))
+    }
+
+    /// Reflect the current processor state into the MM System Table.
+    ///
+    /// Called at the start of each `UserRequest` so dispatched drivers observe
+    /// the CPU that is executing the MM foundation.
+    fn update_cpu_context(&self, currently_executing_cpu: usize, number_of_cpus: usize) {
+        let ptr = self.mm_system_table_ptr();
+        if ptr.is_null() {
+            return;
+        }
+        // SAFETY: The table is heap-allocated, lives for the lifetime of the core, and these two
+        // scalar fields are only written here on the BSP — there is no concurrent writer.
+        unsafe {
+            (*ptr).currently_executing_cpu = currently_executing_cpu;
+            (*ptr).number_of_cpus = number_of_cpus;
+        }
+    }
+
+    /// Main entry point for the MM User Core.
+    ///
+    /// This is called by the supervisor via `invoke_demoted_routine`. The arguments
+    /// correspond to the three parameters passed by the supervisor:
+    ///
+    /// - `arg1`: Command type ([`UserCommandType`])
+    /// - `arg2`: Command-specific data pointer
+    /// - `arg3`: Command-specific size or auxiliary data
+    ///
+    /// Returns 0 on success, or a non-zero status on failure.
+    pub fn entry_point_worker<C: MmComponentInfo>(&'static self, op_code: u64, arg1: u64, arg2: u64) -> u64 {
+        let command = match UserCommandType::try_from(op_code) {
+            Ok(cmd) => cmd,
+            Err(unknown) => {
+                log::error!("Unknown command type: {}", unknown);
+                return efi::Status::INVALID_PARAMETER.as_usize() as u64;
+            }
+        };
+
+        match command {
+            UserCommandType::StartUserCore => self.handle_start_user_core::<C>(arg1 as *const c_void),
+            UserCommandType::UserRequest => self.handle_user_request(arg1, arg2),
+            UserCommandType::UserApProcedure => self.handle_user_ap_procedure(arg1, arg2),
+        }
+    }
+
+    /// Handle the `StartUserCore` command.
+    ///
+    /// This is called once during initialization. The supervisor passes the HOB list
+    /// pointer as `arg2`. We:
+    /// 1. Set the static instance
+    /// 2. Walk HOBs to discover the communication buffer and MM drivers
+    /// 3. Build the MM System Table and publish the HOB list configuration table
+    /// 4. Register the core MMI handlers (driver dispatch is deferred to the
+    ///    `MM_DISPATCH_EVENT` handler, see [`dispatch_drivers`](Self::dispatch_drivers))
+    fn handle_start_user_core<C: MmComponentInfo>(&'static self, hob_list: *const c_void) -> u64 {
+        if !self.set_instance() {
+            log::warn!("MM User Core instance was already set, skipping re-initialization.");
+            return efi::Status::ALREADY_STARTED.as_usize() as u64;
+        }
+
+        // Register this instance as the MmServices provider that the EfiMmSystemTable
+        // thunks forward into. From here, every table call lands in our native impl.
+        mm_services::init_mm_services(self);
+
+        if hob_list.is_null() {
+            log::error!("HOB list pointer is null.");
+            return efi::Status::INVALID_PARAMETER.as_usize() as u64;
+        }
+
+        log::info!("MM User Core v{} starting initialization...", env!("CARGO_PKG_VERSION"));
+
+        // Enable the heap (syscall page allocator) before doing anything that
+        // requires dynamic allocation (driver discovery, depex parsing, etc.).
+        mm_mem::SYSCALL_PAGE_ALLOCATOR.set_initialized();
+
+        // Parse the HOB list
+        let hob_list_info = unsafe {
+            match (hob_list as *const PhaseHandoffInformationTable).as_ref() {
+                Some(info) => info,
+                None => {
+                    log::error!("Failed to read HOB list header.");
+                    return efi::Status::INVALID_PARAMETER.as_usize() as u64;
+                }
+            }
+        };
+
+        let hob = Hob::Handoff(hob_list_info);
+
+        // Discover communication buffer from HOBs
+        self.discover_comm_buffer(&hob);
+
+        // Discover MM drivers from HOBs now, while the HOB list is available. The
+        // actual dispatch is deferred to the `MM_DISPATCH_EVENT` handler.
+        self.dispatcher.discover(&hob);
+
+        // Initialize the MM System Table (heap-allocated, function pointers
+        // are thunks that forward to this instance's databases).
+        let mm_system_table = self.init_mm_system_table();
+        log::info!("MM System Table initialized at {:p}", mm_system_table);
+
+        // Publish the HOB list as a configuration table entry so dispatched
+        // drivers can locate it via the system table (mirrors the C
+        // `MmInstallConfigurationTable(&gMmCoreMmst, &gEfiHobListGuid, ...)`
+        // call in `InitializeMmHobList`).
+        // SAFETY: `hob_list` points to the supervisor-provided HOB list and remains valid for the
+        // lifetime of the configuration-table entry.
+        if let Err(status) =
+            unsafe { self.install_configuration_table(&patina::guids::HOB_LIST, hob_list as *mut c_void, 0) }
+        {
+            log::error!("Failed to install HOB list configuration table: {:?}", status);
+        }
+
+        // Register core MMI handlers (lifecycle events like ready-to-lock,
+        // end-of-DXE, exit-boot-services, etc.). Driver dispatch is deferred to
+        // the `MM_DISPATCH_EVENT` handler, which the supervisor forwards once the
+        // MM foundation is ready.
+        core_handlers::register_core_mmi_handlers();
+
+        // Register and dispatch platform-provided Patina components.
+        self.dispatch_components::<C>(&hob);
+
+        self.initialized.store(true, Ordering::Release);
+        log::info!("MM User Core initialization complete.");
+
+        efi::Status::SUCCESS.as_usize() as u64
+    }
+
+    /// Dispatch the MM drivers discovered during `StartUserCore` in dependency order.
+    ///
+    /// Discovery happens eagerly in [`handle_start_user_core`](Self::handle_start_user_core);
+    /// the dispatch itself is deferred and driven by the `MM_DISPATCH_EVENT` handler
+    /// (see [`mm_driver_dispatch_handler`]).
+    ///
+    /// [`mm_driver_dispatch_handler`]: crate::core_handlers
+    pub(crate) fn dispatch_drivers(&self) -> Result<usize, efi::Status> {
+        self.dispatcher.dispatch(&self.protocol_db, self.mm_system_table_ptr() as *const c_void)
+    }
+
+    /// Register platform-provided Patina components, parse guided HOBs into
+    /// component storage, and dispatch all components to completion.
+    ///
+    /// Runs once during `StartUserCore` on the BSP. Components may install MM
+    /// protocols, register MMI handlers, and consume configs, services, and HOBs
+    /// via dependency injection. Configs are dispatched in two rounds: unlocked
+    /// (for `ConfigMut<T>` components), then locked (for `Config<T>` consumers).
+    fn dispatch_components<C: MmComponentInfo>(&self, hob: &Hob<'_>) {
+        // Expose the MM services (protocol install/locate, MMI handler registration,
+        // pool/page allocation) to components via the `MmServiceProvider` parameter.
+        patina::mm_services::register_component_mm_services(MmUserCore::instance());
+
+        let mut cd = self.component_dispatcher.lock();
+        cd.apply_component_info::<C>();
+        cd.insert_hobs(hob);
+
+        cd.dispatch_to_completion();
+        cd.lock_configs();
+        cd.dispatch_to_completion();
+
+        cd.display_not_dispatched();
+    }
+
+    /// Handle the `UserRequest` command (runtime MMI dispatch).
+    ///
+    /// The supervisor passes a pointer to a buffer containing:
+    /// - `EfiMmEntryContext` (at offset 0)
+    /// - `MmCommBufferStatus` (at offset `context_size`)
+    ///
+    /// For synchronous MMIs the supervisor has already copied the external
+    /// communication buffer into an internal (user-accessible) region.  We:
+    /// 1. Validate the buffer via the `MmIsCommBuffer` syscall
+    /// 2. Parse the `EfiMmCommunicateHeader` to extract the handler GUID and data
+    /// 3. Dispatch via `mmi_manage` with the GUID and data pointer
+    ///
+    /// Asynchronous MMIs (timer, etc.) are always dispatched as root-only
+    /// (`mmi_manage(None, …)`).
+    ///
+    /// Mirrors the C `MmEntryPoint` flow in `StandaloneMmCore.c`.
+    fn handle_user_request(&self, supv_to_user_buffer: u64, context_size: u64) -> u64 {
+        if supv_to_user_buffer == 0 {
+            log::error!("Supervisor-to-user buffer is null.");
+            return efi::Status::INVALID_PARAMETER.as_usize() as u64;
+        }
+
+        // Read the EfiMmEntryContext
+        let entry_context = unsafe { core::ptr::read(supv_to_user_buffer as *const EfiMmEntryContext) };
+
+        self.update_cpu_context(entry_context.currently_executing_cpu as usize, entry_context.number_of_cpus as usize);
+
+        // Read MmCommBufferStatus (immediately after the context)
+        let comm_status = unsafe {
+            core::ptr::read((supv_to_user_buffer as *const u8).add(context_size as usize) as *const MmCommBufferStatus)
+        };
+
+        // ---- Synchronous MMI dispatch ----
+        let comm_buffer_base = COMM_BUFFER_BASE.load(Ordering::Acquire);
+        let comm_buffer_size = COMM_BUFFER_SIZE.load(Ordering::Acquire);
+
+        let mut updated_status = comm_status;
+
+        if comm_buffer_base != 0 && comm_status.is_comm_buffer_valid != 0 {
+            // Validate the communication buffer via a supervisor syscall.
+            let mut return_buffer_size: u64 = 0;
+            let sync_status = if !mm_mem::is_comm_buffer(comm_buffer_base, comm_buffer_size) {
+                log::error!("MmIsCommBuffer rejected buffer at 0x{:x} size 0x{:x}", comm_buffer_base, comm_buffer_size);
+                efi::Status::NOT_FOUND
+            } else {
+                self.dispatch_synchronous_mmi(comm_buffer_base, comm_buffer_size, &mut return_buffer_size)
+            };
+
+            updated_status.is_comm_buffer_valid = 0;
+            updated_status.return_status = if sync_status == efi::Status::SUCCESS {
+                efi::Status::SUCCESS.as_usize() as u64
+            } else {
+                efi::Status::NOT_FOUND.as_usize() as u64
+            };
+            updated_status.return_buffer_size = return_buffer_size;
+        }
+
+        // ---- Asynchronous MMI dispatch (always runs) ----
+        // SAFETY: no comm buffer is supplied for the async (root-handler) dispatch.
+        unsafe { self.mmi_manage(None, core::ptr::null(), core::ptr::null_mut(), core::ptr::null_mut()) };
+
+        // Write back the updated status to the supervisor-to-user buffer
+        unsafe {
+            core::ptr::write(
+                (supv_to_user_buffer as *mut u8).add(context_size as usize) as *mut MmCommBufferStatus,
+                updated_status,
+            );
+        }
+
+        efi::Status::SUCCESS.as_usize() as u64
+    }
+
+    /// Parse the `EfiMmCommunicateHeader` from the communication buffer and
+    /// dispatch the appropriate GUID-specific MMI handler.
+    ///
+    /// Returns the dispatch status and updates `return_buffer_size` with the
+    /// total response size (header + data).
+    fn dispatch_synchronous_mmi(
+        &self,
+        comm_buffer_base: u64,
+        comm_buffer_size: u64,
+        return_buffer_size: &mut u64,
+    ) -> efi::Status {
+        let buffer_size = comm_buffer_size as usize;
+
+        // The buffer must be large enough for at least the communicate header.
+        if buffer_size < EfiMmCommunicateHeader::size() {
+            log::error!(
+                "Communication buffer too small for header: {} < {}",
+                buffer_size,
+                EfiMmCommunicateHeader::size()
+            );
+            return efi::Status::BAD_BUFFER_SIZE;
+        }
+
+        // SAFETY: We verified the buffer is large enough for the header.
+        let header = unsafe { core::ptr::read_unaligned(comm_buffer_base as *const EfiMmCommunicateHeader) };
+
+        // Determine header layout: check for V3 signature first, then fall
+        // back to the legacy `EfiMmCommunicateHeader`.
+        let (comm_guid_ptr, comm_header_size, mut data_size) = if header.header_guid()
+            == patina::Guid::from_ref(&patina::pi::protocols::communication3::COMMUNICATE_HEADER_V3_GUID)
+        {
+            // V3 header
+            let v3 = unsafe {
+                core::ptr::read_unaligned(
+                    comm_buffer_base as *const patina::pi::protocols::communication3::EfiMmCommunicateHeader,
+                )
+            };
+            let header_size = mem::size_of::<patina::pi::protocols::communication3::EfiMmCommunicateHeader>();
+            let total = v3.buffer_size as usize;
+            if total > buffer_size {
+                log::error!("V3 buffer_size 0x{:x} exceeds available 0x{:x}", total, buffer_size);
+                return efi::Status::BAD_BUFFER_SIZE;
+            }
+            // GUID to dispatch is `message_guid` in V3
+            let guid_offset =
+                core::mem::offset_of!(patina::pi::protocols::communication3::EfiMmCommunicateHeader, message_guid);
+            let guid_ptr = (comm_buffer_base as *const u8).wrapping_add(guid_offset) as *const efi::Guid;
+            (guid_ptr, header_size, total.saturating_sub(header_size))
+        } else {
+            // Legacy header
+            let message_length = header.message_length();
+            let total = EfiMmCommunicateHeader::size() + message_length;
+            if total > buffer_size {
+                log::error!(
+                    "Legacy message_length 0x{:x} exceeds available 0x{:x}",
+                    message_length,
+                    buffer_size.saturating_sub(EfiMmCommunicateHeader::size())
+                );
+                return efi::Status::BAD_BUFFER_SIZE;
+            }
+            // GUID to dispatch is `header_guid` in legacy
+            let guid_ptr = comm_buffer_base as *const efi::Guid;
+            (guid_ptr, EfiMmCommunicateHeader::size(), message_length)
+        };
+
+        // Zero the remainder of the buffer past the message (matches C behaviour).
+        let used = comm_header_size + data_size;
+        if used < buffer_size {
+            unsafe {
+                core::ptr::write_bytes((comm_buffer_base as *mut u8).add(used), 0, buffer_size - used);
+            }
+        }
+
+        // Dispatch the GUID-specific handler.
+        let comm_data_ptr = unsafe { (comm_buffer_base as *mut u8).add(comm_header_size) as *mut c_void };
+
+        // SAFETY: `comm_guid_ptr` references the message GUID parsed from the validated comm buffer;
+        // `comm_data_ptr`/`data_size` describe the comm-buffer payload.
+        let status = unsafe {
+            self.mmi_manage(Some(&*comm_guid_ptr), core::ptr::null(), comm_data_ptr, &mut data_size as *mut usize)
+        };
+
+        *return_buffer_size = (data_size + comm_header_size) as u64;
+        status
+    }
+
+    /// Handle the `UserApProcedure` command.
+    ///
+    /// The supervisor passes the procedure pointer and argument. We call the procedure
+    /// directly since we're already in user mode.
+    fn handle_user_ap_procedure(&self, procedure: u64, argument: u64) -> u64 {
+        if procedure == 0 {
+            log::error!("AP procedure pointer is null.");
+            return efi::Status::INVALID_PARAMETER.as_usize() as u64;
+        }
+
+        log::trace!("Executing AP procedure at 0x{:016x} with arg 0x{:016x}", procedure, argument);
+
+        // SAFETY: The supervisor has validated the procedure pointer before dispatching.
+        // The procedure follows the EFI AP_PROCEDURE calling convention.
+        type EfiApProcedure = unsafe extern "efiapi" fn(*mut c_void);
+        let proc_fn: EfiApProcedure = unsafe { core::mem::transmute(procedure) };
+        unsafe { proc_fn(argument as *mut c_void) };
+
+        efi::Status::SUCCESS.as_usize() as u64
+    }
+
+    /// Discover the communication buffer address from HOBs and store it for
+    /// later use in `handle_user_request`.
+    ///
+    /// The supervisor rewrites the HOB's `physical_start` field to point to
+    /// the internal (user-accessible) copy of the buffer before invoking
+    /// `StartUserCore`, so the address we read here is the one we should
+    /// read from at runtime.
+    fn discover_comm_buffer(&self, hob: &Hob<'_>) {
+        for current_hob in hob {
+            if let Hob::GuidHob(guid_hob, data) = current_hob
+                && guid_hob.name == MM_COMM_BUFFER_HOB_GUID
+                && let Ok((buffer_data, _)) = MmCommonBufferHobData::read_from_prefix(data)
+            {
+                let physical_start = buffer_data.physical_start;
+                let number_of_pages = buffer_data.number_of_pages;
+
+                let buffer_size = number_of_pages.saturating_mul(4096);
+
+                COMM_BUFFER_BASE.store(physical_start, Ordering::Release);
+                COMM_BUFFER_SIZE.store(buffer_size, Ordering::Release);
+
+                log::info!(
+                    "Found MM communication buffer: base=0x{:016x}, pages={}, size=0x{:x}",
+                    physical_start,
+                    number_of_pages,
+                    buffer_size,
+                );
+                return;
+            }
+        }
+
+        log::warn!("No MM communication buffer HOB found — only root MMI handlers will be supported.");
+    }
+}

--- a/patina_mm_user_core/src/mm_dispatcher.rs
+++ b/patina_mm_user_core/src/mm_dispatcher.rs
@@ -1,0 +1,361 @@
+//! MM Driver Dispatcher
+//!
+//! This module is responsible for discovering MM drivers from HOBs and dispatching them
+//! in dependency order. It follows the same pattern as the C `StandaloneMmCore` dispatcher
+//! in `FwVol.c` and `Dispatcher.c`, and the Rust DXE Core's `pi_dispatcher.rs`.
+//!
+//! ## Driver Discovery
+//!
+//! MM drivers are discovered from `MemoryAllocationModule` HOBs in the HOB list. Each driver
+//! HOB is identified by having `alloc_descriptor.name == MM_SUPERVISOR_HOB_MEMORY_ALLOC_MODULE_GUID`.
+//! The HOB's `module_name` provides the driver GUID, and `entry_point` provides the address to call.
+//!
+//! Drivers that are the supervisor core or user core themselves are skipped.
+//!
+//! ## Depex Evaluation
+//!
+//! Each driver's `MemoryAllocationModule` HOB is followed by a `GuidHob` with
+//! `name == MM_SUPERVISOR_DEPEX_HOB_GUID` containing the raw dependency expression bytes.
+//! The depex is parsed and evaluated against the protocol database.
+//!
+//! ## Dispatch Order
+//!
+//! Drivers with satisfied dependencies (or `TRUE`/empty depex) are dispatched first.
+//! `BEFORE`/`AFTER` associations are respected: if driver A has `BEFORE(B)`, A is
+//! dispatched immediately before B.
+//!
+//! ## License
+//!
+//! Copyright (c) Microsoft Corporation.
+//!
+//! SPDX-License-Identifier: Apache-2.0
+//!
+
+use alloc::{collections::BTreeMap, vec::Vec};
+use core::{cmp::Ordering, ffi::c_void};
+
+use patina::{
+    boot_services::c_ptr::CPtr,
+    management_mode::supervisor::{MM_SUPERVISOR_HOB_MEMORY_ALLOC_MODULE_GUID, MM_SUPERVISOR_USER_GUID},
+    pi::hob::Hob,
+};
+use patina_internal_core::depex::{AssociatedDependency, Depex};
+use r_efi::efi;
+use spin::Mutex;
+
+use crate::{DepexHobData, MM_SUPERVISOR_CORE_GUID, MM_SUPERVISOR_DEPEX_HOB_GUID, protocol_db::ProtocolDatabase};
+
+/// Represents a discovered MM driver pending dispatch.
+#[derive(Debug)]
+struct DriverEntry {
+    /// The GUID identifying this driver (from `MemoryAllocationModule.module_name`).
+    file_name: efi::Guid,
+    /// The entry point address of the driver.
+    entry_point: u64,
+    /// The base address of the driver image in memory.
+    _image_base: u64,
+    /// The size of the driver image in memory.
+    _image_size: u64,
+    /// The parsed dependency expression, if any.
+    depex: Option<Depex>,
+}
+
+/// Wrapper for `efi::Guid` that implements `Ord` for use in `BTreeMap`.
+#[derive(Debug, Eq, PartialEq)]
+struct OrdGuid(efi::Guid);
+
+impl PartialOrd for OrdGuid {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for OrdGuid {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.0.as_bytes().cmp(other.0.as_bytes())
+    }
+}
+
+/// The MM Driver Dispatcher.
+///
+/// Discovers drivers from HOBs at initialization time, evaluates their dependency
+/// expressions, and dispatches them by calling their entry points.
+pub struct MmDispatcher {
+    /// Tracks whether the dispatcher is currently executing (prevents re-entrance).
+    executing: Mutex<bool>,
+    /// Drivers discovered from HOBs during `StartUserCore`, awaiting dispatch.
+    pending: Mutex<Vec<DriverEntry>>,
+}
+
+impl Default for MmDispatcher {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl MmDispatcher {
+    /// Creates a new `MmDispatcher`.
+    pub const fn new() -> Self {
+        Self { executing: Mutex::new(false), pending: Mutex::new(Vec::new()) }
+    }
+
+    /// Discover drivers from HOBs and dispatch them.
+    ///
+    /// This is the main entry point called during `StartUserCore`. It:
+    /// 1. Walks the HOB list to find `MemoryAllocationModule` HOBs with the supervisor alloc GUID
+    /// 2. Skips the supervisor core and user core modules
+    /// 3. Reads the paired depex `GuidHob` that follows each driver HOB
+    /// 4. Evaluates dependencies and dispatches in order
+    ///
+    /// The discovered drivers are dispatched later by [`dispatch`](Self::dispatch)
+    /// when the `MM_DISPATCH_EVENT` MMI is delivered.
+    pub fn discover(&self, hob: &Hob<'_>) {
+        let drivers = self.discover_drivers(hob);
+        log::info!("Discovered {} MM driver(s) from HOBs.", drivers.len());
+        *self.pending.lock() = drivers;
+    }
+
+    /// Dispatch the drivers recorded by [`discover`](Self::discover) in dependency order.
+    ///
+    /// Evaluates each pending driver's depex against `protocol_db` and calls the
+    /// entry points of drivers whose dependencies are satisfied.
+    ///
+    /// Returns the number of drivers successfully dispatched, or an error status.
+    pub fn dispatch(
+        &self,
+        protocol_db: &ProtocolDatabase,
+        mm_system_table: *const c_void,
+    ) -> Result<usize, efi::Status> {
+        let mut is_executing = self.executing.lock();
+        if *is_executing {
+            return Err(efi::Status::ALREADY_STARTED);
+        }
+        *is_executing = true;
+        drop(is_executing);
+
+        let pending = core::mem::take(&mut *self.pending.lock());
+        let dispatched = self.dispatch_drivers(pending, protocol_db, mm_system_table);
+
+        *self.executing.lock() = false;
+        Ok(dispatched)
+    }
+
+    /// Walk the HOB list and collect driver entries.
+    ///
+    /// For each `MemoryAllocationModule` HOB with the supervisor allocation GUID:
+    /// - Skip if the module is the supervisor core or user core
+    /// - Look at the next HOB for a depex `GuidHob` with `MM_SUPERVISOR_DEPEX_HOB_GUID`
+    /// - Create a `DriverEntry` with the parsed depex
+    fn discover_drivers(&self, hob: &Hob<'_>) -> Vec<DriverEntry> {
+        let mut drivers = Vec::new();
+
+        // Collect all HOBs into a vec for indexed access (we need to look ahead for depex)
+        let all_hobs: Vec<Hob<'_>> = hob.into_iter().collect();
+
+        for (index, current_hob) in all_hobs.iter().enumerate() {
+            if let Hob::MemoryAllocationModule(mem_alloc_mod) = current_hob {
+                // Check if this is an MM Supervisor module allocation
+                if mem_alloc_mod.alloc_descriptor.name != MM_SUPERVISOR_HOB_MEMORY_ALLOC_MODULE_GUID {
+                    continue;
+                }
+
+                let module_name = mem_alloc_mod.module_name;
+
+                // Skip the supervisor core and user core modules
+                if module_name == MM_SUPERVISOR_CORE_GUID || module_name == MM_SUPERVISOR_USER_GUID {
+                    log::info!("Skipping core module: {}", module_name);
+                    continue;
+                }
+
+                log::info!(
+                    "Found MM driver: name={}, entry=0x{:016x}, base=0x{:016x}, size=0x{:x}",
+                    module_name,
+                    mem_alloc_mod.entry_point,
+                    mem_alloc_mod.alloc_descriptor.memory_base_address,
+                    mem_alloc_mod.alloc_descriptor.memory_length,
+                );
+
+                // Look for a paired depex GuidHob in the next HOB
+                let depex: Option<Depex> = if let Some(next_hob) = all_hobs.get(index + 1) {
+                    if let Hob::GuidHob(guid_hob, data) = next_hob {
+                        if guid_hob.name == MM_SUPERVISOR_DEPEX_HOB_GUID {
+                            log::debug!("  Found depex HOB ({} bytes)", data.len());
+                            if data.is_empty() {
+                                None
+                            } else {
+                                // Check the name matches the expected depex HOB GUID before parsing.
+                                let depex_hob_data = <[u8]>::as_ptr(data) as *const DepexHobData;
+                                // SAFETY: We trust that the supervisor correctly formats the depex HOB data
+                                let depex_hob_data = unsafe { &*depex_hob_data };
+                                if depex_hob_data.name != module_name {
+                                    panic!(
+                                        "Depex HOB module name {} does not match driver module name {}",
+                                        depex_hob_data.name, module_name
+                                    );
+                                }
+                                // print depex_hob_data.depex_expression pointer and length
+                                log::info!(
+                                    "  Parsed depex HOB {:p} for driver {} at {:p}: expression length = {}",
+                                    depex_hob_data.as_ptr(),
+                                    module_name,
+                                    depex_hob_data.depex_expression.as_ptr(),
+                                    depex_hob_data.depex_expression_size
+                                );
+                                // SAFETY: depex_expression is a zero-length array (flexible array member).
+                                // The actual bytes follow the struct in memory; use from_raw_parts with the real size.
+                                let depex_bytes = unsafe {
+                                    core::slice::from_raw_parts(
+                                        depex_hob_data.depex_expression.as_ptr(),
+                                        depex_hob_data.depex_expression_size as usize,
+                                    )
+                                };
+                                Some(Depex::from(depex_bytes))
+                            }
+                        } else {
+                            log::debug!("  No depex HOB (next HOB has different GUID)");
+                            None
+                        }
+                    } else {
+                        log::debug!("  No depex HOB (next HOB is not GuidHob)");
+                        None
+                    }
+                } else {
+                    log::debug!("  No depex HOB (no next HOB)");
+                    None
+                };
+
+                log::info!("  Driver {} has depex: {:?}", module_name, depex);
+
+                drivers.push(DriverEntry {
+                    file_name: module_name.into_inner(),
+                    entry_point: mem_alloc_mod.entry_point,
+                    _image_base: mem_alloc_mod.alloc_descriptor.memory_base_address,
+                    _image_size: mem_alloc_mod.alloc_descriptor.memory_length,
+                    depex,
+                });
+            }
+        }
+
+        drivers
+    }
+
+    /// Dispatch drivers in dependency order.
+    ///
+    /// This implements a multi-pass dispatch loop similar to the DXE Core's `PiDispatcher`:
+    /// 1. Evaluate each pending driver's depex against the current protocol database
+    /// 2. Drivers with satisfied (or absent) depexes are scheduled
+    /// 3. Before/After associations are handled by reordering the scheduled list
+    /// 4. Each scheduled driver's entry point is called
+    /// 5. Repeat until no more drivers can be dispatched
+    fn dispatch_drivers(
+        &self,
+        mut pending: Vec<DriverEntry>,
+        protocol_db: &ProtocolDatabase,
+        mm_system_table: *const c_void,
+    ) -> usize {
+        let mut total_dispatched = 0;
+
+        loop {
+            // The protocol DB is shared with the MM System Table thunks, so it already
+            // reflects every protocol installed by previously dispatched drivers.
+            let registered_protocols = protocol_db.registered_protocols();
+            let mut scheduled = Vec::new();
+            let mut still_pending = Vec::new();
+            let mut associated_before: BTreeMap<OrdGuid, Vec<DriverEntry>> = BTreeMap::new();
+            let mut associated_after: BTreeMap<OrdGuid, Vec<DriverEntry>> = BTreeMap::new();
+
+            for mut driver in pending.drain(..) {
+                let depex_satisfied = match driver.depex {
+                    Some(ref mut depex) => depex.eval(&registered_protocols),
+                    // No depex means the driver can be dispatched immediately
+                    None => true,
+                };
+
+                if depex_satisfied {
+                    scheduled.push(driver);
+                } else {
+                    // Check for Before/After associations
+                    match driver.depex.as_ref().map(|d| d.is_associated()) {
+                        Some(Some(AssociatedDependency::Before(guid))) => {
+                            associated_before.entry(OrdGuid(guid)).or_default().push(driver);
+                        }
+                        Some(Some(AssociatedDependency::After(guid))) => {
+                            associated_after.entry(OrdGuid(guid)).or_default().push(driver);
+                        }
+                        _ => {
+                            still_pending.push(driver);
+                        }
+                    }
+                }
+            }
+
+            if scheduled.is_empty() {
+                // No more drivers can be dispatched; move remaining to pending for logging
+                pending = still_pending;
+                break;
+            }
+
+            // Build the final dispatch order respecting Before/After associations
+            let ordered: Vec<DriverEntry> = scheduled
+                .into_iter()
+                .flat_map(|driver| {
+                    let filename = OrdGuid(driver.file_name);
+                    let mut list = associated_before.remove(&filename).unwrap_or_default();
+                    let mut after_list = associated_after.remove(&filename).unwrap_or_default();
+                    list.push(driver);
+                    list.append(&mut after_list);
+                    list
+                })
+                .collect();
+
+            // Dispatch each scheduled driver
+            for driver in ordered {
+                log::info!(
+                    "Dispatching MM driver {} at entry 0x{:016x}",
+                    patina::Guid::from_ref(&driver.file_name),
+                    driver.entry_point,
+                );
+
+                // Call the driver's entry point.
+                // MM driver entry signature: EFI_STATUS EFIAPI DriverEntry(EFI_HANDLE ImageHandle, EFI_MM_SYSTEM_TABLE *MmSystemTable)
+                // We pass a null image handle and the system table pointer.
+                type MmDriverEntryPoint = unsafe extern "efiapi" fn(efi::Handle, *const c_void) -> efi::Status;
+                let entry_fn: MmDriverEntryPoint = unsafe { core::mem::transmute(driver.entry_point) };
+
+                let status = unsafe { entry_fn(core::ptr::null_mut(), mm_system_table) };
+
+                if status == efi::Status::SUCCESS {
+                    log::info!("  Driver {} returned SUCCESS.", patina::Guid::from_ref(&driver.file_name));
+                    total_dispatched += 1;
+                } else {
+                    log::warn!(
+                        "  Driver {} returned status: 0x{:x}",
+                        patina::Guid::from_ref(&driver.file_name),
+                        status.as_usize(),
+                    );
+                }
+            }
+
+            // Remaining unmatched Before/After drivers go back to pending
+            for (_guid, drivers) in associated_before {
+                still_pending.extend(drivers);
+            }
+
+            for (_guid, drivers) in associated_after {
+                still_pending.extend(drivers);
+            }
+
+            pending = still_pending;
+        }
+
+        // Log any remaining drivers
+        for driver in &pending {
+            log::warn!(
+                "Driver {} discovered but not dispatched (unsatisfied depex).",
+                patina::Guid::from_ref(&driver.file_name),
+            );
+        }
+
+        total_dispatched
+    }
+}

--- a/patina_mm_user_core/src/mm_mem.rs
+++ b/patina_mm_user_core/src/mm_mem.rs
@@ -1,0 +1,151 @@
+//! MM User Core Memory Allocator
+//!
+//! Provides a [`SyscallPageAllocator`] that implements [`PageAllocatorBackend`]
+//! by issuing `syscall` instructions to the MM Supervisor for page allocation
+//! and deallocation.
+//!
+//! The pool allocator, `PoolAllocator`, is wired up as the `#[global_allocator]`.
+//!
+//! ## Syscall ABI
+//!
+//! The MM Supervisor exposes page allocation via the following syscall indices
+//! (defined in SysCallLib.h / `SyscallIndex` enum in the supervisor):
+//!
+//! | Syscall     | RAX       | RDX (arg1)     | R8 (arg2)      | R9 (arg3)   |
+//! |-------------|-----------|----------------|----------------|-------------|
+//! | AllocPage   | `0x10004` | alloc_type (0) | mem_type (6)   | page_count  |
+//! | FreePage    | `0x10005` | address        | page_count     | 0           |
+//!
+//! The supervisor returns:
+//! - RAX: result value
+//!
+//! ## License
+//!
+//! Copyright (c) Microsoft Corporation.
+//!
+//! SPDX-License-Identifier: Apache-2.0
+//!
+
+use core::sync::atomic::{AtomicBool, Ordering};
+
+#[cfg(target_os = "uefi")]
+use crate::pool_allocator::PoolAllocator;
+use crate::pool_allocator::{PageAllocError, PageAllocatorBackend};
+use patina::management_mode::supervisor::{SyscallIndex, raw_syscall};
+
+/// `AllocateAnyPages` — allocate any available pages.
+const ALLOCATE_ANY_PAGES: u64 = 0;
+
+/// `EfiRuntimeServicesData` — the memory type used for MM pool allocations.
+const RUNTIME_SERVICES_DATA: u64 = 6;
+
+/// Validate that a given memory range is a valid MM communication buffer by
+/// issuing the `MmIsCommBuffer` syscall to the supervisor.
+///
+/// Returns `true` if the supervisor confirms the range falls entirely within
+/// the user communication buffer region.
+pub fn is_comm_buffer(address: u64, size: u64) -> bool {
+    let result = unsafe { raw_syscall(SyscallIndex::MmIsCommBuffer.as_u64(), address, size, 0) };
+    result != 0
+}
+
+/// A page allocator backend that issues `syscall` instructions to the MM Supervisor.
+///
+/// This is used as the [`PageAllocatorBackend`] for the MM User Core's
+/// [`PoolAllocator`](crate::pool_allocator::PoolAllocator) and global allocator.
+///
+/// ## Initialization
+///
+/// Call [`SyscallPageAllocator::set_initialized`] after the user core has been
+/// set up and is ready to issue syscalls (i.e., during `StartUserCore` handling,
+/// before driver dispatch begins).
+pub struct SyscallPageAllocator {
+    /// Whether the allocator has been activated. Before this is set, all
+    /// allocations will fail immediately. This prevents accidental allocations
+    /// before the syscall interface is ready.
+    initialized: AtomicBool,
+}
+
+// SAFETY: SyscallPageAllocator uses an atomic flag and the syscall interface is
+// re-entrant from the BSP.
+unsafe impl Send for SyscallPageAllocator {}
+unsafe impl Sync for SyscallPageAllocator {}
+
+impl Default for SyscallPageAllocator {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl SyscallPageAllocator {
+    /// Creates a new uninitialized syscall page allocator.
+    pub const fn new() -> Self {
+        Self { initialized: AtomicBool::new(false) }
+    }
+
+    /// Marks the allocator as ready. Must be called after the syscall interface
+    /// is available (i.e., early in `StartUserCore` handling).
+    pub fn set_initialized(&self) {
+        self.initialized.store(true, Ordering::Release);
+        log::info!("SyscallPageAllocator initialized — heap is now available.");
+    }
+}
+
+impl PageAllocatorBackend for SyscallPageAllocator {
+    fn allocate_pages(&self, num_pages: usize) -> Result<u64, PageAllocError> {
+        if !self.initialized.load(Ordering::Acquire) {
+            return Err(PageAllocError::NotInitialized);
+        }
+
+        if num_pages == 0 {
+            return Err(PageAllocError::OutOfMemory);
+        }
+
+        let addr = unsafe {
+            raw_syscall(SyscallIndex::AllocPage.as_u64(), ALLOCATE_ANY_PAGES, RUNTIME_SERVICES_DATA, num_pages as u64)
+        };
+
+        if addr == 0 {
+            log::warn!("SyscallPageAllocator: AllocPage({} pages) returned a null address", num_pages);
+            return Err(PageAllocError::OutOfMemory);
+        }
+
+        log::trace!("SyscallPageAllocator: allocated {} page(s) at 0x{:016x}", num_pages, addr);
+
+        Ok(addr)
+    }
+
+    fn free_pages(&self, addr: u64, num_pages: usize) -> Result<(), PageAllocError> {
+        if !self.initialized.load(Ordering::Acquire) {
+            return Err(PageAllocError::NotInitialized);
+        }
+
+        unsafe { raw_syscall(SyscallIndex::FreePage.as_u64(), addr, num_pages as u64, 0) };
+
+        log::trace!("SyscallPageAllocator: freed {} page(s) at 0x{:016x}", num_pages, addr);
+
+        Ok(())
+    }
+
+    fn is_initialized(&self) -> bool {
+        self.initialized.load(Ordering::Acquire)
+    }
+}
+
+/// Global page allocator instance for the user core.
+///
+/// This issues syscalls to the supervisor for actual page allocation.
+/// Call [`SyscallPageAllocator::set_initialized`] during `StartUserCore`
+/// to enable the heap.
+pub static SYSCALL_PAGE_ALLOCATOR: SyscallPageAllocator = SyscallPageAllocator::new();
+
+/// Global pool allocator instance.
+///
+/// Uses the shared [`PoolAllocator`] from `pool_allocator`,
+/// backed by [`SyscallPageAllocator`] for page allocation via syscalls.
+///
+/// Only installed for the firmware (UEFI) target; host builds use the system allocator, since the
+/// syscall-backed allocator cannot run on the host.
+#[cfg(target_os = "uefi")]
+#[global_allocator]
+static GLOBAL_ALLOCATOR: PoolAllocator<SyscallPageAllocator> = PoolAllocator::new(&SYSCALL_PAGE_ALLOCATOR);

--- a/patina_mm_user_core/src/mm_services.rs
+++ b/patina_mm_user_core/src/mm_services.rs
@@ -1,0 +1,716 @@
+//! MM System Table (MMST) Construction — User Core Implementation
+//!
+//! This module builds the concrete `EfiMmSystemTable` handed to dispatched MM
+//! drivers. The table itself contains **no logic**: every function pointer is a
+//! thin `extern "efiapi"` thunk that locates the singleton
+//! [`MmUserCore`] instance and forwards to the safe Rust implementation living
+//! in its databases ([`ProtocolDatabase`], [`MmiDatabase`],
+//! [`MmConfigurationTableDb`]). In other words the table is the *interface* and
+//! the user core instance is the *implementation* — not the other way around.
+//!
+//! The *type definitions* (`EfiMmSystemTable`, `MmServices`,
+//! `StandardMmServices`, …) live in the Patina SDK at [`patina::mm_services`].
+//!
+//! [`ProtocolDatabase`]: crate::protocol_db::ProtocolDatabase
+//! [`MmiDatabase`]: crate::mmi::MmiDatabase
+//! [`MmConfigurationTableDb`]: crate::config_table::MmConfigurationTableDb
+//!
+//! ## License
+//!
+//! Copyright (c) Microsoft Corporation.
+//!
+//! SPDX-License-Identifier: Apache-2.0
+//!
+
+extern crate alloc;
+
+use alloc::vec::Vec;
+use core::{ffi::c_void, ptr::NonNull};
+
+use r_efi::efi;
+
+use crate::{MmUserCore, pool_allocator::PageAllocatorBackend};
+use patina::{
+    mm_services::{MmServices, ProtocolNotify, Registration, StandardMmServices},
+    pi::mm_cis::{
+        EfiMmSystemTable, MM_MMST_SIGNATURE, MM_SYSTEM_TABLE_REVISION, MmCpuIoAccess, MmCpuIoProtocol, MmNotifyFn,
+        MmiHandlerEntryPoint,
+    },
+};
+
+/// The bridge the `EfiMmSystemTable` thunks dispatch through.
+///
+/// Initialized once in [`init_mm_services`] with the user core's [`MmServices`]
+/// provider ([`MmUserCore`]). Every thunk forwards into this bridge, which in
+/// turn calls the provider — so no Rust ever calls the table's function pointers.
+static MM_SERVICES: StandardMmServices = StandardMmServices::new_uninit();
+
+/// Register the [`MmServices`] provider the `EfiMmSystemTable` thunks forward to.
+///
+/// Must be called once during startup, before any driver can invoke the table.
+pub(crate) fn init_mm_services(provider: &'static dyn MmServices) {
+    MM_SERVICES.init(provider);
+}
+
+/// Build the MM System Table value.
+///
+/// Every field is a thunk that defers to [`MmUserCore::instance`]; the table
+/// carries no state of its own beyond the CPU/configuration fields the core
+/// updates in place. [`MmUserCore::init_mm_system_table`] boxes the returned
+/// value and hands the pointer to dispatched drivers.
+pub(crate) fn build_mm_system_table() -> EfiMmSystemTable {
+    EfiMmSystemTable {
+        hdr: efi::TableHeader {
+            signature: MM_MMST_SIGNATURE as u64,
+            revision: MM_SYSTEM_TABLE_REVISION,
+            header_size: core::mem::size_of::<EfiMmSystemTable>() as u32,
+            crc32: 0,
+            reserved: 0,
+        },
+        mm_firmware_vendor: core::ptr::null_mut(),
+        mm_firmware_revision: 0,
+
+        mm_install_configuration_table: mm_install_configuration_table_impl,
+
+        mm_io: MmCpuIoProtocol {
+            mem: MmCpuIoAccess { read: mm_io_not_available, write: mm_io_not_available },
+            io: MmCpuIoAccess { read: mm_io_not_available, write: mm_io_not_available },
+        },
+
+        mm_allocate_pool: mm_allocate_pool_impl,
+        mm_free_pool: mm_free_pool_impl,
+        mm_allocate_pages: mm_allocate_pages_impl,
+        mm_free_pages: mm_free_pages_impl,
+
+        mm_startup_this_ap: mm_startup_this_ap_not_available,
+
+        currently_executing_cpu: 0,
+        number_of_cpus: 0,
+        cpu_save_state_size: core::ptr::null_mut(),
+        cpu_save_state: core::ptr::null_mut(),
+
+        number_of_table_entries: 0,
+        mm_configuration_table: core::ptr::null_mut(),
+
+        mm_install_protocol_interface: mm_install_protocol_interface_impl,
+        mm_uninstall_protocol_interface: mm_uninstall_protocol_interface_impl,
+        mm_handle_protocol: mm_handle_protocol_impl,
+        mm_register_protocol_notify: mm_register_protocol_notify_impl,
+        mm_locate_handle: mm_locate_handle_impl,
+        mm_locate_protocol: mm_locate_protocol_impl,
+
+        mmi_manage: mmi_manage_impl,
+        mmi_handler_register: mmi_handler_register_impl,
+        mmi_handler_unregister: mmi_handler_unregister_impl,
+    }
+}
+
+/// CPU I/O access stub that always reports the service as unavailable.
+///
+/// # Safety
+///
+/// Part of the C ABI surface invoked through the system table. It dereferences
+/// none of its pointer arguments, so it performs no memory accesses; it remains
+/// `unsafe` only to match the `MmCpuIoFn` signature.
+unsafe extern "efiapi" fn mm_io_not_available(
+    _this: *const MmCpuIoAccess,
+    _width: usize,
+    _address: u64,
+    _count: usize,
+    _buffer: *mut c_void,
+) -> efi::Status {
+    efi::Status::UNSUPPORTED
+}
+
+/// Installs, updates, or removes a configuration table entry.
+///
+/// # Safety
+///
+/// Invoked through the system table by (potentially untrusted) C callers. The
+/// `guid` pointer is null-checked before being dereferenced, but a non-null
+/// pointer is dereferenced on trust because its validity cannot be verified
+/// here — this is intrinsically unsafe as it handles inputs from C code.
+unsafe extern "efiapi" fn mm_install_configuration_table_impl(
+    _system_table: *const EfiMmSystemTable,
+    guid: *const efi::Guid,
+    table: *mut c_void,
+    table_size: usize,
+) -> efi::Status {
+    if guid.is_null() {
+        return efi::Status::INVALID_PARAMETER;
+    }
+
+    // SAFETY: `guid` was null-checked above; the C caller guarantees a non-null pointer references a
+    // valid `efi::Guid`. Dereferenced once into a reference; all further use is safe Rust.
+    let guid = unsafe { &*guid };
+    // SAFETY: `table` is forwarded as provided by the C caller; the `MmServices` contract makes the
+    // caller responsible for its validity and lifetime.
+    match unsafe { MM_SERVICES.install_configuration_table(guid, table, table_size) } {
+        Ok(()) => efi::Status::SUCCESS,
+        Err(status) => status,
+    }
+}
+
+extern "efiapi" fn mm_allocate_pool_impl(
+    pool_type: efi::MemoryType,
+    size: usize,
+    buffer: *mut *mut c_void,
+) -> efi::Status {
+    if buffer.is_null() {
+        return efi::Status::INVALID_PARAMETER;
+    }
+
+    match MM_SERVICES.allocate_pool(pool_type, size) {
+        Ok(ptr) => {
+            // SAFETY: `buffer` was null-checked above; the C caller guarantees it references a writable
+            // `*mut c_void` out-parameter. Written exactly once.
+            unsafe { *buffer = ptr as *mut c_void };
+            efi::Status::SUCCESS
+        }
+        Err(status) => status,
+    }
+}
+
+extern "efiapi" fn mm_free_pool_impl(buffer: *mut c_void) -> efi::Status {
+    match MM_SERVICES.free_pool(buffer as *mut u8) {
+        Ok(()) => efi::Status::SUCCESS,
+        Err(status) => status,
+    }
+}
+
+extern "efiapi" fn mm_allocate_pages_impl(
+    alloc_type: efi::AllocateType,
+    memory_type: efi::MemoryType,
+    pages: usize,
+    memory: *mut efi::PhysicalAddress,
+) -> efi::Status {
+    if memory.is_null() {
+        return efi::Status::INVALID_PARAMETER;
+    }
+
+    match MM_SERVICES.allocate_pages(alloc_type, memory_type, pages) {
+        Ok(addr) => {
+            // SAFETY: `memory` was null-checked above; the C caller guarantees it references a
+            // writable `efi::PhysicalAddress` out-parameter. Written exactly once.
+            unsafe { *memory = addr };
+            efi::Status::SUCCESS
+        }
+        Err(status) => status,
+    }
+}
+
+extern "efiapi" fn mm_free_pages_impl(memory: efi::PhysicalAddress, pages: usize) -> efi::Status {
+    match MM_SERVICES.free_pages(memory, pages) {
+        Ok(()) => efi::Status::SUCCESS,
+        Err(status) => status,
+    }
+}
+
+/// Starts a procedure on an application processor.
+///
+/// # Safety
+///
+/// Part of the C ABI surface invoked through the system table. It dereferences
+/// none of its arguments and is a not-available stub; it remains `unsafe` only
+/// to match the `MmStartupThisApFn` signature.
+unsafe extern "efiapi" fn mm_startup_this_ap_not_available(
+    _procedure: usize,
+    _cpu_number: usize,
+    _proc_arguments: *mut c_void,
+) -> efi::Status {
+    efi::Status::UNSUPPORTED
+}
+
+extern "efiapi" fn mm_install_protocol_interface_impl(
+    handle: *mut efi::Handle,
+    protocol: *mut efi::Guid,
+    _interface_type: efi::InterfaceType,
+    interface: *mut c_void,
+) -> efi::Status {
+    if handle.is_null() || protocol.is_null() {
+        return efi::Status::INVALID_PARAMETER;
+    }
+
+    // SAFETY: `protocol` was null-checked above; the C caller guarantees it references a valid
+    // `efi::Guid`. Dereferenced once into a reference.
+    let guid = unsafe { &*protocol };
+    // SAFETY: `handle` was null-checked above; the C caller guarantees a readable in/out pointer.
+    let caller_handle = unsafe { *handle };
+    let in_handle = (!caller_handle.is_null()).then_some(caller_handle);
+
+    // SAFETY: `interface` is forwarded unchanged; the C caller owns its validity and lifetime.
+    match unsafe { MM_SERVICES.install_protocol_interface(in_handle, guid, interface) } {
+        Ok(new_handle) => {
+            // SAFETY: `handle` was null-checked above; it is a writable out-parameter. Written once.
+            unsafe { *handle = new_handle };
+            efi::Status::SUCCESS
+        }
+        Err(status) => status,
+    }
+}
+
+extern "efiapi" fn mm_uninstall_protocol_interface_impl(
+    handle: efi::Handle,
+    protocol: *mut efi::Guid,
+    interface: *mut c_void,
+) -> efi::Status {
+    if handle.is_null() || protocol.is_null() {
+        return efi::Status::INVALID_PARAMETER;
+    }
+
+    // SAFETY: `protocol` was null-checked above; the C caller guarantees it references a valid
+    // `efi::Guid`. Dereferenced once into a reference.
+    let guid = unsafe { &*protocol };
+
+    // SAFETY: `interface` is forwarded as the pointer the caller previously installed.
+    match unsafe { MM_SERVICES.uninstall_protocol_interface(handle, guid, interface) } {
+        Ok(()) => efi::Status::SUCCESS,
+        Err(status) => status,
+    }
+}
+
+extern "efiapi" fn mm_handle_protocol_impl(
+    handle: efi::Handle,
+    protocol: *mut efi::Guid,
+    interface: *mut *mut c_void,
+) -> efi::Status {
+    if protocol.is_null() {
+        return efi::Status::INVALID_PARAMETER;
+    }
+
+    if interface.is_null() {
+        return efi::Status::INVALID_PARAMETER;
+    }
+    // C reference: *Interface = NULL before lookup.
+    // SAFETY: `interface` was null-checked above; the C caller guarantees it references a writable
+    // `*mut c_void` out-parameter. Written once.
+    unsafe { *interface = core::ptr::null_mut() };
+
+    if handle.is_null() {
+        return efi::Status::INVALID_PARAMETER;
+    }
+
+    // SAFETY: `protocol` was null-checked above; the C caller guarantees it references a valid
+    // `efi::Guid`. Dereferenced once into a reference.
+    let guid = unsafe { &*protocol };
+
+    // SAFETY: `handle` was null-checked above.
+    match unsafe { MM_SERVICES.handle_protocol(handle, guid) } {
+        Ok(i_protocol) => {
+            // SAFETY: `interface` was null-checked above and is a writable out-parameter.
+            unsafe { *interface = i_protocol };
+            efi::Status::SUCCESS
+        }
+        Err(status) => status,
+    }
+}
+
+extern "efiapi" fn mm_register_protocol_notify_impl(
+    protocol: *const efi::Guid,
+    function: usize,
+    registration: *mut *mut c_void,
+) -> efi::Status {
+    if protocol.is_null() || registration.is_null() {
+        return efi::Status::INVALID_PARAMETER;
+    }
+
+    // SAFETY: `protocol` was null-checked above; the C caller guarantees it references a valid
+    // `efi::Guid`. Dereferenced once into a reference.
+    let guid = unsafe { &*protocol };
+
+    if function == 0 {
+        // Function is NULL → unregister the notification identified by *Registration.
+        // SAFETY: `registration` was null-checked above; the C caller guarantees it references a
+        // readable `*mut c_void`. Read once.
+        let reg = unsafe { *registration };
+        match NonNull::new(reg).map(Registration::new) {
+            Some(reg_token) => match MM_SERVICES.unregister_protocol_notify(guid, reg_token) {
+                Ok(()) => efi::Status::SUCCESS,
+                Err(status) => status,
+            },
+            None => efi::Status::INVALID_PARAMETER,
+        }
+    } else {
+        // Register a new notification.
+        // SAFETY: `function` is a non-null `EFI_MM_NOTIFY_FN` function pointer passed as a usize by
+        // the C caller; transmuting it back to the matching ABI function pointer type is sound.
+        let notify_fn: MmNotifyFn = unsafe { core::mem::transmute(function) };
+        match MM_SERVICES.register_protocol_notify(guid, ProtocolNotify::efi(notify_fn)) {
+            Ok(token) => {
+                // SAFETY: `registration` was null-checked above and is a writable out-parameter.
+                unsafe { *registration = token.as_ptr() };
+                efi::Status::SUCCESS
+            }
+            Err(status) => status,
+        }
+    }
+}
+
+extern "efiapi" fn mm_locate_handle_impl(
+    search_type: efi::LocateSearchType,
+    protocol: *mut efi::Guid,
+    _search_key: *mut c_void,
+    buffer_size: *mut usize,
+    buffer: *mut efi::Handle,
+) -> efi::Status {
+    if buffer_size.is_null() {
+        return efi::Status::INVALID_PARAMETER;
+    }
+
+    // SAFETY: `protocol`, when non-null, is guaranteed by the C caller to reference a valid `efi::Guid`.
+    let protocol = if protocol.is_null() { None } else { Some(unsafe { &*protocol }) };
+
+    let handles = match MM_SERVICES.locate_handle(search_type, protocol) {
+        Ok(handles) => handles,
+        Err(status) => return status,
+    };
+
+    if handles.is_empty() {
+        return efi::Status::NOT_FOUND;
+    }
+
+    let required_size = handles.len() * core::mem::size_of::<efi::Handle>();
+    // SAFETY: `buffer_size` was null-checked at the top of the function; the C caller guarantees it
+    // references a readable/writable `usize`. Read once, then written once.
+    let caller_size = unsafe { *buffer_size };
+    // SAFETY: see above — `buffer_size` is a valid writable out-parameter.
+    unsafe { *buffer_size = required_size };
+
+    if caller_size < required_size {
+        return efi::Status::BUFFER_TOO_SMALL;
+    }
+
+    if buffer.is_null() {
+        return efi::Status::INVALID_PARAMETER;
+    }
+
+    // SAFETY: `buffer` was null-checked above and `caller_size >= required_size`, so the destination
+    // holds at least `handles.len()` `efi::Handle` entries. Source and destination do not overlap.
+    unsafe {
+        core::ptr::copy_nonoverlapping(handles.as_ptr(), buffer, handles.len());
+    }
+    efi::Status::SUCCESS
+}
+
+extern "efiapi" fn mm_locate_protocol_impl(
+    protocol: *mut efi::Guid,
+    _registration: *mut c_void,
+    interface: *mut *mut c_void,
+) -> efi::Status {
+    if protocol.is_null() || interface.is_null() {
+        return efi::Status::INVALID_PARAMETER;
+    }
+
+    // SAFETY: `protocol` was null-checked above; the C caller guarantees it references a valid
+    // `efi::Guid`. Dereferenced once into a reference.
+    let guid = unsafe { &*protocol };
+
+    // SAFETY: locating a protocol performs only database lookups.
+    match unsafe { MM_SERVICES.locate_protocol(guid) } {
+        Ok(i_protocol) => {
+            // SAFETY: `interface` was null-checked above and is a writable out-parameter.
+            unsafe { *interface = i_protocol };
+            efi::Status::SUCCESS
+        }
+        Err(status) => status,
+    }
+}
+
+/// Dispatches an MMI of a particular type to the registered handlers.
+///
+/// # Safety
+///
+/// Invoked through the system table by (potentially untrusted) C callers. The
+/// `handler_type` pointer is null-checked before being dereferenced, but a
+/// non-null pointer is dereferenced on trust; `context`/`comm_buffer` are passed
+/// through to the handlers. This is intrinsically unsafe as it handles inputs
+/// from C code.
+unsafe extern "efiapi" fn mmi_manage_impl(
+    handler_type: *const efi::Guid,
+    context: *const c_void,
+    comm_buffer: *mut c_void,
+    comm_buffer_size: *mut usize,
+) -> efi::Status {
+    // SAFETY: `handler_type` is null-checked here; when non-null the C caller guarantees it
+    // references a valid `efi::Guid`, dereferenced once into a reference.
+    let guid = if handler_type.is_null() { None } else { Some(unsafe { &*handler_type }) };
+
+    // SAFETY: `context`/`comm_buffer`/`comm_buffer_size` are forwarded unchanged to the handlers.
+    unsafe { MM_SERVICES.mmi_manage(guid, context, comm_buffer, comm_buffer_size) }
+}
+
+/// Registers an MMI handler entry point for a particular handler type.
+///
+/// # Safety
+///
+/// Invoked through the system table by (potentially untrusted) C callers. The
+/// `dispatch_handle` and `handler_type` pointers are null-checked before being
+/// dereferenced, but non-null pointers are dereferenced on trust. This is
+/// intrinsically unsafe as it handles inputs from C code.
+unsafe extern "efiapi" fn mmi_handler_register_impl(
+    handler: MmiHandlerEntryPoint,
+    handler_type: *const efi::Guid,
+    dispatch_handle: *mut efi::Handle,
+) -> efi::Status {
+    if dispatch_handle.is_null() {
+        return efi::Status::INVALID_PARAMETER;
+    }
+
+    // SAFETY: `handler_type` is null-checked here; when non-null the C caller guarantees it
+    // references a valid `efi::Guid`, dereferenced once into a reference.
+    let guid = if handler_type.is_null() { None } else { Some(unsafe { &*handler_type }) };
+
+    match MM_SERVICES.mmi_handler_register(handler, guid) {
+        Ok(handle) => {
+            // SAFETY: `dispatch_handle` was null-checked above and is a writable out-parameter.
+            unsafe { *dispatch_handle = handle };
+            efi::Status::SUCCESS
+        }
+        Err(status) => status,
+    }
+}
+
+/// Unregisters a previously registered MMI handler.
+///
+/// # Safety
+///
+/// Part of the C ABI surface invoked through the system table. It dereferences
+/// none of its arguments; it remains `unsafe` only to match the
+/// `MmiHandlerUnregisterFn` signature.
+unsafe extern "efiapi" fn mmi_handler_unregister_impl(dispatch_handle: efi::Handle) -> efi::Status {
+    // SAFETY: unregistering by handle is safe even if the handle is unknown.
+    match unsafe { MM_SERVICES.mmi_handler_unregister(dispatch_handle) } {
+        Ok(()) => efi::Status::SUCCESS,
+        Err(status) => status,
+    }
+}
+
+/// Free a pool allocation previously produced by [`MmServices::allocate_pool`].
+///
+/// Kept as a private helper so the public `free_pool` method stays a safe wrapper
+/// around the single raw-pointer deallocation.
+fn dealloc_pool(buffer: *mut u8) {
+    // SAFETY: `Layout::from_size_align_unchecked` is sound for size/alignment of 1. The MM free ABI
+    // provides no size, so the original layout cannot be reconstructed; `buffer` is trusted to be a
+    // pointer previously returned by `allocate_pool` and is freed exactly once.
+    unsafe {
+        let layout = core::alloc::Layout::from_size_align_unchecked(1, 1);
+        alloc::alloc::dealloc(buffer, layout);
+    }
+}
+
+/// Native [`MmServices`] implementation, backed directly by the user core's databases.
+///
+/// This is *the* MM services implementation. Both the `EfiMmSystemTable` thunks
+/// above and the core's own Rust code drive MM services through this trait, so
+/// neither path calls back out through the C function-pointer table.
+impl MmServices for MmUserCore {
+    /// Allocate pool memory.
+    ///
+    /// PI Spec: `EFI_MM_SYSTEM_TABLE.MmAllocatePool`
+    fn allocate_pool(&self, _pool_type: efi::MemoryType, size: usize) -> Result<*mut u8, efi::Status> {
+        if size == 0 {
+            return Err(efi::Status::INVALID_PARAMETER);
+        }
+        let layout = core::alloc::Layout::from_size_align(size, 8).map_err(|_| efi::Status::INVALID_PARAMETER)?;
+        // SAFETY: `layout` has a non-zero size (checked above), satisfying the `GlobalAlloc::alloc` contract.
+        let ptr = unsafe { alloc::alloc::alloc(layout) };
+        if ptr.is_null() { Err(efi::Status::OUT_OF_RESOURCES) } else { Ok(ptr) }
+    }
+
+    /// Free pool memory.
+    ///
+    /// PI Spec: `EFI_MM_SYSTEM_TABLE.MmFreePool`
+    fn free_pool(&self, buffer: *mut u8) -> Result<(), efi::Status> {
+        if buffer.is_null() {
+            return Err(efi::Status::INVALID_PARAMETER);
+        }
+        dealloc_pool(buffer);
+        Ok(())
+    }
+
+    /// Allocate pages.
+    ///
+    /// PI Spec: `EFI_MM_SYSTEM_TABLE.MmAllocatePages`
+    fn allocate_pages(
+        &self,
+        _alloc_type: efi::AllocateType,
+        _memory_type: efi::MemoryType,
+        pages: usize,
+    ) -> Result<u64, efi::Status> {
+        if pages == 0 {
+            return Err(efi::Status::INVALID_PARAMETER);
+        }
+        crate::mm_mem::SYSCALL_PAGE_ALLOCATOR.allocate_pages(pages).map_err(|_| efi::Status::OUT_OF_RESOURCES)
+    }
+
+    /// Free pages.
+    ///
+    /// PI Spec: `EFI_MM_SYSTEM_TABLE.MmFreePages`
+    fn free_pages(&self, memory: u64, pages: usize) -> Result<(), efi::Status> {
+        if memory == 0 || pages == 0 {
+            return Err(efi::Status::INVALID_PARAMETER);
+        }
+        crate::mm_mem::SYSCALL_PAGE_ALLOCATOR.free_pages(memory, pages).map_err(|_| efi::Status::INVALID_PARAMETER)
+    }
+
+    /// Install a protocol interface on a handle.
+    ///
+    /// PI Spec: `EFI_MM_SYSTEM_TABLE.MmInstallProtocolInterface`
+    ///
+    /// # Safety
+    ///
+    /// `interface` must be a valid pointer to the protocol structure or null, and
+    /// must remain valid for as long as the interface is installed.
+    unsafe fn install_protocol_interface(
+        &self,
+        handle: Option<efi::Handle>,
+        protocol: &efi::Guid,
+        interface: *mut c_void,
+    ) -> Result<efi::Handle, efi::Status> {
+        // A `None` handle maps to a null handle, which the database treats as "allocate a new one".
+        self.protocol_db.install_protocol(handle.unwrap_or(core::ptr::null_mut()), protocol, interface)
+    }
+
+    /// Uninstall a protocol interface from a handle.
+    ///
+    /// PI Spec: `EFI_MM_SYSTEM_TABLE.MmUninstallProtocolInterface`
+    ///
+    /// # Safety
+    ///
+    /// `interface` must match the pointer that was installed.
+    unsafe fn uninstall_protocol_interface(
+        &self,
+        handle: efi::Handle,
+        protocol: &efi::Guid,
+        interface: *mut c_void,
+    ) -> Result<(), efi::Status> {
+        self.protocol_db.uninstall_protocol(handle, protocol, interface)
+    }
+
+    /// Query a handle for a protocol.
+    ///
+    /// PI Spec: `EFI_MM_SYSTEM_TABLE.MmHandleProtocol`
+    ///
+    /// # Safety
+    ///
+    /// The returned pointer must be used carefully to avoid aliasing violations.
+    unsafe fn handle_protocol(&self, handle: efi::Handle, protocol: &efi::Guid) -> Result<*mut c_void, efi::Status> {
+        self.protocol_db.handle_protocol(handle, protocol).ok_or(efi::Status::UNSUPPORTED)
+    }
+
+    /// Locate the first device that supports a protocol.
+    ///
+    /// PI Spec: `EFI_MM_SYSTEM_TABLE.MmLocateProtocol`
+    ///
+    /// # Safety
+    ///
+    /// The returned pointer must be used carefully to avoid aliasing violations.
+    unsafe fn locate_protocol(&self, protocol: &efi::Guid) -> Result<*mut c_void, efi::Status> {
+        self.protocol_db.locate_protocol(protocol).ok_or(efi::Status::NOT_FOUND)
+    }
+
+    /// Manage (dispatch) an MMI.
+    ///
+    /// PI Spec: `EFI_MM_SYSTEM_TABLE.MmiManage`
+    ///
+    /// # Safety
+    ///
+    /// `context`, `comm_buffer`, and `comm_buffer_size` are all optional pointers.
+    /// But they must be valid if provided.
+    unsafe fn mmi_manage(
+        &self,
+        handler_type: Option<&efi::Guid>,
+        context: *const c_void,
+        comm_buffer: *mut c_void,
+        comm_buffer_size: *mut usize,
+    ) -> efi::Status {
+        self.mmi_db.mmi_manage(handler_type, context, comm_buffer, comm_buffer_size)
+    }
+
+    /// Register an MMI handler.
+    ///
+    /// PI Spec: `EFI_MM_SYSTEM_TABLE.MmiHandlerRegister`
+    fn mmi_handler_register(
+        &self,
+        handler: MmiHandlerEntryPoint,
+        handler_type: Option<&efi::Guid>,
+    ) -> Result<efi::Handle, efi::Status> {
+        self.mmi_db.mmi_handler_register(handler, handler_type)
+    }
+
+    /// Unregister an MMI handler.
+    ///
+    /// PI Spec: `EFI_MM_SYSTEM_TABLE.MmiHandlerUnRegister`
+    ///
+    /// # Safety
+    ///
+    /// `dispatch_handle` should be a valid handle returned by a previous call to `mmi_handler_register`.
+    /// Otherwise, this function will do nothing and return `EFI_NOT_FOUND`.
+    /// So this operation is safe to call with an invalid handle, but it will not have any effect.
+    unsafe fn mmi_handler_unregister(&self, dispatch_handle: efi::Handle) -> Result<(), efi::Status> {
+        self.mmi_db.mmi_handler_unregister(dispatch_handle)
+    }
+
+    /// Add, update, or remove a configuration-table entry.
+    ///
+    /// PI Spec: `EFI_MM_SYSTEM_TABLE.MmInstallConfigurationTable`
+    ///
+    /// # Safety
+    ///
+    /// `table` must remain valid for as long as the entry is installed, or be
+    /// null to remove an existing entry.
+    unsafe fn install_configuration_table(
+        &self,
+        guid: &efi::Guid,
+        table: *mut c_void,
+        _table_size: usize,
+    ) -> Result<(), efi::Status> {
+        let status = self.config_table_db.install_configuration_table(self.mm_system_table_ptr(), guid, table);
+        if status == efi::Status::SUCCESS { Ok(()) } else { Err(status) }
+    }
+
+    /// Register a callback invoked when a protocol interface is installed.
+    ///
+    /// PI Spec: `EFI_MM_SYSTEM_TABLE.MmRegisterProtocolNotify` (register form)
+    ///
+    /// Returns a [`Registration`] token that can be passed to
+    /// `unregister_protocol_notify`.
+    fn register_protocol_notify(
+        &self,
+        protocol: &efi::Guid,
+        notify: ProtocolNotify,
+    ) -> Result<Registration, efi::Status> {
+        // Tokens are derived from a non-zero counter, so they are never null.
+        let token = self.protocol_db.register_protocol_notify(protocol, notify);
+        NonNull::new(token).map(Registration::new).ok_or(efi::Status::OUT_OF_RESOURCES)
+    }
+
+    /// Unregister a previously registered protocol-install notification.
+    ///
+    /// PI Spec: `EFI_MM_SYSTEM_TABLE.MmRegisterProtocolNotify` (unregister form)
+    fn unregister_protocol_notify(&self, protocol: &efi::Guid, registration: Registration) -> Result<(), efi::Status> {
+        self.protocol_db.unregister_protocol_notify(protocol, registration.as_ptr())
+    }
+
+    /// Return the handles matching a search type and optional protocol.
+    ///
+    /// PI Spec: `EFI_MM_SYSTEM_TABLE.MmLocateHandle`
+    fn locate_handle(
+        &self,
+        search_type: efi::LocateSearchType,
+        protocol: Option<&efi::Guid>,
+    ) -> Result<Vec<efi::Handle>, efi::Status> {
+        match search_type {
+            efi::ALL_HANDLES => Ok(self.protocol_db.all_handles()),
+            efi::BY_PROTOCOL => {
+                let guid = protocol.ok_or(efi::Status::INVALID_PARAMETER)?;
+                Ok(self.protocol_db.locate_handle_by_protocol(guid))
+            }
+            _ => {
+                log::warn!("MmLocateHandle: search type {} not yet supported", search_type);
+                Err(efi::Status::UNSUPPORTED)
+            }
+        }
+    }
+}

--- a/patina_mm_user_core/src/mmi.rs
+++ b/patina_mm_user_core/src/mmi.rs
@@ -1,0 +1,387 @@
+//! MMI (Management Mode Interrupt) Handler Database
+//!
+//! This module manages the registration and dispatch of MMI handlers, following the
+//! same patterns as the C `Mmi.c` in `StandaloneMmPkg/Core`.
+//!
+//! ## Handler Types
+//!
+//! - **Root handlers**: Registered with `handler_type = None`. Called on every MMI regardless
+//!   of the communication buffer contents. Used for hardware-level interrupt sources.
+//! - **GUID-specific handlers**: Registered with a specific GUID. Called only when an MMI
+//!   communication targets that GUID.
+//!
+//! ## External vs Internal Handlers
+//!
+//! The database supports two calling conventions:
+//! - **External** (`MmiHandlerEntryPoint`): `unsafe extern "efiapi" fn` — used by drivers
+//!   registering through the MMST `MmiHandlerRegister` service.
+//! - **Internal** (`InternalMmiHandler`): Safe Rust `fn` — used by the core's own lifecycle
+//!   handlers (ready-to-lock, end-of-DXE, etc.) without going through the C ABI.
+//!
+//! ## Dispatch Flow
+//!
+//! [`MmiDatabase::mmi_manage`] is the main dispatch entry point:
+//! 1. If `handler_type` is `None`, iterate root handlers
+//! 2. If `handler_type` is `Some(guid)`, find the `MmiEntry` for that GUID and iterate its handlers
+//! 3. Each handler returns a status that determines whether dispatch continues
+//!
+//! **Lock safety**: The database lock is released before calling handlers and
+//! re-acquired afterwards, so handlers may safely call `mmi_handler_register` or
+//! `mmi_handler_unregister` without deadlocking.
+//!
+//! ## License
+//!
+//! Copyright (c) Microsoft Corporation.
+//!
+//! SPDX-License-Identifier: Apache-2.0
+//!
+
+use alloc::{vec, vec::Vec};
+use core::ffi::c_void;
+
+use r_efi::efi;
+use spin::Mutex;
+
+/// MMI handler entry point signature (external / C ABI).
+///
+/// Re-exported from [`patina::pi::mm_cis::MmiHandlerEntryPoint`].
+use patina::pi::mm_cis::MmiHandlerEntryPoint;
+
+/// EFI_WARN_INTERRUPT_SOURCE_QUIESCED — PI spec warning status code.
+/// Indicates an interrupt source was quiesced.
+const WARN_INTERRUPT_SOURCE_QUIESCED: efi::Status = efi::Status::from_usize(3);
+
+/// EFI_WARN_INTERRUPT_SOURCE_PENDING — PI spec warning status code.
+/// Indicates an interrupt source was processed but not quiesced.
+const WARN_INTERRUPT_SOURCE_PENDING: efi::Status = efi::Status::from_usize(2);
+
+/// EFI_INTERRUPT_PENDING — PI spec status for pending interrupts.
+const INTERRUPT_PENDING: efi::Status = efi::Status::from_usize(0x80000000 | 0x00000004);
+
+/// Signature for internal (Rust-native) MMI handlers.
+///
+/// These are registered by the core itself for lifecycle events and do not go
+/// through the `unsafe extern "efiapi"` calling convention. `handler_type` is the GUID that
+/// triggered the handler (the same GUID used at registration), `comm_buffer` points to the
+/// communication data (may be null for async MMIs), and `comm_buffer_size` is a mutable pointer
+/// to the communication buffer size. The handler returns an [`efi::Status`] following the
+/// standard `MmiManage` return protocol.
+pub type InternalMmiHandler =
+    fn(handler_type: &efi::Guid, comm_buffer: *mut c_void, comm_buffer_size: *mut usize) -> efi::Status;
+
+/// An MMI handler callback — either an external (C ABI) or internal (Rust) function.
+#[derive(Clone, Copy)]
+enum HandlerKind {
+    /// External handler registered by a driver through the MMST.
+    External(MmiHandlerEntryPoint),
+    /// Internal handler registered by the MM Core directly.
+    Internal(InternalMmiHandler),
+}
+
+impl core::fmt::Debug for HandlerKind {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        // Print only the variant; the wrapped function pointers are not meaningfully
+        // formattable and their ABI does not guarantee a `Debug` impl.
+        match self {
+            HandlerKind::External(_) => f.write_str("External"),
+            HandlerKind::Internal(_) => f.write_str("Internal"),
+        }
+    }
+}
+
+/// An MMI entry groups all handlers registered for a specific GUID.
+#[derive(Clone)]
+struct MmiEntry {
+    /// The handler type GUID.
+    handler_type: efi::Guid,
+    /// All handlers registered for this GUID.
+    handlers: Vec<MmiHandler>,
+}
+
+/// A registered MMI handler.
+#[derive(Clone, Copy)]
+struct MmiHandler {
+    /// The handler callback.
+    kind: HandlerKind,
+    /// Monotonic ID used as the dispatch handle for unregistering.
+    id: usize,
+    /// Whether this handler is marked for removal (deferred removal during dispatch).
+    to_remove: bool,
+}
+
+/// The MMI handler database.
+///
+/// Manages root handlers (called for all MMIs) and GUID-specific handlers.
+/// Thread-safe via internal `Mutex`.
+pub struct MmiDatabase {
+    /// Internal state protected by a mutex.
+    inner: Mutex<MmiDatabaseInner>,
+}
+
+struct MmiDatabaseInner {
+    /// Root MMI handlers (called for every MMI, regardless of GUID).
+    root_handlers: Vec<MmiHandler>,
+    /// GUID-specific MMI entries.
+    entries: Vec<MmiEntry>,
+    /// Re-entrance depth counter for `mmi_manage`.
+    manage_calling_depth: usize,
+    /// Monotonic ID counter for handler dispatch handles.
+    next_id: usize,
+}
+
+impl Default for MmiDatabase {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl MmiDatabase {
+    /// Creates a new empty `MmiDatabase`.
+    pub const fn new() -> Self {
+        Self {
+            inner: Mutex::new(MmiDatabaseInner {
+                root_handlers: Vec::new(),
+                entries: Vec::new(),
+                manage_calling_depth: 0,
+                next_id: 1,
+            }),
+        }
+    }
+
+    /// Register an external (C ABI) MMI handler.
+    ///
+    /// If `handler_type` is `None`, the handler is registered as a root handler.
+    /// If `handler_type` is `Some(guid)`, the handler is registered for that specific GUID.
+    ///
+    /// Returns `Ok(dispatch_handle)` on success, where `dispatch_handle` is an opaque handle
+    /// that can be used to unregister the handler.
+    pub fn mmi_handler_register(
+        &self,
+        handler: MmiHandlerEntryPoint,
+        handler_type: Option<&efi::Guid>,
+    ) -> Result<efi::Handle, efi::Status> {
+        let mut inner = self.inner.lock();
+        let id = inner.next_id;
+        inner.next_id += 1;
+
+        let mmi_handler = MmiHandler { kind: HandlerKind::External(handler), id, to_remove: false };
+
+        Self::insert_handler(&mut inner, handler_type, mmi_handler);
+
+        let handle = id as efi::Handle;
+        log::info!("Registered external MMI handler id={} for {:?}", id, handler_type.map(patina::Guid::from_ref));
+        Ok(handle)
+    }
+
+    /// Register an internal (Rust-native) MMI handler.
+    ///
+    /// Works like [`mmi_handler_register`](Self::mmi_handler_register) but takes a safe
+    /// Rust function pointer instead of an `unsafe extern "efiapi" fn`.
+    ///
+    /// Returns the dispatch handle (an opaque `usize`-based ID) on success.
+    pub fn register_internal_handler(
+        &self,
+        handler: InternalMmiHandler,
+        handler_type: Option<&efi::Guid>,
+    ) -> Result<efi::Handle, efi::Status> {
+        let mut inner = self.inner.lock();
+        let id = inner.next_id;
+        inner.next_id += 1;
+
+        let mmi_handler = MmiHandler { kind: HandlerKind::Internal(handler), id, to_remove: false };
+
+        Self::insert_handler(&mut inner, handler_type, mmi_handler);
+
+        let handle = id as efi::Handle;
+        log::debug!("Registered internal MMI handler id={} for {:?}", id, handler_type.map(patina::Guid::from_ref));
+        Ok(handle)
+    }
+
+    /// Insert a handler into the appropriate list (root or GUID-specific).
+    fn insert_handler(inner: &mut MmiDatabaseInner, handler_type: Option<&efi::Guid>, handler: MmiHandler) {
+        match handler_type {
+            None => {
+                inner.root_handlers.push(handler);
+            }
+            Some(guid) => {
+                if let Some(entry) = inner.entries.iter_mut().find(|e| e.handler_type == *guid) {
+                    entry.handlers.push(handler);
+                } else {
+                    inner.entries.push(MmiEntry { handler_type: *guid, handlers: vec![handler] });
+                }
+            }
+        }
+    }
+
+    /// Unregister an MMI handler by its dispatch handle.
+    ///
+    /// If we are inside a dispatch (`manage_calling_depth > 0`) the handler is
+    /// marked for deferred removal. Otherwise it is removed immediately.
+    pub fn mmi_handler_unregister(&self, dispatch_handle: efi::Handle) -> Result<(), efi::Status> {
+        let target_id = dispatch_handle as usize;
+        let mut inner = self.inner.lock();
+
+        // Search root handlers
+        for handler in inner.root_handlers.iter_mut() {
+            if handler.id == target_id {
+                handler.to_remove = true;
+                log::debug!("Marked root MMI handler id={} for removal.", target_id);
+                if inner.manage_calling_depth == 0 {
+                    Self::cleanup_removed_handlers(&mut inner);
+                }
+                return Ok(());
+            }
+        }
+
+        // Search GUID-specific handlers
+        for entry in inner.entries.iter_mut() {
+            for handler in entry.handlers.iter_mut() {
+                if handler.id == target_id {
+                    handler.to_remove = true;
+                    log::debug!(
+                        "Marked MMI handler id={} for removal (GUID: {}).",
+                        target_id,
+                        patina::Guid::from_ref(&entry.handler_type)
+                    );
+                    if inner.manage_calling_depth == 0 {
+                        Self::cleanup_removed_handlers(&mut inner);
+                    }
+                    return Ok(());
+                }
+            }
+        }
+
+        log::warn!("MMI handler {:?} not found for unregistering.", dispatch_handle);
+        Err(efi::Status::NOT_FOUND)
+    }
+
+    /// Manage (dispatch) an MMI.
+    ///
+    /// This is the main dispatch function, equivalent to the C `MmiManage`.
+    ///
+    /// - If `handler_type` is `None`, root handlers are dispatched.
+    /// - If `handler_type` is `Some(guid)`, the handlers for that GUID are dispatched.
+    ///
+    /// **Lock safety**: The database lock is released before calling any handler
+    /// and re-acquired afterwards, so handlers may call `mmi_handler_register` /
+    /// `mmi_handler_unregister` without deadlocking.
+    ///
+    /// Returns:
+    /// - `EFI_SUCCESS` if at least one handler returned success
+    /// - `EFI_WARN_INTERRUPT_SOURCE_QUIESCED` if a source was quiesced
+    /// - `EFI_INTERRUPT_PENDING` if a handler indicated the interrupt is still pending
+    /// - `EFI_NOT_FOUND` if no handlers are registered for the given type
+    pub fn mmi_manage(
+        &self,
+        handler_type: Option<&efi::Guid>,
+        context: *const c_void,
+        comm_buffer: *mut c_void,
+        comm_buffer_size: *mut usize,
+    ) -> efi::Status {
+        // ----- Phase 1: snapshot handlers under the lock -----
+        let handlers_snapshot = {
+            let mut inner = self.inner.lock();
+            inner.manage_calling_depth += 1;
+
+            match handler_type {
+                None => inner.root_handlers.iter().filter(|h| !h.to_remove).cloned().collect::<Vec<_>>(),
+                Some(guid) => {
+                    if let Some(entry) = inner.entries.iter().find(|e| e.handler_type == *guid) {
+                        entry.handlers.iter().filter(|h| !h.to_remove).cloned().collect::<Vec<_>>()
+                    } else {
+                        Vec::new()
+                    }
+                }
+            }
+            // lock released here
+        };
+
+        log::info!("Dispatching MMI with handler_type = {:?}", handler_type.map(patina::Guid::from_ref));
+        // ----- Phase 2: dispatch without the lock held -----
+        let return_status =
+            Self::dispatch_handler_snapshot(&handlers_snapshot, handler_type, context, comm_buffer, comm_buffer_size);
+
+        // ----- Phase 3: update depth and clean up under the lock -----
+        let mut inner = self.inner.lock();
+        inner.manage_calling_depth -= 1;
+
+        if inner.manage_calling_depth == 0 {
+            Self::cleanup_removed_handlers(&mut inner);
+        }
+
+        return_status
+    }
+
+    /// Dispatch a snapshot of handlers. The database lock is NOT held.
+    fn dispatch_handler_snapshot(
+        handlers: &[MmiHandler],
+        handler_type: Option<&efi::Guid>,
+        context: *const c_void,
+        comm_buffer: *mut c_void,
+        comm_buffer_size: *mut usize,
+    ) -> efi::Status {
+        if handlers.is_empty() {
+            return efi::Status::NOT_FOUND;
+        }
+
+        let short_circuit = handler_type.is_some();
+
+        let mut return_status = efi::Status::NOT_FOUND;
+
+        // Provide a dummy GUID for root dispatch (handlers don't use it).
+        let null_guid = efi::Guid::from_fields(0, 0, 0, 0, 0, &[0; 6]);
+        let guid_ref = handler_type.unwrap_or(&null_guid);
+
+        for handler in handlers {
+            log::info!("Dispatching handler with id = {}, kind = {:?}", handler.id, handler.kind);
+            let status = match handler.kind {
+                HandlerKind::External(entry_point) => {
+                    // SAFETY: External handler follows the PI spec efiapi calling convention.
+                    // The dispatch_handle is the monotonic ID cast to a handle.
+                    unsafe { entry_point(handler.id as efi::Handle, context, comm_buffer, comm_buffer_size) }
+                }
+                HandlerKind::Internal(fn_ptr) => fn_ptr(guid_ref, comm_buffer, comm_buffer_size),
+            };
+
+            match status {
+                efi::Status::SUCCESS => {
+                    return_status = efi::Status::SUCCESS;
+                    if short_circuit {
+                        log::info!("Short-circuiting after successful handler dispatch.");
+                        break;
+                    }
+                }
+                s if s == INTERRUPT_PENDING => {
+                    if short_circuit {
+                        log::info!("Short-circuiting due to pending interrupt.");
+                        return INTERRUPT_PENDING;
+                    }
+                    if return_status != efi::Status::SUCCESS {
+                        return_status = status;
+                    }
+                }
+                s if s == WARN_INTERRUPT_SOURCE_QUIESCED => {
+                    return_status = efi::Status::SUCCESS;
+                }
+                s if s == WARN_INTERRUPT_SOURCE_PENDING && return_status != efi::Status::SUCCESS => {
+                    return_status = status;
+                }
+                _ => {
+                    // Other statuses are ignored per PI spec
+                }
+            }
+        }
+        log::info!("Finished dispatching handlers with final status = {:?}", return_status);
+        return_status
+    }
+
+    /// Remove handlers marked with `to_remove` and clean up empty entries.
+    fn cleanup_removed_handlers(inner: &mut MmiDatabaseInner) {
+        inner.root_handlers.retain(|h| !h.to_remove);
+
+        inner.entries.retain_mut(|entry| {
+            entry.handlers.retain(|h| !h.to_remove);
+            !entry.handlers.is_empty()
+        });
+    }
+}

--- a/patina_mm_user_core/src/pool_allocator.rs
+++ b/patina_mm_user_core/src/pool_allocator.rs
@@ -1,0 +1,299 @@
+//! Pool Allocator
+//!
+//! This module provides a trait-based page allocator abstraction and a generic pool
+//! allocator for the MM User Core.
+//!
+//! ## Design
+//!
+//! The [`PageAllocatorBackend`] trait abstracts the page allocation mechanism.
+//! The user core implements it by issuing `syscall` instructions that thunk
+//! into the supervisor for page allocation.
+//!
+//! The [`PoolAllocator`] is a bump-allocator built on top of any `PageAllocatorBackend`.
+//! It implements [`GlobalAlloc`] so it can be used as `#[global_allocator]`.
+//!
+//! ## Block Management
+//!
+//! Block metadata is stored **in-band** at the start of each page allocation, forming
+//! an intrusive linked list. This means there is no fixed cap on the number of blocks —
+//! the allocator grows dynamically as needed by requesting more pages from the backend.
+//! When all allocations within a block are freed, the block is unlinked from the list
+//! and the pages are returned to the backend.
+//!
+//! ## Safety
+//!
+//! The intrusive list is built from `NonNull<PoolBlockHeader>` pointers into
+//! pages we own but Rust does not track. A single `spin::Mutex` guards the
+//! head pointer and (by convention) the entire list — every traversal,
+//! insertion, and removal is performed while the lock is held, and no list
+//! pointer ever escapes this module.
+//!
+//! As a consequence of that discipline, while holding the head lock,
+//! dereferencing any `NonNull<PoolBlockHeader>` reachable from the head is
+//! sound: it points to a fully-initialized header that no other code can
+//! concurrently free or alias. Individual `SAFETY:` comments below refer back
+//! to this invariant rather than restating it in full.
+//!
+//! ## License
+//!
+//! Copyright (c) Microsoft Corporation.
+//!
+//! SPDX-License-Identifier: Apache-2.0
+//!
+
+use core::{
+    alloc::{GlobalAlloc, Layout},
+    mem,
+    ptr::{self, NonNull},
+};
+use patina::{uefi_pages_to_size, uefi_size_to_pages};
+use spin::Mutex;
+
+/// Errors that can occur during page allocation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PageAllocError {
+    /// The allocator has not been initialized.
+    NotInitialized,
+    /// No free pages available to satisfy the request.
+    OutOfMemory,
+    /// The requested address is not aligned to page boundary.
+    NotAligned,
+    /// The address is not within any known SMRAM region.
+    InvalidAddress,
+    /// The address was not previously allocated.
+    NotAllocated,
+    /// Too many regions to track.
+    TooManyRegions,
+    /// A syscall to the supervisor failed.
+    SyscallFailed(u64),
+}
+
+/// Minimum allocation size for the pool allocator.
+const MIN_POOL_ALLOC_SIZE: usize = 16;
+
+/// Trait for page-granularity memory allocation.
+///
+/// Implementors provide the actual page allocation mechanism. The user core
+/// implements this by issuing syscalls to the supervisor.
+pub trait PageAllocatorBackend: Send + Sync {
+    /// Allocates `num_pages` contiguous pages.
+    ///
+    /// Returns the physical base address of the allocated region on success.
+    fn allocate_pages(&self, num_pages: usize) -> Result<u64, PageAllocError>;
+
+    /// Frees `num_pages` contiguous pages starting at `addr`.
+    fn free_pages(&self, addr: u64, num_pages: usize) -> Result<(), PageAllocError>;
+
+    /// Returns whether the page allocator has been initialized and is ready for use.
+    fn is_initialized(&self) -> bool;
+}
+
+/// In-band header stored at the beginning of each pool page block.
+///
+/// By placing the metadata inside the allocated pages themselves, we avoid
+/// any fixed-size bookkeeping array. Blocks form a singly-linked list so
+/// traversal, insertion, and removal are straightforward.
+#[repr(C)]
+struct PoolBlockHeader {
+    /// Pointer to the next block in the linked list (`None` if this is the tail).
+    next: Option<NonNull<PoolBlockHeader>>,
+    /// Number of pages backing this block (includes the header).
+    num_pages: usize,
+    /// Current bump offset (in bytes from the block base). Starts just past the header.
+    offset: usize,
+    /// Number of live allocations served from this block.
+    alloc_count: usize,
+}
+
+impl PoolBlockHeader {
+    /// Base address of this block (== address of the header itself).
+    fn base(&self) -> usize {
+        self as *const Self as usize
+    }
+
+    /// Total usable capacity of this block in bytes.
+    fn capacity(&self) -> usize {
+        uefi_pages_to_size!(self.num_pages)
+    }
+
+    /// Remaining bytes available for bump allocation.
+    fn remaining(&self) -> usize {
+        self.capacity().saturating_sub(self.offset)
+    }
+
+    /// Returns `true` if the given address falls within this block's page range.
+    fn contains(&self, addr: usize) -> bool {
+        addr >= self.base() && addr < self.base() + self.capacity()
+    }
+
+    /// Try to bump-allocate `layout` from this block.
+    fn try_alloc(&mut self, layout: Layout) -> Option<*mut u8> {
+        let current_ptr = self.base() + self.offset;
+        let align = layout.align().max(MIN_POOL_ALLOC_SIZE);
+        let aligned_ptr = (current_ptr + align - 1) & !(align - 1);
+        let padding = aligned_ptr - current_ptr;
+        let total_size = padding + layout.size();
+
+        if total_size > self.remaining() {
+            return None;
+        }
+
+        self.offset += total_size;
+        self.alloc_count += 1;
+
+        Some(aligned_ptr as *mut u8)
+    }
+}
+
+/// Pool allocator built on top of a [`PageAllocatorBackend`].
+///
+/// This allocator provides smaller-granularity allocations by requesting
+/// full pages from the backend and subdividing them via bump allocation.
+pub struct PoolAllocator<P: PageAllocatorBackend + 'static> {
+    /// Reference to the underlying page allocator.
+    page_allocator: &'static P,
+    /// Head of the intrusive linked list of pool blocks. The mutex guards
+    /// both the head pointer and (transitively) every node reachable from it
+    /// — see the module-level safety invariant.
+    head: Mutex<Option<NonNull<PoolBlockHeader>>>,
+}
+
+// SAFETY: `NonNull<PoolBlockHeader>` is `!Send`/`!Sync` only because raw
+// pointers are. The list it heads is guarded by `head`'s mutex and never
+// exposed outside this module, so transferring or sharing a `PoolAllocator`
+// across threads cannot create a data race.
+unsafe impl<P: PageAllocatorBackend> Send for PoolAllocator<P> {}
+unsafe impl<P: PageAllocatorBackend> Sync for PoolAllocator<P> {}
+
+impl<P: PageAllocatorBackend> PoolAllocator<P> {
+    /// Creates a new pool allocator backed by the given page allocator.
+    pub const fn new(page_allocator: &'static P) -> Self {
+        Self { page_allocator, head: Mutex::new(None) }
+    }
+
+    /// Allocate a fresh page block large enough to satisfy `layout`, link it
+    /// at the head of the list, and bump-allocate `layout` from it.
+    ///
+    /// Returns the pointer to the new allocation, or `None` if either the
+    /// page allocation or the subsequent bump allocation fails.
+    fn allocate_in_new_block(&self, head: &mut Option<NonNull<PoolBlockHeader>>, layout: Layout) -> Option<*mut u8> {
+        let header_size = mem::size_of::<PoolBlockHeader>();
+        let needed = layout.size() + header_size;
+        let num_pages = uefi_size_to_pages!(needed).max(1);
+
+        let base = match self.page_allocator.allocate_pages(num_pages) {
+            Ok(addr) => addr,
+            Err(e) => {
+                log::warn!("Pool allocator: failed to allocate {} pages: {:?}", num_pages, e);
+                return None;
+            }
+        };
+
+        let mut header_ptr = NonNull::new(base as *mut PoolBlockHeader)?;
+        let next = head.replace(header_ptr);
+
+        // SAFETY: `base` was returned by `allocate_pages`, so it points to
+        // `num_pages * UEFI_PAGE_SIZE` page-aligned, writable bytes that we own
+        // exclusively. `ptr::write` initializes the header without dropping
+        // the prior (uninitialized) contents. After that, the module-level
+        // invariant holds and `as_mut()` yields the unique `&mut` we use to
+        // perform the first bump allocation.
+        let header = unsafe {
+            ptr::write(header_ptr.as_ptr(), PoolBlockHeader { next, num_pages, offset: header_size, alloc_count: 0 });
+            header_ptr.as_mut()
+        };
+
+        log::trace!("Pool allocator: new block at {:#018x} ({} pages)", base, num_pages);
+
+        header.try_alloc(layout)
+    }
+}
+
+// SAFETY: Uphold the `GlobalAlloc` contract:
+// * `alloc` returns either a null pointer (on failure) or a pointer to a
+//   block of at least `layout.size()` bytes, aligned to `layout.align()`.
+//   `PoolBlockHeader::try_alloc` enforces this by aligning the bump pointer
+//   to `max(layout.align(), MIN_POOL_ALLOC_SIZE)` and checking the resulting
+//   region fits in the block.
+// * Returned pointers remain valid until passed back to `dealloc`: the page
+//   backing them is owned by a `PoolBlockHeader` whose `alloc_count` covers
+//   this allocation, so the block cannot be unlinked and freed while live.
+// * `dealloc` only frees the backing pages once `alloc_count` reaches zero,
+//   so it neither invalidates other live allocations nor double-frees pages.
+unsafe impl<P: PageAllocatorBackend> GlobalAlloc for PoolAllocator<P> {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        if !self.page_allocator.is_initialized() {
+            return ptr::null_mut();
+        }
+
+        let mut head = self.head.lock();
+
+        // Walk the list and try to bump-allocate from an existing block.
+        let mut cursor = *head;
+        while let Some(mut node) = cursor {
+            // SAFETY: `node` is reachable from the locked head, so by the
+            // module-level invariant it points to a live `PoolBlockHeader`
+            // we have exclusive access to for the duration of this borrow.
+            let block = unsafe { node.as_mut() };
+            if let Some(ptr) = block.try_alloc(layout) {
+                return ptr;
+            }
+            cursor = block.next;
+        }
+
+        // No block had room; grow the pool and serve from a fresh block.
+        self.allocate_in_new_block(&mut head, layout).unwrap_or(ptr::null_mut())
+    }
+
+    unsafe fn dealloc(&self, ptr: *mut u8, _layout: Layout) {
+        if ptr.is_null() {
+            return;
+        }
+
+        let mut head = self.head.lock();
+        let addr = ptr as usize;
+
+        let mut prev: Option<NonNull<PoolBlockHeader>> = None;
+        let mut cursor = *head;
+        while let Some(mut node) = cursor {
+            // SAFETY: `node` is reachable from the locked head, see module
+            // invariant. The borrow ends at the `if !contains` early-continue
+            // or at the field reads below.
+            let block = unsafe { node.as_mut() };
+            if !block.contains(addr) {
+                prev = Some(node);
+                cursor = block.next;
+                continue;
+            }
+
+            block.alloc_count = block.alloc_count.saturating_sub(1);
+            if block.alloc_count > 0 {
+                return;
+            }
+
+            // Capture what we need before re-borrowing through `prev`.
+            let base = block.base() as u64;
+            let num_pages = block.num_pages;
+            let next = block.next;
+
+            match prev {
+                None => *head = next,
+                // SAFETY: `prev` was set on a previous iteration to a node we
+                // had just dereferenced safely; it is still linked (nothing
+                // in this walk has freed it) and we hold the head lock. The
+                // borrow of `block` ended after the field reads above, so
+                // this fresh `as_mut()` does not alias any live reference.
+                Some(mut p) => unsafe { p.as_mut().next = next },
+            }
+
+            if let Err(e) = self.page_allocator.free_pages(base, num_pages) {
+                log::warn!("Pool allocator: failed to free block at {:#018x}: {:?}", base, e);
+            } else {
+                log::trace!("Pool allocator: freed block at {:#018x} ({} pages)", base, num_pages);
+            }
+            return;
+        }
+
+        log::warn!("Pool allocator: dealloc called with unknown pointer {:#018x}", addr);
+    }
+}

--- a/patina_mm_user_core/src/protocol_db.rs
+++ b/patina_mm_user_core/src/protocol_db.rs
@@ -1,0 +1,298 @@
+//! Protocol / Handle Database
+//!
+//! Idiomatic Rust implementation of the MM handle-and-protocol database that
+//! backs the `EfiMmSystemTable` protocol services (`MmInstallProtocolInterface`,
+//! `MmLocateProtocol`, `MmHandleProtocol`, …).
+//!
+//! The database is owned by the [`MmUserCore`](crate::MmUserCore) instance. The
+//! `extern "efiapi"` thunks in [`crate::mm_services`] simply locate that
+//! instance and call the safe Rust methods below — the table is a thin shim,
+//! this module is the implementation.
+//!
+//! ## Model
+//!
+//! * Each *handle* is an opaque, non-zero id under which a list of installed
+//!   protocol interfaces lives.
+//! * Handles are stored in a [`BTreeMap`] keyed by id, so iteration order
+//!   matches creation order (the order EFI consumers expect from
+//!   `MmLocateHandle`) without any manual bookkeeping.
+//! * Across the MM ABI a handle is just its id reinterpreted as an
+//!   `efi::Handle` (`*mut c_void`). The pointer is never dereferenced — it is a
+//!   token — so the round trip is sound.
+//!
+//! ## License
+//!
+//! Copyright (c) Microsoft Corporation.
+//!
+//! SPDX-License-Identifier: Apache-2.0
+//!
+
+use alloc::{collections::BTreeMap, vec::Vec};
+use core::{ffi::c_void, num::NonZeroUsize};
+
+use r_efi::efi;
+use spin::Mutex;
+
+/// The SDK [`ProtocolNotify`] callback type, shared with the `MmServices` trait
+/// so the user core and the trait agree on a single notify representation.
+use patina::mm_services::ProtocolNotify;
+
+/// A single protocol interface installed on a handle.
+struct ProtocolInterface {
+    /// Protocol GUID.
+    guid: efi::Guid,
+    /// Opaque interface pointer supplied by the installer.
+    interface: *mut c_void,
+}
+
+/// A registered protocol-install notification.
+struct NotifyRegistration {
+    /// GUID whose installation triggers the callback.
+    guid: efi::Guid,
+    /// The callback to invoke.
+    notify: ProtocolNotify,
+    /// Unique token returned to the registrant (and used to unregister).
+    token: NonZeroUsize,
+}
+
+/// A notification captured while the lock is held, fired once it is released.
+struct PendingNotify {
+    notify: ProtocolNotify,
+    guid: efi::Guid,
+    interface: *mut c_void,
+    handle: efi::Handle,
+}
+
+/// A stable address used to deduplicate identical `(GUID, callback)` registrations.
+fn notify_identity(notify: &ProtocolNotify) -> usize {
+    match notify {
+        ProtocolNotify::Efi(callback) => *callback as usize,
+        ProtocolNotify::Native(callback) => core::ptr::from_ref(*callback) as *const () as usize,
+    }
+}
+
+/// Internal, lock-protected state of the [`ProtocolDatabase`].
+struct Inner {
+    /// Installed protocols grouped by handle id (id order == creation order).
+    handles: BTreeMap<NonZeroUsize, Vec<ProtocolInterface>>,
+    /// Registered protocol-install notifications.
+    notifications: Vec<NotifyRegistration>,
+    /// Monotonic source of unique ids for both handles and notify tokens.
+    next_id: NonZeroUsize,
+}
+
+impl Inner {
+    /// Returns a fresh, never-before-used id.
+    fn next_id(&mut self) -> NonZeroUsize {
+        let id = self.next_id;
+        self.next_id = self.next_id.checked_add(1).expect("MM protocol id space exhausted");
+        id
+    }
+}
+
+/// Handle-aware protocol database for the MM User Core.
+pub struct ProtocolDatabase {
+    inner: Mutex<Inner>,
+}
+
+// SAFETY: every interior value (including the raw interface and notify
+// pointers) is owned by the database and only accessed while the `Mutex` is
+// held. No interior reference escapes — only opaque id-tokens are handed across
+// the MM ABI — so sharing a `ProtocolDatabase` across threads cannot race.
+unsafe impl Send for ProtocolDatabase {}
+unsafe impl Sync for ProtocolDatabase {}
+
+impl Default for ProtocolDatabase {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl ProtocolDatabase {
+    /// Creates a new, empty protocol database.
+    pub const fn new() -> Self {
+        Self {
+            inner: Mutex::new(Inner {
+                handles: BTreeMap::new(),
+                notifications: Vec::new(),
+                next_id: NonZeroUsize::MIN,
+            }),
+        }
+    }
+
+    /// Reinterprets a handle id as an `efi::Handle` token.
+    fn id_to_handle(id: NonZeroUsize) -> efi::Handle {
+        id.get() as efi::Handle
+    }
+
+    /// Reinterprets an `efi::Handle` token back into a handle id, or `None` if null.
+    fn handle_to_id(handle: efi::Handle) -> Option<NonZeroUsize> {
+        NonZeroUsize::new(handle as usize)
+    }
+
+    /// Install a protocol interface onto a handle.
+    ///
+    /// A null `handle` allocates a fresh handle. Any matching protocol-install
+    /// notifications are fired after the internal lock is released (so the
+    /// callbacks may freely re-enter the database). Returns the handle the
+    /// interface was installed on.
+    pub fn install_protocol(
+        &self,
+        handle: efi::Handle,
+        guid: &efi::Guid,
+        interface: *mut c_void,
+    ) -> Result<efi::Handle, efi::Status> {
+        let (installed_handle, pending) = {
+            let mut inner = self.inner.lock();
+
+            let id = match Self::handle_to_id(handle) {
+                // Existing handle: it must exist and must not already carry this protocol.
+                Some(id) => match inner.handles.get(&id) {
+                    None => return Err(efi::Status::INVALID_PARAMETER),
+                    Some(protocols) if protocols.iter().any(|p| p.guid == *guid) => {
+                        return Err(efi::Status::INVALID_PARAMETER);
+                    }
+                    Some(_) => id,
+                },
+                // Null handle: allocate a new one.
+                None => {
+                    let id = inner.next_id();
+                    inner.handles.insert(id, Vec::new());
+                    id
+                }
+            };
+
+            inner.handles.entry(id).or_default().push(ProtocolInterface { guid: *guid, interface });
+
+            let installed_handle = Self::id_to_handle(id);
+            let pending: Vec<PendingNotify> = inner
+                .notifications
+                .iter()
+                .filter(|n| n.guid == *guid)
+                .map(|n| PendingNotify { notify: n.notify, guid: *guid, interface, handle: installed_handle })
+                .collect();
+
+            (installed_handle, pending)
+        };
+
+        for event in pending {
+            // SAFETY: the callback was previously registered by a driver. The GUID reference is to a
+            // local that outlives the call, and the interface/handle are passed through unchanged.
+            unsafe {
+                event.notify.invoke(&event.guid, event.interface, event.handle);
+            }
+        }
+
+        log::debug!("MmInstallProtocolInterface: {:?} on handle {:p}", guid, installed_handle);
+        Ok(installed_handle)
+    }
+
+    /// Uninstall a protocol interface from a handle.
+    ///
+    /// When the handle has no remaining protocols it is removed entirely
+    /// (matching the C `MmUninstallProtocolInterface` behaviour).
+    pub fn uninstall_protocol(
+        &self,
+        handle: efi::Handle,
+        guid: &efi::Guid,
+        interface: *mut c_void,
+    ) -> Result<(), efi::Status> {
+        let id = Self::handle_to_id(handle).ok_or(efi::Status::INVALID_PARAMETER)?;
+        let mut inner = self.inner.lock();
+
+        let now_empty = {
+            let protocols = inner.handles.get_mut(&id).ok_or(efi::Status::INVALID_PARAMETER)?;
+            let pos = protocols
+                .iter()
+                .position(|p| p.guid == *guid && p.interface == interface)
+                .ok_or(efi::Status::NOT_FOUND)?;
+            protocols.remove(pos);
+            protocols.is_empty()
+        };
+
+        if now_empty {
+            inner.handles.remove(&id);
+        }
+        Ok(())
+    }
+
+    /// Look up a specific protocol on a specific handle (`MmHandleProtocol`).
+    pub fn handle_protocol(&self, handle: efi::Handle, guid: &efi::Guid) -> Option<*mut c_void> {
+        let id = Self::handle_to_id(handle)?;
+        let inner = self.inner.lock();
+        inner.handles.get(&id)?.iter().find(|p| p.guid == *guid).map(|p| p.interface)
+    }
+
+    /// Locate the first installed interface for a GUID across all handles.
+    pub fn locate_protocol(&self, guid: &efi::Guid) -> Option<*mut c_void> {
+        let inner = self.inner.lock();
+        inner.handles.values().flatten().find(|p| p.guid == *guid).map(|p| p.interface)
+    }
+
+    /// Return every handle that carries a given protocol.
+    pub fn locate_handle_by_protocol(&self, guid: &efi::Guid) -> Vec<efi::Handle> {
+        let inner = self.inner.lock();
+        inner
+            .handles
+            .iter()
+            .filter(|(_, protocols)| protocols.iter().any(|p| p.guid == *guid))
+            .map(|(id, _)| Self::id_to_handle(*id))
+            .collect()
+    }
+
+    /// Return every handle in the database.
+    pub fn all_handles(&self) -> Vec<efi::Handle> {
+        let inner = self.inner.lock();
+        inner.handles.keys().map(|id| Self::id_to_handle(*id)).collect()
+    }
+
+    /// Register a notification callback for a protocol GUID.
+    ///
+    /// Registering the same `(GUID, function)` pair twice returns the existing
+    /// token rather than creating a duplicate (matching the C implementation).
+    pub fn register_protocol_notify(&self, guid: &efi::Guid, notify: ProtocolNotify) -> *mut c_void {
+        let mut inner = self.inner.lock();
+        let identity = notify_identity(&notify);
+
+        if let Some(existing) =
+            inner.notifications.iter().find(|n| n.guid == *guid && notify_identity(&n.notify) == identity)
+        {
+            return existing.token.get() as *mut c_void;
+        }
+
+        let token = inner.next_id();
+        inner.notifications.push(NotifyRegistration { guid: *guid, notify, token });
+        token.get() as *mut c_void
+    }
+
+    /// Unregister a notification by its registration token.
+    pub fn unregister_protocol_notify(&self, guid: &efi::Guid, registration: *mut c_void) -> Result<(), efi::Status> {
+        let token = NonZeroUsize::new(registration as usize).ok_or(efi::Status::INVALID_PARAMETER)?;
+        let mut inner = self.inner.lock();
+        let pos = inner
+            .notifications
+            .iter()
+            .position(|n| n.guid == *guid && n.token == token)
+            .ok_or(efi::Status::NOT_FOUND)?;
+        inner.notifications.remove(pos);
+        Ok(())
+    }
+
+    /// Check whether a protocol GUID is installed on any handle.
+    pub fn is_protocol_installed(&self, guid: &efi::Guid) -> bool {
+        let inner = self.inner.lock();
+        inner.handles.values().flatten().any(|p| p.guid == *guid)
+    }
+
+    /// Return all unique installed protocol GUIDs (used for depex evaluation).
+    pub fn registered_protocols(&self) -> Vec<efi::Guid> {
+        let inner = self.inner.lock();
+        let mut guids = Vec::new();
+        for protocol in inner.handles.values().flatten() {
+            if !guids.contains(&protocol.guid) {
+                guids.push(protocol.guid);
+            }
+        }
+        guids
+    }
+}

--- a/sdk/patina/Cargo.toml
+++ b/sdk/patina/Cargo.toml
@@ -72,7 +72,7 @@ doc = ['alloc']
 alloc = ["dep:goblin", "dep:fixedbitset"]
 mockall = ["dep:mockall", "std"]
 global_allocator = []
-default = ['alloc']
+default = []
 serde = ["alloc", "dep:serde", "serde/alloc", "dep:serde_json"]
 serde-with-yaml = ["serde", "dep:serde_yaml"]
 

--- a/sdk/patina/src/lib.rs
+++ b/sdk/patina/src/lib.rs
@@ -51,6 +51,8 @@ pub mod hash;
 pub mod log;
 pub mod management_mode;
 #[cfg(any(test, feature = "alloc"))]
+pub mod mm_services;
+#[cfg(any(test, feature = "alloc"))]
 pub mod performance;
 pub mod pi;
 #[cfg(any(test, feature = "alloc"))]

--- a/sdk/patina/src/management_mode.rs
+++ b/sdk/patina/src/management_mode.rs
@@ -11,6 +11,7 @@
 
 pub mod comm_buffer_hob;
 pub mod protocol;
+pub mod supervisor;
 
 // Re-export commonly used items for easier access
 pub use comm_buffer_hob::MmCommBufferStatus;

--- a/sdk/patina/src/management_mode/comm_buffer_hob.rs
+++ b/sdk/patina/src/management_mode/comm_buffer_hob.rs
@@ -31,7 +31,7 @@ pub const MM_COMM_BUFFER_HOB_GUID: BinaryGuid = BinaryGuid::from_string("6c2a252
 ///
 /// Describes the communication buffer region passed via HOB from PEI to MM.
 #[repr(C, packed)]
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, FromBytes, Immutable)]
 pub struct MmCommonBufferHobData {
     /// Physical start address of the common region.
     pub physical_start: u64,

--- a/sdk/patina/src/management_mode/supervisor.rs
+++ b/sdk/patina/src/management_mode/supervisor.rs
@@ -1,0 +1,174 @@
+//! Shared type definitions for MM supervisor and user cores.
+//!
+//! This crate provides the communication structures and enumerations that define
+//! the ABI between the supervisor (ring 0) and user (ring 3) MM modules.
+
+// GUID for gMmSupervisorHobMemoryAllocModuleGuid
+// { 0x3efafe72, 0x3dbf, 0x4341, { 0xad, 0x04, 0x1c, 0xb6, 0xe8, 0xb6, 0x8e, 0x5e }}
+/// GUID used in MemoryAllocationModule HOBs to identify MM Supervisor module allocations.
+pub const MM_SUPERVISOR_HOB_MEMORY_ALLOC_MODULE_GUID: crate::BinaryGuid =
+    crate::BinaryGuid::from_string("3efafe72-3dbf-4341-ad04-1cb6e8b68e5e");
+
+// GUID for gMmSupervisorUserGuid
+// { 0x30d1cc3f, 0xc1db, 0x41ed, { 0xb1, 0x13, 0xab, 0xce, 0x21, 0xb0, 0x2b, 0xce }}
+/// GUID identifying the MM Supervisor User module.
+pub const MM_SUPERVISOR_USER_GUID: crate::BinaryGuid =
+    crate::BinaryGuid::from_string("30d1cc3f-c1db-41ed-b113-abce21b02bce");
+
+/// Command types passed from the supervisor to the user core via `invoke_demoted_routine`.
+///
+/// Discriminant values are part of the supervisor↔user ABI and must not change.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u64)]
+pub enum UserCommandType {
+    /// Initialize the user core: walk HOBs, discover drivers, dispatch.
+    StartUserCore = 0,
+    /// Handle a runtime MMI request: parse communication buffer and dispatch handlers.
+    UserRequest = 1,
+    /// Execute a procedure on an AP.
+    UserApProcedure = 2,
+}
+
+impl TryFrom<u64> for UserCommandType {
+    type Error = u64;
+
+    fn try_from(value: u64) -> Result<Self, Self::Error> {
+        match value {
+            0 => Ok(UserCommandType::StartUserCore),
+            1 => Ok(UserCommandType::UserRequest),
+            2 => Ok(UserCommandType::UserApProcedure),
+            other => Err(other),
+        }
+    }
+}
+
+/// Syscall indices for the MM Supervisor ↔ User Core syscall interface.
+///
+/// These match the definitions in SysCallLib.h and define the ABI used when
+/// Ring 3 code issues a `syscall` instruction to the Ring 0 supervisor.
+///
+/// ## ABI
+///
+/// - RAX = call index ([`SyscallIndex`])
+/// - RDX = arg1
+/// - R8  = arg2
+/// - R9  = arg3
+///
+/// On return:
+/// - RAX = result value (the supervisor communicates only through RAX)
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u64)]
+pub enum SyscallIndex {
+    /// Read MSR - Arg1: MSR index, Returns: MSR value
+    RdMsr = 0x0000,
+    /// Write MSR - Arg1: MSR index, Arg2: value
+    WrMsr = 0x0001,
+    /// CLI - Clear interrupts
+    Cli = 0x0002,
+    /// IO Read - Arg1: port, Arg2: width
+    IoRead = 0x0003,
+    /// IO Write - Arg1: port, Arg2: width, Arg3: value
+    IoWrite = 0x0004,
+    /// WBINVD - Write back and invalidate cache
+    Wbinvd = 0x0005,
+    /// HLT - Halt processor
+    Hlt = 0x0006,
+    /// Save State Read - Arg1: register, Arg2: CPU index
+    SaveStateRead = 0x0007,
+    /// Maximum value for legacy syscall indices
+    LegacyMax = 0xFFFF,
+    /// Allocate Pages - Arg1: alloc_type, Arg2: mem_type, Arg3: page_count
+    AllocPage = 0x10004,
+    /// Free Pages - Arg1: address, Arg2: page_count
+    FreePage = 0x10005,
+    /// Start AP Procedure - Arg1: procedure, Arg2: CPU index, Arg3: argument
+    StartApProc = 0x10006,
+    /// Save state read with extended support - Arg1: width, Arg2: buffer pointer
+    SaveStateRead2 = 0x10021,
+    /// MM memory unblocked - Arg1: address, Arg2: size
+    MmMemoryUnblocked = 0x10022,
+    /// MM is communication buffer - Arg1: address, Arg2: size
+    MmIsCommBuffer = 0x10023,
+}
+
+impl SyscallIndex {
+    /// Creates a `SyscallIndex` from a raw `u64` value.
+    pub fn from_u64(value: u64) -> Option<Self> {
+        match value {
+            0x0000 => Some(Self::RdMsr),
+            0x0001 => Some(Self::WrMsr),
+            0x0002 => Some(Self::Cli),
+            0x0003 => Some(Self::IoRead),
+            0x0004 => Some(Self::IoWrite),
+            0x0005 => Some(Self::Wbinvd),
+            0x0006 => Some(Self::Hlt),
+            0x0007 => Some(Self::SaveStateRead),
+            0xFFFF => Some(Self::LegacyMax),
+            0x10004 => Some(Self::AllocPage),
+            0x10005 => Some(Self::FreePage),
+            0x10006 => Some(Self::StartApProc),
+            0x10021 => Some(Self::SaveStateRead2),
+            0x10022 => Some(Self::MmMemoryUnblocked),
+            0x10023 => Some(Self::MmIsCommBuffer),
+            _ => None,
+        }
+    }
+
+    /// Returns the raw `u64` value of this syscall index.
+    pub fn as_u64(self) -> u64 {
+        self as u64
+    }
+}
+
+/// Issue a raw `syscall` to the MM Supervisor from Ring 3 (user) MM.
+///
+/// This is the low-level primitive behind every user supervisor syscall (page
+/// allocation, save-state reads, comm-buffer validation). Higher-level typed
+/// wrappers should build on it.
+///
+/// ## ABI
+///
+/// - `RAX` = `call_index` ([`SyscallIndex`]), `RDX` = `arg1`, `R8` = `arg2`,
+///   `R9` = `arg3`.
+/// - On return, `RAX` holds the result value.
+///
+/// ## Safety
+///
+/// Transfers control to the supervisor; the arguments must be valid for the
+/// given syscall index. Only meaningful in Ring 3 user MM on x86-64” on any
+/// other target this is a stub reporting `EFI_UNSUPPORTED`.
+#[cfg(all(target_os = "uefi", target_arch = "x86_64"))]
+pub unsafe fn raw_syscall(call_index: u64, arg1: u64, arg2: u64, arg3: u64) -> u64 {
+    let value: u64;
+
+    // SAFETY: A `syscall` into the MM Supervisor with the documented register ABI.
+    // The listed clobbers (RCX, R11) match the `syscall` instruction.
+    unsafe {
+        core::arch::asm!(
+            "syscall",
+            inlateout("rax") call_index => value,
+            in("rdx") arg1,
+            in("r8") arg2,
+            in("r9") arg3,
+            lateout("rcx") _,
+            lateout("r11") _,
+            options(nostack),
+        );
+    }
+
+    value
+}
+
+/// Host/non-UEFI stub so the SDK links for tests and non-x86 UEFI targets.
+///
+/// Supervisor syscalls are only meaningful in Ring 3 user MM on x86-64; anywhere
+/// else the operation is reported as unsupported.
+///
+/// ## Safety
+///
+/// This stub performs no operation and is always safe to call; the `unsafe`
+/// marker only keeps the signature identical to the real implementation.
+#[cfg(not(all(target_os = "uefi", target_arch = "x86_64")))]
+pub unsafe fn raw_syscall(_call_index: u64, _arg1: u64, _arg2: u64, _arg3: u64) -> u64 {
+    r_efi::efi::Status::UNSUPPORTED.as_usize() as u64
+}

--- a/sdk/patina/src/mm_services.rs
+++ b/sdk/patina/src/mm_services.rs
@@ -1,0 +1,540 @@
+//! MM (Management Mode) Services interface.
+//!
+//! This module defines the [`MmServices`] trait — the safe Rust interface to the
+//! PI `EFI_MM_SYSTEM_TABLE` services — and [`StandardMmServices`], a bridge that
+//! attaches a concrete `MmServices` implementation to the C
+//! [`EfiMmSystemTable`](crate::pi::mm_cis::EfiMmSystemTable).
+//!
+//! ## Direction
+//!
+//! A core (e.g. `patina_mm_user_core`) implements [`MmServices`] backed by its
+//! own databases and registers that implementation with a [`StandardMmServices`]
+//! via [`StandardMmServices::init`]. The `EfiMmSystemTable` function-pointer
+//! thunks then resolve that bridge and forward each call **into** the registered
+//! implementation.
+//!
+//! As a result the C function pointers exist purely for C callers: Rust code uses
+//! the `MmServices` implementation directly and never dispatches through the
+//! shared `EfiMmSystemTable` function pointers.
+//!
+//! ## License
+//!
+//! Copyright (c) Microsoft Corporation.
+//!
+//! SPDX-License-Identifier: Apache-2.0
+//!
+
+use core::{ffi::c_void, ptr::NonNull};
+
+use alloc::vec::Vec;
+
+use crate::pi::mm_cis::{MmNotifyFn, MmiHandlerEntryPoint};
+use r_efi::efi;
+use spin::Once;
+
+/// Opaque token identifying a registered protocol-install notification.
+///
+/// Returned by [`MmServices::register_protocol_notify`] and passed back to
+/// [`MmServices::unregister_protocol_notify`] to remove the registration.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Registration(NonNull<c_void>);
+
+impl Registration {
+    /// Wraps a non-null registration token.
+    pub fn new(token: NonNull<c_void>) -> Self {
+        Self(token)
+    }
+
+    /// Returns the raw token pointer.
+    pub fn as_ptr(&self) -> *mut c_void {
+        self.0.as_ptr()
+    }
+}
+
+/// The protocol-install event delivered to a native [`ProtocolNotify`] callback.
+///
+/// Bundles the event data into a single typed context so native callbacks never
+/// receive the raw `*mut c_void` interface pointer that the C
+/// `EFI_MM_NOTIFY_FN` ABI passes. When the just-installed interface is needed,
+/// query it with [`MmServices::handle_protocol`] using [`handle`](Self::handle).
+#[derive(Clone, Copy, Debug)]
+#[non_exhaustive]
+pub struct ProtocolInstalled<'a> {
+    /// GUID of the protocol interface that was installed.
+    pub protocol: &'a efi::Guid,
+    /// Opaque handle the interface was installed on.
+    pub handle: efi::Handle,
+}
+
+/// A protocol-install notification callback passed to
+/// [`MmServices::register_protocol_notify`].
+///
+/// Rust callers register a native closure or function via
+/// [`ProtocolNotify::native`]; it receives a typed [`ProtocolInstalled`] event
+/// and never has to author an `extern "efiapi"` function or handle raw pointers.
+/// The raw C form is still available via [`ProtocolNotify::efi`] for interop
+/// with C drivers and the MM System Table thunks.
+#[derive(Clone, Copy)]
+pub enum ProtocolNotify {
+    /// A native Rust callback receiving a typed [`ProtocolInstalled`] event.
+    Native(&'static (dyn Fn(ProtocolInstalled<'_>) -> efi::Status + Send + Sync)),
+    /// A raw C `EFI_MM_NOTIFY_FN` callback.
+    Efi(MmNotifyFn),
+}
+
+impl ProtocolNotify {
+    /// Register a native Rust callback.
+    ///
+    /// The callback receives a [`ProtocolInstalled`] event and must be `'static`
+    /// (e.g. a plain function or a reference to a `static` closure) so it can be
+    /// stored for the lifetime of MM.
+    pub const fn native(callback: &'static (dyn Fn(ProtocolInstalled<'_>) -> efi::Status + Send + Sync)) -> Self {
+        Self::Native(callback)
+    }
+
+    /// Wrap a raw C `EFI_MM_NOTIFY_FN` callback.
+    pub const fn efi(callback: MmNotifyFn) -> Self {
+        Self::Efi(callback)
+    }
+
+    /// Invoke the callback for a protocol-install event.
+    ///
+    /// # Safety
+    ///
+    /// For the [`Efi`](Self::Efi) variant this performs an FFI call into a C
+    /// `EFI_MM_NOTIFY_FN`; the caller must ensure `interface` and `handle` are
+    /// valid arguments for that callback.
+    pub unsafe fn invoke(&self, protocol: &efi::Guid, interface: *mut c_void, handle: efi::Handle) -> efi::Status {
+        match self {
+            Self::Native(callback) => callback(ProtocolInstalled { protocol, handle }),
+            // SAFETY: `protocol` is a valid reference for the duration of the call; the caller
+            // upholds the validity of `interface` and `handle` per this method's contract.
+            Self::Efi(callback) => unsafe { callback(protocol as *const efi::Guid, interface, handle) },
+        }
+    }
+}
+
+impl core::fmt::Debug for ProtocolNotify {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Self::Native(_) => f.write_str("ProtocolNotify::Native(..)"),
+            Self::Efi(callback) => write!(f, "ProtocolNotify::Efi({:#x})", *callback as usize),
+        }
+    }
+}
+
+/// Bridges a concrete [`MmServices`] implementation to the C `EfiMmSystemTable`.
+///
+/// A core implements [`MmServices`] (backed by its own state) and registers that
+/// implementation here with [`init`](Self::init). The `EfiMmSystemTable` thunks
+/// then forward every call into the registered provider, so the implementation
+/// is reached directly — never through the C function pointers.
+pub struct StandardMmServices {
+    provider: Once<&'static dyn MmServices>,
+}
+
+// SAFETY: `provider` is written once via `init` and only read afterwards. The
+// registered implementation is itself `Sync`, and the bridge is shared
+// read-only, so it is safe to share across threads.
+unsafe impl Sync for StandardMmServices {}
+// SAFETY: Same as above.
+unsafe impl Send for StandardMmServices {}
+
+impl StandardMmServices {
+    /// Create an uninitialized bridge.
+    ///
+    /// Register the backing implementation with [`init`](Self::init) before any
+    /// service method (or `EfiMmSystemTable` thunk) is invoked.
+    pub const fn new_uninit() -> Self {
+        Self { provider: Once::new() }
+    }
+
+    /// Register the [`MmServices`] implementation to forward calls to.
+    ///
+    /// The first registration wins; subsequent calls are ignored.
+    pub fn init(&self, provider: &'static dyn MmServices) {
+        self.provider.call_once(|| provider);
+    }
+
+    /// Returns `true` once a provider has been registered.
+    pub fn is_init(&self) -> bool {
+        self.provider.is_completed()
+    }
+
+    /// Returns the registered provider, or `None` if one has not been registered.
+    pub fn get(&self) -> Option<&'static dyn MmServices> {
+        self.provider.get().copied()
+    }
+
+    /// Returns the registered provider.
+    ///
+    /// # Panics
+    ///
+    /// Panics if no provider has been registered via [`init`](Self::init).
+    fn provider(&self) -> &'static dyn MmServices {
+        *self.provider.get().expect("StandardMmServices provider is not initialized!")
+    }
+}
+
+impl core::fmt::Debug for StandardMmServices {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("StandardMmServices").field("initialized", &self.is_init()).finish()
+    }
+}
+
+/// Safe Rust interface to the MM System Table services.
+///
+/// This is the MM analogue of
+/// [`BootServices`](crate::boot_services::BootServices).
+/// Each method maps 1:1 to a function pointer in
+/// [`EfiMmSystemTable`](crate::pi::mm_cis::EfiMmSystemTable).
+pub trait MmServices {
+    // ---- Memory services ------------------------------------------------
+
+    /// Allocate pool memory.
+    ///
+    /// PI Spec: `EFI_MM_SYSTEM_TABLE.MmAllocatePool`
+    fn allocate_pool(&self, pool_type: efi::MemoryType, size: usize) -> Result<*mut u8, efi::Status>;
+
+    /// Free pool memory.
+    ///
+    /// PI Spec: `EFI_MM_SYSTEM_TABLE.MmFreePool`
+    fn free_pool(&self, buffer: *mut u8) -> Result<(), efi::Status>;
+
+    /// Allocate pages.
+    ///
+    /// PI Spec: `EFI_MM_SYSTEM_TABLE.MmAllocatePages`
+    fn allocate_pages(
+        &self,
+        alloc_type: efi::AllocateType,
+        memory_type: efi::MemoryType,
+        pages: usize,
+    ) -> Result<u64, efi::Status>;
+
+    /// Free pages.
+    ///
+    /// PI Spec: `EFI_MM_SYSTEM_TABLE.MmFreePages`
+    fn free_pages(&self, memory: u64, pages: usize) -> Result<(), efi::Status>;
+
+    // ---- Protocol services ----------------------------------------------
+
+    /// Install a protocol interface on a handle.
+    ///
+    /// PI Spec: `EFI_MM_SYSTEM_TABLE.MmInstallProtocolInterface`
+    ///
+    /// # Safety
+    ///
+    /// `interface` must be a valid pointer to the protocol structure or null, and
+    /// must remain valid for as long as the interface is installed.
+    unsafe fn install_protocol_interface(
+        &self,
+        handle: Option<efi::Handle>,
+        protocol: &efi::Guid,
+        interface: *mut c_void,
+    ) -> Result<efi::Handle, efi::Status>;
+
+    /// Uninstall a protocol interface from a handle.
+    ///
+    /// PI Spec: `EFI_MM_SYSTEM_TABLE.MmUninstallProtocolInterface`
+    ///
+    /// # Safety
+    ///
+    /// `interface` must match the pointer that was installed.
+    unsafe fn uninstall_protocol_interface(
+        &self,
+        handle: efi::Handle,
+        protocol: &efi::Guid,
+        interface: *mut c_void,
+    ) -> Result<(), efi::Status>;
+
+    /// Query a handle for a protocol.
+    ///
+    /// PI Spec: `EFI_MM_SYSTEM_TABLE.MmHandleProtocol`
+    ///
+    /// # Safety
+    ///
+    /// The returned pointer must be used carefully to avoid aliasing violations.
+    unsafe fn handle_protocol(&self, handle: efi::Handle, protocol: &efi::Guid) -> Result<*mut c_void, efi::Status>;
+
+    /// Locate the first device that supports a protocol.
+    ///
+    /// PI Spec: `EFI_MM_SYSTEM_TABLE.MmLocateProtocol`
+    ///
+    /// # Safety
+    ///
+    /// The returned pointer must be used carefully to avoid aliasing violations.
+    unsafe fn locate_protocol(&self, protocol: &efi::Guid) -> Result<*mut c_void, efi::Status>;
+
+    // ---- MMI management -------------------------------------------------
+
+    /// Manage (dispatch) an MMI.
+    ///
+    /// PI Spec: `EFI_MM_SYSTEM_TABLE.MmiManage`
+    ///
+    /// # Safety
+    ///
+    /// `context`, `comm_buffer`, and `comm_buffer_size` are all optional pointers.
+    /// But they must be valid if provided.
+    unsafe fn mmi_manage(
+        &self,
+        handler_type: Option<&efi::Guid>,
+        context: *const c_void,
+        comm_buffer: *mut c_void,
+        comm_buffer_size: *mut usize,
+    ) -> efi::Status;
+
+    /// Register an MMI handler.
+    ///
+    /// PI Spec: `EFI_MM_SYSTEM_TABLE.MmiHandlerRegister`
+    fn mmi_handler_register(
+        &self,
+        handler: MmiHandlerEntryPoint,
+        handler_type: Option<&efi::Guid>,
+    ) -> Result<efi::Handle, efi::Status>;
+
+    /// Unregister an MMI handler.
+    ///
+    /// PI Spec: `EFI_MM_SYSTEM_TABLE.MmiHandlerUnRegister`
+    ///
+    /// # Safety
+    ///
+    /// `dispatch_handle` should be a valid handle returned by a previous call to `mmi_handler_register`.
+    /// Otherwise, this function will do nothing and return `EFI_NOT_FOUND`.
+    /// So this operation is safe to call with an invalid handle, but it will not have any effect.
+    unsafe fn mmi_handler_unregister(&self, dispatch_handle: efi::Handle) -> Result<(), efi::Status>;
+
+    // ---- Configuration table --------------------------------------------
+
+    /// Add, update, or remove a configuration-table entry.
+    ///
+    /// PI Spec: `EFI_MM_SYSTEM_TABLE.MmInstallConfigurationTable`
+    ///
+    /// # Safety
+    ///
+    /// `table` must remain valid for as long as the entry is installed, or be
+    /// null to remove an existing entry.
+    unsafe fn install_configuration_table(
+        &self,
+        guid: &efi::Guid,
+        table: *mut c_void,
+        table_size: usize,
+    ) -> Result<(), efi::Status>;
+
+    // ---- Protocol notifications -----------------------------------------
+
+    /// Register a callback invoked when a protocol interface is installed.
+    ///
+    /// PI Spec: `EFI_MM_SYSTEM_TABLE.MmRegisterProtocolNotify` (register form)
+    ///
+    /// Returns a [`Registration`] token that can be passed to
+    /// [`unregister_protocol_notify`](Self::unregister_protocol_notify).
+    fn register_protocol_notify(
+        &self,
+        protocol: &efi::Guid,
+        notify: ProtocolNotify,
+    ) -> Result<Registration, efi::Status>;
+
+    /// Unregister a previously registered protocol-install notification.
+    ///
+    /// PI Spec: `EFI_MM_SYSTEM_TABLE.MmRegisterProtocolNotify` (unregister form)
+    fn unregister_protocol_notify(&self, protocol: &efi::Guid, registration: Registration) -> Result<(), efi::Status>;
+
+    // ---- Handle location ------------------------------------------------
+
+    /// Return the handles matching a search type and optional protocol.
+    ///
+    /// PI Spec: `EFI_MM_SYSTEM_TABLE.MmLocateHandle`
+    fn locate_handle(
+        &self,
+        search_type: efi::LocateSearchType,
+        protocol: Option<&efi::Guid>,
+    ) -> Result<Vec<efi::Handle>, efi::Status>;
+}
+
+impl MmServices for StandardMmServices {
+    fn allocate_pool(&self, pool_type: efi::MemoryType, size: usize) -> Result<*mut u8, efi::Status> {
+        self.provider().allocate_pool(pool_type, size)
+    }
+
+    fn free_pool(&self, buffer: *mut u8) -> Result<(), efi::Status> {
+        self.provider().free_pool(buffer)
+    }
+
+    fn allocate_pages(
+        &self,
+        alloc_type: efi::AllocateType,
+        memory_type: efi::MemoryType,
+        pages: usize,
+    ) -> Result<u64, efi::Status> {
+        self.provider().allocate_pages(alloc_type, memory_type, pages)
+    }
+
+    fn free_pages(&self, memory: u64, pages: usize) -> Result<(), efi::Status> {
+        self.provider().free_pages(memory, pages)
+    }
+
+    unsafe fn install_protocol_interface(
+        &self,
+        handle: Option<efi::Handle>,
+        protocol: &efi::Guid,
+        interface: *mut c_void,
+    ) -> Result<efi::Handle, efi::Status> {
+        // SAFETY: forwarded unchanged to the registered provider; the caller of this `unsafe fn`
+        // upholds the provider's contract.
+        unsafe { self.provider().install_protocol_interface(handle, protocol, interface) }
+    }
+
+    unsafe fn uninstall_protocol_interface(
+        &self,
+        handle: efi::Handle,
+        protocol: &efi::Guid,
+        interface: *mut c_void,
+    ) -> Result<(), efi::Status> {
+        // SAFETY: forwarded unchanged to the registered provider; the caller upholds the contract.
+        unsafe { self.provider().uninstall_protocol_interface(handle, protocol, interface) }
+    }
+
+    unsafe fn handle_protocol(&self, handle: efi::Handle, protocol: &efi::Guid) -> Result<*mut c_void, efi::Status> {
+        // SAFETY: forwarded unchanged to the registered provider; the caller upholds the contract.
+        unsafe { self.provider().handle_protocol(handle, protocol) }
+    }
+
+    unsafe fn locate_protocol(&self, protocol: &efi::Guid) -> Result<*mut c_void, efi::Status> {
+        // SAFETY: forwarded unchanged to the registered provider; the caller upholds the contract.
+        unsafe { self.provider().locate_protocol(protocol) }
+    }
+
+    unsafe fn mmi_manage(
+        &self,
+        handler_type: Option<&efi::Guid>,
+        context: *const c_void,
+        comm_buffer: *mut c_void,
+        comm_buffer_size: *mut usize,
+    ) -> efi::Status {
+        // SAFETY: forwarded unchanged to the registered provider; the caller upholds the contract.
+        unsafe { self.provider().mmi_manage(handler_type, context, comm_buffer, comm_buffer_size) }
+    }
+
+    fn mmi_handler_register(
+        &self,
+        handler: MmiHandlerEntryPoint,
+        handler_type: Option<&efi::Guid>,
+    ) -> Result<efi::Handle, efi::Status> {
+        self.provider().mmi_handler_register(handler, handler_type)
+    }
+
+    unsafe fn mmi_handler_unregister(&self, dispatch_handle: efi::Handle) -> Result<(), efi::Status> {
+        // SAFETY: forwarded unchanged to the registered provider; the caller upholds the contract.
+        unsafe { self.provider().mmi_handler_unregister(dispatch_handle) }
+    }
+
+    unsafe fn install_configuration_table(
+        &self,
+        guid: &efi::Guid,
+        table: *mut c_void,
+        table_size: usize,
+    ) -> Result<(), efi::Status> {
+        // SAFETY: forwarded unchanged to the registered provider; the caller upholds the contract.
+        unsafe { self.provider().install_configuration_table(guid, table, table_size) }
+    }
+
+    fn register_protocol_notify(
+        &self,
+        protocol: &efi::Guid,
+        notify: ProtocolNotify,
+    ) -> Result<Registration, efi::Status> {
+        self.provider().register_protocol_notify(protocol, notify)
+    }
+
+    fn unregister_protocol_notify(&self, protocol: &efi::Guid, registration: Registration) -> Result<(), efi::Status> {
+        self.provider().unregister_protocol_notify(protocol, registration)
+    }
+
+    fn locate_handle(
+        &self,
+        search_type: efi::LocateSearchType,
+        protocol: Option<&efi::Guid>,
+    ) -> Result<Vec<efi::Handle>, efi::Status> {
+        self.provider().locate_handle(search_type, protocol)
+    }
+}
+
+/// Global bridge exposing the MM services to Patina components.
+///
+/// The MM User Core registers its [`MmServices`] provider here during startup
+/// via [`register_component_mm_services`]; the [`MmServiceProvider`] component
+/// parameter then resolves to it. This is kept separate from the
+/// `EfiMmSystemTable` thunk bridge so component access does not depend on the C
+/// system-table plumbing.
+static COMPONENT_MM_SERVICES: StandardMmServices = StandardMmServices::new_uninit();
+
+/// Register the [`MmServices`] provider that [`MmServiceProvider`] resolves to.
+///
+/// Called once by the MM User Core during startup. The first registration wins.
+pub fn register_component_mm_services(provider: &'static dyn MmServices) {
+    COMPONENT_MM_SERVICES.init(provider);
+}
+
+/// Returns the component [`MmServices`] provider, if one has been registered.
+pub fn component_mm_services() -> Option<&'static dyn MmServices> {
+    COMPONENT_MM_SERVICES.get()
+}
+
+/// A component parameter granting access to the MM System Table services
+/// ([`MmServices`]).
+///
+/// This is the MM analogue of
+/// [`StandardBootServices`](crate::boot_services::StandardBootServices) in the
+/// component model. The provider must be registered via [`register_component_mm_services`]
+/// (done by the MM User Core) before a component requesting this parameter is
+/// dispatched; until then the parameter is unavailable and the component is not
+/// scheduled.
+#[derive(Clone, Copy)]
+pub struct MmServiceProvider {
+    /// The registered MM services implementation.
+    services: &'static dyn MmServices,
+}
+
+impl MmServiceProvider {
+    /// Returns the underlying [`MmServices`] implementation.
+    #[inline(always)]
+    pub fn get(&self) -> &'static dyn MmServices {
+        self.services
+    }
+}
+
+impl core::ops::Deref for MmServiceProvider {
+    type Target = dyn MmServices + 'static;
+
+    #[inline(always)]
+    fn deref(&self) -> &Self::Target {
+        self.services
+    }
+}
+
+// SAFETY: `MmServiceProvider` reads only the process-global component MM services
+// provider (a `&'static dyn MmServices`) and never accesses component `Storage`,
+// so it registers no storage access and cannot conflict with any other parameter.
+unsafe impl crate::component::params::Param for MmServiceProvider {
+    type State = ();
+    type Item<'storage, 'state> = Self;
+
+    unsafe fn get_param<'storage, 'state>(
+        _state: &'state Self::State,
+        _storage: crate::component::UnsafeStorageCell<'storage>,
+    ) -> Self::Item<'storage, 'state> {
+        // `validate` guarantees the provider is registered before this is called.
+        MmServiceProvider { services: component_mm_services().expect("component MM services not registered") }
+    }
+
+    fn validate(_state: &Self::State, _storage: crate::component::UnsafeStorageCell) -> bool {
+        component_mm_services().is_some()
+    }
+
+    fn init_state(
+        _storage: &mut crate::component::Storage,
+        _meta: &mut crate::component::MetaData,
+    ) -> Result<Self::State, alloc::borrow::Cow<'static, str>> {
+        Ok(())
+    }
+}

--- a/sdk/patina/src/pi/mm_cis.rs
+++ b/sdk/patina/src/pi/mm_cis.rs
@@ -156,6 +156,21 @@ pub type MmUninstallProtocolInterfaceFn = BootUninstallProtocolInterface;
 /// This function matches the C typedef `EFI_HANDLE_PROTOCOL`, which is already defined in `r_efi::efi` as `BootHandleProtocol`.
 pub type MmHandleProtocolFn = BootHandleProtocol;
 
+/// Callback invoked when a protocol interface is installed.
+///
+/// This function matches the C typedef `EFI_MM_NOTIFY_FN`:
+/// ```c
+/// typedef
+/// EFI_STATUS
+/// (EFIAPI *EFI_MM_NOTIFY_FN)(
+///   IN CONST EFI_GUID  *Protocol,
+///   IN VOID            *Interface,
+///   IN EFI_HANDLE      Handle
+///   );
+/// ```
+pub type MmNotifyFn =
+    unsafe extern "efiapi" fn(protocol: *const efi::Guid, interface: *mut c_void, handle: efi::Handle) -> efi::Status;
+
 /// Register a callback function be called when a particular protocol interface is installed.
 ///
 /// This function matches the C typedef `EFI_MM_REGISTER_PROTOCOL_NOTIFY`:


### PR DESCRIPTION
## Description

This is the initial implementation of MM supervisor and user core in Rust.

- [x] Impacts functionality?
- [x] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

This was tested on QEMU Q35 platform and booted to OS desktop as well as passed supervisor test app.

## Integration Instructions

The integration guide is listed in: https://github.com/kuqin12/mu_feature_mm_supv/blob/personal/kuqin/supv_init/SeaPkg/Docs/PlatformIntegration/PlatformIntegrationSteps.md#integraion-guide-for-rust-based-supervisor. Because it provides the implementation of MM supervisor init module.
