### PR TITLE
patina_internal_cpu: Allow refining impl trait in Mtrr mock

### DIFF
--- a/core/patina_internal_cpu/src/paging/x64.rs
+++ b/core/patina_internal_cpu/src/paging/x64.rs
@@ -199,6 +199,7 @@ mod tests {
                 attribute: MtrrMemoryCacheType,
             ) -> MtrrResult<()>;
             fn set_memory_attributes(&mut self, ranges: &[MtrrMemoryRange]) -> MtrrResult<()>;
+            #[allow(refining_impl_trait_internal)]
             fn get_memory_ranges(&self) -> MtrrResult<Vec<MtrrMemoryRange>>;
 
             fn debug_print_all_mtrrs(&self);


### PR DESCRIPTION
## Description

patina_mtrr 1.1.5 changed the `Mtrr` trait's `get_memory_ranges()` return type from `Vec<MtrrMemoryRange>` to
`impl IntoIterator<Item = MtrrMemoryRange>`.

The mockall `mock!` block still uses the concrete Vec type, triggering the `refining_impl_trait_internal` lint. This commit adds an allow attribute to the `get_memory_ranges()` method in the mock to suppress the lint.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

- `cargo make all`

## Integration Instructions

- N/A