### PR TITLE
Ingest patina-paging 11.0.2 and use new open_active interface

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ patina_lzma_rs = { version = "0.3.1", default-features = false }
 patina_macro = { version = "20.1.1", path = "sdk/patina_macro" }
 patina_mm = { version = "20.1.1", path = "components/patina_mm" }
 patina_mtrr = { version = "^1.1.4" }
-patina_paging = { version = "11" }
+patina_paging = { version = "11.0.2" }
 patina_performance = { version = "20.1.1", path = "components/patina_performance" }
 patina_smbios = { version = "20.1.1", path = "components/patina_smbios" }
 patina_stacktrace = { version = "20.1.1", path = "core/patina_stacktrace" }

--- a/core/patina_debugger/src/arch/aarch64.rs
+++ b/core/patina_debugger/src/arch/aarch64.rs
@@ -216,19 +216,11 @@ impl DebuggerArch for Aarch64Arch {
     }
 
     fn get_page_table() -> Result<Self::PageTable, ()> {
-        // TODO: Check for EL1?
-        let ttbr0_el2 = read_sysreg!(ttbr0_el2);
-
-        // SAFETY: We are creating from the existing page table root, so the
-        // page tables should be a valid structure. Using PageAllocatorStub
-        // ensures that no allocations are attempted.
+        // SAFETY: We are operating in an exception context with interrupts disabled. No other entity is altering
+        // the page tables.
         unsafe {
-            patina_paging::aarch64::AArch64PageTable::from_existing(
-                ttbr0_el2,
-                patina_paging::page_allocator::PageAllocatorStub,
-                patina_paging::PagingType::Paging4Level,
-            )
-            .map_err(|_| ())
+            patina_paging::aarch64::AArch64PageTable::open_active(patina_paging::page_allocator::PageAllocatorStub)
+                .map_err(|_| ())
         }
     }
 

--- a/core/patina_debugger/src/arch/x64.rs
+++ b/core/patina_debugger/src/arch/x64.rs
@@ -10,7 +10,6 @@ use gdbstub::{
 };
 use patina_internal_cpu::interrupts::ExceptionContext;
 use patina_mtrr::Mtrr;
-use patina_paging::PagingType;
 
 use super::{DebuggerArch, UefiArchRegs};
 use crate::{ExceptionInfo, ExceptionType};
@@ -148,25 +147,11 @@ impl DebuggerArch for X64Arch {
     }
 
     fn get_page_table() -> Result<Self::PageTable, ()> {
-        let cr3: u64;
-        // SAFETY: This is simply reading the CR3 register, which is safe.
-        unsafe { asm!("mov {}, cr3", out(reg) cr3) };
-        let cr4: u64;
-        // SAFETY: This is simply reading the CR4 register, which is safe.
-        unsafe { asm!("mov {}, cr4", out(reg) cr4) };
-
-        // Check CR4 to determine if we are using 4-level or 5-level paging.
-        let paging_type = { if cr4 & (1 << 12) != 0 { PagingType::Paging5Level } else { PagingType::Paging4Level } };
-
-        // SAFETY: The CR3 is currently being should be identity mapped and so
-        // should point to a valid page table.
+        // SAFETY: We are operating in an exception context with interrupts disabled. No other entity is altering
+        // the page tables.
         unsafe {
-            patina_paging::x64::X64PageTable::from_existing(
-                cr3,
-                patina_paging::page_allocator::PageAllocatorStub,
-                paging_type,
-            )
-            .map_err(|_| ())
+            patina_paging::x64::X64PageTable::open_active(patina_paging::page_allocator::PageAllocatorStub)
+                .map_err(|_| ())
         }
     }
 

--- a/core/patina_internal_cpu/src/interrupts/aarch64/interrupt_manager.rs
+++ b/core/patina_internal_cpu/src/interrupts/aarch64/interrupt_manager.rs
@@ -13,7 +13,7 @@ use patina::{
     component::service::IntoService,
     error::EfiError,
 };
