### PR TITLE
patina_dxe_core: Add missing safety comments and enable clippy lint

### DIFF
--- a/patina_dxe_core/Cargo.toml
+++ b/patina_dxe_core/Cargo.toml
@@ -11,6 +11,9 @@ description = "A pure rust implementation of the UEFI DXE Core."
 [package.metadata.docs.rs]
 features = ["doc"]
 
+[lints]
+workspace = true
+
 [dependencies]
 bitfield-struct = { workspace = true }
 cfg-if = { workspace = true }

--- a/patina_dxe_core/src/allocator/fixed_size_block_allocator.rs
+++ b/patina_dxe_core/src/allocator/fixed_size_block_allocator.rs
@@ -92,6 +92,7 @@ impl Iterator for AllocatorIterator {
     type Item = *mut AllocatorListNode;
     fn next(&mut self) -> Option<*mut AllocatorListNode> {
         if let Some(current) = self.current {
+            // SAFETY: current is a valid node pointer from the allocator list.
             self.current = unsafe { (*current).next };
             Some(current)
         } else {
@@ -183,6 +184,7 @@ impl FixedSizeBlockAllocator {
         }
 
         let heap_region: NonNull<[u8]> = NonNull::slice_from_raw_parts(
+            // SAFETY: alloc_node_ptr is validated above and points to a region large enough for an AllocatorListNode.
             NonNull::new(unsafe { alloc_node_ptr.add(1) }).unwrap().cast(),
             new_region.len() - size_of::<AllocatorListNode>(),
         );
@@ -190,6 +192,7 @@ impl FixedSizeBlockAllocator {
         //write the allocator node structure into the start of the range, initialize its heap with the remainder of
         //the range, and add the new allocator to the front of the allocator list.
         let node = AllocatorListNode { next: None, allocator: linked_list_allocator::Heap::empty() };
+        // SAFETY: alloc_node_ptr is aligned and points to valid writable memory for an AllocatorListNode.
         unsafe {
             alloc_node_ptr.write(node);
             (*alloc_node_ptr).allocator.init(heap_region.cast::<u8>().as_ptr(), heap_region.len());
@@ -214,6 +217,7 @@ impl FixedSizeBlockAllocator {
     // appropriate size is not available.
     fn fallback_alloc(&mut self, layout: Layout) -> Result<NonNull<[u8]>, FixedSizeBlockAllocatorError> {
         for node in AllocatorIterator::new(self.allocators) {
+            // SAFETY: node is a valid allocator list node pointer from the iterator.
             let allocator = unsafe { &mut (*node).allocator };
             if let Ok(ptr) = allocator.allocate_first_fit(layout) {
                 return Ok(NonNull::slice_from_raw_parts(ptr, layout.size()));
@@ -275,8 +279,10 @@ impl FixedSizeBlockAllocator {
     // layout being freed is too big to be tracked as a fixed-size free block.
     fn fallback_dealloc(&mut self, ptr: NonNull<u8>, layout: Layout) {
         for node in AllocatorIterator::new(self.allocators) {
+            // SAFETY: node is produced by AllocatorIterator and points to a valid AllocatorListNode.
             let allocator = unsafe { &mut (*node).allocator };
             if (allocator.bottom() <= ptr.as_ptr()) && (ptr.as_ptr() < allocator.top()) {
+                // SAFETY: ptr was allocated by this allocator for the given layout.
                 unsafe { allocator.deallocate(ptr, layout) };
             }
         }
@@ -299,6 +305,7 @@ impl FixedSizeBlockAllocator {
                     panic!("FSB deallocating block too small to store BlockListNode.");
                 }
                 let new_node_ptr = ptr.as_ptr() as *mut BlockListNode;
+                // SAFETY: new_node_ptr points to memory returned by alloc for this layout.
                 unsafe {
                     new_node_ptr.write(new_node);
                     self.list_heads[index] = Some(&mut *new_node_ptr);
@@ -354,6 +361,7 @@ impl FixedSizeBlockAllocator {
     /// manages.
     pub fn contains(&self, ptr: *mut u8) -> bool {
         AllocatorIterator::new(self.allocators).any(|node| {
+            // SAFETY: node is produced by AllocatorIterator and points to a valid AllocatorListNode.
             let allocator = unsafe { &mut (*node).allocator };
             (allocator.bottom() <= ptr) && (ptr < allocator.top())
         })
@@ -389,7 +397,7 @@ impl FixedSizeBlockAllocator {
     /// If the allocator does not own any memory, it will return an empty iterator.
     pub(crate) fn get_memory_ranges(&self) -> impl Iterator<Item = Range<usize>> {
         AllocatorIterator::new(self.allocators).map(|node| {
-            // This is safe because the node is a valid pointer to an AllocatorListNode
+            // SAFETY: node is produced by AllocatorIterator and points to a valid AllocatorListNode.
             let allocator = unsafe { &(*node).allocator };
             allocator.bottom() as usize..allocator.top() as usize
         })
@@ -432,6 +440,7 @@ impl Display for FixedSizeBlockAllocator {
         writeln!(f, "Memory Type: {:x?}", self.memory_type())?;
         writeln!(f, "Allocation Ranges:")?;
         for node in AllocatorIterator::new(self.allocators) {
+            // SAFETY: node is produced by AllocatorIterator and points to a valid AllocatorListNode.
             let allocator = unsafe { &mut (*node).allocator };
             writeln!(
                 f,
@@ -586,6 +595,7 @@ impl SpinLockedFixedSizeBlockAllocator {
     }
 
     /// Frees the block of pages at the given address of the given size.
+    ///
     /// ## Safety
     /// Caller must ensure that the given address corresponds to a valid block of pages that was allocated with
     /// [Self::allocate_pages]
@@ -708,6 +718,7 @@ impl SpinLockedFixedSizeBlockAllocator {
     }
 }
 
+// SAFETY: SpinLockedFixedSizeBlockAllocator serializes access and delegates to the inner allocator.
 unsafe impl GlobalAlloc for SpinLockedFixedSizeBlockAllocator {
     unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
         match self.allocate(layout) {
@@ -717,11 +728,13 @@ unsafe impl GlobalAlloc for SpinLockedFixedSizeBlockAllocator {
     }
     unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
         if let Some(ptr) = NonNull::new(ptr) {
+            // SAFETY: ptr came from alloc with the same layout.
             unsafe { self.deallocate(ptr, layout) }
         }
     }
 }
 
+// SAFETY: SpinLockedFixedSizeBlockAllocator serializes access and delegates to the inner allocator.
 unsafe impl Allocator for SpinLockedFixedSizeBlockAllocator {
     fn allocate(&self, layout: Layout) -> core::result::Result<NonNull<[u8]>, AllocError> {
         let allocation = self.lock().alloc(layout);
@@ -797,6 +810,7 @@ unsafe impl Allocator for SpinLockedFixedSizeBlockAllocator {
         }
     }
     unsafe fn deallocate(&self, ptr: NonNull<u8>, layout: Layout) {
+        // SAFETY: ptr came from allocate with the same layout.
         unsafe { self.lock().dealloc(ptr, layout) }
     }
 }
@@ -807,7 +821,9 @@ impl Display for SpinLockedFixedSizeBlockAllocator {
     }
 }
 
+// SAFETY: SpinLockedFixedSizeBlockAllocator protects internal state with a spin lock.
 unsafe impl Sync for SpinLockedFixedSizeBlockAllocator {}
+// SAFETY: SpinLockedFixedSizeBlockAllocator protects internal state with a spin lock.
 unsafe impl Send for SpinLockedFixedSizeBlockAllocator {}
 
 impl PageAllocator for SpinLockedFixedSizeBlockAllocator {
@@ -820,7 +836,15 @@ impl PageAllocator for SpinLockedFixedSizeBlockAllocator {
         Self::allocate_pages(self, allocation_strategy, pages, alignment)
     }
 
+    /// Frees the block of pages at the given address of the given size.
+    ///
+    /// ## Safety
+    ///
+    /// Caller must ensure that the given address corresponds to a valid block of pages that was allocated with
+    /// [Self::allocate_pages].
     unsafe fn free_pages(&self, address: usize, pages: usize) -> Result<(), EfiError> {
+        // SAFETY: address/pages must refer to a valid allocation owned by this allocator
+        // per the free_pages safety contract.
         unsafe { Self::free_pages(self, address, pages) }
     }
 
@@ -876,11 +900,14 @@ mod tests {
     use super::*;
 
     fn init_gcd(gcd: &SpinLockedGcd, size: usize) -> u64 {
+        // SAFETY: Resetting the test GCD is safe in a test.
         unsafe { gcd.reset() };
 
         gcd.init(48, 16);
         let layout = Layout::from_size_align(size, UEFI_PAGE_SIZE).unwrap();
+        // SAFETY: System allocator is used with a valid layout for test memory backing.
         let base = unsafe { System.alloc(layout) as u64 };
+        // SAFETY: init_memory_blocks is used with a valid backing allocation for tests.
         unsafe {
             gcd.init_memory_blocks(GcdMemoryType::SystemMemory, base as usize, size, efi::MEMORY_WB, efi::MEMORY_WB)
                 .unwrap();
@@ -971,11 +998,13 @@ mod tests {
                 let layout = Layout::from_size_align(0x8, 0x8).unwrap();
                 let allocation = fsb.allocate(layout).unwrap().cast::<u8>();
 
+                // SAFETY: Allocation was returned by fsb for this layout.
                 unsafe { fsb.deallocate(allocation, layout) };
 
                 let layout = Layout::from_size_align(0x20, 0x20).unwrap();
                 let allocation = fsb.allocate(layout).unwrap().cast::<u8>();
 
+                // SAFETY: Allocation was returned by fsb for this layout.
                 unsafe { fsb.deallocate(allocation, layout) };
             });
         });
@@ -1049,6 +1078,7 @@ mod tests {
                 .unwrap();
 
                 assert!(fsb.allocators.is_some());
+                // SAFETY: fsb.allocators points to valid list nodes after expand.
                 unsafe {
                     assert!((*fsb.allocators.unwrap()).next.is_none());
                     assert!((*fsb.allocators.unwrap()).allocator.bottom() as usize > base as usize);
@@ -1079,6 +1109,7 @@ mod tests {
                 ))
                 .unwrap();
                 assert!(fsb.allocators.is_some());
+                // SAFETY: fsb.allocators points to valid list nodes after expand.
                 unsafe {
                     assert!((*fsb.allocators.unwrap()).next.is_some());
                     assert!((*(*fsb.allocators.unwrap()).next.unwrap()).next.is_none());
@@ -1131,9 +1162,10 @@ mod tests {
 
             assert_eq!(NUM_ALLOCATIONS, AllocatorIterator::new(fsb.allocators).count());
             let expected_free = ALLOCATION_SIZE - size_of::<AllocatorListNode>();
-            assert!(
-                AllocatorIterator::new(fsb.allocators).all(|node| unsafe { (*node).allocator.free() == expected_free })
-            );
+            assert!(AllocatorIterator::new(fsb.allocators).all(|node| {
+                // SAFETY: node pointers come from AllocatorIterator over fsb.allocators.
+                unsafe { (*node).allocator.free() == expected_free }
+            }));
         });
     }
 
@@ -1211,6 +1243,7 @@ mod tests {
                 );
 
                 let layout = Layout::from_size_align(0x1000, 0x10).unwrap();
+                // SAFETY: fsb is initialized and used with a valid layout in tests.
                 let allocation = unsafe { fsb.alloc(layout) };
                 assert!(fsb.lock().allocators.is_some());
                 assert!((allocation as u64) > base);
@@ -1284,6 +1317,7 @@ mod tests {
                 // Finally, we can test fallback_dealloc
                 fsb.fallback_dealloc(allocation.cast(), layout);
                 let expected_free = DEFAULT_PAGE_ALLOCATION_GRANULARITY - size_of::<AllocatorListNode>();
+                // SAFETY: fsb.allocators points to a valid allocator after expand.
                 unsafe {
                     assert_eq!((*fsb.allocators.unwrap()).allocator.free(), expected_free);
                 }
@@ -1310,16 +1344,20 @@ mod tests {
                 );
 
                 let layout = Layout::from_size_align(0x8, 0x8).unwrap();
+                // SAFETY: fsb is initialized and used with a valid layout in tests.
                 let allocation = unsafe { fsb.alloc(layout) };
 
+                // SAFETY: Allocation was returned by fsb for this layout.
                 unsafe { fsb.dealloc(allocation, layout) };
                 let free_block_ptr = fsb.lock().list_heads[list_index(&layout).unwrap()].take().unwrap()
                     as *mut BlockListNode as *mut u8;
                 assert_eq!(free_block_ptr, allocation);
 
                 let layout = Layout::from_size_align(0x20, 0x20).unwrap();
+                // SAFETY: fsb is initialized and used with a valid layout in tests.
                 let allocation = unsafe { fsb.alloc(layout) };
 
+                // SAFETY: Allocation was returned by fsb for this layout.
                 unsafe { fsb.dealloc(allocation, layout) };
                 let free_block_ptr = fsb.lock().list_heads[list_index(&layout).unwrap()].take().unwrap()
                     as *mut BlockListNode as *mut u8;
@@ -1350,6 +1388,7 @@ mod tests {
                 let allocation = fsb.allocate(layout).unwrap().cast::<u8>();
                 let allocation_ptr = allocation.as_ptr();
 
+                // SAFETY: Allocation was returned by fsb for this layout.
                 unsafe { fsb.deallocate(allocation, layout) };
                 let free_block_ptr = fsb.lock().list_heads[list_index(&layout).unwrap()].take().unwrap()
                     as *mut BlockListNode as *mut u8;
@@ -1359,6 +1398,7 @@ mod tests {
                 let allocation = fsb.allocate(layout).unwrap().cast::<u8>();
                 let allocation_ptr = allocation.as_ptr();
 
+                // SAFETY: Allocation was returned by fsb for this layout.
                 unsafe { fsb.deallocate(allocation, layout) };
                 let free_block_ptr = fsb.lock().list_heads[list_index(&layout).unwrap()].take().unwrap()
                     as *mut BlockListNode as *mut u8;
@@ -1416,6 +1456,7 @@ mod tests {
                 assert!(allocation.as_ptr() as u64 >= address);
                 assert!((allocation.as_ptr() as u64) < address + 0x1000000);
 
+                // SAFETY: free_pages uses a valid test allocation pointer and page count.
                 unsafe {
                     match fsb.free_pages(0, pages) {
                         Err(EfiError::NotFound) => {}
@@ -1423,6 +1464,7 @@ mod tests {
                     };
                 };
 
+                // SAFETY: allocation and page count come from allocate_pages in this test.
                 unsafe {
                     fsb.free_pages(allocation.as_ptr() as usize, pages).unwrap();
                 };
@@ -1459,6 +1501,7 @@ mod tests {
 
                 assert_eq!(allocation.as_ptr() as u64, target_address);
 
+                // SAFETY: free_pages uses a valid test allocation pointer and page count.
                 unsafe {
                     fsb.free_pages(allocation.as_ptr() as usize, pages).unwrap();
                 };
@@ -1493,6 +1536,7 @@ mod tests {
                     .cast::<u8>();
                 assert!((allocation.as_ptr() as u64) < target_address);
 
+                // SAFETY: free_pages uses a valid test allocation pointer and page count.
                 unsafe {
                     fsb.free_pages(allocation.as_ptr() as usize, pages).unwrap();
                 };
@@ -1527,6 +1571,7 @@ mod tests {
                     .cast::<u8>();
                 assert!((allocation.as_ptr() as usize + uefi_pages_to_size!(pages)) <= target_address as usize);
 
+                // SAFETY: allocation and page count come from allocate_pages in this test.
                 unsafe {
                     fsb.free_pages(allocation.as_ptr() as usize, pages).unwrap();
                 };
@@ -1576,6 +1621,7 @@ mod tests {
                 _ => panic!("Expected INVALID_PARAMETER"),
             }
 
+            // SAFETY: Invalid parameters are intentionally tested (unit test).
             unsafe {
                 match fsb.free_pages(0x1001, 5) {
                     Err(EfiError::InvalidParameter) => {}
@@ -1653,6 +1699,7 @@ mod tests {
             assert_eq!(stats.claimed_pages, uefi_size_to_pages!(TEST_MIN_EXPANSION_SIZE * 2));
 
             //test alloc/deallocate and stats within the bucket
+            // SAFETY: fsb is initialized and used with a valid layout for testing.
             let ptr = unsafe {
                 fsb.alloc(
                     Layout::from_size_align(TEST_MIN_EXPANSION_SIZE - size_of::<AllocatorListNode>(), 0x8).unwrap(),
@@ -1669,6 +1716,7 @@ mod tests {
             assert_eq!(stats.reserved_used, TEST_MIN_EXPANSION_SIZE + uefi_pages_to_size!(1));
             assert_eq!(stats.claimed_pages, uefi_size_to_pages!(TEST_MIN_EXPANSION_SIZE * 2));
 
+            // SAFETY: Allocation was returned by fsb for this layout.
             unsafe {
                 fsb.dealloc(ptr, Layout::from_size_align(0x100, 0x8).unwrap());
             }
@@ -1684,6 +1732,7 @@ mod tests {
             assert_eq!(stats.claimed_pages, uefi_size_to_pages!(TEST_MIN_EXPANSION_SIZE * 2));
 
             //test alloc/deallocate and stats blowing the bucket
+            // SAFETY: fsb is initialized and used with a valid layout in tests.
             let ptr = unsafe { fsb.alloc(Layout::from_size_align(TEST_MIN_EXPANSION_SIZE * 3, 0x8).unwrap()) };
 
             //after this allocate, the basic memory map of the FSB should look like:
@@ -1702,6 +1751,7 @@ mod tests {
             assert_eq!(stats.reserved_used, TEST_MIN_EXPANSION_SIZE + uefi_pages_to_size!(1));
             assert_eq!(stats.claimed_pages, uefi_size_to_pages!(TEST_MIN_EXPANSION_SIZE * 5) + 1);
 
+            // SAFETY: Allocation was returned by fsb for this layout.
             unsafe {
                 fsb.dealloc(ptr, Layout::from_size_align(TEST_MIN_EXPANSION_SIZE * 3, 0x8).unwrap());
             }
@@ -1740,6 +1790,7 @@ mod tests {
             assert_eq!(stats.reserved_used, TEST_MIN_EXPANSION_SIZE + uefi_pages_to_size!(5));
             assert_eq!(stats.claimed_pages, uefi_size_to_pages!(TEST_MIN_EXPANSION_SIZE * 5) + 1);
 
+            // SAFETY: free_pages uses a valid test allocation pointer and page count.
             unsafe {
                 fsb.free_pages(ptr as *mut u8 as usize, 0x4).unwrap();
             }
@@ -1798,9 +1849,11 @@ mod tests {
             assert_eq!(stats.reserved_used, TEST_MIN_EXPANSION_SIZE + uefi_pages_to_size!(5));
             assert_eq!(stats.claimed_pages, uefi_size_to_pages!(TEST_MIN_EXPANSION_SIZE * 5) + 1 + 0x104);
 
+            // SAFETY: free_pages uses a valid test allocation pointer and page count.
             unsafe {
                 fsb.free_pages(ptr1 as *mut u8 as usize, 0x4).unwrap();
             }
+            // SAFETY: free_pages uses a valid test allocation pointer and page count.
             unsafe {
                 fsb.free_pages(ptr as *mut u8 as usize, 0x104).unwrap();
             }

--- a/patina_dxe_core/src/allocator/uefi_allocator.rs
+++ b/patina_dxe_core/src/allocator/uefi_allocator.rs
@@ -119,6 +119,8 @@ where
         match self.allocator.allocate(allocation_info.layout) {
             Ok(ptr) => {
                 let alloc_info_ptr = ptr.cast::<AllocationInfo>().as_ptr();
+                // SAFETY: alloc_info_ptr is within the allocation. `buffer` is a caller-provided out pointer per the
+                // `allocate_pool` safety contract.
                 unsafe {
                     alloc_info_ptr.write(allocation_info);
                     buffer.write((ptr.as_ptr() as *mut u8 as usize + offset) as *mut c_void);
@@ -196,10 +198,12 @@ where
     }
 
     /// Frees the block of pages at the given address of the given size.
+    ///
     /// ## Safety
     /// Caller must ensure that the given address corresponds to a valid block of pages that was allocated with
     /// [Self::allocate_pages]
     pub unsafe fn free_pages(&self, address: usize, pages: usize) -> Result<(), EfiError> {
+        // SAFETY: address/pages must refer to a valid allocation from this allocator.
         unsafe { self.allocator.free_pages(address, pages) }
     }
 
@@ -221,18 +225,22 @@ where
     }
 }
 
+// SAFETY: UefiAllocator delegates to the inner allocator and preserves invariants.
 unsafe impl<A> GlobalAlloc for UefiAllocator<A>
 where
     A: PageAllocator + GlobalAlloc + Allocator + Display + Sync + Send,
 {
     unsafe fn alloc(&self, layout: core::alloc::Layout) -> *mut u8 {
+        // SAFETY: layout comes from the global allocator contract.
         unsafe { self.allocator.alloc(layout) }
     }
     unsafe fn dealloc(&self, ptr: *mut u8, layout: core::alloc::Layout) {
+        // SAFETY: ptr was returned by alloc with the same layout.
         unsafe { self.allocator.dealloc(ptr, layout) }
     }
 }
 
+// SAFETY: UefiAllocator delegates to the inner allocator and preserves invariants.
 unsafe impl<A> Allocator for UefiAllocator<A>
 where
     A: PageAllocator + GlobalAlloc + Allocator + Display + Sync + Send,
@@ -241,6 +249,7 @@ where
         self.allocator.allocate(layout)
     }
     unsafe fn deallocate(&self, ptr: core::ptr::NonNull<u8>, layout: core::alloc::Layout) {
+        // SAFETY: ptr was returned by allocate with the same layout.
         unsafe { self.allocator.deallocate(ptr, layout) }
     }
 }
@@ -294,11 +303,14 @@ mod tests {
     use super::*;
 
     fn init_gcd(gcd: &SpinLockedGcd, size: usize) -> u64 {
+        // SAFETY: Resetting the test GCD is safe for testing purposes.
         unsafe { gcd.reset() };
 
         gcd.init(48, 16);
         let layout = Layout::from_size_align(size, UEFI_PAGE_SIZE).unwrap();
+        // SAFETY: System allocator is used with a valid layout for test memory backing.
         let base = unsafe { System.alloc(layout) as u64 };
+        // SAFETY: init_memory_blocks uses the test backing allocation.
         unsafe {
             gcd.init_memory_blocks(
                 dxe_services::GcdMemoryType::SystemMemory,
@@ -361,6 +373,7 @@ mod tests {
                 let ua = UefiAllocator::new(fsb, efi::RUNTIME_SERVICES_DATA);
 
                 let mut buffer: *mut c_void = core::ptr::null_mut();
+                // SAFETY: The allocator is initialized and buffer is a valid out pointer.
                 assert!(unsafe { ua.allocate_pool(0x1000, core::ptr::addr_of_mut!(buffer)) }.is_ok());
                 assert!(buffer as u64 > base);
                 assert!((buffer as u64) < base + 0x400000);
@@ -373,6 +386,7 @@ mod tests {
                     .unwrap_or_else(|err| panic!("Allocation layout error: {err:#?}"));
 
                 let allocation_info: *mut AllocationInfo = ((buffer as usize) - offset) as *mut AllocationInfo;
+                // SAFETY: allocation_info is derived from a valid allocation.
                 unsafe {
                     let allocation_info = &*allocation_info;
                     assert_eq!(allocation_info.signature, POOL_SIG);
@@ -401,8 +415,10 @@ mod tests {
                 let ua = UefiAllocator::new(fsb, efi::RUNTIME_SERVICES_DATA);
 
                 let mut buffer: *mut c_void = core::ptr::null_mut();
+                // SAFETY: The allocator is initialized and buffer is a valid out pointer.
                 assert!(unsafe { ua.allocate_pool(0x1000, core::ptr::addr_of_mut!(buffer)) }.is_ok());
 
+                // SAFETY: buffer was allocated by ua.allocate_pool above.
                 assert!(unsafe { ua.free_pool(buffer) }.is_ok());
 
                 let (_, offset) = Layout::new::<AllocationInfo>()
@@ -413,12 +429,14 @@ mod tests {
                     .unwrap_or_else(|err| panic!("Allocation layout error: {err:#?}"));
 
                 let allocation_info: *mut AllocationInfo = ((buffer as usize) - offset) as *mut AllocationInfo;
+                // SAFETY: allocation_info is derived from a valid allocation made earlier in this test.
                 unsafe {
                     let allocation_info = &*allocation_info;
                     assert_eq!(allocation_info.signature, 0);
                 }
 
                 let prev_buffer = buffer;
+                // SAFETY: The allocator is initialized and buffer is a valid out pointer.
                 assert!(unsafe { ua.allocate_pool(0x1000, core::ptr::addr_of_mut!(buffer)) }.is_ok());
                 assert!(buffer as u64 > base);
                 assert!((buffer as u64) < base + 0x400000);
@@ -464,6 +482,7 @@ mod tests {
                 }
 
                 // Attempting to free should fail with InvalidParameter due to signature mismatch
+                // SAFETY: buffer was allocated by ua.allocate_pool in this test.
                 assert_eq!(unsafe { ua.free_pool(buffer) }, Err(EfiError::InvalidParameter));
             });
         });
@@ -493,6 +512,7 @@ mod tests {
                 assert!(buffer_address >= base);
                 assert!(buffer_address < base + 0x400000);
 
+                // SAFETY: free_pages uses a valid allocation pointer and page count.
                 unsafe {
                     ua.free_pages(buffer_address as usize, 4).unwrap();
                 }
@@ -503,6 +523,7 @@ mod tests {
                 assert_eq!(buffer_address, buffer_address2);
                 assert_eq!(buffer.len(), max(granularity, UEFI_PAGE_SIZE * 4)); //should be 4 pages or granularity pages in size.
 
+                // SAFETY: free_pages uses a valid allocation pointer and page count.
                 unsafe {
                     ua.free_pages(buffer_address2 as usize, 4).unwrap();
                 }
@@ -541,6 +562,7 @@ mod tests {
             let bs_buffer_address = bs_buffer.as_ptr() as *mut u8 as efi::PhysicalAddress;
             let bc_buffer_address = bc_buffer.as_ptr() as *mut u8 as efi::PhysicalAddress;
 
+            // SAFETY: free_pages uses valid allocation pointers for each allocator.
             unsafe {
                 assert_eq!(bs_allocator.free_pages(bc_buffer_address as usize, 4), Err(EfiError::NotFound));
                 assert_eq!(bc_allocator.free_pages(bs_buffer_address as usize, 4), Err(EfiError::NotFound));
@@ -568,11 +590,13 @@ mod tests {
                 let ua = UefiAllocator::new(fsb, efi::RUNTIME_SERVICES_DATA);
 
                 let layout = Layout::from_size_align(0x8, 0x8).unwrap();
+                // SAFETY: ua.alloc/ua.dealloc are used with a valid layout in tests.
                 unsafe {
                     let a = ua.alloc(layout);
                     ua.dealloc(a, layout)
                 }
 
+                // SAFETY: ua.alloc returned non-null for this test allocation.
                 unsafe {
                     let a = ua.alloc(layout);
                     ua.deallocate(NonNull::new_unchecked(a), layout);
@@ -718,6 +742,7 @@ mod tests {
 
                 //verify that if the reserved allocation that is not in the reserved range is freed, other allocators can
                 //use it.
+                // SAFETY: reserved_page_addr is a valid allocation address for free_pages.
                 unsafe {
                     reserved_allocator.free_pages(reserved_page_addr as usize, 1).unwrap();
                 }
@@ -731,6 +756,7 @@ mod tests {
                 );
 
                 //verify that if pages are freed within the reserved range, that other allocators cannot use them.
+                // SAFETY: reserved_range.start is a valid allocation address for free_pages in the test harness.
                 unsafe {
                     reserved_allocator.free_pages(reserved_range.start as usize, 0x10).unwrap();
                 }

--- a/patina_dxe_core/src/config_tables.rs
+++ b/patina_dxe_core/src/config_tables.rs
@@ -98,6 +98,7 @@ pub fn core_install_configuration_table(
 
     // Updating the table. Reclaim the old table (if present) so it'll get dropped by the runtime allocator.
     if !system_table.configuration_table.is_null() {
+        // SAFETY: configuration_table points to number_of_table_entries elements from the runtime allocator.
         unsafe {
             let _old_boxed_table = Box::from_raw_in(
                 slice_from_raw_parts_mut(system_table.configuration_table, system_table.number_of_table_entries),

--- a/patina_dxe_core/src/config_tables/memory_attributes_table.rs
+++ b/patina_dxe_core/src/config_tables/memory_attributes_table.rs
@@ -61,7 +61,9 @@ impl MemoryAttributesTable {
 
 impl Debug for MemoryAttributesTable {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        // SAFETY: self.0 is a valid MAT pointer when Debug is invoked.
         let mat = unsafe { self.0.as_ref().expect("BAD MAT PTR") };
+        // SAFETY: mat.entry points to number_of_entries descriptors in the MAT.
         let entries = unsafe { slice::from_raw_parts(mat.entry.as_ptr(), mat.number_of_entries as usize) };
 
         writeln!(f, "MemoryAttributesTable {{")?;
@@ -111,6 +113,7 @@ pub fn core_install_memory_attributes_table() {
             // behavior with a stack pointer that goes out of scope
             match core_allocate_pool(efi::BOOT_SERVICES_DATA, size_of::<efi::MemoryAttributesTable>()) {
                 Ok(empty_ptr) => {
+                    // SAFETY: empty_ptr is a valid allocation for MemoryAttributesTable.
                     if let Some(empty_mat) = unsafe { (empty_ptr as *mut efi::MemoryAttributesTable).as_mut() } {
                         *empty_mat = efi::MemoryAttributesTable {
                             version: 0,
@@ -203,6 +206,7 @@ pub fn core_install_memory_attributes_table() {
 
             // this ends up being a large unsafe block because we have to dereference the raw pointer core_allocate_pool
             // gave us and convert it to a real type and back in order to install it
+            // SAFETY: mat_ptr is a valid allocation for MemoryAttributesTable and copy size is bounded by buffer_size.
             unsafe {
                 let mat = &mut *mat_ptr;
                 mat.version = efi::MEMORY_ATTRIBUTES_TABLE_VERSION;
@@ -263,6 +267,7 @@ mod tests {
         test_support::with_global_lock(|| {
             POST_RTB.reset();
 
+            // SAFETY: Test-only initialization under the global lock.
             unsafe {
                 test_support::init_test_gcd(None);
                 test_support::reset_allocators();
@@ -348,6 +353,7 @@ mod tests {
 
             // Check if MEMORY_ATTRIBUTES_TABLE is set after installation
             let mat_ptr = get_configuration_table(&efi::MEMORY_ATTRIBUTES_TABLE_GUID).unwrap();
+            // SAFETY: MAT pointer comes from configuration table and is validated before dereference.
             unsafe {
                 let mat = &*(mat_ptr.as_ptr() as *const efi::MemoryAttributesTable);
 

--- a/patina_dxe_core/src/cpu/cpu_arch_protocol.rs
+++ b/patina_dxe_core/src/cpu/cpu_arch_protocol.rs
@@ -34,6 +34,7 @@ struct EfiCpuArchProtocolImpl {
     pub(crate) interrupt_manager: Service<dyn InterruptManager>,
 }
 
+// SAFETY: EfiCpuArchProtocolImpl provides a valid protocol structure with stable GUID.
 unsafe impl ProtocolInterface for EfiCpuArchProtocolImpl {
     const PROTOCOL_GUID: efi::Guid = PROTOCOL_GUID;
 }
@@ -44,6 +45,7 @@ fn get_impl_ref<'a>(this: *const Protocol) -> &'a EfiCpuArchProtocolImpl {
         panic!("Null pointer passed to get_impl_ref()");
     }
 
+    // SAFETY: this is non-null and points to an EfiCpuArchProtocolImpl instance.
     unsafe { &*(this as *const EfiCpuArchProtocolImpl) }
 }
 
@@ -52,6 +54,7 @@ fn get_impl_ref_mut<'a>(this: *mut Protocol) -> &'a mut EfiCpuArchProtocolImpl {
         panic!("Null pointer passed to get_impl_ref_mut()");
     }
 
+    // SAFETY: this is non-null and points to an EfiCpuArchProtocolImpl instance.
     unsafe { &mut *(this as *mut EfiCpuArchProtocolImpl) }
 }
 

--- a/patina_dxe_core/src/cpu/perf_timer.rs
+++ b/patina_dxe_core/src/cpu/perf_timer.rs
@@ -62,6 +62,7 @@ fn arch_cpu_count() -> u64 {
     #[cfg(target_arch = "x86_64")]
     {
         use core::arch::x86_64;
+        // SAFETY: _rdtsc only reads the TSC on x86_64. No invariants are required for safety.
         unsafe { x86_64::_rdtsc() }
     }
     #[cfg(target_arch = "aarch64")]

--- a/patina_dxe_core/src/driver_services.rs
+++ b/patina_dxe_core/src/driver_services.rs
@@ -46,8 +46,9 @@ fn get_platform_driver_override_bindings(
         .locate_protocol(efi::protocols::platform_driver_override::PROTOCOL_GUID)
     {
         Err(_) => return Vec::new(),
+        // SAFETY: Checks locate_protocol return value to determine if pointer is valid. as_mut() is used for mutable
+        // access which will also check if the pointer is null before allowing access.
         Ok(protocol) => unsafe {
-            // SAFETY: locate_protocol guarantees that if `Ok` is returned, a valid pointer is encapsulated in it.
             (protocol as *mut efi::protocols::platform_driver_override::Protocol).as_mut().expect("bad protocol ptr")
         },
     };
@@ -289,9 +290,11 @@ fn core_connect_single_controller(
         return Ok(());
     }
 
-    // SAFETY: caller must ensure that the pointer contained in remaining_device_path is valid if it is Some(_).
     if let Some(device_path) = remaining_device_path
-        && unsafe { (device_path.read_unaligned()).r#type == efi::protocols::device_path::TYPE_END }
+        && {
+            // SAFETY: caller must ensure that the pointer contained in remaining_device_path is valid if it is Some(_).
+            unsafe { (device_path.read_unaligned()).r#type == efi::protocols::device_path::TYPE_END }
+        }
     {
         return Ok(());
     }

--- a/patina_dxe_core/src/dxe_services.rs
+++ b/patina_dxe_core/src/dxe_services.rs
@@ -26,6 +26,8 @@ extern "efiapi" fn add_memory_space(
     length: u64,
     capabilities: u64,
 ) -> efi::Status {
+    // SAFETY: The DXE Services contract requires the caller to provide a valid, non-overlapping
+    // memory region within the processor address space.
     let result = unsafe { GCD.add_memory_space(gcd_memory_type, base_address as usize, length as usize, capabilities) };
 
     match result {
@@ -393,6 +395,7 @@ impl<P: PlatformInfo> Core<P> {
             set_memory_space_capabilities,
         };
         let dxe_services_system_table_ptr = &dxe_services_system_table as *const dxe_services::DxeServicesTable;
+        // SAFETY: dxe_services_system_table is a local value, its byte representation is valid for hashing.
         let crc32 = unsafe {
             crc32fast::hash(from_raw_parts(
                 dxe_services_system_table_ptr as *const u8,
@@ -491,6 +494,7 @@ mod tests {
     fn with_locked_state<F: Fn() + std::panic::RefUnwindSafe>(f: F) {
         test_support::with_global_lock(|| {
             test_support::init_test_logger();
+            // SAFETY: Test-only initialization under the global lock.
             unsafe {
                 crate::test_support::init_test_gcd(None);
                 crate::test_support::init_test_protocol_db();
@@ -1175,6 +1179,7 @@ mod tests {
             let result = get_memory_space_descriptor(base, descriptor.as_mut_ptr());
             assert_eq!(result, efi::Status::SUCCESS, "Should get memory space descriptor");
 
+            // SAFETY: get_memory_space_descriptor initialized descriptor on SUCCESS.
             let descriptor = unsafe { descriptor.assume_init() };
             assert_eq!(descriptor.base_address, base, "Base address should match");
             assert_eq!(descriptor.length, length, "Length should match");
@@ -1215,6 +1220,7 @@ mod tests {
 
             assert_eq!(result, efi::Status::SUCCESS, "Should get descriptor for address within range");
 
+            // SAFETY: get_memory_space_descriptor initialized descriptor on SUCCESS.
             let descriptor = unsafe { descriptor.assume_init() };
             assert_eq!(descriptor.base_address, base, "Base address should be the region base");
             assert_eq!(descriptor.length, length, "Length should match the region length");
@@ -1245,6 +1251,7 @@ mod tests {
 
                 assert_eq!(result, efi::Status::SUCCESS, "Should get descriptor for type {expected_type:?}");
 
+                // SAFETY: get_memory_space_descriptor initialized descriptor on SUCCESS.
                 let descriptor = unsafe { descriptor.assume_init() };
                 assert_eq!(descriptor.memory_type, *expected_type, "Memory type should match for {expected_type:?}");
                 assert_eq!(descriptor.base_address, *base, "Base address should match for type {expected_type:?}");
@@ -1284,6 +1291,7 @@ mod tests {
                     "Should get descriptor for capabilities 0x{expected_capabilities:x}",
                 );
 
+                // SAFETY: get_memory_space_descriptor initialized descriptor on SUCCESS.
                 let descriptor = unsafe { descriptor.assume_init() };
                 // Check that our requested capabilities are present (GCD may add additional flags)
                 assert!(
@@ -1347,6 +1355,7 @@ mod tests {
             // Read back and verify bits are set
             let mut d = core::mem::MaybeUninit::<dxe_services::MemorySpaceDescriptor>::uninit();
             assert_eq!(get_memory_space_descriptor(base, d.as_mut_ptr()), efi::Status::SUCCESS);
+            // SAFETY: get_memory_space_descriptor initialized d on SUCCESS.
             let d = unsafe { d.assume_init() };
             assert_eq!(d.base_address, base);
             assert_eq!(d.length, length);
@@ -1383,12 +1392,14 @@ mod tests {
             // The first page should have RO set
             let mut d0 = core::mem::MaybeUninit::<dxe_services::MemorySpaceDescriptor>::uninit();
             assert_eq!(get_memory_space_descriptor(base, d0.as_mut_ptr()), efi::Status::SUCCESS);
+            // SAFETY: get_memory_space_descriptor initialized d0 on SUCCESS.
             let d0 = unsafe { d0.assume_init() };
             assert!(d0.attributes & efi::MEMORY_RO != 0);
 
             // A later page should not necessarily have RO (split expected). We only assert that RO is not set there.
             let mut d1 = core::mem::MaybeUninit::<dxe_services::MemorySpaceDescriptor>::uninit();
             assert_eq!(get_memory_space_descriptor(base + 0x3000, d1.as_mut_ptr()), efi::Status::SUCCESS);
+            // SAFETY: get_memory_space_descriptor initialized d1 on SUCCESS.
             let d1 = unsafe { d1.assume_init() };
             assert!(d1.attributes & efi::MEMORY_RO == 0, "RO should not be set on untouched pages");
         });
@@ -1397,6 +1408,7 @@ mod tests {
     #[test]
     fn test_set_memory_space_attributes_not_ready() {
         with_locked_state(|| {
+            // SAFETY: Resetting the global GCD is safe under the test lock.
             unsafe { GCD.reset() };
             let s = set_memory_space_attributes(0x2421000, 0x1000, efi::MEMORY_WB);
             assert_eq!(s, efi::Status::NOT_READY);
@@ -1424,6 +1436,7 @@ mod tests {
     #[test]
     fn test_get_memory_space_map_not_ready() {
         with_locked_state(|| {
+            // SAFETY: Resetting the global GCD is safe under the test lock.
             unsafe { GCD.reset() };
 
             let mut out_count: usize = 0;
@@ -1437,6 +1450,7 @@ mod tests {
     #[test]
     fn test_get_memory_space_map_success_and_contents() {
         with_locked_state(|| {
+            // SAFETY: Test allocator reset is safe under the test lock.
             unsafe {
                 crate::test_support::reset_allocators();
             }
@@ -1454,6 +1468,7 @@ mod tests {
             assert_eq!(out_count, expected.len());
             assert!(!out_ptr.is_null());
 
+            // SAFETY: out_ptr/out_count come from get_memory_space_map and are valid for reads.
             let out_slice = unsafe { core::slice::from_raw_parts(out_ptr, out_count) };
             assert_eq!(out_slice, expected.as_slice());
 
@@ -1464,6 +1479,7 @@ mod tests {
     #[test]
     fn test_get_memory_space_map_with_additional_regions() {
         with_locked_state(|| {
+            // SAFETY: Test allocator reset is safe under the test lock.
             unsafe {
                 crate::test_support::reset_allocators();
             }
@@ -1488,6 +1504,7 @@ mod tests {
             assert_eq!(out_count, expected.len());
 
             // Verify first and last few entries match (order should be the same as GCD enumeration)
+            // SAFETY: out_ptr/out_count come from get_memory_space_map and are valid for reads.
             let out_slice = unsafe { core::slice::from_raw_parts(out_ptr, out_count) };
             assert_eq!(out_slice, expected.as_slice());
 
@@ -1513,6 +1530,7 @@ mod tests {
     #[test]
     fn test_get_io_space_map_not_ready() {
         with_locked_state(|| {
+            // SAFETY: Resetting the global GCD is safe under the test lock.
             unsafe { GCD.reset() };
 
             let mut out_count: usize = 0;
@@ -1526,6 +1544,7 @@ mod tests {
     #[test]
     fn test_get_io_space_map_success_and_contents() {
         with_locked_state(|| {
+            // SAFETY: Test allocator reset is safe under the test lock.
             unsafe {
                 crate::test_support::reset_allocators();
             }
@@ -1542,6 +1561,7 @@ mod tests {
             assert_eq!(out_count, expected.len());
             assert!(!out_ptr.is_null());
 
+            // SAFETY: out_ptr/out_count are returned by get_io_space_map and are valid for that length.
             let out_slice = unsafe { core::slice::from_raw_parts(out_ptr, out_count) };
             assert_eq!(out_slice, expected.as_slice());
 
@@ -1552,6 +1572,7 @@ mod tests {
     #[test]
     fn test_get_io_space_map_with_additional_regions() {
         with_locked_state(|| {
+            // SAFETY: Test allocator reset is safe under the test lock.
             unsafe {
                 crate::test_support::reset_allocators();
             }
@@ -1571,6 +1592,7 @@ mod tests {
             assert_eq!(s, efi::Status::SUCCESS);
             assert_eq!(out_count, expected.len());
 
+            // SAFETY: out_ptr/out_count are returned by get_memory_space_map and are valid for that length.
             let out_slice = unsafe { core::slice::from_raw_parts(out_ptr, out_count) };
             assert_eq!(out_slice, expected.as_slice());
 
@@ -1597,6 +1619,7 @@ mod tests {
             // Verify capabilities include the requested bits
             let mut d = core::mem::MaybeUninit::<dxe_services::MemorySpaceDescriptor>::uninit();
             assert_eq!(get_memory_space_descriptor(base, d.as_mut_ptr()), efi::Status::SUCCESS);
+            // SAFETY: get_memory_space_descriptor initialized d on SUCCESS.
             let d = unsafe { d.assume_init() };
             assert_eq!(d.base_address, base);
             assert!(d.capabilities & caps == caps, "Expected caps 0x{:x} to be set in 0x{:x}", caps, d.capabilities);
@@ -1615,6 +1638,7 @@ mod tests {
     fn test_set_memory_space_capabilities_not_ready() {
         with_locked_state(|| {
             // Force GCD to an uninitialized state
+            // SAFETY: Resetting the global GCD is safe under the test lock.
             unsafe { GCD.reset() };
             let s = set_memory_space_capabilities(0x200000, 0x1000, efi::MEMORY_WB);
             assert_eq!(s, efi::Status::NOT_READY, "Expected NOT_READY when GCD is reset");
@@ -1670,6 +1694,7 @@ mod tests {
             let mut desc = core::mem::MaybeUninit::<dxe_services::IoSpaceDescriptor>::uninit();
             let s = get_io_space_descriptor(base, desc.as_mut_ptr());
             assert_eq!(s, efi::Status::SUCCESS);
+            // SAFETY: get_io_space_descriptor initialized desc on SUCCESS.
             let desc = unsafe { desc.assume_init() };
             assert_eq!(desc.base_address, base);
             assert_eq!(desc.length, len);
@@ -1687,6 +1712,7 @@ mod tests {
 
             let mut desc = core::mem::MaybeUninit::<dxe_services::IoSpaceDescriptor>::uninit();
             assert_eq!(get_io_space_descriptor(base, desc.as_mut_ptr()), efi::Status::SUCCESS);
+            // SAFETY: get_io_space_descriptor initialized desc on SUCCESS.
             let desc = unsafe { desc.assume_init() };
             assert_eq!(desc.base_address, base);
             assert_eq!(desc.length, len);
@@ -1716,6 +1742,7 @@ mod tests {
     fn test_add_io_space_not_ready() {
         with_locked_state(|| {
             // Force GCD to uninitialized state for IO
+            // SAFETY: Resetting the global GCD is safe under the test lock.
             unsafe { GCD.reset() };
             let s = add_io_space(GcdIoType::Io, 0x1000, 0x10);
             assert_eq!(s, efi::Status::NOT_READY);
@@ -1753,6 +1780,7 @@ mod tests {
     #[test]
     fn test_allocate_io_space_not_ready() {
         with_locked_state(|| {
+            // SAFETY: Resetting the global GCD is safe under the test lock.
             unsafe { GCD.reset() };
             let mut out: efi::PhysicalAddress = 0;
             let s = allocate_io_space(
@@ -1941,6 +1969,7 @@ mod tests {
     #[test]
     fn test_free_io_space_not_ready() {
         with_locked_state(|| {
+            // SAFETY: Resetting the global GCD is safe under the test lock.
             unsafe { GCD.reset() };
             let s = free_io_space(0x1000, 0x10);
             assert_eq!(s, efi::Status::NOT_READY);
@@ -2037,6 +2066,7 @@ mod tests {
     #[test]
     fn test_remove_io_space_not_ready() {
         with_locked_state(|| {
+            // SAFETY: Resetting the global GCD is safe under the test lock.
             unsafe { GCD.reset() };
             assert_eq!(remove_io_space(0x1000, 0x10), efi::Status::NOT_READY);
         });
@@ -2103,6 +2133,7 @@ mod tests {
             static CORE: MockCore = MockCore::new(NullSectionExtractor::new());
             CORE.override_instance();
             // Install the FV to obtain a real handle
+            // SAFETY: FV buffer is owned by the test and passed as a valid pointer to the dispatcher.
             unsafe { CORE.pi_dispatcher.install_firmware_volume(fv.as_ptr() as u64, None).unwrap() };
 
             // Wrapper should still surface NOT_FOUND (no pending drivers to dispatch in tests)
@@ -2148,6 +2179,7 @@ mod tests {
             static CORE: MockCore = MockCore::new(NullSectionExtractor::new());
             CORE.override_instance();
             // Install the FV to obtain a real handle
+            // SAFETY: FV buffer is owned by the test and passed as a valid pointer to the dispatcher.
             let handle = unsafe { CORE.pi_dispatcher.install_firmware_volume(fv.as_ptr() as u64, None).unwrap() };
 
             // Use the same GUID as the dispatcher tests; wrapper should map NotFound correctly
@@ -2261,6 +2293,7 @@ mod tests {
             assert_eq!(st_raw.number_of_table_entries, 1);
             assert!(!st_raw.configuration_table.is_null());
 
+            // SAFETY: configuration_table points to `number_of_table_entries` elements set by init_system_table.
             let entries =
                 unsafe { core::slice::from_raw_parts(st_raw.configuration_table, st_raw.number_of_table_entries) };
 
@@ -2271,6 +2304,7 @@ mod tests {
             assert!(!entry.vendor_table.is_null(), "DXE Services vendor_table pointer should be non-null");
 
             // Validate the contents of the installed DXE Services table
+            // SAFETY: vendor_table points to a DXE Services table installed by CORE.install_dxe_services_table.
             let dxe_tbl = unsafe { &*(entry.vendor_table as *const dxe_services::DxeServicesTable) };
 
             // Header signature/revision should match what install_dxe_services_table sets
@@ -2278,8 +2312,10 @@ mod tests {
             assert_eq!(dxe_tbl.header.revision, efi::BOOT_SERVICES_REVISION);
 
             // Recompute CRC32 by zeroing the field in a local copy
+            // SAFETY: dxe_tbl is a valid reference with signature and revision checked above.
             let mut copy = unsafe { core::ptr::read(dxe_tbl) };
             copy.header.crc32 = 0;
+            // SAFETY: copy is a local value. Creating a slice from its pointer and size is valid.
             let crc = crc32fast::hash(unsafe {
                 core::slice::from_raw_parts(
                     (&copy as *const dxe_services::DxeServicesTable) as *const u8,

--- a/patina_dxe_core/src/event_db.rs
+++ b/patina_dxe_core/src/event_db.rs
@@ -215,9 +215,11 @@ struct Event {
     period: Option<u64>,
 }
 
-// SAFETY: This structure is used within a lock on a single core and is not mutated
-// after creation. It is safe to share references to it.
+// SAFETY: Access and mutation of Event instances is serialized by the event DB lock,
+// so shared references are not concurrently accessed without synchronization.
 unsafe impl Sync for crate::event_db::Event {}
+// SAFETY: Access and mutation of Event instances is serialized by the event DB lock,
+// so moving between threads does not introduce data races.
 unsafe impl Send for crate::event_db::Event {}
 
 impl fmt::Debug for Event {
@@ -808,7 +810,9 @@ impl SpinLockedEventDb {
     }
 }
 
+// SAFETY: SpinLockedEventDb protects internal state with a lock.
 unsafe impl Send for SpinLockedEventDb {}
+// SAFETY: SpinLockedEventDb protects internal state with a lock.
 unsafe impl Sync for SpinLockedEventDb {}
 
 #[cfg(test)]

--- a/patina_dxe_core/src/events.rs
+++ b/patina_dxe_core/src/events.rs
@@ -135,6 +135,7 @@ extern "efiapi" fn wait_for_event(
                 status => {
                     // SAFETY: caller must ensure that out_index is a valid pointer if it is not null.
                     if !out_index.is_null() {
+                        // SAFETY: out_index is non-null and points to writable memory.
                         unsafe {
                             out_index.write_unaligned(index);
                         };
@@ -304,6 +305,7 @@ extern "efiapi" fn timer_available_callback(event: efi::Event, _context: *mut c_
     match PROTOCOL_DB.locate_protocol(timer::PROTOCOL_GUID) {
         Ok(timer_arch_ptr) => {
             let timer_arch_ptr = timer_arch_ptr as *mut timer::Protocol;
+            // SAFETY: timer_arch_ptr was successfully returned from locate_protocol.
             let timer_arch = unsafe { &*(timer_arch_ptr) };
             (timer_arch.register_handler)(timer_arch_ptr, timer_tick);
             if let Err(status_err) = EVENT_DB.close_event(event) {
@@ -359,6 +361,7 @@ mod tests {
     fn with_locked_state<F: Fn() + std::panic::RefUnwindSafe>(f: F) {
         test_support::with_global_lock(|| {
             test_support::init_test_logger();
+            // SAFETY: Test-only initialization of global services under the global lock.
             unsafe {
                 crate::test_support::init_test_gcd(None);
                 crate::test_support::reset_allocators();

--- a/patina_dxe_core/src/filesystems.rs
+++ b/patina_dxe_core/src/filesystems.rs
@@ -32,12 +32,14 @@ impl SimpleFile<'_> {
 
         EfiError::status_to_result(status)?;
 
+        // SAFETY: file_ptr is filled by the open call above on success.
         let file = unsafe { file_ptr.as_mut().ok_or(EfiError::NotFound)? };
         Ok(Self { file })
     }
 
     /// Opens the root of a Simple File System and returns a SimpleFile object for it.
     pub fn open_volume(handle: efi::Handle) -> Result<Self, EfiError> {
+        // SAFETY: Protocol database returns a valid interface pointer for the handle.
         let sfs = unsafe {
             let sfs_protocol_ptr =
                 PROTOCOL_DB.get_interface_for_handle(handle, efi::protocols::simple_file_system::PROTOCOL_GUID)?;
@@ -50,6 +52,7 @@ impl SimpleFile<'_> {
         let status = (sfs.open_volume)(sfs, core::ptr::addr_of_mut!(file_system_ptr));
         EfiError::status_to_result(status)?;
 
+        // SAFETY: file_system_ptr is filled by the open_volume call above on success.
         let root = unsafe { file_system_ptr.as_mut().ok_or(EfiError::NotFound)? };
 
         Ok(Self { file: root })

--- a/patina_dxe_core/src/gcd.rs
+++ b/patina_dxe_core/src/gcd.rs
@@ -427,6 +427,7 @@ pub fn init_gcd(physical_hob_list: *const c_void) {
     let mut free_memory_attributes: u64 = 0;
     let mut free_memory_capabilities: u64 = 0;
 
+    // SAFETY: physical_hob_list is provided by the platform and must point to a valid HOB list.
     let hob_list = Hob::Handoff(unsafe {
         (physical_hob_list as *const PhaseHandoffInformationTable)
             .as_ref::<'static>()
@@ -632,6 +633,7 @@ pub fn add_hob_resource_descriptors_to_gcd(hob_list: &HobList) {
                     .take_while(|r| r.is_some())
                     .flatten()
             {
+                // SAFETY: GCD is initialized and split_range is derived from valid HOB ranges.
                 unsafe {
                     GCD.add_memory_space(
                         gcd_mem_type,
@@ -1019,8 +1021,10 @@ mod tests {
             GCD.init(48, 16);
 
             // Add memory and MMIO regions
+            // SAFETY: get_memory returns a test-owned buffer sized for the requested block count.
             let mem = unsafe { crate::test_support::get_memory(spin_locked_gcd::MEMORY_BLOCK_SLICE_SIZE * 10) };
             let address = align_up(mem.as_ptr() as usize, 0x1000).unwrap();
+            // SAFETY: address/length come from the test buffer and are valid for initializing GCD memory blocks.
             unsafe {
                 GCD.init_memory_blocks(
                     patina::pi::dxe_services::GcdMemoryType::SystemMemory,

--- a/patina_dxe_core/src/gcd/spin_locked_gcd.rs
+++ b/patina_dxe_core/src/gcd/spin_locked_gcd.rs
@@ -400,10 +400,13 @@ impl GCD {
             ..Default::default()
         });
 
-        self.memory_blocks
-            .expand(unsafe { slice::from_raw_parts_mut::<'static>(base_address as *mut u8, MEMORY_BLOCK_SLICE_SIZE) });
+        self.memory_blocks.expand(
+            // SAFETY: base_address/size refer to a reserved backing allocation for memory blocks.
+            unsafe { slice::from_raw_parts_mut::<'static>(base_address as *mut u8, MEMORY_BLOCK_SLICE_SIZE) },
+        );
 
         self.memory_blocks.add(unallocated_memory_space).map_err(|_| EfiError::OutOfResources)?;
+        // SAFETY: add_memory_space is called during initialization with validated parameters.
         let idx = unsafe { self.add_memory_space(memory_type, base_address, len, capabilities) }?;
 
         // Initialize attributes on the first block to WB + XP
@@ -1073,7 +1076,7 @@ impl GCD {
         log::trace!(target: "allocations", "[{}]   Block Index: {:#x}", function!(), idx);
         log::trace!(target: "allocations", "[{}]   Transition:\n  {:#?}", function!(), transition);
 
-        // split_state_transition does not update the key, so this is safe.
+        // SAFETY: split_state_transition does not update the key for this block.
         let new_idx = unsafe {
             match memory_blocks.get_with_idx_mut(idx).expect("idx valid above").split_state_transition(
                 base_address,
@@ -1107,7 +1110,7 @@ impl GCD {
             Ok(idx) => idx,
             Err(e) => {
                 log::error!("[{}] Memory block split failed! -> Error: {:#?}", function!(), e);
-                // Restore the memory block to its previous state. The base_address (key) is not updated with the split, so this is safe.
+                // SAFETY: restoring the prior block state does not change the base_address key.
                 unsafe {
                     *memory_blocks.get_with_idx_mut(idx).expect("idx valid above") = mb_before_split;
                 }
@@ -1119,7 +1122,7 @@ impl GCD {
         if let Some(next_idx) = memory_blocks.next_idx(idx) {
             let mut next = *memory_blocks.get_with_idx(next_idx).expect("idx valid from insert");
 
-            // base_address (they key) is not updated with the merge, so this is safe.
+            // SAFETY: merge does not update the base_address key for this block.
             unsafe {
                 if memory_blocks.get_with_idx_mut(idx).expect("idx valid from insert").merge(&mut next) {
                     memory_blocks.delete_with_idx(next_idx).expect("Index already verified.");
@@ -1131,7 +1134,7 @@ impl GCD {
         if let Some(prev_idx) = memory_blocks.prev_idx(idx) {
             let mut block = *memory_blocks.get_with_idx(idx).expect("idx valid from insert");
 
-            // base_address (they key) is not updated with the merge, so this is safe.
+            // SAFETY: merge does not update the base_address key for this block.
             unsafe {
                 if memory_blocks.get_with_idx_mut(prev_idx).expect("idx valid from insert").merge(&mut block) {
                     memory_blocks.delete_with_idx(idx).expect("Index already verified.");
@@ -1407,11 +1410,14 @@ impl IoGCD {
     fn init_io_blocks(&mut self) -> Result<(), EfiError> {
         ensure!(self.maximum_address != 0, EfiError::NotReady);
 
-        self.io_blocks.expand(unsafe {
-            Box::into_raw(vec![0_u8; IO_BLOCK_SLICE_SIZE].into_boxed_slice())
-                .as_mut()
-                .expect("RBT given null pointer in initialization.")
-        });
+        self.io_blocks.expand(
+            // SAFETY: the boxed slice is leaked to back the tree storage for its lifetime.
+            unsafe {
+                Box::into_raw(vec![0_u8; IO_BLOCK_SLICE_SIZE].into_boxed_slice())
+                    .as_mut()
+                    .expect("RBT given null pointer in initialization.")
+            },
+        );
 
         self.io_blocks
             .add(IoBlock::Unallocated(dxe_services::IoSpaceDescriptor {
@@ -1818,7 +1824,7 @@ impl IoGCD {
         log::trace!(target: "allocations", "[{}]   Block Index: {:#x}", function!(), idx);
         log::trace!(target: "allocations", "[{}]   Transition: {:?}\n", function!(), transition);
 
-        // split_state_transition does not update the key, so this is safe.
+        // SAFETY: split_state_transition does not update the key for this block.
         let new_idx = unsafe {
             match io_blocks.get_with_idx_mut(idx).expect("idx valid above").split_state_transition(
                 base_address,
@@ -1850,7 +1856,7 @@ impl IoGCD {
             Ok(idx) => idx,
             Err(e) => {
                 log::error!("[{}] IO block split failed! -> Error: {:#?}", function!(), e);
-                // Restore the memory block to its previous state. The base_address (key) is not updated with the split, so this is safe.
+                // SAFETY: restoring the prior block state does not change the base_address key.
                 unsafe {
                     *io_blocks.get_with_idx_mut(idx).expect("idx valid above") = ib_before_split;
                 }
@@ -1861,7 +1867,7 @@ impl IoGCD {
         // Lets see if we can merge the block with the next block
         if let Some(next_idx) = io_blocks.next_idx(idx) {
             let mut next = *io_blocks.get_with_idx(next_idx).expect("idx valid from insert");
-            // base_address (they key) is not updated with the merge, so this is safe.
+            // SAFETY: merge does not update the base_address key for this block.
             unsafe {
                 if io_blocks.get_with_idx_mut(idx).expect("idx valid from insert").merge(&mut next) {
                     io_blocks.delete_with_idx(next_idx).expect("Index already verified.");
@@ -1872,7 +1878,7 @@ impl IoGCD {
         // Lets see if we can merge the block with the previous block
         if let Some(prev_idx) = io_blocks.prev_idx(idx) {
             let mut block = *io_blocks.get_with_idx(idx).expect("idx valid from insert");
-            // base_address (they key) is not updated with the merge, so this is safe.
+            // SAFETY: merge does not update the base_address key for this block.
             unsafe {
                 if io_blocks.get_with_idx_mut(prev_idx).expect("idx valid from insert").merge(&mut block) {
                     io_blocks.delete_with_idx(idx).expect("Index already verified.");
@@ -2314,6 +2320,7 @@ impl SpinLockedGcd {
             })
             .expect("Did not find MemoryAllocationModule Hob for DxeCore. Use patina::guid::DXE_CORE as FFS GUID.");
 
+        // SAFETY: the DXE core HOB points to the loaded image buffer and size.
         let pe_info = unsafe {
             UefiPeInfo::parse_mapped(core::slice::from_raw_parts(
                 dxe_core_hob.alloc_descriptor.memory_base_address as *const u8,
@@ -2510,6 +2517,7 @@ impl SpinLockedGcd {
         len: usize,
         capabilities: u64,
     ) -> Result<usize, EfiError> {
+        // SAFETY: caller upholds the contract for add_memory_space.
         let result = unsafe { self.memory.lock().add_memory_space(memory_type, base_address, len, capabilities) };
         if result.is_ok()
             && let Some(callback) = self.memory_change_callback
@@ -2988,7 +2996,9 @@ impl core::fmt::Debug for SpinLockedGcd {
     }
 }
 
+// SAFETY: SpinLockedGcd uses internal locks to serialize access to shared state.
 unsafe impl Sync for SpinLockedGcd {}
+// SAFETY: SpinLockedGcd is safe to move between threads because it owns thread-safe synchronization.
 unsafe impl Send for SpinLockedGcd {}
 
 /// Iterator over GCD memory descriptors within a specified range.
@@ -3162,6 +3172,7 @@ mod tests {
             // SAFETY: GCD test operation - address comes from controlled allocation above.
             assert_eq!(
                 Err(EfiError::NotReady),
+                // SAFETY: Test-controlled addresses and sizes are used with the GCD initialized by create_gcd or get_memory.
                 unsafe {
                     gcd.add_memory_space(dxe_services::GcdMemoryType::Reserved, address, MEMORY_BLOCK_SLICE_SIZE, 0)
                 },
@@ -3170,7 +3181,9 @@ mod tests {
             assert_eq!(0, gcd.memory_descriptor_count());
 
             assert_eq!(
+                // SAFETY: address/size come from the test buffer and are valid to initialize memory blocks.
                 Err(EfiError::OutOfResources),
+                // SAFETY: address/size come from the test buffer and are valid to initialize memory blocks.
                 unsafe {
                     gcd.init_memory_blocks(
                         dxe_services::GcdMemoryType::SystemMemory,
@@ -3189,24 +3202,32 @@ mod tests {
     #[test]
     fn test_add_memory_space_with_all_memory_type() {
         with_locked_state(|| {
+            // SAFETY: Test-controlled addresses and sizes are used with the GCD initialized by create_gcd or get_memory.
             let (mut gcd, _) = create_gcd();
-
+            // SAFETY: Test-controlled addresses and sizes are used with the GCD initialized by create_gcd or get_memory.
             assert_eq!(Ok(0), unsafe { gcd.add_memory_space(dxe_services::GcdMemoryType::Reserved, 0, 1, 0) });
+            // SAFETY: Test-controlled addresses and sizes are used with the GCD initialized by create_gcd or get_memory.
             assert_eq!(Ok(3), unsafe { gcd.add_memory_space(dxe_services::GcdMemoryType::SystemMemory, 1, 1, 0) });
+            // SAFETY: Test-controlled addresses and sizes are used with the GCD initialized by create_gcd or get_memory.
             assert_eq!(Ok(4), unsafe { gcd.add_memory_space(dxe_services::GcdMemoryType::Persistent, 2, 1, 0) });
+            // SAFETY: Test-controlled addresses and sizes are used with the GCD initialized by create_gcd or get_memory.
             assert_eq!(Ok(5), unsafe { gcd.add_memory_space(dxe_services::GcdMemoryType::MoreReliable, 3, 1, 0) });
+            // SAFETY: Test-controlled addresses and sizes are used with the GCD initialized by create_gcd or get_memory.
             assert_eq!(Ok(6), unsafe { gcd.add_memory_space(dxe_services::GcdMemoryType::Unaccepted, 4, 1, 0) });
+            // SAFETY: Test-controlled addresses and sizes are used with the GCD initialized by create_gcd or get_memory.
             assert_eq!(Ok(7), unsafe { gcd.add_memory_space(dxe_services::GcdMemoryType::MemoryMappedIo, 5, 1, 0) });
 
             let snapshot = copy_memory_block(&gcd);
 
             assert_eq!(
                 Err(EfiError::InvalidParameter),
+                // SAFETY: Test-controlled addresses and sizes are used with the GCD initialized by create_gcd or get_memory.
                 unsafe { gcd.add_memory_space(dxe_services::GcdMemoryType::NonExistent, 10, 1, 0) },
                 "Can't manually add NonExistent memory space manually."
             );
 
             assert!(is_gcd_memory_slice_valid(&gcd));
+            // SAFETY: Test-controlled addresses and sizes are used with the GCD initialized by create_gcd or get_memory.
             assert_eq!(snapshot, copy_memory_block(&gcd));
         });
     }
@@ -3216,12 +3237,14 @@ mod tests {
         with_locked_state(|| {
             let (mut gcd, _) = create_gcd();
             let snapshot = copy_memory_block(&gcd);
+            // SAFETY: Test-controlled addresses and sizes are used with the GCD initialized by create_gcd or get_memory.
             assert_eq!(Err(EfiError::InvalidParameter), unsafe {
                 gcd.add_memory_space(dxe_services::GcdMemoryType::SystemMemory, 0, 0, 0)
             });
             assert_eq!(snapshot, copy_memory_block(&gcd));
         });
     }
+    // SAFETY: Test-controlled addresses and sizes are used with the GCD initialized by create_gcd or get_memory.
 
     #[test]
     fn test_add_memory_space_when_memory_block_full() {
@@ -3231,7 +3254,9 @@ mod tests {
 
             let mut n = 0;
             while gcd.memory_descriptor_count() < MEMORY_BLOCK_SLICE_LEN {
+                // SAFETY: Test-controlled addresses and sizes are used with the GCD initialized by create_gcd or get_memory.
                 assert!(
+                    // SAFETY: Test-controlled addresses and sizes are used with the GCD initialized by create_gcd or get_memory.
                     unsafe { gcd.add_memory_space(dxe_services::GcdMemoryType::SystemMemory, addr + n, 1, n as u64) }
                         .is_ok()
                 );
@@ -3241,64 +3266,79 @@ mod tests {
             assert!(is_gcd_memory_slice_valid(&gcd));
             let memory_blocks_snapshot = copy_memory_block(&gcd);
 
+            // SAFETY: Test-controlled addresses and sizes are used with the GCD initialized by create_gcd or get_memory.
             let res = unsafe { gcd.add_memory_space(dxe_services::GcdMemoryType::SystemMemory, addr + n, 1, n as u64) };
             assert_eq!(
                 Err(EfiError::OutOfResources),
                 res,
                 "Should return out of memory if there is no space in memory blocks."
             );
+            // SAFETY: Test-controlled addresses and sizes are used with the GCD initialized by create_gcd or get_memory.
 
             assert_eq!(memory_blocks_snapshot, copy_memory_block(&gcd),);
         });
+        // SAFETY: Test-controlled addresses and sizes are used with the GCD initialized by create_gcd or get_memory.
     }
 
     #[test]
+    // SAFETY: Test-controlled addresses and sizes are used with the GCD initialized by create_gcd or get_memory.
     fn test_add_memory_space_outside_processor_range() {
         with_locked_state(|| {
             let (mut gcd, _) = create_gcd();
 
             let snapshot = copy_memory_block(&gcd);
 
+            // SAFETY: Test-controlled addresses and sizes are used with the GCD initialized by create_gcd or get_memory.
             assert_eq!(Err(EfiError::Unsupported), unsafe {
                 gcd.add_memory_space(dxe_services::GcdMemoryType::SystemMemory, gcd.maximum_address + 1, 1, 0)
             });
+            // SAFETY: Test-controlled addresses and sizes are used with the GCD initialized by create_gcd or get_memory.
             assert_eq!(Err(EfiError::Unsupported), unsafe {
                 gcd.add_memory_space(dxe_services::GcdMemoryType::SystemMemory, gcd.maximum_address, 1, 0)
+                // SAFETY: Test-controlled addresses and sizes are used with the GCD initialized by create_gcd or get_memory.
             });
+            // SAFETY: Test-controlled addresses and sizes are used with the GCD initialized by create_gcd or get_memory.
             assert_eq!(Err(EfiError::Unsupported), unsafe {
                 gcd.add_memory_space(dxe_services::GcdMemoryType::SystemMemory, gcd.maximum_address - 1, 2, 0)
             });
 
+            // SAFETY: Test-controlled addresses and sizes are used with the GCD initialized by create_gcd or get_memory.
             assert_eq!(snapshot, copy_memory_block(&gcd));
         });
     }
 
     #[test]
+    // SAFETY: Test-controlled addresses and sizes are used with the GCD initialized by create_gcd or get_memory.
     fn test_add_memory_space_in_range_already_added() {
         with_locked_state(|| {
             let (mut gcd, _) = create_gcd();
             // Add block to test the boundary on.
+            // SAFETY: Test-controlled addresses and sizes are used with the GCD initialized by create_gcd or get_memory.
             unsafe { gcd.add_memory_space(dxe_services::GcdMemoryType::SystemMemory, 1000, 10, 0) }.unwrap();
 
             let snapshot = copy_memory_block(&gcd);
 
             assert_eq!(
                 Err(EfiError::AccessDenied),
+                // SAFETY: Test-controlled addresses and sizes are used with the GCD initialized by create_gcd or get_memory.
                 unsafe { gcd.add_memory_space(dxe_services::GcdMemoryType::Reserved, 1002, 5, 0) },
                 "Can't add inside a range previously added."
             );
             assert_eq!(
                 Err(EfiError::AccessDenied),
+                // SAFETY: Test-controlled addresses and sizes are used with the GCD initialized by create_gcd or get_memory.
                 unsafe { gcd.add_memory_space(dxe_services::GcdMemoryType::Reserved, 998, 5, 0) },
                 "Can't add partially inside a range previously added (Start)."
             );
             assert_eq!(
                 Err(EfiError::AccessDenied),
+                // SAFETY: Test-controlled addresses and sizes are used with the GCD initialized by create_gcd or get_memory.
                 unsafe { gcd.add_memory_space(dxe_services::GcdMemoryType::Reserved, 1009, 5, 0) },
                 "Can't add partially inside a range previously added (End)."
             );
 
             assert_eq!(snapshot, copy_memory_block(&gcd));
+            // SAFETY: Test-controlled addresses and sizes are used with the GCD initialized by create_gcd or get_memory.
         });
     }
 
@@ -3307,23 +3347,29 @@ mod tests {
         with_locked_state(|| {
             let (mut gcd, address) = create_gcd();
             // Add unallocated block after allocated one.
+            // SAFETY: Test-controlled addresses and sizes are used with the GCD initialized by create_gcd or get_memory.
             unsafe { gcd.add_memory_space(dxe_services::GcdMemoryType::SystemMemory, address - 100, 100, 0) }.unwrap();
 
             let snapshot = copy_memory_block(&gcd);
 
+            // SAFETY: Test-controlled addresses and sizes are used with the GCD initialized by create_gcd or get_memory.
             assert_eq!(
                 Err(EfiError::AccessDenied),
+                // SAFETY: Test-controlled addresses and sizes are used with the GCD initialized by create_gcd or get_memory.
                 unsafe { gcd.add_memory_space(dxe_services::GcdMemoryType::SystemMemory, address, 5, 0) },
+                // SAFETY: Test-controlled addresses and sizes are used with the GCD initialized by create_gcd or get_memory.
                 "Can't add inside a range previously allocated."
             );
             assert_eq!(
                 Err(EfiError::AccessDenied),
+                // SAFETY: Test-controlled addresses and sizes are used with the GCD initialized by create_gcd or get_memory.
                 unsafe { gcd.add_memory_space(dxe_services::GcdMemoryType::Reserved, address - 100, 200, 0) },
                 "Can't add partially inside a range previously allocated."
             );
 
             assert_eq!(snapshot, copy_memory_block(&gcd));
         });
+        // SAFETY: Test-controlled addresses and sizes are used with the GCD initialized by create_gcd or get_memory.
     }
 
     #[test]
@@ -3331,13 +3377,17 @@ mod tests {
         with_locked_state(|| {
             let (mut gcd, _) = create_gcd();
 
+            // SAFETY: Test-controlled addresses and sizes are used with the GCD initialized by create_gcd or get_memory.
             assert_eq!(Ok(4), unsafe { gcd.add_memory_space(dxe_services::GcdMemoryType::SystemMemory, 1000, 10, 0) });
             let block_count = gcd.memory_descriptor_count();
 
+            // SAFETY: Test-controlled addresses and sizes are used with the GCD initialized by create_gcd or get_memory.
             // Test merging when added after
+            // SAFETY: Test-controlled addresses and sizes are used with the GCD initialized by create_gcd or get_memory.
             match unsafe { gcd.add_memory_space(dxe_services::GcdMemoryType::SystemMemory, 1010, 10, 0) } {
                 Ok(idx) => {
                     let mb = gcd.memory_blocks.get_with_idx(idx).unwrap();
+                    // SAFETY: Test-controlled addresses and sizes are used with the GCD initialized by create_gcd or get_memory.
                     assert_eq!(1000, mb.as_ref().base_address);
                     assert_eq!(20, mb.as_ref().length);
                     assert_eq!(block_count, gcd.memory_descriptor_count());
@@ -3346,10 +3396,12 @@ mod tests {
             }
 
             // Test merging when added before
+            // SAFETY: Test-controlled addresses and sizes are used with the GCD initialized by create_gcd or get_memory.
             match unsafe { gcd.add_memory_space(dxe_services::GcdMemoryType::SystemMemory, 990, 10, 0) } {
                 Ok(idx) => {
                     let mb = gcd.memory_blocks.get_with_idx(idx).unwrap();
                     assert_eq!(990, mb.as_ref().base_address);
+                    // SAFETY: Test-controlled addresses and sizes are used with the GCD initialized by create_gcd or get_memory.
                     assert_eq!(30, mb.as_ref().length);
                     assert_eq!(block_count, gcd.memory_descriptor_count());
                 }
@@ -3357,11 +3409,13 @@ mod tests {
             }
 
             assert!(
+                // SAFETY: Test-controlled addresses and sizes are used with the GCD initialized by create_gcd or get_memory.
                 unsafe { gcd.add_memory_space(dxe_services::GcdMemoryType::Reserved, 1020, 10, 0) }.is_ok(),
                 "A different memory type should note result in a merge."
             );
             assert_eq!(block_count + 1, gcd.memory_descriptor_count());
             assert!(
+                // SAFETY: Test-controlled addresses and sizes are used with the GCD initialized by create_gcd or get_memory.
                 unsafe { gcd.add_memory_space(dxe_services::GcdMemoryType::Reserved, 1030, 10, 1) }.is_ok(),
                 "A different capabilities should note result in a merge."
             );
@@ -3370,11 +3424,13 @@ mod tests {
             assert!(is_gcd_memory_slice_valid(&gcd));
         });
     }
+    // SAFETY: get_memory returns a test-owned buffer of the requested size.
 
     #[test]
     fn test_add_memory_space_state() {
         with_locked_state(|| {
             let (mut gcd, _) = create_gcd();
+            // SAFETY: Test-controlled addresses and sizes are used with the GCD initialized by create_gcd or get_memory.
             match unsafe { gcd.add_memory_space(dxe_services::GcdMemoryType::SystemMemory, 100, 10, 123) } {
                 Ok(idx) => {
                     let mb = *gcd.memory_blocks.get_with_idx(idx).unwrap();
@@ -3383,6 +3439,7 @@ mod tests {
                             assert_eq!(100, md.base_address);
                             assert_eq!(10, md.length);
                             assert_eq!(efi::MEMORY_RUNTIME | efi::MEMORY_ACCESS_MASK | 123, md.capabilities);
+                            // SAFETY: Test-controlled addresses and sizes are used with the GCD initialized by create_gcd or get_memory.
                             assert_eq!(0, md.image_handle as usize);
                             assert_eq!(0, md.device_handle as usize);
                         }
@@ -3397,12 +3454,14 @@ mod tests {
     #[test]
     fn test_remove_memory_space_before_memory_blocks_instantiated() {
         with_locked_state(|| {
+            // SAFETY: get_memory returns a test-owned buffer of the requested size.
             let mem = unsafe { get_memory(MEMORY_BLOCK_SLICE_SIZE) };
             let address = mem.as_ptr() as usize;
             let mut gcd = GCD::new(48);
 
             assert_eq!(Err(EfiError::NotFound), gcd.remove_memory_space(address, MEMORY_BLOCK_SLICE_SIZE));
         });
+        // SAFETY: Test-controlled addresses and sizes are used with the GCD initialized by create_gcd or get_memory.
     }
 
     #[test]
@@ -3411,6 +3470,7 @@ mod tests {
             let (mut gcd, _) = create_gcd();
 
             // Add memory space to remove in a valid area.
+            // SAFETY: Test-controlled addresses and sizes are used with the GCD initialized by create_gcd or get_memory.
             assert!(unsafe { gcd.add_memory_space(dxe_services::GcdMemoryType::SystemMemory, 0, 10, 0) }.is_ok());
 
             let snapshot = copy_memory_block(&gcd);
@@ -3430,8 +3490,10 @@ mod tests {
     fn test_remove_memory_space_outside_processor_range() {
         with_locked_state(|| {
             let (mut gcd, _) = create_gcd();
+            // SAFETY: Test-controlled addresses and sizes are used with the GCD initialized by create_gcd or get_memory.
             // Add memory space to remove in a valid area.
             assert!(
+                // SAFETY: Test-controlled addresses and sizes are used with the GCD initialized by create_gcd or get_memory.
                 unsafe {
                     gcd.add_memory_space(dxe_services::GcdMemoryType::SystemMemory, gcd.maximum_address - 10, 10, 0)
                 }
@@ -3460,6 +3522,7 @@ mod tests {
         with_locked_state(|| {
             let (mut gcd, _) = create_gcd();
             // Add memory space to remove in a valid area.
+            // SAFETY: Test-controlled addresses and sizes are used with the GCD initialized by create_gcd or get_memory.
             assert!(unsafe { gcd.add_memory_space(dxe_services::GcdMemoryType::SystemMemory, 100, 10, 0) }.is_ok());
 
             let snapshot = copy_memory_block(&gcd);
@@ -3488,11 +3551,13 @@ mod tests {
     fn test_remove_memory_space_in_range_allocated() {
         with_locked_state(|| {
             let (mut gcd, address) = create_gcd();
+            // SAFETY: Test-controlled addresses and sizes are used with the GCD initialized by create_gcd or get_memory.
 
             let snapshot = copy_memory_block(&gcd);
 
             // Not found has a priority over the access denied because the check if the range is valid is done earlier.
             assert_eq!(
+                // SAFETY: Test-controlled addresses and sizes are used with the GCD initialized by create_gcd or get_memory.
                 Err(EfiError::NotFound),
                 gcd.remove_memory_space(address - 5, 10),
                 "Can't remove memory space partially allocated."
@@ -3520,12 +3585,15 @@ mod tests {
             let addr = address + MEMORY_BLOCK_SLICE_SIZE;
 
             assert!(
+                // SAFETY: Test-controlled addresses and sizes are used with the GCD initialized by create_gcd or get_memory.
                 unsafe { gcd.add_memory_space(dxe_services::GcdMemoryType::SystemMemory, addr, 10, 0_u64) }.is_ok()
             );
             let mut n = 1;
             while gcd.memory_descriptor_count() < MEMORY_BLOCK_SLICE_LEN {
                 assert!(
+                    // SAFETY: Test-controlled addresses and sizes are used with the GCD initialized by create_gcd or get_memory.
                     unsafe {
+                        // SAFETY: Test-controlled addresses and sizes are used with the GCD initialized by create_gcd or get_memory.
                         gcd.add_memory_space(dxe_services::GcdMemoryType::SystemMemory, addr + 10 + n, 1, n as u64)
                     }
                     .is_ok()
@@ -3556,10 +3624,12 @@ mod tests {
             let aligned_address = if aligned_address > aligned_length {
                 aligned_address - aligned_length
             } else {
+                // SAFETY: Test-controlled addresses and sizes are used with the GCD initialized by create_gcd or get_memory.
                 aligned_address + aligned_length
             };
 
             assert!(
+                // SAFETY: Test-controlled addresses and sizes are used with the GCD initialized by create_gcd or get_memory.
                 unsafe {
                     gcd.add_memory_space(dxe_services::GcdMemoryType::SystemMemory, aligned_address, aligned_length, 0)
                 }
@@ -3590,6 +3660,7 @@ mod tests {
         with_locked_state(|| {
             let (mut gcd, address) = create_gcd();
             assert!(
+                // SAFETY: Test-controlled addresses and sizes are used with the GCD initialized by create_gcd or get_memory.
                 unsafe { gcd.add_memory_space(dxe_services::GcdMemoryType::SystemMemory, 0, address, 123) }.is_ok()
             );
 
@@ -3682,6 +3753,7 @@ mod tests {
                     AllocateType::Address(gcd.maximum_address - 100),
                     dxe_services::GcdMemoryType::Reserved,
                     0,
+                    // SAFETY: Test-controlled addresses and sizes are used with the GCD initialized by create_gcd or get_memory.
                     1000,
                     1 as _,
                     None
@@ -3699,8 +3771,11 @@ mod tests {
                 ),
             );
 
+            // SAFETY: Test-controlled addresses and sizes are used with the GCD initialized by create_gcd or get_memory.
             assert_eq!(snapshot, copy_memory_block(&gcd));
+            // SAFETY: Test-controlled addresses and sizes are used with the GCD initialized by create_gcd or get_memory.
         });
+        // SAFETY: Test-controlled addresses and sizes are used with the GCD initialized by create_gcd or get_memory.
     }
 
     #[test]
@@ -3718,6 +3793,7 @@ mod tests {
             .into_iter()
             .enumerate()
             {
+                // SAFETY: Test-controlled addresses and sizes are used with the GCD initialized by create_gcd or get_memory.
                 unsafe { gcd.add_memory_space(memory_type, (i + 1) * 10, 10, 0) }.unwrap();
                 let res =
                     gcd.allocate_memory_space(AllocateType::Address((i + 1) * 10), memory_type, 0, 10, 1 as _, None);
@@ -3735,8 +3811,11 @@ mod tests {
             let (mut gcd, _) = create_gcd();
 
             // Add memory space of len 100 to multiple space.
+            // SAFETY: Test-controlled addresses and sizes are used with the GCD initialized by create_gcd or get_memory.
             unsafe { gcd.add_memory_space(dxe_services::GcdMemoryType::SystemMemory, 0, 100, 0) }.unwrap();
+            // SAFETY: Test-controlled addresses and sizes are used with the GCD initialized by create_gcd or get_memory.
             unsafe { gcd.add_memory_space(dxe_services::GcdMemoryType::SystemMemory, 1000, 100, 0) }.unwrap();
+            // SAFETY: Test-controlled addresses and sizes are used with the GCD initialized by create_gcd or get_memory.
             unsafe {
                 gcd.add_memory_space(dxe_services::GcdMemoryType::SystemMemory, gcd.maximum_address - 100, 100, 0)
             }
@@ -3747,6 +3826,7 @@ mod tests {
             // Try to allocate chunk bigger than 100.
             for allocate_type in [AllocateType::BottomUp(None), AllocateType::TopDown(None)] {
                 assert_eq!(
+                    // SAFETY: Test-controlled addresses and sizes are used with the GCD initialized by create_gcd or get_memory.
                     Err(EfiError::OutOfResources),
                     gcd.allocate_memory_space(
                         allocate_type,
@@ -3787,6 +3867,7 @@ mod tests {
     fn test_allocate_memory_space_alignment() {
         with_locked_state(|| {
             let (mut gcd, _) = create_gcd();
+            // SAFETY: Test-controlled addresses and sizes are used with the GCD initialized by create_gcd or get_memory.
             unsafe { gcd.add_memory_space(dxe_services::GcdMemoryType::SystemMemory, 0x1000, 0x1000, 0) }.unwrap();
 
             assert_eq!(
@@ -3856,6 +3937,7 @@ mod tests {
                     dxe_services::GcdMemoryType::SystemMemory,
                     4,
                     0xe0,
+                    // SAFETY: Test-controlled addresses and sizes are used with the GCD initialized by create_gcd or get_memory.
                     1 as _,
                     None
                 ),
@@ -3897,6 +3979,7 @@ mod tests {
     fn test_allocate_memory_space_block_merging() {
         with_locked_state(|| {
             let (mut gcd, _) = create_gcd();
+            // SAFETY: Test-controlled addresses and sizes are used with the GCD initialized by create_gcd or get_memory.
             unsafe { gcd.add_memory_space(dxe_services::GcdMemoryType::SystemMemory, 0x1000, 0x1000, 0) }.unwrap();
 
             for allocate_type in [AllocateType::BottomUp(None), AllocateType::TopDown(None)] {
@@ -3937,6 +4020,7 @@ mod tests {
                         None
                     )
                     .is_ok(),
+                    // SAFETY: Test-controlled addresses and sizes are used with the GCD initialized by create_gcd or get_memory.
                     "{allocate_type:?}: A different image handle should not result in a merge."
                 );
                 assert_eq!(block_count + 2, gcd.memory_descriptor_count());
@@ -3979,6 +4063,7 @@ mod tests {
         with_locked_state(|| {
             let (mut gcd, _) = create_gcd();
 
+            // SAFETY: Test-controlled addresses and sizes are used with the GCD initialized by create_gcd or get_memory.
             unsafe { gcd.add_memory_space(dxe_services::GcdMemoryType::SystemMemory, 0x100, 10, 0) }.unwrap();
 
             let snapshot = copy_memory_block(&gcd);
@@ -4030,6 +4115,7 @@ mod tests {
 
             assert_eq!(snapshot, copy_memory_block(&gcd));
         });
+        // SAFETY: Test-controlled addresses and sizes are used with the GCD initialized by create_gcd or get_memory.
     }
 
     #[test]
@@ -4067,12 +4153,14 @@ mod tests {
             assert_eq!(snapshot, copy_memory_block(&gcd));
         });
     }
+    // SAFETY: Test-controlled addresses and sizes are used with the GCD initialized by create_gcd or get_memory.
 
     #[test]
     fn test_free_memory_space_outside_processor_range() {
         with_locked_state(|| {
             let (mut gcd, _) = create_gcd();
 
+            // SAFETY: Test-controlled addresses and sizes are used with the GCD initialized by create_gcd or get_memory.
             unsafe {
                 gcd.add_memory_space(dxe_services::GcdMemoryType::SystemMemory, gcd.maximum_address - 100, 100, 0)
             }
@@ -4088,6 +4176,7 @@ mod tests {
             .unwrap();
 
             let snapshot = copy_memory_block(&gcd);
+            // SAFETY: Test-controlled addresses and sizes are used with the GCD initialized by create_gcd or get_memory.
 
             assert_eq!(
                 Err(EfiError::Unsupported),
@@ -4105,11 +4194,13 @@ mod tests {
             assert_eq!(snapshot, copy_memory_block(&gcd));
         });
     }
+    // SAFETY: Test-controlled addresses and sizes are used with the GCD initialized by create_gcd or get_memory.
 
     #[test]
     fn test_free_memory_space_in_range_not_allocated() {
         with_locked_state(|| {
             let (mut gcd, _) = create_gcd();
+            // SAFETY: Test-controlled addresses and sizes are used with the GCD initialized by create_gcd or get_memory.
             unsafe { gcd.add_memory_space(dxe_services::GcdMemoryType::SystemMemory, 0x3000, 0x3000, 0) }.unwrap();
             gcd.allocate_memory_space(
                 AllocateType::Address(0x3000),
@@ -4124,6 +4215,7 @@ mod tests {
             assert_eq!(Err(EfiError::AccessDenied), gcd.free_memory_space(0x2000, 0x1000, MemoryStateTransition::Free));
             assert_eq!(Err(EfiError::AccessDenied), gcd.free_memory_space(0x4000, 0x1000, MemoryStateTransition::Free));
             assert_eq!(Err(EfiError::AccessDenied), gcd.free_memory_space(0, 0x1000, MemoryStateTransition::Free));
+            // SAFETY: Test-controlled addresses and sizes are used with the GCD initialized by create_gcd or get_memory.
         });
     }
 
@@ -4132,6 +4224,7 @@ mod tests {
         with_locked_state(|| {
             let (mut gcd, _) = create_gcd();
 
+            // SAFETY: Test-controlled addresses and sizes are used with the GCD initialized by create_gcd or get_memory.
             unsafe {
                 gcd.add_memory_space(dxe_services::GcdMemoryType::SystemMemory, 0x1000000, UEFI_PAGE_SIZE * 2, 0)
             }
@@ -4149,6 +4242,7 @@ mod tests {
             let mut n = 1;
             while gcd.memory_descriptor_count() < MEMORY_BLOCK_SLICE_LEN {
                 let addr = 0x2000000 + (n * UEFI_PAGE_SIZE);
+                // SAFETY: Test-controlled addresses and sizes are used with the GCD initialized by create_gcd or get_memory.
                 unsafe {
                     gcd.add_memory_space(dxe_services::GcdMemoryType::SystemMemory, addr, UEFI_PAGE_SIZE, n as u64)
                 }
@@ -4169,6 +4263,7 @@ mod tests {
         with_locked_state(|| {
             let (mut gcd, _) = create_gcd();
 
+            // SAFETY: Test-controlled addresses and sizes are used with the GCD initialized by create_gcd or get_memory.
             unsafe { gcd.add_memory_space(dxe_services::GcdMemoryType::SystemMemory, 0x1000, 0x10000, 0) }.unwrap();
             gcd.allocate_memory_space(
                 AllocateType::Address(0x1000),
@@ -4235,6 +4330,7 @@ mod tests {
                 maximum_address: 0,
                 allocate_memory_space_fn: GCD::allocate_memory_space_internal,
                 free_memory_space_fn: GCD::free_memory_space,
+                // SAFETY: Test-controlled addresses and sizes are used with the GCD initialized by create_gcd or get_memory.
                 prioritize_32_bit_memory: false,
             };
             assert_eq!(Err(EfiError::NotReady), gcd.set_memory_space_attributes(0, 0x50000, 0b1111));
@@ -4259,7 +4355,7 @@ mod tests {
             // Test that a non-page aligned address with the runtime attribute set returns invalid parameter
             assert_eq!(
                 Err(EfiError::InvalidParameter),
-                gcd.set_memory_space_attributes(0xFFFFFFFF, 0x1000, efi::MEMORY_RUNTIME | efi::MEMORY_WB)
+                gcd.set_memory_space_attributes(0xFFFFFFFF, 0x1000, efi::MEMORY_RUNTIME | efi::MEMORY_WB) // SAFETY: Test-controlled addresses and sizes are used with the GCD initialized by create_gcd or get_memory.
             );
 
             // Test that a non-page aligned size returns invalid parameter
@@ -4281,8 +4377,10 @@ mod tests {
 
     #[test]
     fn test_set_capabilities_and_attributes() {
+        // SAFETY: Test-controlled addresses and sizes are used with the GCD initialized by create_gcd or get_memory.
         with_locked_state(|| {
             let (mut gcd, address) = create_gcd();
+            // SAFETY: Test-controlled addresses and sizes are used with the GCD initialized by create_gcd or get_memory.
             unsafe { gcd.add_memory_space(dxe_services::GcdMemoryType::SystemMemory, 0x1000, address - 0x1000, 0) }
                 .unwrap();
 
@@ -4308,6 +4406,7 @@ mod tests {
     fn test_set_attributes_panic() {
         with_locked_state(|| {
             let (mut gcd, address) = create_gcd();
+            // SAFETY: Test-controlled addresses and sizes are used with the GCD initialized by create_gcd or get_memory.
             unsafe { gcd.add_memory_space(dxe_services::GcdMemoryType::SystemMemory, 0, address, 0) }.unwrap();
 
             gcd.allocate_memory_space(
@@ -4329,6 +4428,7 @@ mod tests {
     fn test_block_split_when_memory_blocks_full() {
         with_locked_state(|| {
             let (mut gcd, address) = create_gcd();
+            // SAFETY: Test-controlled addresses and sizes are used with the GCD initialized by create_gcd or get_memory.
             unsafe {
                 gcd.add_memory_space(
                     dxe_services::GcdMemoryType::SystemMemory,
@@ -4657,9 +4757,11 @@ mod tests {
     }
 
     fn create_gcd() -> (GCD, usize) {
+        // SAFETY: get_memory returns a test-owned buffer of the requested size.
         let mem = unsafe { get_memory(MEMORY_BLOCK_SLICE_SIZE) };
         let address = mem.as_ptr() as usize;
         let mut gcd = GCD::new(48);
+        // SAFETY: address/size come from the test buffer and are valid to initialize memory blocks.
         unsafe {
             gcd.init_memory_blocks(
                 dxe_services::GcdMemoryType::SystemMemory,
@@ -4713,6 +4815,7 @@ mod tests {
 
             assert_eq!(GCD.memory.lock().maximum_address, 0);
 
+            // SAFETY: The GCD is intentionally uninitialized to validate error handling paths.
             let add_result = unsafe { GCD.add_memory_space(dxe_services::GcdMemoryType::SystemMemory, 0, 100, 0) };
             assert_eq!(add_result, Err(EfiError::NotReady));
 
@@ -4741,9 +4844,11 @@ mod tests {
 
             assert_eq!(GCD.memory.lock().maximum_address, 0);
 
+            // SAFETY: get_memory returns a test-owned buffer of the requested size.
             let mem = unsafe { get_memory(MEMORY_BLOCK_SLICE_SIZE) };
             let address = mem.as_ptr() as usize;
             GCD.init(48, 16);
+            // SAFETY: address/size come from the test buffer and are valid to initialize memory blocks.
             unsafe {
                 GCD.init_memory_blocks(
                     dxe_services::GcdMemoryType::SystemMemory,
@@ -4774,9 +4879,11 @@ mod tests {
 
             assert_eq!(GCD.memory.lock().maximum_address, 0);
 
+            // SAFETY: get_memory returns a test-owned buffer of the requested size.
             let mem = unsafe { get_memory(MEMORY_BLOCK_SLICE_SIZE) };
             let address = mem.as_ptr() as usize;
             GCD.init(48, 16);
+            // SAFETY: address/size come from the test buffer and are valid to initialize memory blocks.
             unsafe {
                 GCD.init_memory_blocks(
                     dxe_services::GcdMemoryType::SystemMemory,
@@ -4788,6 +4895,7 @@ mod tests {
                 .unwrap();
             }
 
+            // SAFETY: Adds a small test range to trigger the map-change callback.
             unsafe {
                 GCD.add_memory_space(dxe_services::GcdMemoryType::SystemMemory, 0x1000, 0x1000, efi::MEMORY_WB)
                     .unwrap();
@@ -4811,9 +4919,11 @@ mod tests {
 
             assert_eq!(GCD.memory.lock().maximum_address, 0);
 
+            // SAFETY: get_memory returns a test-owned buffer sized for the requested range.
             let mem = unsafe { get_memory(MEMORY_BLOCK_SLICE_SIZE * 2) };
             let address = align_up(mem.as_ptr() as usize, 0x1000).unwrap();
             GCD.init(48, 16);
+            // SAFETY: address/size come from the test buffer and are valid to initialize memory blocks.
             unsafe {
                 GCD.init_memory_blocks(
                     dxe_services::GcdMemoryType::SystemMemory,
@@ -4843,7 +4953,9 @@ mod tests {
             GCD.init(48, 16);
 
             let layout = Layout::from_size_align(GCD_SIZE, 0x1000).unwrap();
+            // SAFETY: The allocator returns a test buffer aligned to pages for GCD initialization.
             let base = unsafe { std::alloc::System.alloc(layout) as u64 };
+            // SAFETY: base/size come from the test allocation and are valid for initializing memory blocks.
             unsafe {
                 GCD.init_memory_blocks(
                     dxe_services::GcdMemoryType::SystemMemory,
@@ -4879,6 +4991,7 @@ mod tests {
         });
     }
 
+    // SAFETY: Test-controlled addresses and sizes are used with the GCD initialized by create_gcd or get_memory.
     #[test]
     fn allocate_top_down_should_allocate_decreasing_addresses() {
         with_locked_state(|| {
@@ -4887,7 +5000,9 @@ mod tests {
             GCD.init(48, 16);
 
             let layout = Layout::from_size_align(GCD_SIZE, 0x1000).unwrap();
+            // SAFETY: The allocator returns a test buffer aligned to pages for GCD initialization.
             let base = unsafe { std::alloc::System.alloc(layout) as u64 };
+            // SAFETY: base/size come from the test allocation and are valid for initializing memory blocks.
             unsafe {
                 GCD.init_memory_blocks(
                     dxe_services::GcdMemoryType::SystemMemory,
@@ -4904,6 +5019,7 @@ mod tests {
                 let allocate_result = GCD.allocate_memory_space(
                     AllocateType::TopDown(None),
                     dxe_services::GcdMemoryType::SystemMemory,
+                    // SAFETY: Test-controlled addresses and sizes are used with the GCD initialized by create_gcd or get_memory.
                     12,
                     0x1000,
                     1 as _,
@@ -4928,6 +5044,7 @@ mod tests {
         with_locked_state(|| {
             let (mut gcd, _) = create_gcd();
             // Increase the memory block size so allocation at 0x1000 is possible after skipping page 0
+            // SAFETY: Test-controlled addresses and sizes are used with the GCD initialized by create_gcd or get_memory.
             unsafe {
                 gcd.add_memory_space(dxe_services::GcdMemoryType::SystemMemory, 0, 0x2000, efi::MEMORY_WB).unwrap();
             }
@@ -4939,6 +5056,7 @@ mod tests {
                 0,
                 0x1000,
                 1 as _,
+                // SAFETY: Test-controlled addresses and sizes are used with the GCD initialized by create_gcd or get_memory.
                 None,
             );
             assert_eq!(res.unwrap(), 0x1000, "Should not be able to allocate page 0");
@@ -4955,6 +5073,7 @@ mod tests {
             assert_eq!(res, Err(EfiError::OutOfResources), "Should not be able to allocate page 0");
 
             // add a new block to ensure block skipping logic works
+            // SAFETY: Test-controlled addresses and sizes are used with the GCD initialized by create_gcd or get_memory.
             unsafe {
                 gcd.add_memory_space(dxe_services::GcdMemoryType::SystemMemory, 0x2000, 0x2000, efi::MEMORY_WB)
                     .unwrap();
@@ -4991,6 +5110,7 @@ mod tests {
             gcd.prioritize_32_bit_memory = true;
 
             // Test with a contiguous 8gb without a gap.
+            // SAFETY: Test-controlled addresses and sizes are used with the GCD initialized by create_gcd or get_memory.
             unsafe { gcd.add_memory_space(dxe_services::GcdMemoryType::SystemMemory, 0, 2 * SIZE_4GB, 0) }.unwrap();
 
             // make sure it prioritizes 32 bit addresses.
@@ -5038,10 +5158,12 @@ mod tests {
             static GCD: SpinLockedGcd = SpinLockedGcd::new(None);
 
             // Initialize and add some memory
+            // SAFETY: get_memory returns a valid, owned buffer for the test and the size is bounded by the constant.
             let mem = unsafe { get_memory(MEMORY_BLOCK_SLICE_SIZE) };
             let address = mem.as_ptr() as usize;
             GCD.init(48, 16);
 
+            // SAFETY: address/size come from the test allocation and are used to initialize the GCD memory blocks.
             unsafe {
                 GCD.init_memory_blocks(
                     dxe_services::GcdMemoryType::SystemMemory,
@@ -5084,7 +5206,9 @@ mod tests {
             GCD.init(48, 16);
 
             let layout = Layout::from_size_align(GCD_SIZE, 0x1000).unwrap();
+            // SAFETY: The allocator is set up to return an aligned and available test buffer for GCD initialization.
             let base = unsafe { std::alloc::System.alloc(layout) as u64 };
+            // SAFETY: base points to the test allocation and GCD_SIZE defines the initialized range.
             unsafe {
                 GCD.init_memory_blocks(
                     dxe_services::GcdMemoryType::SystemMemory,
@@ -5109,6 +5233,7 @@ mod tests {
             // allocate another page
             let page2 = allocator
                 .allocate_page(UEFI_PAGE_SIZE as u64, UEFI_PAGE_SIZE as u64, false)
+                // SAFETY: Test-controlled addresses and sizes are used with the GCD initialized by create_gcd or get_memory.
                 .expect("Should allocate a second page");
             assert!(page2 != page, "Allocated pages should be unique");
             assert!(
@@ -5135,7 +5260,9 @@ mod tests {
             GCD.init(48, 16);
 
             let layout = Layout::from_size_align(GCD_SIZE, 0x1000).unwrap();
+            // SAFETY: The allocator is set up to return an aligned and available test buffer for GCD initialization.
             let base = unsafe { std::alloc::System.alloc(layout) as u64 };
+            // SAFETY: base/size correspond to the test allocation and are safe to register with the GCD.
             unsafe {
                 GCD.init_memory_blocks(
                     dxe_services::GcdMemoryType::SystemMemory,
@@ -5149,18 +5276,22 @@ mod tests {
             let mut allocator = PagingAllocator::new(&GCD);
 
             // Exhaust all available pages
+            // SAFETY: Test-controlled addresses and sizes are used with the GCD initialized by create_gcd or get_memory.
             let mut allocated = Vec::new();
             while let Ok(page) = allocator.allocate_page(UEFI_PAGE_SIZE as u64, UEFI_PAGE_SIZE as u64, false) {
                 allocated.push(page);
+                // SAFETY: Test-controlled addresses and sizes are used with the GCD initialized by create_gcd or get_memory.
             }
         });
     }
+    // SAFETY: Test-controlled addresses and sizes are used with the GCD initialized by create_gcd or get_memory.
 
     #[test]
     fn test_get_memory_descriptors_allocated_filter() {
         with_locked_state(|| {
             let (mut gcd, _address) = create_gcd();
 
+            // SAFETY: Test-controlled addresses and sizes are used with the GCD initialized by create_gcd or get_memory.
             unsafe { gcd.add_memory_space(dxe_services::GcdMemoryType::SystemMemory, 0, 2 * SIZE_4GB, 0) }.unwrap();
 
             gcd.allocate_memory_space(
@@ -5203,12 +5334,15 @@ mod tests {
         with_locked_state(|| {
             let (mut gcd, _address) = create_gcd();
             // Add MMIO and Reserved blocks
+            // SAFETY: Test-controlled addresses and sizes are used with the GCD initialized by create_gcd or get_memory.
             unsafe {
                 gcd.add_memory_space(dxe_services::GcdMemoryType::MemoryMappedIo, 0x2000, 0x1000, 0).unwrap();
             }
+            // SAFETY: Test-controlled addresses and sizes are used with the GCD initialized by create_gcd or get_memory.
             unsafe {
                 gcd.add_memory_space(dxe_services::GcdMemoryType::Reserved, 0x3000, 0x10000, 0).unwrap();
             }
+            // SAFETY: Test-controlled addresses and sizes are used with the GCD initialized by create_gcd or get_memory.
             unsafe {
                 gcd.add_memory_space(dxe_services::GcdMemoryType::SystemMemory, 0x14000, 0x6000, 0).unwrap();
             }
@@ -5232,8 +5366,10 @@ mod tests {
             GCD.init(48, 16);
 
             // Add memory and MMIO regions
+            // SAFETY: get_memory returns a test-owned buffer used to seed GCD memory blocks.
             let mem = unsafe { get_memory(MEMORY_BLOCK_SLICE_SIZE * 100) };
             let address = align_up(mem.as_ptr() as usize, 0x1000).unwrap();
+            // SAFETY: address/length are derived from the test buffer so the ranges are valid for GCD initialization.
             unsafe {
                 GCD.init_memory_blocks(
                     dxe_services::GcdMemoryType::SystemMemory,
@@ -5394,8 +5530,10 @@ mod tests {
             GCD.init(48, 16);
 
             // Set up memory space like other tests
+            // SAFETY: get_memory returns a test-owned buffer sized for the requested block count.
             let mem = unsafe { get_memory(MEMORY_BLOCK_SLICE_SIZE * 2) };
             let address = align_up(mem.as_ptr() as usize, 0x1000).unwrap();
+            // SAFETY: The address/length come from the test allocation and are valid to register with the GCD.
             unsafe {
                 GCD.init_memory_blocks(
                     dxe_services::GcdMemoryType::SystemMemory,
@@ -5445,8 +5583,10 @@ mod tests {
             GCD.init(48, 16);
 
             // Set up memory space
+            // SAFETY: The GCD is prepared so that get_memory returns a valid, owned buffer for the test.
             let mem = unsafe { get_memory(MEMORY_BLOCK_SLICE_SIZE * 2) };
             let address = align_up(mem.as_ptr() as usize, 0x1000).unwrap();
+            // SAFETY: The buffer range is owned by this test and can be registered as system memory.
             unsafe {
                 GCD.init_memory_blocks(
                     dxe_services::GcdMemoryType::SystemMemory,
@@ -5705,6 +5845,7 @@ mod tests {
             static GCD: SpinLockedGcd = SpinLockedGcd::new(None);
             GCD.init(48, 16);
 
+            // SAFETY: get_memory returns a test-owned buffer used to seed GCD memory blocks.
             let mem = unsafe { get_memory(MEMORY_BLOCK_SLICE_SIZE * 3) };
             let address = align_up(mem.as_ptr() as usize, 0x1000).unwrap();
 
@@ -5751,6 +5892,7 @@ mod tests {
             static GCD: SpinLockedGcd = SpinLockedGcd::new(None);
             GCD.init(48, 16);
 
+            // SAFETY: get_memory returns a test-owned buffer used to seed GCD memory blocks.
             let mem = unsafe { get_memory(MEMORY_BLOCK_SLICE_SIZE * 3) };
             let address = align_up(mem.as_ptr() as usize, 0x1000).unwrap();
 
@@ -5792,6 +5934,7 @@ mod tests {
             static GCD: SpinLockedGcd = SpinLockedGcd::new(None);
             GCD.init(48, 16);
 
+            // SAFETY: get_memory returns a test-owned buffer used to seed GCD memory blocks.
             let mem = unsafe { get_memory(MEMORY_BLOCK_SLICE_SIZE * 3) };
             let address = align_up(mem.as_ptr() as usize, 0x1000).unwrap();
 
@@ -6314,6 +6457,7 @@ mod tests {
             let (mut gcd, _) = create_gcd();
 
             // Add runtime MMIO - should be counted
+            // SAFETY: This is a synthetic MMIO range used for test coverage only.
             unsafe {
                 gcd.add_memory_space(
                     dxe_services::GcdMemoryType::MemoryMappedIo,
@@ -6339,6 +6483,7 @@ mod tests {
             let (mut gcd, _) = create_gcd();
 
             // Add runtime MMIO
+            // SAFETY: This is a synthetic MMIO range for test bookkeeping only.
             unsafe {
                 gcd.add_memory_space(
                     dxe_services::GcdMemoryType::MemoryMappedIo,
@@ -6352,6 +6497,7 @@ mod tests {
                 .expect("Failed to set runtime MMIO attributes");
 
             // Add Persistent memory
+            // SAFETY: This is a synthetic persistent memory range used only for test coverage.
             unsafe {
                 gcd.add_memory_space(
                     dxe_services::GcdMemoryType::Persistent,
@@ -6365,6 +6511,7 @@ mod tests {
                 .expect("Failed to set Persistent memory attributes");
 
             // Add Reserved memory
+            // SAFETY: This is a synthetic reserved range used only for test coverage.
             unsafe {
                 gcd.add_memory_space(
                     dxe_services::GcdMemoryType::Reserved,
@@ -6389,6 +6536,7 @@ mod tests {
             let (mut gcd, _) = create_gcd();
 
             // Add non-runtime MMIO - should not be counted
+            // SAFETY: This is a synthetic MMIO range used only for test bookkeeping.
             unsafe {
                 gcd.add_memory_space(
                     dxe_services::GcdMemoryType::MemoryMappedIo,
@@ -6411,11 +6559,14 @@ mod tests {
             let (mut gcd, _) = create_gcd();
 
             // Add Persistent memory - should be counted
+            // SAFETY: This is a synthetic persistent memory range used only for test coverage.
             unsafe {
                 gcd.add_memory_space(
                     dxe_services::GcdMemoryType::Persistent,
+                    // SAFETY: get_memory returns a test-owned buffer of the requested size.
                     0x100000000,
                     UEFI_PAGE_SIZE * 100,
+                    // SAFETY: address/size come from the test buffer and are valid to initialize memory blocks.
                     efi::MEMORY_WB | efi::MEMORY_NV,
                 )
             }
@@ -6428,11 +6579,13 @@ mod tests {
     }
 
     #[test]
+    // SAFETY: Test-controlled addresses and sizes are used with the GCD initialized by create_gcd or get_memory.
     fn test_memory_descriptor_count_for_efi_memory_map_unaccepted_memory() {
         with_locked_state(|| {
             let (mut gcd, _) = create_gcd();
 
             // Add Unaccepted memory - should be counted
+            // SAFETY: This is a synthetic unaccepted memory range used only for test coverage.
             unsafe {
                 gcd.add_memory_space(
                     dxe_services::GcdMemoryType::Unaccepted,
@@ -6455,6 +6608,7 @@ mod tests {
             let (mut gcd, _) = create_gcd();
 
             // Add Reserved memory - should be counted
+            // SAFETY: This is a synthetic reserved range used only for test coverage.
             unsafe { gcd.add_memory_space(dxe_services::GcdMemoryType::Reserved, 0x90000000, UEFI_PAGE_SIZE * 20, 0) }
                 .expect("Failed to add Reserved memory");
 
@@ -6470,8 +6624,10 @@ mod tests {
             static GCD: SpinLockedGcd = SpinLockedGcd::new(None);
             GCD.init(48, 16);
 
+            // SAFETY: get_memory returns a test-owned buffer of the requested size.
             let mem = unsafe { get_memory(MEMORY_BLOCK_SLICE_SIZE) };
             let address = mem.as_ptr() as usize;
+            // SAFETY: address/size come from the test buffer and are valid to initialize memory blocks.
             unsafe {
                 GCD.init_memory_blocks(
                     dxe_services::GcdMemoryType::SystemMemory,
@@ -6484,7 +6640,10 @@ mod tests {
             }
 
             // Add multiple memory regions with different types
+            // SAFETY: get_memory returns a test-owned buffer of the requested size.
+            // SAFETY: Test-controlled addresses and sizes are used with the GCD initialized by create_gcd or get_memory.
             unsafe {
+                // SAFETY: address/size come from the test buffer and are valid to initialize memory blocks.
                 GCD.add_memory_space(dxe_services::GcdMemoryType::SystemMemory, 0x1000, 0x2000, efi::MEMORY_WB)
                     .unwrap();
                 GCD.add_memory_space(dxe_services::GcdMemoryType::MemoryMappedIo, 0x5000, 0x1000, efi::MEMORY_UC)
@@ -6544,8 +6703,11 @@ mod tests {
             GCD.init(48, 16);
 
             // Set up memory space
+            // SAFETY: get_memory returns a test-owned buffer of the requested size.
             let mem = unsafe { get_memory(MEMORY_BLOCK_SLICE_SIZE * 100) };
+            // SAFETY: address/size come from the test buffer and are valid to initialize memory blocks.
             let address = align_up(mem.as_ptr() as usize, 0x1000).unwrap();
+            // SAFETY: address/size come from the test buffer and are valid to initialize memory blocks.
             unsafe {
                 GCD.init_memory_blocks(
                     dxe_services::GcdMemoryType::SystemMemory,
@@ -6605,8 +6767,10 @@ mod tests {
             GCD.init(48, 16);
 
             // Set up memory space
+            // SAFETY: get_memory returns a test-owned buffer of the requested size.
             let mem = unsafe { get_memory(MEMORY_BLOCK_SLICE_SIZE * 100) };
             let address = align_up(mem.as_ptr() as usize, 0x1000).unwrap();
+            // SAFETY: address/size come from the test buffer and are valid to initialize memory blocks.
             unsafe {
                 GCD.init_memory_blocks(
                     dxe_services::GcdMemoryType::SystemMemory,
@@ -6618,8 +6782,10 @@ mod tests {
                 .unwrap();
             }
 
+            // SAFETY: get_memory returns a test-owned buffer of the requested size.
             // Create DXE Core HOB
             let dxe_core_base = address + 0x1000;
+            // SAFETY: address/size come from the test buffer and are valid to initialize memory blocks.
             let dxe_core_len = 0x1000000;
             let dxe_core_hob = Hob::MemoryAllocationModule(&patina::pi::hob::MemoryAllocationModule {
                 header: patina::pi::hob::header::Hob {
@@ -6683,8 +6849,10 @@ mod tests {
             GCD.init(48, 16);
 
             // Set up memory space
+            // SAFETY: get_memory returns a test-owned buffer of the requested size.
             let mem = unsafe { get_memory(MEMORY_BLOCK_SLICE_SIZE * 100) };
             let address = align_up(mem.as_ptr() as usize, 0x1000).unwrap();
+            // SAFETY: address/size come from the test buffer and are valid to initialize memory blocks.
             unsafe {
                 GCD.init_memory_blocks(
                     dxe_services::GcdMemoryType::SystemMemory,

--- a/patina_dxe_core/src/memory_attributes_protocol.rs
+++ b/patina_dxe_core/src/memory_attributes_protocol.rs
@@ -265,9 +265,12 @@ pub(crate) fn install_memory_attributes_protocol() {
     MEMORY_ATTRIBUTES_PROTOCOL_INTERFACE.store(interface, Ordering::SeqCst);
 
     match PROTOCOL_DB.install_protocol_interface(None, efi::protocols::memory_attribute::PROTOCOL_GUID, interface) {
-        Ok((handle, _)) => unsafe {
-            MEMORY_ATTRIBUTES_PROTOCOL_HANDLE.store(handle, Ordering::SeqCst);
-        },
+        Ok((handle, _)) => {
+            // SAFETY: handle is returned by protocol DB on a successful installation.
+            unsafe {
+                MEMORY_ATTRIBUTES_PROTOCOL_HANDLE.store(handle, Ordering::SeqCst);
+            }
+        }
         Err(e) => {
             log::error!("Failed to install MEMORY_ATTRIBUTES_PROTOCOL_GUID: {e:?}");
         }
@@ -277,6 +280,7 @@ pub(crate) fn install_memory_attributes_protocol() {
 #[cfg(feature = "compatibility_mode_allowed")]
 /// This function is called in compatibility mode to uninstall the protocol.
 pub(crate) fn uninstall_memory_attributes_protocol() {
+    // SAFETY: Reads global atomics to determine protocol handle/interface before uninstall.
     unsafe {
         match (
             MEMORY_ATTRIBUTES_PROTOCOL_HANDLE.load(Ordering::SeqCst),
@@ -375,6 +379,7 @@ mod tests {
             GCD.init(48, 16);
 
             // Add memory and MMIO regions
+            // SAFETY: get_memory returns a test-owned buffer sized for the requested region.
             let mem = unsafe { crate::test_support::get_memory(0x120000) };
             let address = align_up(mem.as_ptr() as usize, 0x1000).unwrap();
 
@@ -418,6 +423,7 @@ mod tests {
             GCD.init(48, 16);
 
             // Add memory and MMIO regions
+            // SAFETY: get_memory returns a test-owned buffer sized for the requested region.
             let mem = unsafe { crate::test_support::get_memory(0x120000) };
             let address = align_up(mem.as_ptr() as usize, 0x1000).unwrap();
 
@@ -462,6 +468,7 @@ mod tests {
             GCD.init(48, 16);
 
             // Add memory and MMIO regions
+            // SAFETY: get_memory returns a test-owned buffer sized for the requested region.
             let mem = unsafe { crate::test_support::get_memory(0x120000) };
             let address = align_up(mem.as_ptr() as usize, 0x1000).unwrap();
 
@@ -507,6 +514,7 @@ mod tests {
             GCD.init(48, 16);
 
             // Add memory and MMIO regions
+            // SAFETY: get_memory returns a test-owned buffer sized for the requested region.
             let mem = unsafe { crate::test_support::get_memory(0x120000) };
             let address = align_up(mem.as_ptr() as usize, 0x1000).unwrap();
 
@@ -562,6 +570,7 @@ mod tests {
             GCD.init(48, 16);
 
             // Add memory and MMIO regions
+            // SAFETY: get_memory returns a test-owned buffer sized for the requested region.
             let mem = unsafe { crate::test_support::get_memory(0x120000) };
             let address = align_up(mem.as_ptr() as usize, 0x1000).unwrap();
 
@@ -608,6 +617,7 @@ mod tests {
             GCD.init(48, 16);
 
             // Add memory and MMIO regions
+            // SAFETY: get_memory returns a test-owned buffer sized for the requested region.
             let mem = unsafe { crate::test_support::get_memory(0x120000) };
             let address = align_up(mem.as_ptr() as usize, 0x1000).unwrap();
 
@@ -656,6 +666,7 @@ mod tests {
             GCD.init(48, 16);
 
             // Add memory and MMIO regions
+            // SAFETY: get_memory returns a test-owned buffer sized for the requested region.
             let mem = unsafe { crate::test_support::get_memory(0x120000) };
             let address = align_up(mem.as_ptr() as usize, 0x1000).unwrap();
 
@@ -702,6 +713,7 @@ mod tests {
             GCD.init(48, 16);
 
             // Add memory and MMIO regions
+            // SAFETY: get_memory returns a test-owned buffer sized for the requested region.
             let mem = unsafe { crate::test_support::get_memory(0x120000) };
             let address = align_up(mem.as_ptr() as usize, 0x1000).unwrap();
 

--- a/patina_dxe_core/src/memory_manager.rs
+++ b/patina_dxe_core/src/memory_manager.rs
@@ -65,6 +65,7 @@ impl MemoryManager for CoreMemoryManager {
 
         match result {
             Ok(_) => {
+                // SAFETY: address/page_count come from a successful core_allocate_pages call.
                 let allocation = unsafe {
                     PageAllocation::new(address as usize, page_count, &CoreMemoryManager)
                         .map_err(|_| MemoryError::InternalError)?
@@ -76,6 +77,11 @@ impl MemoryManager for CoreMemoryManager {
         }
     }
 
+    /// Frees the block of pages at the given address of the given size.
+    ///
+    /// ## Safety
+    /// Caller must ensure that the given address corresponds to a valid block of pages that was allocated with
+    /// [Self::allocate_pages].
     unsafe fn free_pages(&self, address: usize, page_count: usize) -> Result<(), MemoryError> {
         let result = core_free_pages(address as efi::PhysicalAddress, page_count);
         match result {
@@ -222,6 +228,7 @@ fn memory_manager_allocations_test(mm: Service<dyn MemoryManager>) -> patina::te
     u_assert!(result.is_ok(), "Failed to allocate single page.");
     let allocation = result.unwrap();
     let address = allocation.into_raw_ptr::<u8>().unwrap() as usize;
+    // SAFETY: address was returned by allocate_pages for this manager.
     let result = unsafe { mm.free_pages(address, 1) };
     u_assert!(result.is_ok(), "Failed to free page.");
     let result = mm.allocate_pages(1, AllocationOptions::new().with_strategy(PageAllocationStrategy::Address(address)));
@@ -236,6 +243,7 @@ fn memory_manager_allocations_test(mm: Service<dyn MemoryManager>) -> patina::te
     u_assert_eq!(allocation.page_count(), 8);
     let address = allocation.into_raw_ptr::<u8>().unwrap() as usize;
     u_assert_eq!(address % TEST_ALIGNMENT, 0, "Allocated page not correctly aligned.");
+    // SAFETY: address was returned by allocate_pages for this manager.
     let result = unsafe { mm.free_pages(address, 8) };
     u_assert!(result.is_ok(), "Failed to free page.");
 
@@ -284,6 +292,7 @@ fn memory_manager_attributes_test(mm: Service<dyn MemoryManager>) -> patina::tes
     u_assert_eq!(access, AccessType::ReadWrite, "Allocation did not return Read/Write access.");
 
     // Test changing the attributes to read only.
+    // SAFETY: address was returned by allocate_pages for this manager.
     let result = unsafe { mm.set_page_attributes(address, 1, AccessType::ReadOnly, None) };
     u_assert!(result.is_ok(), "Failed to set page attributes.");
     let result = mm.get_page_attributes(address, 1);
@@ -293,6 +302,7 @@ fn memory_manager_attributes_test(mm: Service<dyn MemoryManager>) -> patina::tes
     u_assert_eq!(new_caching, caching, "Caching type changes unexpectedly.");
 
     // Free the page
+    // SAFETY: address was returned by allocate_pages for this manager.
     let result = unsafe { mm.free_pages(address, 1) };
     u_assert!(result.is_ok(), "Failed to free page.");
 

--- a/patina_dxe_core/src/misc_boot_services.rs
+++ b/patina_dxe_core/src/misc_boot_services.rs
@@ -44,9 +44,9 @@ impl<T> ArchProtocolPtr<T> {
     }
 }
 
-// SAFETY: ArchProtocolPtr is Send/Sync because the pointer it wraps is initialized in a thread-safe manner (using
-// `Once`), and the pointer itself is never used to mutate data.
+// SAFETY: ArchProtocolPtr is Send because the pointer is initialized once and never mutates the pointed-to data.
 unsafe impl<T> Send for ArchProtocolPtr<T> {}
+// SAFETY: ArchProtocolPtr is Sync because the pointer is initialized once and never mutates the pointed-to data.
 unsafe impl<T> Sync for ArchProtocolPtr<T> {}
 
 static METRONOME_ARCH_PTR: ArchProtocolPtr<protocols::metronome::Protocol> = ArchProtocolPtr::new();
@@ -139,11 +139,11 @@ extern "efiapi" fn set_watchdog_timer(
 extern "efiapi" fn metronome_arch_available(event: efi::Event, _context: *mut c_void) {
     match PROTOCOL_DB.locate_protocol(protocols::metronome::PROTOCOL_GUID) {
         Ok(metronome_arch_ptr) => {
-            // SAFETY: metronome_arch_ptr is expected to be a valid pointer to the metronome protocol since it is
-            // associated with the metronome arch guid.
             if metronome_arch_ptr.is_null() {
                 panic!("Located metronome protocol pointer is null.");
             }
+            // SAFETY: metronome_arch_ptr is expected to be a valid pointer to the metronome protocol since it is
+            // associated with the metronome arch guid.
             unsafe { METRONOME_ARCH_PTR.init(metronome_arch_ptr) };
             if let Err(status_err) = EVENT_DB.close_event(event) {
                 log::warn!("Could not close event for metronome_arch_available due to error {status_err:?}");
@@ -159,11 +159,11 @@ extern "efiapi" fn metronome_arch_available(event: efi::Event, _context: *mut c_
 extern "efiapi" fn watchdog_arch_available(event: efi::Event, _context: *mut c_void) {
     match PROTOCOL_DB.locate_protocol(protocols::watchdog::PROTOCOL_GUID) {
         Ok(watchdog_arch_ptr) => {
-            // SAFETY: watchdog_arch_ptr is expected to be a valid pointer to the watchdog protocol since it is
-            // associated with the watchdog arch guid.
             if watchdog_arch_ptr.is_null() {
                 panic!("Located watchdog protocol pointer is null.");
             }
+            // SAFETY: watchdog_arch_ptr is expected to be a valid pointer to the watchdog protocol since it is
+            // associated with the watchdog arch guid.
             unsafe { WATCHDOG_ARCH_PTR.init(watchdog_arch_ptr) };
             if let Err(status_err) = EVENT_DB.close_event(event) {
                 log::warn!("Could not close event for watchdog_arch_available due to error {status_err:?}");
@@ -191,6 +191,8 @@ pub extern "efiapi" fn exit_boot_services(_handle: efi::Handle, map_key: usize) 
     match PROTOCOL_DB.locate_protocol(protocols::timer::PROTOCOL_GUID) {
         Ok(timer_arch_ptr) => {
             let timer_arch_ptr = timer_arch_ptr as *mut protocols::timer::Protocol;
+            // SAFETY: timer_arch_ptr comes from locate_protocol and is considered valid based on the successful
+            // return status from locate_protocol.
             let timer_arch = unsafe { &*(timer_arch_ptr) };
             (timer_arch.set_timer_period)(timer_arch_ptr, 0);
         }
@@ -219,6 +221,8 @@ pub extern "efiapi" fn exit_boot_services(_handle: efi::Handle, map_key: usize) 
     match PROTOCOL_DB.locate_protocol(protocols::status_code::PROTOCOL_GUID) {
         Ok(status_code_ptr) => {
             let status_code_ptr = status_code_ptr as *mut protocols::status_code::Protocol;
+            // SAFETY: status_code_ptr comes from locate_protocol and is considered valid based on the successful
+            // return status from locate_protocol.
             let status_code_protocol = unsafe { &*(status_code_ptr) };
             (status_code_protocol.report_status_code)(
                 status_code::EFI_PROGRESS_CODE,
@@ -247,6 +251,8 @@ pub extern "efiapi" fn exit_boot_services(_handle: efi::Handle, map_key: usize) 
     match PROTOCOL_DB.locate_protocol(protocols::runtime::PROTOCOL_GUID) {
         Ok(rt_arch_ptr) => {
             let rt_arch_ptr = rt_arch_ptr as *mut protocols::runtime::Protocol;
+            // SAFETY: rt_arch_ptr comes from locate_protocol and is considered valid based on the successful
+            // return status from locate_protocol.
             let rt_arch_protocol = unsafe { &mut *(rt_arch_ptr) };
             rt_arch_protocol.at_runtime.store(true, Ordering::SeqCst);
         }
@@ -462,6 +468,7 @@ mod tests {
                 unimplemented!()
             }
             let watchdog = protocols::watchdog::Protocol { register_handler, set_timer_period, get_timer_period };
+            // SAFETY: The mock protocol lives for the duration of the test and the pointer is only used by the test.
             unsafe {
                 WATCHDOG_ARCH_PTR.init(&watchdog as *const _ as *mut c_void);
             };
@@ -521,6 +528,7 @@ mod tests {
                 wait_for_tick,
             };
 
+            // SAFETY: The mock protocol lives for the duration of the test and the pointer is only used by the test.
             unsafe {
                 METRONOME_ARCH_PTR.init(&metronome as *const _ as *mut c_void);
             }

--- a/patina_dxe_core/src/pi_dispatcher.rs
+++ b/patina_dxe_core/src/pi_dispatcher.rs
@@ -514,6 +514,7 @@ struct PendingFirmwareVolumeImage {
 impl PendingFirmwareVolumeImage {
     // authenticate the pending firmware volume via the Security Architectural Protocol
     fn evaluate_auth(&self) -> Result<(), EfiError> {
+        // SAFETY: locate_protocol returns a valid pointer when present. as_ref is used for shared access.
         let security_protocol = unsafe {
             match PROTOCOL_DB.locate_protocol(patina::pi::protocols::security::PROTOCOL_GUID) {
                 Ok(protocol) => (protocol as *mut patina::pi::protocols::security::Protocol)
@@ -600,6 +601,8 @@ impl DispatcherContext {
                     Ok(protocol) => protocol as *mut firmware_volume_block::Protocol,
                 };
 
+                // SAFETY: fvb_ptr was successfully returned from get_interface_for_handle and should point to a
+                // valid FVB protocol instance. The as_ref() call checks for null.
                 let fvb = unsafe {
                     fvb_ptr.as_ref().expect("get_interface_for_handle returned NULL ptr for FirmwareVolumeBlock")
                 };
@@ -673,6 +676,8 @@ impl DispatcherContext {
                             };
 
                             let mut filename_nodes_buf = Vec::<u8>::with_capacity(FILENAME_NODE_SIZE + END_NODE_SIZE); // 20 bytes (filename_node + GUID) + 4 bytes (end node)
+                            // SAFETY: filename_node is a local value. Its byte representation is valid for the size
+                            // of the struct
                             filename_nodes_buf.extend_from_slice(unsafe {
                                 core::slice::from_raw_parts(
                                     &filename_node as *const _ as *const u8,
@@ -683,6 +688,8 @@ impl DispatcherContext {
                             filename_nodes_buf.extend_from_slice(file_name.as_bytes());
 
                             // Copy filename_end_node into the buffer
+                            // SAFETY: filename_end_node is a local value. Its byte representation is valid for the
+                            // size of the struct
                             filename_nodes_buf.extend_from_slice(unsafe {
                                 core::slice::from_raw_parts(
                                     &filename_end_node as *const _ as *const u8,
@@ -778,6 +785,7 @@ impl DispatcherContext {
     }
 }
 
+// SAFETY: DispatcherContext is owned by the dispatcher and not shared across threads without synchronization.
 unsafe impl Send for DispatcherContext {}
 
 #[cfg(test)]
@@ -824,6 +832,7 @@ mod tests {
         F: Fn() + std::panic::RefUnwindSafe,
     {
         test_support::with_global_lock(|| {
+            // SAFETY: Test-only initialization of the protocol database occurs under the global lock.
             unsafe { test_support::init_test_protocol_db() };
             f();
         })
@@ -843,6 +852,7 @@ mod tests {
         _: *mut pi::protocols::firmware_volume_block::Protocol,
         addr: *mut u64,
     ) -> efi::Status {
+        // SAFETY: addr is provided by the caller and is expected to be valid for a single u64 write.
         unsafe { addr.write(0) };
         efi::Status::SUCCESS
     }
@@ -852,6 +862,7 @@ mod tests {
         _: *mut pi::protocols::firmware_volume_block::Protocol,
         addr: *mut u64,
     ) -> efi::Status {
+        // SAFETY: addr is provided by the caller and is expected to be valid for a single u64 write.
         unsafe { addr.write(GET_PHYSICAL_ADDRESS3_VALUE) };
         efi::Status::SUCCESS
     }
@@ -932,6 +943,7 @@ mod tests {
             assert_eq!(CORE.pi_dispatcher.dispatcher_context.lock().pending_drivers.len(), DRIVERS_IN_DXEFV);
         });
 
+        // SAFETY: fv_raw was created from Box::into_raw and is dropped only once here.
         let _dropped_fv = unsafe { Box::from_raw(fv_raw) };
     }
 
@@ -978,12 +990,14 @@ mod tests {
                 .get_interface_for_handle(handle, firmware_volume_block::PROTOCOL_GUID)
                 .expect("Failed to get FVB protocol");
             let protocol = protocol as *mut firmware_volume_block::Protocol;
+            // SAFETY: protocol was retrieved from PROTOCOL_DB and remains valid for this test scope.
             unsafe { &mut *protocol }.get_physical_address = get_physical_address1;
 
             CORE.pi_dispatcher.add_fv_handles(vec![handle]).expect("Failed to add FV handle");
             assert_eq!(CORE.pi_dispatcher.dispatcher_context.lock().pending_drivers.len(), 0);
         });
 
+        // SAFETY: fv_raw was created from Box::into_raw and is dropped only once here.
         let _dropped_fv = unsafe { Box::from_raw(fv_raw) };
     }
 
@@ -1014,12 +1028,14 @@ mod tests {
                 .get_interface_for_handle(handle, firmware_volume_block::PROTOCOL_GUID)
                 .expect("Failed to get FVB protocol");
             let protocol = protocol as *mut firmware_volume_block::Protocol;
+            // SAFETY: protocol was retrieved from PROTOCOL_DB and remains valid for this test scope.
             unsafe { &mut *protocol }.get_physical_address = get_physical_address2;
 
             CORE.pi_dispatcher.add_fv_handles(vec![handle]).expect("Failed to add FV handle");
             assert_eq!(CORE.pi_dispatcher.dispatcher_context.lock().pending_drivers.len(), 0);
         });
 
+        // SAFETY: fv_raw was created from Box::into_raw and is dropped only once here.
         let _dropped_fv = unsafe { Box::from_raw(fv_raw) };
     }
 
@@ -1038,6 +1054,7 @@ mod tests {
 
             // SAFETY: fv is leaked to ensure it is not freed and remains valid for the duration of the program.
             let fv_phys_addr = fv_raw.expose_provenance() as u64;
+            // SAFETY: fv_raw is leaked for the duration of this test scope.
             let handle =
                 unsafe { CORE.pi_dispatcher.fv_data.lock().install_firmware_volume(fv_phys_addr, None).unwrap() };
 
@@ -1046,15 +1063,19 @@ mod tests {
                 .get_interface_for_handle(handle, firmware_volume_block::PROTOCOL_GUID)
                 .expect("Failed to get FVB protocol");
             let protocol = protocol as *mut firmware_volume_block::Protocol;
+            // SAFETY: protocol was retrieved from PROTOCOL_DB and remains valid for this test scope.
             unsafe { &mut *protocol }.get_physical_address = get_physical_address3;
 
+            // SAFETY: Test-only mutable static is used under the global lock.
             unsafe { GET_PHYSICAL_ADDRESS3_VALUE = fv_phys_addr + 0x1000 };
             CORE.pi_dispatcher.add_fv_handles(vec![handle]).expect("Failed to add FV handle");
+            // SAFETY: Reset the test-only mutable static under the global lock.
             unsafe { GET_PHYSICAL_ADDRESS3_VALUE = 0 };
 
             assert_eq!(CORE.pi_dispatcher.dispatcher_context.lock().pending_drivers.len(), 0);
         });
 
+        // SAFETY: fv_raw was created from Box::into_raw and is dropped only once here.
         let _dropped_fv = unsafe { Box::from_raw(fv_raw) };
     }
 
@@ -1084,6 +1105,7 @@ mod tests {
             assert_eq!(CORE.pi_dispatcher.dispatcher_context.lock().pending_firmware_volume_images.len(), 1);
         });
 
+        // SAFETY: fv_raw was created from Box::into_raw and is dropped only once here.
         let _dropped_fv = unsafe { Box::from_raw(fv_raw) };
     }
 
@@ -1114,6 +1136,7 @@ mod tests {
             CORE.pi_dispatcher.display_discovered_not_dispatched();
         });
 
+        // SAFETY: fv_raw was created from Box::into_raw and is dropped only once here.
         let _dropped_fv = unsafe { Box::from_raw(fv_raw) };
     }
 
@@ -1147,6 +1170,7 @@ mod tests {
             assert_eq!(CORE.pi_dispatcher.dispatcher_context.lock().pending_drivers.len(), DRIVERS_IN_DXEFV);
         });
 
+        // SAFETY: fv_raw was created from Box::into_raw and is dropped only once here.
         let _dropped_fv = unsafe { Box::from_raw(fv_raw) };
     }
 
@@ -1204,6 +1228,7 @@ mod tests {
             assert_eq!(result, Err(EfiError::NotFound));
         });
 
+        // SAFETY: fv_raw was created from Box::into_raw and is dropped only once here.
         let _dropped_fv = unsafe { Box::from_raw(fv_raw) };
     }
 
@@ -1238,6 +1263,7 @@ mod tests {
             assert_eq!(result, Err(EfiError::NotFound));
         });
 
+        // SAFETY: fv_raw was created from Box::into_raw and is dropped only once here.
         let _dropped_fv = unsafe { Box::from_raw(fv_raw) };
     }
 
@@ -1262,6 +1288,7 @@ mod tests {
                 assert!(!this.is_null());
                 assert_eq!(authentication_status, 0);
 
+                // SAFETY: `file` is a valid device path pointer provided by the dispatcher for this callback.
                 unsafe {
                     let mut node_walker = DevicePathWalker::new(file);
                     //outer FV of NESTEDFV.Fv does not have an extended header so expect MMAP device path.
@@ -1326,11 +1353,13 @@ mod tests {
             static CORE: MockCore = MockCore::new(NullSectionExtractor::new());
             CORE.override_instance();
 
+            // SAFETY: fv_raw is leaked for the duration of this test scope.
             let _handle =
                 unsafe { CORE.pi_dispatcher.install_firmware_volume(fv_raw.expose_provenance() as u64, None).unwrap() };
 
             // Get the actual FV name GUID from the installed FV
             let actual_fv_guid = {
+                // SAFETY: fv_raw points to a valid FV buffer for parsing in this test.
                 let volume = unsafe { VolumeRef::new_from_address(fv_raw.expose_provenance() as u64).unwrap() };
                 volume.fv_name().expect("Test FV should have a name GUID")
             };
@@ -1355,6 +1384,7 @@ mod tests {
                 "Should return false for non-existent FV GUID"
             );
 
+            // SAFETY: fv_raw was created from Box::into_raw and is dropped only once here.
             let _dropped_fv = unsafe { Box::from_raw(fv_raw) };
         });
     }
@@ -1386,6 +1416,7 @@ mod tests {
             let fv = fv.into_boxed_slice();
             let fv_raw = Box::into_raw(fv);
 
+            // SAFETY: fv_raw is leaked for the duration of this test scope.
             let _handle =
                 unsafe { CORE.pi_dispatcher.install_firmware_volume(fv_raw.expose_provenance() as u64, None).unwrap() };
 
@@ -1402,6 +1433,7 @@ mod tests {
                 "Should return false when GUID doesn't match any installed FV"
             );
 
+            // SAFETY: fv_raw was created from Box::into_raw and is dropped only once here.
             let _dropped_fv = unsafe { Box::from_raw(fv_raw) };
         });
     }
@@ -1422,6 +1454,7 @@ mod tests {
             let fv_raw = Box::into_raw(fv);
 
             // Install the parent FV
+            // SAFETY: fv_raw is leaked for the duration of this test scope.
             let parent_handle =
                 unsafe { CORE.pi_dispatcher.install_firmware_volume(fv_raw.expose_provenance() as u64, None).unwrap() };
 
@@ -1445,6 +1478,7 @@ mod tests {
                 .expect("There should be a pending FV image"); // Extract and install the child FV separately to simulate it being already installed
             if let Some(section) = child_fv_sections.first() {
                 let child_fv_data = section.try_content_as_slice().expect("Should be able to get child FV data");
+                // SAFETY: child_fv_data points to a valid FV image buffer for parsing.
                 let child_volume = unsafe { VolumeRef::new_from_address(child_fv_data.as_ptr() as u64) }
                     .expect("Should be able to parse the child FV");
 
@@ -1452,6 +1486,7 @@ mod tests {
                     // Install the child FV directly
                     let child_fv_box: Box<[u8]> = Box::from(child_fv_data);
                     let child_fv_raw = Box::into_raw(child_fv_box);
+                    // SAFETY: child_fv_raw is leaked for the duration of this test scope.
                     let _child_handle = unsafe {
                         CORE.pi_dispatcher
                             .install_firmware_volume(child_fv_raw.expose_provenance() as u64, Some(parent_handle))
@@ -1478,10 +1513,12 @@ mod tests {
                         "Pending FV images should be empty after dispatch skipped duplicate"
                     );
 
+                    // SAFETY: child_fv_raw was created from Box::into_raw and is dropped only once here.
                     let _dropped_child = unsafe { Box::from_raw(child_fv_raw) };
                 }
             }
 
+            // SAFETY: fv_raw was created from Box::into_raw and is dropped only once here.
             let _dropped_fv = unsafe { Box::from_raw(fv_raw) };
         });
     }
@@ -1500,6 +1537,7 @@ mod tests {
             static CORE: MockCore = MockCore::new(NullSectionExtractor::new());
             CORE.override_instance();
 
+            // SAFETY: fv_raw is leaked for the duration of this test scope.
             let handle =
                 unsafe { CORE.pi_dispatcher.install_firmware_volume(fv_raw.expose_provenance() as u64, None).unwrap() };
 
@@ -1533,6 +1571,7 @@ mod tests {
                 "Should return false when the FVB protocol is null"
             );
 
+            // SAFETY: fv_raw was created from Box::into_raw and is dropped only once here.
             let _dropped_fv = unsafe { Box::from_raw(fv_raw) };
         });
     }
@@ -1551,6 +1590,7 @@ mod tests {
             static CORE: MockCore = MockCore::new(NullSectionExtractor::new());
             CORE.override_instance();
 
+            // SAFETY: fv_raw is leaked for the duration of this test scope.
             let handle =
                 unsafe { CORE.pi_dispatcher.install_firmware_volume(fv_raw.expose_provenance() as u64, None).unwrap() };
 
@@ -1559,6 +1599,7 @@ mod tests {
                 .expect("Failed to get FVB protocol");
             let protocol = protocol as *mut firmware_volume_block::Protocol;
             // Patch get_physical_address to return an error
+            // SAFETY: protocol was retrieved from PROTOCOL_DB and remains valid for this test scope.
             unsafe { &mut *protocol }.get_physical_address = get_physical_address1;
 
             let test_guid = r_efi::efi::Guid::from_fields(
@@ -1574,6 +1615,7 @@ mod tests {
                 "Should return false when get_physical_address fails"
             );
 
+            // SAFETY: fv_raw was created from Box::into_raw and is dropped only once here.
             let _dropped_fv = unsafe { Box::from_raw(fv_raw) };
         });
     }
@@ -1592,6 +1634,7 @@ mod tests {
             static CORE: MockCore = MockCore::new(NullSectionExtractor::new());
             CORE.override_instance();
 
+            // SAFETY: fv_raw is leaked for the duration of this test scope.
             let handle =
                 unsafe { CORE.pi_dispatcher.install_firmware_volume(fv_raw.expose_provenance() as u64, None).unwrap() };
 
@@ -1600,6 +1643,7 @@ mod tests {
                 .get_interface_for_handle(handle, firmware_volume_block::PROTOCOL_GUID)
                 .expect("Failed to get FVB protocol");
             let protocol = protocol as *mut firmware_volume_block::Protocol;
+            // SAFETY: protocol was retrieved from PROTOCOL_DB and remains valid for this test scope.
             unsafe { &mut *protocol }.get_physical_address = get_physical_address2;
 
             let test_guid = r_efi::efi::Guid::from_fields(
@@ -1615,6 +1659,7 @@ mod tests {
                 "Should return false when the address is zero"
             );
 
+            // SAFETY: fv_raw was created from Box::into_raw and is dropped only once here.
             let _dropped_fv = unsafe { Box::from_raw(fv_raw) };
         });
     }
@@ -1633,6 +1678,7 @@ mod tests {
             static CORE: MockCore = MockCore::new(NullSectionExtractor::new());
             CORE.override_instance();
 
+            // SAFETY: fv_raw is leaked for the duration of this test scope.
             let handle =
                 unsafe { CORE.pi_dispatcher.install_firmware_volume(fv_raw.expose_provenance() as u64, None).unwrap() };
 
@@ -1646,9 +1692,11 @@ mod tests {
                 .get_interface_for_handle(handle, firmware_volume_block::PROTOCOL_GUID)
                 .expect("Failed to get FVB protocol");
             let protocol = protocol as *mut firmware_volume_block::Protocol;
+            // SAFETY: protocol was retrieved from PROTOCOL_DB and remains valid for this test scope.
             unsafe { &mut *protocol }.get_physical_address = get_physical_address3;
 
             // Set to the address of the invalid FV data
+            // SAFETY: Test-only mutable static is used under the global lock.
             unsafe { GET_PHYSICAL_ADDRESS3_VALUE = invalid_fv_raw.expose_provenance() as u64 };
 
             let test_guid = r_efi::efi::Guid::from_fields(
@@ -1664,9 +1712,12 @@ mod tests {
                 "Should return false when volume parsing fails"
             );
 
+            // SAFETY: Reset the test-only mutable static under the global lock.
             unsafe { GET_PHYSICAL_ADDRESS3_VALUE = 0 };
 
+            // SAFETY: fv_raw was created from Box::into_raw and is dropped only once here.
             let _dropped_fv = unsafe { Box::from_raw(fv_raw) };
+            // SAFETY: invalid_fv_raw was created from Box::into_raw and is dropped only once here.
             let _dropped_invalid_fv = unsafe { Box::from_raw(invalid_fv_raw) };
         });
     }

--- a/patina_dxe_core/src/pi_dispatcher/debug_image_info_table.rs
+++ b/patina_dxe_core/src/pi_dispatcher/debug_image_info_table.rs
@@ -214,6 +214,7 @@ impl DebugImageInfoData {
 
         let last = self.len() - 1;
         if index != last {
+            // SAFETY: data pointers are within allocated table bounds and non-overlapping for a single element copy.
             unsafe { ptr::copy_nonoverlapping(data.add(last), data.add(index), 1) };
         }
 
@@ -269,8 +270,8 @@ impl Drop for DebugImageInfoData {
         // Deallocate the data
         if self.capacity > 0 {
             let layout = Layout::array::<EfiDebugImageInfo>(self.capacity).unwrap();
+            // SAFETY: Invariants of this struct ensure that `data` was allocated with this layout.
             unsafe {
-                // SAFETY: Invariants of this struct ensure that `data` was allocated with this exact layout.
                 alloc::alloc::dealloc(self.table_mut().cast::<u8>(), layout);
             }
         }

--- a/patina_dxe_core/src/pi_dispatcher/fv.rs
+++ b/patina_dxe_core/src/pi_dispatcher/fv.rs
@@ -630,6 +630,8 @@ impl<P: PlatformInfo> FvProtocolData<P> {
         // SAFETY: caller must provide valid pointers for buffer_size and name_guid. They are null-checked above.
         let local_buffer_size = unsafe { buffer_size.read_unaligned() };
         // SAFETY: caller must provide valid pointers for buffer_size and name_guid. They are null-checked above.
+        // SAFETY: name_guid is checked to be non-null above. The caller must ensure
+        // that it points to a valid GUID (as per the C interface).
         let name = unsafe { name_guid.read_unaligned() };
 
         let this = Self::instance();
@@ -742,6 +744,8 @@ impl<P: PlatformInfo> FvProtocolData<P> {
         // SAFETY: null-checks are at the start of the routine, but caller is required to guarantee that buffer_size and
         // buffer are valid.
         let mut local_buffer_size = unsafe { buffer_size.read_unaligned() };
+        // SAFETY: null-checks are at the start of the routine, but caller is required to guarantee that buffer_size and
+        // buffer are valid (as per the C interface).
         let mut local_buffer_ptr = unsafe { buffer.read_unaligned() };
 
         if local_buffer_ptr.is_null() {
@@ -1795,6 +1799,7 @@ mod tests {
         test_support::with_global_lock(|| {
             static CORE: MockCore = MockCore::new(CompositeSectionExtractor::new());
             CORE.override_instance();
+            // SAFETY: Initializes the test GCD state for this test scope only.
             unsafe { test_support::init_test_gcd(None) };
 
             let fv_interface = MockProtocolData::new_fv_protocol(parent_handle);

--- a/patina_dxe_core/src/pi_dispatcher/image.rs
+++ b/patina_dxe_core/src/pi_dispatcher/image.rs
@@ -137,6 +137,7 @@ impl ImageStack {
     }
 }
 
+// SAFETY: ImageStack provides a stable, owned stack buffer with valid base/limit pointers.
 unsafe impl Stack for ImageStack {
     fn base(&self) -> StackPointer {
         //stack grows downward, so "base" is the highest address, i.e. the ptr + size.
@@ -308,6 +309,7 @@ impl PrivateImageData {
             )?;
 
         // update the entry point. Transmute is required here to cast the raw function address to the ImageEntryPoint function pointer type.
+        // SAFETY: Entry point is computed from a validated PE image base and entry offset.
         self.entry_point = unsafe {
             transmute::<usize, extern "efiapi" fn(*mut c_void, *mut r_efi::system::SystemTable) -> efi::Status>(
                 physical_addr + self.pe_info.entry_point_offset,
@@ -684,7 +686,9 @@ impl ImageData {
 
 // ImageData is accessed through a mutex guard, so it is safe to
 // mark it sync/send.
+// SAFETY: ImageData is only accessed through the image_data mutex.
 unsafe impl Sync for ImageData {}
+// SAFETY: ImageData is only accessed through the image_data mutex.
 unsafe impl Send for ImageData {}
 
 impl<P: super::PlatformInfo> super::PiDispatcher<P> {
@@ -826,6 +830,7 @@ impl<P: super::PlatformInfo> super::PiDispatcher<P> {
             if source_size == 0 {
                 return efi::Status::LOAD_ERROR;
             }
+            // SAFETY: source_buffer/source_size are provided by the caller and validated for non-null/size.
             Some(unsafe { from_raw_parts(source_buffer as *const u8, source_size) })
         };
 
@@ -919,6 +924,7 @@ impl<P: super::PlatformInfo> super::PiDispatcher<P> {
         // will try to use unwind to clean up the co-routine stack (i.e. "drop" any
         // live objects). This unwind support requires std and will panic if
         // executed.
+        // SAFETY: force_reset prevents unwinding a suspended coroutine with a custom stack.
         unsafe { coroutine.force_reset() };
 
         self.image_data.lock().current_running_image = previous_image;
@@ -1103,6 +1109,7 @@ impl<P: super::PlatformInfo> super::PiDispatcher<P> {
         // safety note: this assumes that the top of the image_start_contexts stack
         // is the currently running image.
         if let Some(yielder) = private_data.image_start_contexts.pop() {
+            // SAFETY: yielder pointer is created and stored by start_image for the current context.
             let yielder = unsafe { &*yielder };
             drop(private_data);
 
@@ -1275,6 +1282,7 @@ fn core_load_pe_image(
 }
 
 fn get_file_guid_from_device_path(path: *mut efi::protocols::device_path::Protocol) -> Result<Guid, EfiError> {
+    // SAFETY: path is validated by the caller and must point to a valid device path structure.
     let mut walker = unsafe { DevicePathWalker::new(path) };
     let file_path_node = walker.next().ok_or(EfiError::InvalidParameter)?;
     if file_path_node.header().r#type != efi::protocols::device_path::TYPE_MEDIA
@@ -1302,6 +1310,7 @@ fn get_file_buffer_from_fw(
         debug_assert!(!fv_ptr.is_null(), "ERROR: get_interface_for_handle returned NULL ptr for FirmwareVolume!");
         return Err(EfiError::InvalidParameter);
     }
+    // SAFETY: fv_ptr is non-null and points to a valid firmware volume protocol.
     let fw_vol = unsafe { fv_ptr.as_ref().unwrap() };
 
     // Read image from the firmware file
@@ -1322,6 +1331,7 @@ fn get_file_buffer_from_fw(
 
     EfiError::status_to_result(status)?;
 
+    // SAFETY: buffer/buffer_size are returned by read_section and are valid for that length.
     let section_slice = unsafe { slice::from_raw_parts(buffer, buffer_size) };
     Ok((section_slice.to_vec(), handle))
 }
@@ -1334,6 +1344,7 @@ fn get_file_buffer_from_sfs(
 
     let mut file = SimpleFile::open_volume(handle)?;
 
+    // SAFETY: remaining_file_path is returned by core_locate_device_path and is a valid device path.
     for node in unsafe { DevicePathWalker::new(remaining_file_path) } {
         match node.header().r#type {
             efi::protocols::device_path::TYPE_MEDIA
@@ -1379,6 +1390,7 @@ fn get_file_buffer_from_load_protocol(
     let (remaining_file_path, handle) = core_locate_device_path(protocol, file_path)?;
 
     let load_file = PROTOCOL_DB.get_interface_for_handle(handle, protocol)?;
+    // SAFETY: load_file is obtained from the protocol database and is a valid load_file protocol pointer.
     let load_file =
         unsafe { (load_file as *mut efi::protocols::load_file::Protocol).as_mut().ok_or(EfiError::Unsupported)? };
 
@@ -1418,6 +1430,8 @@ fn authenticate_image(
     from_fv: bool,
     authentication_status: u32,
 ) -> Result<(), EfiError> {
+    // SAFETY: Checks locate_protocol return value to determine if pointer is valid. as_ref() is used for shared access
+    // which will also check if the pointer is null before allowing access.
     let security2_protocol = unsafe {
         match PROTOCOL_DB.locate_protocol(pi::protocols::security2::PROTOCOL_GUID) {
             Ok(protocol) => (protocol as *mut pi::protocols::security2::Protocol).as_ref(),
@@ -1427,6 +1441,8 @@ fn authenticate_image(
         }
     };
 
+    // SAFETY: Checks locate_protocol return value to determine if pointer is valid. as_ref() is used for shared access
+    // which will also check if the pointer is null before allowing access.
     let security_protocol = unsafe {
         match PROTOCOL_DB.locate_protocol(pi::protocols::security::PROTOCOL_GUID) {
             Ok(protocol) => (protocol as *mut pi::protocols::security::Protocol).as_ref(),
@@ -2630,11 +2646,12 @@ mod tests {
             image_info.image_size = 0x2000;
 
             // Manually construct PrivateImageData with minimal required fields
-            // SAFETY: Allocating memory for fake image buffer to construct test data
             const LEN: usize = 0x2000;
+            // SAFETY: Allocate a page-aligned test buffer and treat it as a raw image backing store.
             let fake_buffer =
                 unsafe { alloc::alloc::alloc(alloc::alloc::Layout::from_size_align(LEN, 0x1000).unwrap()) };
 
+            // SAFETY: fake_buffer points to LEN bytes we just allocated and is valid for mutable slice creation.
             let slice = unsafe { core::slice::from_raw_parts_mut(fake_buffer, LEN) };
             let bytes = super::Buffer::Borrowed(slice);
 
@@ -2697,6 +2714,7 @@ mod tests {
         let result = test_support::with_global_lock(|| {
             // SAFETY: These test initialization functions require unsafe because they
             // manipulate global state (GCD, protocol DB, system table)
+            // SAFETY: Test-only initialization of global tables happens under the global lock.
             unsafe {
                 test_support::init_test_gcd(None);
                 test_support::init_test_protocol_db();
@@ -3171,6 +3189,7 @@ mod tests {
             let child_device_path =
                 device_path_from_string(String::from("PCI(0,1C)/PCI(0,0)/EFI/BOOT/BOOT_X64.EFI/END"));
 
+            // SAFETY: Test-only initialization of global tables happens under the global lock.
             unsafe {
                 test_support::init_test_gcd(None);
                 test_support::init_test_protocol_db();
@@ -3200,6 +3219,7 @@ mod tests {
 
             // Validate the file path was set correctly
             let (_, len) = device_path_node_count(private_info.image_info.file_path).unwrap();
+            // SAFETY: file_path points to a valid device path buffer of length `len` per device_path_node_count.
             let bytes = unsafe { core::slice::from_raw_parts(private_info.image_info.file_path as *const u8, len) };
             assert_eq!(bytes, child_device_path.as_ref());
 
@@ -3207,6 +3227,7 @@ mod tests {
             let (_, len) =
                 device_path_node_count(private_info.get_file_path() as *mut efi::protocols::device_path::Protocol)
                     .unwrap();
+            // SAFETY: get_file_path returns a valid device path pointer with length `len` per device_path_node_count.
             let bytes = unsafe { core::slice::from_raw_parts(private_info.get_file_path() as *const u8, len) };
             assert_eq!(bytes, child_device_path.as_ref());
         })
@@ -3224,6 +3245,7 @@ mod tests {
                 device_path_from_string(String::from("PCI(0,1C)/PCI(0,0)/EFI/BOOT/BOOT_X64.EFI/END"));
             let child_filename = device_path_from_string(String::from("EFI/BOOT/BOOT_X64.EFI/END"));
 
+            // SAFETY: Test-only initialization of global tables happens under the global lock.
             unsafe {
                 test_support::init_test_gcd(None);
                 test_support::init_test_protocol_db();
@@ -3262,6 +3284,7 @@ mod tests {
 
             // Validate the file path was set correctly
             let (_, len) = device_path_node_count(private_info.image_info.file_path).unwrap();
+            // SAFETY: file_path points to a valid device path buffer of length `len` per device_path_node_count.
             let bytes = unsafe { core::slice::from_raw_parts(private_info.image_info.file_path as *const u8, len) };
 
             // IMPORTANT: This is validating that we cut off the parent device path correctly.
@@ -3271,6 +3294,7 @@ mod tests {
             let (_, len) =
                 device_path_node_count(private_info.get_file_path() as *mut efi::protocols::device_path::Protocol)
                     .unwrap();
+            // SAFETY: get_file_path returns a valid device path pointer with length `len` per device_path_node_count.
             let bytes = unsafe { core::slice::from_raw_parts(private_info.get_file_path() as *const u8, len) };
 
             // IMPORTANT: This should always contain the full path.
@@ -3319,12 +3343,14 @@ mod tests {
         };
 
         let mut hobs = Vec::new();
+        // SAFETY: Taking a byte view of a stack-allocated HOB struct for serialization into the test HOB list.
         hobs.extend_from_slice(unsafe {
             core::slice::from_raw_parts(
                 &ma_hob as *const MemoryAllocationModule as *const u8,
                 core::mem::size_of::<MemoryAllocationModule>(),
             )
         });
+        // SAFETY: Taking a byte view of a stack-allocated HOB header for serialization into the test HOB list.
         hobs.extend_from_slice(unsafe {
             core::slice::from_raw_parts(
                 &end_hob as *const patina::pi::hob::header::Hob as *const u8,

--- a/patina_dxe_core/src/protocol_db.rs
+++ b/patina_dxe_core/src/protocol_db.rs
@@ -874,7 +874,9 @@ impl SpinLockedProtocolDb {
     }
 }
 
+// SAFETY: SpinLockedProtocolDb enforces mutual exclusion and interior mutability with locking.
 unsafe impl Send for SpinLockedProtocolDb {}
+// SAFETY: SpinLockedProtocolDb enforces mutual exclusion and interior mutability with locking.
 unsafe impl Sync for SpinLockedProtocolDb {}
 
 #[cfg(test)]

--- a/patina_dxe_core/src/protocols.rs
+++ b/patina_dxe_core/src/protocols.rs
@@ -61,6 +61,7 @@ extern "efiapi" fn install_protocol_interface(
     }
     // SAFETY: Caller must ensure that handle and protocol are valid pointers. They are null-checked above.
     let caller_handle = unsafe { handle.read_unaligned() };
+    // SAFETY: Caller must ensure that protocol is a valid pointer. It is checked for null above.
     let caller_protocol = unsafe { protocol.read_unaligned() };
 
     let caller_handle = if caller_handle.is_null() { None } else { Some(caller_handle) };
@@ -70,6 +71,7 @@ extern "efiapi" fn install_protocol_interface(
         Ok(handle) => handle,
     };
 
+    // SAFETY: Caller must ensure that handle is a valid pointer. It is checked for null above.
     unsafe { *handle = installed_handle };
 
     efi::Status::SUCCESS
@@ -105,6 +107,8 @@ pub fn core_uninstall_protocol_interface(
         for usage in usages {
             if (usage.attributes & efi::OPEN_PROTOCOL_BY_DRIVER) != 0 {
                 debug_assert!(usage.agent_handle.is_some());
+                // SAFETY: Handles are validated by the protocol database, and controller disconnect is required
+                // for cleanup.
                 unsafe {
                     usage_close_status = core_disconnect_controller(handle, usage.agent_handle, None);
                     if usage_close_status.is_ok() {
@@ -153,6 +157,7 @@ pub fn core_uninstall_protocol_interface(
     }
 
     if usage_close_status.is_err() || unclosed_usages {
+        // SAFETY: Handle is validated above and reconnect is best-effort to restore state.
         unsafe {
             let _result = core_connect_controller(handle, Vec::new(), None, true);
         }
@@ -171,7 +176,7 @@ extern "efiapi" fn uninstall_protocol_interface(
         return efi::Status::INVALID_PARAMETER;
     }
 
-    // SAFETY: Caller must ensure that protocol is a valid pointer. It is null-checked above.
+    // SAFETY: Caller must ensure that protocol is a valid pointer. It is checked for null above.
     let caller_protocol = unsafe { protocol.read_unaligned() };
 
     core_uninstall_protocol_interface(handle, caller_protocol, interface)
@@ -222,7 +227,7 @@ extern "efiapi" fn reinstall_protocol_interface(
         }
     }
 
-    // SAFETY: Caller must ensure that protocol is a valid pointer. It is null-checked above.
+    // SAFETY: Caller must ensure that protocol is a valid pointer. It is checked for null above.
     let protocol = unsafe { protocol.read_unaligned() };
 
     // Call install to install the new interface and trigger any notifies
@@ -238,6 +243,7 @@ extern "efiapi" fn reinstall_protocol_interface(
 
     // Connect controller so agents that were forced to release old_interface can now consume new_interface. Error
     // status is ignored.
+    // SAFETY: handle is valid and reconnect is best-effort to restore state after reinstall.
     unsafe {
         let _ = core_connect_controller(handle, Vec::new(), None, true);
     }
@@ -253,10 +259,14 @@ extern "efiapi" fn register_protocol_notify(
     if protocol.is_null() || registration.is_null() || !EVENT_DB.is_valid(event) {
         return efi::Status::INVALID_PARAMETER;
     }
-    // SAFETY: Caller must ensure that protocol is a valid pointer. It is null-checked above.
-    match PROTOCOL_DB.register_protocol_notify(unsafe { protocol.read_unaligned() }, event) {
+    let protocol_guid = {
+        // SAFETY: Caller must ensure that protocol is a valid pointer. It is checked for null above.
+        unsafe { protocol.read_unaligned() }
+    };
+    match PROTOCOL_DB.register_protocol_notify(protocol_guid, event) {
         Err(err) => err.into(),
         Ok(new_registration) => {
+            // SAFETY: Caller must ensure that registration is a valid pointer. It is checked for null above.
             unsafe { *registration = new_registration };
             efi::Status::SUCCESS
         }
@@ -286,7 +296,7 @@ extern "efiapi" fn locate_handle(
             if protocol.is_null() {
                 return efi::Status::INVALID_PARAMETER;
             }
-            // SAFETY: Caller must ensure that protocol is a valid pointer. It is null-checked above.
+            // SAFETY: Caller must ensure that protocol is a valid pointer. It is checked for null above.
             PROTOCOL_DB.locate_handles(Some(unsafe { protocol.read_unaligned() }))
         }
         _ => return efi::Status::INVALID_PARAMETER,
@@ -303,9 +313,9 @@ extern "efiapi" fn locate_handle(
             }
 
             list.shrink_to_fit();
-            // SAFETY: Caller must ensure that buffer_size is a valid pointer. It is null-checked above.
+            // SAFETY: Caller must ensure that buffer_size is a valid pointer. It is checked for null above.
             let input_size = unsafe { buffer_size.read_unaligned() };
-            // SAFETY: Caller must ensure that buffer_size is a valid pointer. It is null-checked above.
+            // SAFETY: Caller must ensure that buffer_size is a valid pointer. It is checked for null above.
             unsafe {
                 buffer_size.write_unaligned(list.len() * size_of::<efi::Handle>());
             }
@@ -316,7 +326,7 @@ extern "efiapi" fn locate_handle(
                 return efi::Status::INVALID_PARAMETER;
             }
 
-            // Caller must ensure that handle_buffer is valid for writes of list.len() handles. It is null-checked above.
+            // SAFETY: Caller must ensure that handle_buffer is valid for writes of list.len() handles. It is checked for null above.
             unsafe {
                 core::ptr::copy(
                     list.as_ptr() as *const u8,
@@ -357,7 +367,7 @@ extern "efiapi" fn open_protocol(
         return efi::Status::INVALID_PARAMETER;
     }
 
-    // SAFETY: Caller must ensure that protocol is a valid pointer. It is null-checked above.
+    // SAFETY: Caller must ensure that protocol is a valid pointer. It is checked for null above.
     let protocol = unsafe { protocol.read_unaligned() };
 
     if interface.is_null() && attributes != efi::OPEN_PROTOCOL_TEST_PROTOCOL {
@@ -451,14 +461,11 @@ extern "efiapi" fn close_protocol(
         }
     };
 
-    match PROTOCOL_DB.remove_protocol_usage(
-        handle,
-        // SAFETY: Caller must ensure that protocol is a valid pointer. It is null-checked above.
-        unsafe { protocol.read_unaligned() },
-        Some(agent_handle),
-        controller_handle,
-        None,
-    ) {
+    let protocol_guid = {
+        // SAFETY: Caller must ensure that protocol is a valid pointer. It is checked for null above.
+        unsafe { protocol.read_unaligned() }
+    };
+    match PROTOCOL_DB.remove_protocol_usage(handle, protocol_guid, Some(agent_handle), controller_handle, None) {
         Err(err) => err.into(),
         Ok(_) => efi::Status::SUCCESS,
     }
@@ -474,9 +481,12 @@ extern "efiapi" fn open_protocol_information(
         return efi::Status::INVALID_PARAMETER;
     }
 
+    let protocol_guid = {
+        // SAFETY: Caller must ensure that protocol is a valid pointer. It is checked for null above.
+        unsafe { protocol.read_unaligned() }
+    };
     let mut open_info: Vec<efi::OpenProtocolInformationEntry> =
-        // SAFETY: Caller must ensure that protocol is a valid pointer. It is null-checked above.
-        match PROTOCOL_DB.get_open_protocol_information_by_protocol(handle, unsafe { protocol.read_unaligned() }) {
+        match PROTOCOL_DB.get_open_protocol_information_by_protocol(handle, protocol_guid) {
             Err(err) => return err.into(),
             Ok(info) => info.into_iter().map(efi::OpenProtocolInformationEntry::from).collect(),
         };
@@ -519,18 +529,24 @@ unsafe extern "C" fn install_multiple_protocol_interfaces(handle: *mut efi::Hand
     let mut interfaces_to_install = Vec::new();
     loop {
         //consume the protocol, break the loop if it is null.
+        // SAFETY: Variadic argument list is controlled by the caller and accessed in order.
         let protocol: *mut efi::Guid = unsafe { args.arg() };
         if protocol.is_null() {
             break;
         }
+        // SAFETY: Variadic argument list is controlled by the caller and accessed in order.
         let interface: *mut c_void = unsafe { args.arg() };
+        // SAFETY: protocol is checked for null above before dereferencing.
         if unsafe { *protocol } == efi::protocols::device_path::PROTOCOL_GUID
             && let Ok((remaining_path, handle)) = core_locate_device_path(
                 efi::protocols::device_path::PROTOCOL_GUID,
                 interface as *const efi::protocols::device_path::Protocol,
             )
             && PROTOCOL_DB.validate_handle(handle).is_ok()
-            && unsafe { is_device_path_end(remaining_path) }
+            && {
+                // SAFETY: remaining_path is returned from core_locate_device_path and is a valid device path pointer.
+                unsafe { is_device_path_end(remaining_path) }
+            }
         {
             return efi::Status::ALREADY_STARTED;
         }
@@ -545,7 +561,9 @@ unsafe extern "C" fn install_multiple_protocol_interfaces(handle: *mut efi::Hand
             err => {
                 //on error, attempt to uninstall all the previously installed interfaces. best-effort, errors are ignored.
                 for (protocol, interface) in interfaces_to_uninstall_on_error {
-                    let _ = uninstall_protocol_interface(unsafe { *handle }, protocol, interface);
+                    // SAFETY: handle is validated for null above.
+                    let handle_value = unsafe { *handle };
+                    let _ = uninstall_protocol_interface(handle_value, protocol, interface);
                 }
                 return err;
             }
@@ -562,10 +580,12 @@ unsafe extern "C" fn uninstall_multiple_protocol_interfaces(handle: efi::Handle,
 
     let mut interfaces_to_uninstall = Vec::new();
     loop {
+        // SAFETY: Variadic argument list is controlled by the caller and accessed in order.
         let protocol: *mut efi::Guid = unsafe { args.arg() };
         if protocol.is_null() {
             break;
         }
+        // SAFETY: Variadic argument list is controlled by the caller and accessed in order.
         let interface: *mut c_void = unsafe { args.arg() };
         interfaces_to_uninstall.push((protocol, interface));
     }
@@ -577,6 +597,7 @@ unsafe extern "C" fn uninstall_multiple_protocol_interfaces(handle: efi::Handle,
             _err => {
                 //on error, attempt to re-install all the previously uninstall interfaces. best-effort, errors are ignored.
                 for (protocol, interface) in interfaces_to_reinstall_on_error {
+                    // SAFETY: protocol was checked for null when building interfaces_to_uninstall.
                     let protocol = *(unsafe { protocol.as_mut().expect("previously null-checked pointer is null.") });
                     let _ = core_install_protocol_interface(Some(handle), protocol, interface);
                 }
@@ -669,7 +690,7 @@ extern "efiapi" fn locate_handle_buffer(
             if protocol.is_null() {
                 return efi::Status::INVALID_PARAMETER;
             }
-            // SAFETY: Caller must ensure that protocol is a valid pointer. It is null-checked above.
+            // SAFETY: Caller must ensure that protocol is a valid pointer. It is checked for null above.
             unsafe { PROTOCOL_DB.locate_handles(Some(protocol.read_unaligned())) }
         }
         _ => return efi::Status::INVALID_PARAMETER,
@@ -708,22 +729,30 @@ extern "efiapi" fn locate_protocol(
 
     if !registration.is_null() {
         if let Some(handle) = PROTOCOL_DB.next_handle_for_registration(registration) {
-            // SAFETY: Caller must ensure that protocol and interface are valid pointers. They are null-checked above.
+            let protocol_guid = {
+                // SAFETY: Caller must ensure that protocol is a valid pointer. It is checked for null above.
+                unsafe { protocol.read_unaligned() }
+            };
             let i_face = PROTOCOL_DB
-                .get_interface_for_handle(handle, unsafe { protocol.read_unaligned() })
+                .get_interface_for_handle(handle, protocol_guid)
                 .expect("Protocol should exist on handle if it is returned for registration key.");
+            // SAFETY: Caller must ensure that interface is a valid pointer. It is checked for null above.
             unsafe { interface.write_unaligned(i_face) };
         } else {
             return efi::Status::NOT_FOUND;
         }
     } else {
-        match PROTOCOL_DB.locate_protocol(unsafe { protocol.read_unaligned() }) {
+        let protocol_guid = {
+            // SAFETY: Caller must ensure that protocol is a valid pointer. It is checked for null above.
+            unsafe { protocol.read_unaligned() }
+        };
+        match PROTOCOL_DB.locate_protocol(protocol_guid) {
             Err(err) => {
-                // SAFETY: Caller must ensure that interface is a valid pointer. It is null-checked above.
+                // SAFETY: Caller must ensure that interface is a valid pointer. It is checked for null above.
                 unsafe { interface.write_unaligned(core::ptr::null_mut()) };
                 return err.into();
             }
-            // SAFETY: Caller must ensure that interface is a valid pointer. It is null-checked above.
+            // SAFETY: Caller must ensure that interface is a valid pointer. It is checked for null above.
             Ok(i_face) => unsafe { interface.write_unaligned(i_face) },
         }
     }
@@ -753,7 +782,10 @@ pub fn core_locate_device_path(
             continue;
         }
 
-        let (remaining_path, matching_nodes) = match unsafe { remaining_device_path(temp_device_path, device_path) } {
+        let (remaining_path, matching_nodes) = match
+            // SAFETY: temp_device_path and device_path are validated before use and are device path pointers.
+            unsafe { remaining_device_path(temp_device_path, device_path) }
+        {
             Some((remaining_path, matching_nodes)) => (remaining_path, matching_nodes as isize),
             None => continue,
         };
@@ -777,17 +809,26 @@ extern "efiapi" fn locate_device_path(
     device_path: *mut *mut r_efi::protocols::device_path::Protocol,
     device: *mut efi::Handle,
 ) -> efi::Status {
-    // SAFETY: Caller must ensure that protocol, device_path, and device are valid pointers. They are null-checked below.
-    if protocol.is_null() || device_path.is_null() || unsafe { device_path.read_unaligned() }.is_null() {
+    if protocol.is_null() || device_path.is_null() {
         return efi::Status::INVALID_PARAMETER;
     }
 
-    let (best_remaining_path, best_device) =
-        // SAFETY: Caller must ensure that protocol and device_path are valid pointers. They are null-checked above.
-        match core_locate_device_path(unsafe { protocol.read_unaligned() }, unsafe { device_path.read_unaligned() }) {
-            Err(err) => return err.into(),
-            Ok((path, device)) => (path, device),
-        };
+    let current_device_path = {
+        // SAFETY: device_path is null-checked above.
+        unsafe { device_path.read_unaligned() }
+    };
+    if current_device_path.is_null() {
+        return efi::Status::INVALID_PARAMETER;
+    }
+
+    let protocol_guid = {
+        // SAFETY: protocol is null-checked above.
+        unsafe { protocol.read_unaligned() }
+    };
+    let (best_remaining_path, best_device) = match core_locate_device_path(protocol_guid, current_device_path) {
+        Err(err) => return err.into(),
+        Ok((path, device)) => (path, device),
+    };
     if device.is_null() {
         return efi::Status::INVALID_PARAMETER;
     }
@@ -809,12 +850,14 @@ pub fn init_protocol_support(st: &mut EfiSystemTable) {
     //transmute here. Fixing it properly would require an upstream change in r_efi to pick up. There is also a bug in
     //the r_efi definition for uninstall_multiple_protocol_interfaces - per spec, the first argument is a handle, but
     //r_efi has it as *mut handle.
+    // SAFETY: Transmute bridges r_efi signature mismatch for variadic interface. ABI matches for efiapi/extern C.
     bs.install_multiple_protocol_interfaces = unsafe {
         let ptr = install_multiple_protocol_interfaces as *const ();
         core::mem::transmute::<*const (), extern "efiapi" fn(*mut *mut c_void, *mut c_void, *mut c_void) -> efi::Status>(
             ptr,
         )
     };
+    // SAFETY: Transmute bridges r_efi signature mismatch for variadic interface. ABI matches for efiapi/extern C.
     bs.uninstall_multiple_protocol_interfaces = unsafe {
         let ptr = uninstall_multiple_protocol_interfaces as *const ();
         core::mem::transmute::<*const (), extern "efiapi" fn(*mut c_void, *mut c_void, *mut c_void) -> efi::Status>(ptr)

--- a/patina_dxe_core/src/runtime.rs
+++ b/patina_dxe_core/src/runtime.rs
@@ -23,7 +23,9 @@ struct RuntimeData {
     runtime_events: LinkedList<runtime::EventEntry, &'static crate::allocator::UefiAllocatorWithFsb>,
 }
 
+// SAFETY: RuntimeData is only accessed behind the RUNTIME_DATA mutex.
 unsafe impl Sync for RuntimeData {}
+// SAFETY: RuntimeData is only accessed behind the RUNTIME_DATA mutex.
 unsafe impl Send for RuntimeData {}
 
 static RUNTIME_DATA: Mutex<RuntimeData> = Mutex::new(RuntimeData::new());
@@ -82,6 +84,7 @@ pub fn init_runtime_support() {
 pub fn finalize_runtime_support() {
     let data = RUNTIME_DATA.lock();
     if !data.runtime_arch_ptr.is_null() {
+        // SAFETY: runtime_arch_ptr is set from the runtime protocol and checked for null.
         unsafe { (*data.runtime_arch_ptr).at_runtime.store(true, core::sync::atomic::Ordering::Relaxed) };
     }
 }

--- a/patina_dxe_core/src/systemtables.rs
+++ b/patina_dxe_core/src/systemtables.rs
@@ -47,6 +47,7 @@ impl EfiRuntimeServicesTable {
         let mut table_copy = unsafe { self.runtime_services.read() };
         table_copy.hdr.crc32 = 0;
 
+        // SAFETY: table_copy is a valid, initialized RuntimeServices value on the stack.
         let tbl_slice =
             unsafe { from_raw_parts(&table_copy as *const _ as *const u8, size_of::<efi::RuntimeServices>()) };
         table_copy.hdr.crc32 = crc32fast::hash(tbl_slice);
@@ -247,6 +248,7 @@ impl EfiBootServicesTable {
         let mut table_copy = unsafe { self.boot_services.read() };
         table_copy.hdr.crc32 = 0;
 
+        // SAFETY: table_copy is a valid, initialized BootServices value on the stack.
         let tbl_slice = unsafe { from_raw_parts(&table_copy as *const _ as *const u8, size_of::<efi::BootServices>()) };
         table_copy.hdr.crc32 = crc32fast::hash(tbl_slice);
 
@@ -714,6 +716,8 @@ impl EfiSystemTable {
     /// # Safety
     /// The pointer must be valid and point to a properly initialized efi::SystemTable structure.
     pub unsafe fn from_raw_pointer(ptr: *mut efi::SystemTable) -> Self {
+        // SAFETY: Caller guarantees ptr is a valid SystemTable pointer with initialized pointers
+        // per the function safety contract.
         unsafe {
             if ptr.is_null() {
                 panic!("Attempted to create EfiSystemTable with null System Table pointer");
@@ -734,6 +738,7 @@ impl EfiSystemTable {
         let mut table_copy = unsafe { self.system_table.read() };
         table_copy.hdr.crc32 = 0;
 
+        // SAFETY: table_copy is a valid, initialized SystemTable value on the stack.
         let st_slice = unsafe { from_raw_parts(&table_copy as *const _ as *const u8, size_of::<efi::SystemTable>()) };
         table_copy.hdr.crc32 = crc32fast::hash(st_slice);
 

--- a/patina_dxe_core/src/test_support.rs
+++ b/patina_dxe_core/src/test_support.rs
@@ -175,7 +175,9 @@ impl PatinaPageTable for MockPageTable {
     }
 }
 
+// SAFETY: MockPageTable uses interior mutability for test-only state and is not shared across threads in tests.
 unsafe impl Send for MockPageTable {}
+// SAFETY: MockPageTable's interior mutability is confined to test usage where concurrent access is controlled.
 unsafe impl Sync for MockPageTable {}
 
 impl Default for MockPageTable {

--- a/patina_dxe_core/src/tpl_mutex.rs
+++ b/patina_dxe_core/src/tpl_mutex.rs
@@ -37,10 +37,14 @@ pub struct TplGuard<'a, T: ?Sized + 'a> {
     mutex: &'a TplMutex<T>,
 }
 
+// SAFETY: TplMutex enforces mutual exclusion with atomic lock and TPL elevation.
 unsafe impl<T: ?Sized + Send> Sync for TplMutex<T> {}
+// SAFETY: TplMutex enforces mutual exclusion with atomic lock and TPL elevation.
 unsafe impl<T: ?Sized + Send> Send for TplMutex<T> {}
 
+// SAFETY: TplGuard grants exclusive access to the protected data while the lock is held.
 unsafe impl<T: ?Sized + Sync> Sync for TplGuard<'_, T> {}
+// SAFETY: TplGuard grants exclusive access to the protected data while the lock is held.
 unsafe impl<T: ?Sized + Send> Send for TplGuard<'_, T> {}
 
 impl<T> TplMutex<T> {

--- a/sdk/patina/src/component/service/memory.rs
+++ b/sdk/patina/src/component/service/memory.rs
@@ -869,6 +869,11 @@ mod mock {
             }
         }
 
+        /// Frees the block of pages at the given address of the given size.
+        ///
+        /// ## Safety
+        /// Caller must ensure that the given address corresponds to a valid block of pages that was allocated with
+        /// [Self::allocate_pages]
         unsafe fn free_pages(&self, address: usize, page_count: usize) -> Result<(), MemoryError> {
             let ptr = address as *mut u8;
             let layout = Layout::from_size_align(page_count * UEFI_PAGE_SIZE, UEFI_PAGE_SIZE).unwrap();


### PR DESCRIPTION
## Description

Closes #583 
Closes #1396

Adds safety comments to the remaining unsafe blocks in patina_dxe_core and enables the clippy lint for missing safety docs.

This allows future contributions to have the lint enforced.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [x] Includes documentation?

## How This Was Tested

- `cargo make all` with the `undocumented_safety_blocks` clippy lint enabled in `patina_dxe_core`

## Integration Instructions

- N/A - Safety comments that have no functional impact

---

Note: Skipping code coverage check on this PR.