### PR TITLE
Use Xorshift64starHasher for SMBIOS table modification detection

### DIFF
--- a/components/patina_smbios/src/manager/core.rs
+++ b/components/patina_smbios/src/manager/core.rs
@@ -85,7 +85,7 @@ pub struct SmbiosManager {
     /// Pre-allocated buffer for entry point structure
     ep_buffer_addr: RefCell<Option<PhysicalAddress>>,
     /// Checksum of published table (for detecting direct modifications)
-    published_table_checksum: RefCell<Option<u32>>,
+    published_table_checksum: RefCell<Option<u64>>,
     /// Size of the published table (needed for checksum verification)
     published_table_size: RefCell<usize>,
 }
@@ -470,12 +470,15 @@ impl SmbiosManager {
         self.table_64_address.replace(Some(table_address));
     }
 
-    /// Calculate a simple checksum for table data
+    /// Calculate a hash for table data using Xorshift64*
     ///
-    /// Uses a simple sum of all bytes (wrapping). This is sufficient for
-    /// detecting accidental modifications, not cryptographic integrity.
-    fn calculate_table_checksum(data: &[u8]) -> u32 {
-        data.iter().fold(0u32, |acc, &byte| acc.wrapping_add(byte as u32))
+    /// Uses Xorshift64starHasher to detect modifications including byte swaps
+    /// that a simple checksum would miss. Not for cryptographic integrity.
+    fn calculate_table_checksum(data: &[u8]) -> u64 {
+        use core::hash::Hasher;
+        let mut hasher = patina::hash::Xorshift64starHasher::default();
+        hasher.write(data);
+        hasher.finish()
     }
 
     /// Verify that the published table has not been modified directly

--- a/patina_dxe_core/Cargo.toml
+++ b/patina_dxe_core/Cargo.toml
@@ -14,7 +14,6 @@ features = ["doc"]
 [dependencies]
 bitfield-struct = { workspace = true }
 cfg-if = { workspace = true }
-compile-time = { workspace = true }
 crc32fast = { workspace = true }
 goblin = { workspace = true, features = ["pe32", "pe64", "te"] }
 lazy_static = { workspace = true, features = ["spin_no_std"] }

--- a/patina_dxe_core/src/protocol_db.rs
+++ b/patina_dxe_core/src/protocol_db.rs
@@ -16,7 +16,7 @@ use alloc::{
     vec::Vec,
 };
 use core::{cmp::Ordering, ffi::c_void, hash::Hasher};
-use patina::error::EfiError;
+use patina::{error::EfiError, hash::Xorshift64starHasher};
 use r_efi::efi;
 
 use crate::tpl_mutex;
@@ -876,48 +876,6 @@ impl SpinLockedProtocolDb {
 
 unsafe impl Send for SpinLockedProtocolDb {}
 unsafe impl Sync for SpinLockedProtocolDb {}
-
-/// A hasher that uses the Xorshift64* algorithm to generate a random number to xor with the input bytes.
-///
-/// https://en.wikipedia.org/wiki/Xorshift#xorshift*
-struct Xorshift64starHasher {
-    state: u64,
-}
-
-impl Xorshift64starHasher {
-    /// Initialize the hasher with a seed.
-    fn new(seed: u64) -> Self {
-        Xorshift64starHasher { state: seed }
-    }
-
-    /// Generate a new random state.
-    fn next_state(&mut self) -> u64 {
-        self.state ^= self.state >> 12;
-        self.state ^= self.state << 25;
-        self.state ^= self.state >> 27;
-        self.state = self.state.wrapping_mul(0x2545F4914F6CDD1D);
-        self.state
-    }
-}
-
-impl Default for Xorshift64starHasher {
-    fn default() -> Self {
-        Xorshift64starHasher::new(compile_time::unix!())
-    }
-}
-
-impl Hasher for Xorshift64starHasher {
-    fn finish(&self) -> u64 {
-        self.state
-    }
-
-    fn write(&mut self, bytes: &[u8]) {
-        for &byte in bytes {
-            self.state ^= byte as u64;
-            self.state = self.next_state();
-        }
-    }
-}
 
 #[cfg(test)]
 #[coverage(off)]
@@ -2164,30 +2122,5 @@ mod tests {
                 assert!(child_list.contains(&child));
             }
         });
-    }
-
-    #[test]
-    fn xorshift64starhasher_test_different_seeds() {
-        let seed1 = 12345;
-        let seed2 = 54321;
-        let mut hasher1 = Xorshift64starHasher::new(seed1);
-        let mut hasher2 = Xorshift64starHasher::new(seed2);
-
-        let num1 = hasher1.next_state();
-        let num2 = hasher2.next_state();
-
-        assert_ne!(num1, num2, "Random numbers should be different for different seeds");
-    }
-
-    #[test]
-    fn xorshift64starhasher_test_same_seed() {
-        let seed = 12345;
-        let mut hasher1 = Xorshift64starHasher::new(seed);
-        let mut hasher2 = Xorshift64starHasher::new(seed);
-
-        let num1 = hasher1.next_state();
-        let num2 = hasher2.next_state();
-
-        assert_eq!(num1, num2, "Random numbers should be the same for the same seed");
     }
 }

--- a/sdk/patina/Cargo.toml
+++ b/sdk/patina/Cargo.toml
@@ -30,6 +30,7 @@ patina_macro = { workspace = true }
 fixedbitset = { workspace = true }
 
 cfg-if = { workspace = true }