-use patina_paging::{PageTable, PagingType};
+use patina_paging::PageTable;
 
 use crate::interrupts::{
     EfiExceptionStackTrace, EfiSystemContext, HandlerType, InterruptManager, aarch64::ExceptionContextAArch64,
@@ -201,25 +201,10 @@ extern "efiapi" fn synchronous_exception_handler(_exception_type: isize, context
 }
 
 fn dump_pte(far: u64) {
-    // Needed because attributes on expressions are not stable.
-    // https://github.com/rust-lang/rust/issues/15701
-    #[allow(clippy::needless_late_init)]
-    let ttbr0_el2;
-    cfg_if::cfg_if! {
-        if #[cfg(all(not(test), target_arch = "aarch64"))]  {
-            ttbr0_el2 = read_sysreg!(ttbr0_el2);
-        } else {
-            ttbr0_el2 = 0u64;
-        }
-    }
-
-    // SAFETY: TTBR0 must be valid as it is the current page table base.
+    // SAFETY: We are in an exception handler and want to dump the page tables, there is no other active code
+    // modifying the page tables.
     if let Ok(pt) = unsafe {
-        patina_paging::aarch64::AArch64PageTable::from_existing(
-            ttbr0_el2,
-            patina_paging::page_allocator::PageAllocatorStub,
-            PagingType::Paging4Level,
-        )
+        patina_paging::aarch64::AArch64PageTable::open_active(patina_paging::page_allocator::PageAllocatorStub)
     } {
         let _ = pt.dump_page_tables(far & !(UEFI_PAGE_MASK as u64), UEFI_PAGE_SIZE as u64);
         log::error!("");

--- a/core/patina_internal_cpu/src/interrupts/x64/interrupt_manager.rs
+++ b/core/patina_internal_cpu/src/interrupts/x64/interrupt_manager.rs
@@ -16,7 +16,7 @@ use patina::{
 };
 #[cfg(target_arch = "x86_64")]
 use patina_mtrr::Mtrr;
-use patina_paging::{PageTable, PagingType};
+use patina_paging::PageTable;
 use patina_stacktrace::{StackFrame, StackTrace};
 
 use crate::interrupts::{EfiExceptionStackTrace, HandlerType, InterruptManager, x64::ExceptionContextX64};
@@ -116,11 +116,7 @@ extern "efiapi" fn page_fault_handler(_exception_type: isize, context: EfiSystem
 
     (x64_context as &ExceptionContextX64).dump_system_context_registers();
 
-    let paging_type =
-        { if x64_context.cr4 & (1 << 12) != 0 { PagingType::Paging5Level } else { PagingType::Paging4Level } };
-
-    // SAFETY: CR3 and the paging type are correct as they are from the current context.
-    unsafe { dump_pte(x64_context.cr2, x64_context.cr3, paging_type) };
+    dump_pte(x64_context.cr2);
 
     log::error!("Dumping Exception Stack Trace:");
     let stack_frame = StackFrame { pc: x64_context.rip, sp: x64_context.rsp, fp: x64_context.rbp };
@@ -178,21 +174,17 @@ fn interpret_gp_fault_exception_data(exception_data: u64) {
 
 // There is no value in coverage for this function.
 #[coverage(off)]
-/// Dumps the page table entries for the given CR2 and CR3 values.
+/// Dumps the page table entries for the given CR2. This uses the active page tables as they should be the same as the
+/// ones at the time of the fault.
 ///
-/// ## Safety
-///
-/// The caller is responsible for ensuring that the CR3 value is a valid and well-formed page table base address and
-/// matches the paging type requested.
-unsafe fn dump_pte(cr2: u64, cr3: u64, paging_type: PagingType) {
-    // SAFETY: Caller must ensure cr3 & paging type are correct.
-    if let Ok(pt) = unsafe {
-        patina_paging::x64::X64PageTable::from_existing(
-            cr3,
-            patina_paging::page_allocator::PageAllocatorStub,
-            paging_type,
-        )
-    } {
+fn dump_pte(cr2: u64) {
+    if let Ok(pt) =
+        // SAFETY: We are in an exception handler and want to dump the page tables, there is no other active code
+        // modifying the page tables.
+        unsafe {
+            patina_paging::x64::X64PageTable::open_active(patina_paging::page_allocator::PageAllocatorStub)
+        }
+    {
         let _ = pt.dump_page_tables(cr2 & !(UEFI_PAGE_MASK as u64), UEFI_PAGE_SIZE as u64);
     }
 


### PR DESCRIPTION
## Description

Patina-paging 11.0.2 introduces support for reading/editing existing 5-level page tables on AArch64. This is required for EDK2 20511 based system that have FEAT_LPA2 support. To use this change, this commit switches to use the new `open_active` interface for both AArch64 and x64, which also simplifies the consumer by handling level detection in the paging library.

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

- [x] Boot test w/ debugger on Q35
- [x] Boot test w/ debugger on SBSA

## Integration Instructions

N/A