### PR TITLE
Add From<SmbiosError> for efi::Status conversion

### DIFF
--- a/components/patina_smbios/src/error.rs
+++ b/components/patina_smbios/src/error.rs
@@ -71,6 +71,13 @@ pub enum SmbiosError {
     TableDirectlyModified,
 }
 
+impl From<SmbiosError> for r_efi::efi::Status {
+    fn from(error: SmbiosError) -> Self {
+        let efi_error: patina::error::EfiError = error.into();
+        efi_error.into()
+    }
+}
+
 impl From<SmbiosError> for patina::error::EfiError {
     fn from(error: SmbiosError) -> Self {
         match error {
@@ -214,5 +221,30 @@ mod tests {
         // Test table integrity errors map to DEVICE_ERROR
         let efi_err: patina::error::EfiError = SmbiosError::TableDirectlyModified.into();
         assert_eq!(efi_err, patina::error::EfiError::DeviceError);
+    }
+
+    #[test]
+    fn test_smbios_error_to_efi_status_conversion() {
+        use r_efi::efi;
+
+        // Verify the SmbiosError -> efi::Status conversion produces the same result
+        // as going through SmbiosError -> EfiError -> efi::Status manually.
+        let status: efi::Status = SmbiosError::AllocationFailed.into();
+        assert_eq!(status, efi::Status::OUT_OF_RESOURCES);
+
+        let status: efi::Status = SmbiosError::StringTooLong.into();
+        assert_eq!(status, efi::Status::INVALID_PARAMETER);
+
+        let status: efi::Status = SmbiosError::RecordTooSmall.into();
+        assert_eq!(status, efi::Status::BUFFER_TOO_SMALL);
+
+        let status: efi::Status = SmbiosError::RecordNotFound.into();
+        assert_eq!(status, efi::Status::NOT_FOUND);
+
+        let status: efi::Status = SmbiosError::UnsupportedVersion.into();
+        assert_eq!(status, efi::Status::UNSUPPORTED);
+
+        let status: efi::Status = SmbiosError::TableDirectlyModified.into();
+        assert_eq!(status, efi::Status::DEVICE_ERROR);
     }
 }

--- a/components/patina_smbios/src/manager/protocol.rs
+++ b/components/patina_smbios/src/manager/protocol.rs
@@ -196,7 +196,7 @@ impl SmbiosProtocol {
 
                 efi::Status::SUCCESS
             }
-            Err(e) => patina::error::EfiError::from(e).into(),
+            Err(e) => e.into(),
         }
     }
 
@@ -246,7 +246,7 @@ impl SmbiosProtocol {
 
                 efi::Status::SUCCESS
             }
-            Err(e) => patina::error::EfiError::from(e).into(),
+            Err(e) => e.into(),
         }
     }
 
@@ -276,7 +276,7 @@ impl SmbiosProtocol {
 
                 efi::Status::SUCCESS
             }
-            Err(e) => patina::error::EfiError::from(e).into(),
+            Err(e) => e.into(),
         }
     }
 


### PR DESCRIPTION
## Description

Adds `impl From<SmbiosError> for efi::Status` to streamline error conversion in FFI protocol functions, simplifying `add_ext`, `update_string_ext`, and `remove_ext` from `patina::error::EfiError::from(e).into()` to `e.into()`.

Implements feedback from @Javagedes on #1384 (which auto-merged before this could be addressed).

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

`cargo make all` passes — all tests, clippy, fmt, deny, and doc checks clean.

## Integration Instructions

N/A