+compile-time = { workspace = true }
 goblin = { workspace = true, features = ["pe32", "pe64", "te", "alloc"]}
 log = { workspace = true }
 r-efi = { workspace = true }

--- a/sdk/patina/src/hash.rs
+++ b/sdk/patina/src/hash.rs
@@ -1,0 +1,121 @@
+//! Hash utilities for Patina
+//!
+//! Provides hash implementations for general use across Patina components.
+//!
+//! ## License
+//!
+//! Copyright (c) Microsoft Corporation.
+//!
+//! SPDX-License-Identifier: Apache-2.0
+
+use core::hash::Hasher;
+
+/// A hasher that uses the Xorshift64* algorithm to generate a random number to xor with the input bytes.
+///
+/// **Note:** This hasher is not cryptographically secure. It is intended for fast, non-adversarial
+/// hash-based change detection only.
+///
+/// [Xorshift64*](https://en.wikipedia.org/wiki/Xorshift#xorshift*)
+pub struct Xorshift64starHasher {
+    state: u64,
+}
+
+impl Xorshift64starHasher {
+    /// Initialize the hasher with a seed.
+    pub fn new(seed: u64) -> Self {
+        Xorshift64starHasher { state: seed }
+    }
+
+    /// Generate a new random state.
+    fn next_state(&mut self) -> u64 {
+        self.state ^= self.state >> 12;
+        self.state ^= self.state << 25;
+        self.state ^= self.state >> 27;
+        self.state = self.state.wrapping_mul(0x2545F4914F6CDD1D);
+        self.state
+    }
+}
+
+/// The default seed is derived from [`compile_time::unix!`], so all `Default` instances within the
+/// same binary share the same seed. This means two default-constructed hashers will produce
+/// identical output for identical input.
+impl Default for Xorshift64starHasher {
+    fn default() -> Self {
+        Xorshift64starHasher::new(compile_time::unix!())
+    }
+}
+
+impl Hasher for Xorshift64starHasher {
+    fn finish(&self) -> u64 {
+        self.state
+    }
+
+    fn write(&mut self, bytes: &[u8]) {
+        for &byte in bytes {
+            self.state ^= byte as u64;
+            self.state = self.next_state();
+        }
+    }
+}
+
+#[cfg(test)]
+#[coverage(off)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_different_seeds() {
+        let seed1 = 12345;
+        let seed2 = 54321;
+        let mut hasher1 = Xorshift64starHasher::new(seed1);
+        let mut hasher2 = Xorshift64starHasher::new(seed2);
+
+        let num1 = hasher1.next_state();
+        let num2 = hasher2.next_state();
+
+        assert_ne!(num1, num2, "Random numbers should be different for different seeds");
+    }
+
+    #[test]
+    fn test_same_seed() {
+        let seed = 12345;
+        let mut hasher1 = Xorshift64starHasher::new(seed);
+        let mut hasher2 = Xorshift64starHasher::new(seed);
+
+        let num1 = hasher1.next_state();
+        let num2 = hasher2.next_state();
+
+        assert_eq!(num1, num2, "Random numbers should be the same for the same seed");
+    }
+
+    #[test]
+    fn test_default_hasher() {
+        let hasher = Xorshift64starHasher::default();
+        assert_ne!(hasher.state, 0, "Default hasher should have a non-zero seed");
+    }
+
+    #[test]
+    fn test_write_and_finish() {
+        let mut hasher1 = Xorshift64starHasher::new(42);
+        let mut hasher2 = Xorshift64starHasher::new(42);
+
+        hasher1.write(b"hello");
+        hasher2.write(b"hello");
+        assert_eq!(hasher1.finish(), hasher2.finish(), "Same input should produce same hash");
+
+        let mut hasher3 = Xorshift64starHasher::new(42);
+        hasher3.write(b"world");
+        assert_ne!(hasher1.finish(), hasher3.finish(), "Different input should produce different hash");
+    }
+
+    #[test]
+    fn test_detects_swapped_bytes() {
+        // This is the key advantage over simple checksum: detecting byte swaps
+        let mut hasher1 = Xorshift64starHasher::new(42);
+        let mut hasher2 = Xorshift64starHasher::new(42);
+
+        hasher1.write(&[1, 0]);
+        hasher2.write(&[0, 1]);
+        assert_ne!(hasher1.finish(), hasher2.finish(), "Swapped bytes should produce different hashes");
+    }
+}

--- a/sdk/patina/src/lib.rs
+++ b/sdk/patina/src/lib.rs
@@ -47,6 +47,7 @@ pub mod driver_binding;
 pub mod efi_types;
 pub mod error;
 pub mod guids;
+pub mod hash;
 pub mod log;
 #[cfg(any(test, feature = "alloc"))]
 pub mod performance;


### PR DESCRIPTION
## Description

Move `Xorshift64starHasher` from `patina_dxe_core` to a shared `patina::hash` module and replace the simple wrapping-add checksum in `SmbiosManager` with the hasher. This avoids false negatives when multiple byte changes cancel each other out.

Closes #1161

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [x] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Existing tests in `patina_smbios` (134 passed) and `patina_dxe_core` (541 passed) continue to pass. New unit tests added in `patina::hash` covering seed behavior, determinism, and byte-swap detection.

## Integration Instructions

N/A