### PR TITLE
patina_dxe_core: Add DxeDispatch service for driver dispatch

### DIFF
--- a/patina_dxe_core/src/dxe_dispatch_service.rs
+++ b/patina_dxe_core/src/dxe_dispatch_service.rs
@@ -1,0 +1,38 @@
+//! DXE Core Dispatch Service
+//!
+//! Provides the [`CoreDxeDispatch`] service implementation, which exposes
+//! the PI dispatcher to components via dependency injection. This allows
+//! components to trigger DXE driver dispatch passes (e.g., to interleave
+//! controller connection with driver dispatch during boot).
+//!
+//! ## License
+//!
+//! Copyright (c) Microsoft Corporation.
+//!
+//! SPDX-License-Identifier: Apache-2.0
+//!
+use patina::{
+    component::service::{IntoService, dxe_dispatch::DxeDispatch},
+    error::Result,
+};
+
+use crate::{Core, PlatformInfo};
+
+/// DXE dispatch service backed by the PI dispatcher.
+#[derive(IntoService)]
+#[service(dyn DxeDispatch)]
+pub(crate) struct CoreDxeDispatch<P: PlatformInfo>(&'static Core<P>);
+
+#[coverage(off)]
+impl<P: PlatformInfo> CoreDxeDispatch<P> {
+    pub(crate) fn new(core: &'static Core<P>) -> Self {
+        Self(core)
+    }
+}
+
+#[coverage(off)]
+impl<P: PlatformInfo> DxeDispatch for CoreDxeDispatch<P> {
+    fn dispatch(&self) -> Result<bool> {
+        self.0.pi_dispatcher.dispatch()
+    }
+}

--- a/patina_dxe_core/src/lib.rs
+++ b/patina_dxe_core/src/lib.rs
@@ -77,6 +77,7 @@ mod cpu;
 mod debugger_reload;
 mod decompress;
 mod driver_services;
+mod dxe_dispatch_service;
 mod dxe_services;
 mod event_db;
 mod events;
@@ -401,7 +402,7 @@ impl<P: PlatformInfo> Core<P> {
     /// Initializes the core with the given configuration, including GCD initialization, enabling allocations.
     ///
     /// Returns the relocated HOB list pointer that should be used for all subsequent operations.
-    fn init_memory(&self, physical_hob_list: *const c_void) -> *mut c_void {
+    fn init_memory(&'static self, physical_hob_list: *const c_void) -> *mut c_void {
         log::info!("DXE Core Crate v{DXE_CORE_VERSION}");
 
         GCD.prioritize_32_bit_memory(P::MemoryInfo::prioritize_32_bit_memory());
@@ -474,6 +475,7 @@ impl<P: PlatformInfo> Core<P> {
         component_dispatcher.add_service(cpu);
         component_dispatcher.add_service(interrupt_manager);
         component_dispatcher.add_service(CoreMemoryManager);
+        component_dispatcher.add_service(dxe_dispatch_service::CoreDxeDispatch::new(self));
         component_dispatcher
             .add_service(cpu::PerfTimer::with_frequency(P::CpuInfo::perf_timer_frequency().unwrap_or(0)));
 

--- a/sdk/patina/src/component/service.rs
+++ b/sdk/patina/src/component/service.rs
@@ -124,6 +124,7 @@ use crate::component::{
     storage::{Storage, UnsafeStorageCell},
 };
 
+pub mod dxe_dispatch;
 pub mod memory;
 pub mod perf_timer;
 

--- a/sdk/patina/src/component/service/dxe_dispatch.rs
+++ b/sdk/patina/src/component/service/dxe_dispatch.rs
@@ -1,0 +1,32 @@
+//! DXE Dispatch Service Definition.
+//!
+//! This module contains the [`DxeDispatch`] trait for services that expose
+//! DXE driver dispatch capability. See [`DxeDispatch`] for the primary interface.
+//!
+//! ## License
+//!
+//! Copyright (c) Microsoft Corporation.
+//!
+//! SPDX-License-Identifier: Apache-2.0
+//!
+#[cfg(any(test, feature = "mockall"))]
+use mockall::automock;
+
+use crate::error::Result;
+
+/// Service interface for DXE driver dispatch.
+///
+/// Provides access to the PI dispatcher for components that need to trigger
+/// additional driver dispatch passes beyond the core's built-in dispatch loop
+/// (e.g., to interleave controller connection with driver dispatch during boot).
+///
+/// Note: The DXE core already runs a PI dispatch loop automatically. This
+/// service is only needed when a component must explicitly trigger a dispatch
+/// pass at a specific point in its execution.
+#[cfg_attr(any(test, feature = "mockall"), automock)]
+pub trait DxeDispatch {
+    /// Performs a single DXE driver dispatch pass.
+    ///
+    /// Returns `true` if any drivers were dispatched, `false` if no drivers were dispatched.
+    fn dispatch(&self) -> Result<bool>;
+}


### PR DESCRIPTION
## Description

Add a `DxeDispatch` service trait in the SDK and a `CoreDxeDispatch`
implementation in patina_dxe_core that delegates to the PI dispatcher.
The service is registered alongside other core services (MemoryManager,
PerfTimer, etc.) and consumed via dependency injection by components
that need to trigger driver dispatch passes.

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

- Built SBSA DXE core binary with `BootDispatcher` + `SimpleBootManager` consuming the service via DI
- Booted Windows ARM64 under QEMU SBSA-ref with Patina BDS handling the full boot flow
- Connect-dispatch interleaving discovered AHCI device, expanded partial device path, loaded Windows bootloader, ExitBootServices completed
- 106 on-system unit tests passed (0 fails)

## Integration Instructions

The `DxeDispatch` service is registered automatically by the DXE core.
Components consume it via dependency injection:

```rust
fn entry_point(self, dxe_dispatch: Service<dyn DxeDispatch>) -> Result<()> {
    dxe_dispatch.dispatch()?;
    Ok(())
}
```