### PR TITLE
[feature/patina-boot] patina_boot: Add connect-dispatch interleaving with DxeServices

### DIFF
--- a/components/patina_boot/README.md
+++ b/components/patina_boot/README.md
@@ -4,22 +4,24 @@ Boot orchestration component for Patina-based firmware implementing UEFI boot ma
 
 ## Components
 
-- **BootOrchestrator**: Orchestrates device enumeration, BDS phase events, and boot option execution.
-- **ConsoleDiscovery**: Discovers console devices and populates UEFI console variables.
+- **BootDispatcher**: Installs the BDS architectural protocol and delegates to a `BootOrchestrator` implementation.
+- **BootOrchestrator**: Trait for custom boot flows. Platforms implement this to define boot behavior.
+- **SimpleBootManager**: Default `BootOrchestrator` for platforms with straightforward boot topologies.
 
 ## Usage
 
 ```rust
-use patina_boot::{component::BootOrchestrator, config::BootOptions};
+use patina_boot::{BootDispatcher, SimpleBootManager, config::BootConfig};
 
-// Configure boot options (devices are tried in order)
-let config = BootOptions::new()
-    .with_device(primary_boot_path)
-    .with_device(fallback_boot_path)
-    .with_failure_handler(|| { /* handle boot failure */ });
+// Minimal boot:
+let orchestrator = SimpleBootManager::new(
+    BootConfig::new(nvme_esp_path())
+        .with_device(nvme_recovery_path()),
+);
+add.component(BootDispatcher::new(orchestrator));
 
-// Add BootOrchestrator as a platform component
-add.component(BootOrchestrator);
+// Custom orchestrator:
+add.component(BootDispatcher::new(MyCustomOrchestrator::new()));
 ```
 
 ## Helper Functions

--- a/components/patina_boot/src/boot_dispatcher.rs
+++ b/components/patina_boot/src/boot_dispatcher.rs
@@ -17,7 +17,11 @@ use core::ffi::c_void;
 
 use patina::{
     boot_services::{BootServices, StandardBootServices},
-    component::{component, params::Handle},
+    component::{
+        component,
+        params::Handle,
+        service::{Service, dxe_dispatch::DxeDispatch},
+    },
     error::{EfiError, Result},
     pi::protocols::bds,
     runtime_services::StandardRuntimeServices,
@@ -29,6 +33,7 @@ use crate::boot_orchestrator::BootOrchestrator;
 /// Context stored in a static for the BDS protocol callback to access.
 struct BdsContext {
     orchestrator: Box<dyn BootOrchestrator>,
+    dxe_dispatch: &'static dyn DxeDispatch,
     boot_services: StandardBootServices,
     runtime_services: StandardRuntimeServices,
     image_handle: r_efi::efi::Handle,
@@ -50,6 +55,7 @@ static BDS_CONTEXT: Once<BdsContext> = Once::new();
 /// This is the single Patina component for driving boot orchestration. It:
 /// - Accepts a [`BootOrchestrator`] implementation via [`BootDispatcher::new()`]
 /// - Installs the BDS architectural protocol during component dispatch
+/// - Consumes the [`DxeDispatch`] service via dependency injection
 /// - When the DXE core invokes BDS: delegates to `orchestrator.execute()`
 ///
 /// ## Usage
@@ -92,6 +98,7 @@ impl BootDispatcher {
         self,
         boot_services: StandardBootServices,
         runtime_services: StandardRuntimeServices,
+        dxe_dispatch: Service<dyn DxeDispatch>,
         image_handle: Option<Handle>,
     ) -> Result<()> {
         let handle = image_handle.ok_or_else(|| {
@@ -102,6 +109,7 @@ impl BootDispatcher {
         // Store the orchestrator and services for the BDS callback
         BDS_CONTEXT.call_once(|| BdsContext {
             orchestrator: self.orchestrator,
+            dxe_dispatch: *dxe_dispatch,
             boot_services: boot_services.clone(),
             runtime_services: runtime_services.clone(),
             image_handle: *handle,
@@ -136,14 +144,22 @@ extern "efiapi" fn bds_entry_point(_this: *mut bds::Protocol) {
         panic!("BDS context not initialized — BootDispatcher entry_point was not called");
     };
 
-    let Err(e) = context.orchestrator.execute(&context.boot_services, &context.runtime_services, context.image_handle);
+    let Err(e) = context.orchestrator.execute(
+        &context.boot_services,
+        &context.runtime_services,
+        context.dxe_dispatch,
+        context.image_handle,
+    );
     panic!("BootOrchestrator::execute() failed: {e:?}");
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use patina::{boot_services::StandardBootServices, runtime_services::StandardRuntimeServices};
+    use patina::{
+        boot_services::StandardBootServices, component::service::dxe_dispatch::DxeDispatch,
+        runtime_services::StandardRuntimeServices,
+    };
     use r_efi::efi;
 
     struct MockOrchestrator;
@@ -153,6 +169,7 @@ mod tests {
             &self,
             _boot_services: &StandardBootServices,
             _runtime_services: &StandardRuntimeServices,
+            _dxe_dispatch: &dyn DxeDispatch,
             _image_handle: efi::Handle,
         ) -> core::result::Result<!, patina::error::EfiError> {
             Err(patina::error::EfiError::NotFound)

--- a/components/patina_boot/src/boot_orchestrator.rs
+++ b/components/patina_boot/src/boot_orchestrator.rs
@@ -11,7 +11,10 @@
 //!
 //! SPDX-License-Identifier: Apache-2.0
 //!
-use patina::{boot_services::StandardBootServices, error::EfiError, runtime_services::StandardRuntimeServices};
+use patina::{
+    boot_services::StandardBootServices, component::service::dxe_dispatch::DxeDispatch, error::EfiError,
+    runtime_services::StandardRuntimeServices,
+};
 use r_efi::efi;
 
 /// Trait for boot orchestration.
@@ -38,6 +41,7 @@ use r_efi::efi;
 ///         &self,
 ///         boot_services: &StandardBootServices,
 ///         runtime_services: &StandardRuntimeServices,
+///         dxe_services: &dyn DxeDispatch,
 ///         image_handle: efi::Handle,
 ///     ) -> Result<!, EfiError> {
 ///         // Custom boot flow...
@@ -65,6 +69,7 @@ pub trait BootOrchestrator: Send + Sync + 'static {
         &self,
         boot_services: &StandardBootServices,
         runtime_services: &StandardRuntimeServices,
+        dxe_services: &dyn DxeDispatch,
         image_handle: efi::Handle,
     ) -> Result<!, EfiError>;
 }

--- a/components/patina_boot/src/orchestrators/simple_boot_manager.rs
+++ b/components/patina_boot/src/orchestrators/simple_boot_manager.rs
@@ -23,7 +23,39 @@ use patina::{
 };
 use r_efi::efi;
 
+use patina::component::service::dxe_dispatch::DxeDispatch;
+
+use patina::boot_services::BootServices;
+
 use crate::{boot_orchestrator::BootOrchestrator, config::BootConfig, helpers};
+
+/// Interleave controller connection with DXE driver dispatch.
+///
+/// Alternates between connecting all controllers and dispatching newly loaded
+/// drivers (e.g., PCI option ROMs) until both the device topology stabilizes
+/// and no new drivers are dispatched.
+///
+/// This ensures that drivers loaded from firmware volumes during device
+/// enumeration (such as PCI option ROM drivers) are dispatched before
+/// continuing enumeration, allowing those drivers to bind to newly
+/// discovered controllers.
+fn interleave_connect_and_dispatch<B: BootServices, D: DxeDispatch + ?Sized>(
+    boot_services: &B,
+    dxe_services: &D,
+) -> patina::error::Result<()> {
+    const MAX_ROUNDS: usize = 10;
+
+    for _round in 0..MAX_ROUNDS {
+        helpers::connect_all(boot_services)?;
+        if !dxe_services.dispatch()? {
+            return Ok(());
+        }
+    }
+
+    debug_assert!(false, "connect-dispatch interleaving did not converge after {MAX_ROUNDS} rounds");
+
+    Ok(())
+}
 
 /// Simple boot manager implementing [`BootOrchestrator`].
 ///
@@ -32,7 +64,7 @@ use crate::{boot_orchestrator::BootOrchestrator, config::BootConfig, helpers};
 ///
 /// ## Boot Flow
 ///
-/// 1. Connect all controllers for device enumeration
+/// 1. Interleave controller connection with DXE driver dispatch for device enumeration
 /// 2. Signal EndOfDxe (security lockdown)
 /// 3. Discover console devices
 /// 4. Detect hotkey (if configured); select alternate devices if pressed
@@ -78,10 +110,11 @@ impl BootOrchestrator for SimpleBootManager {
         &self,
         boot_services: &StandardBootServices,
         runtime_services: &StandardRuntimeServices,
+        dxe_dispatch: &dyn DxeDispatch,
         image_handle: efi::Handle,
     ) -> Result<!, EfiError> {
-        if let Err(e) = helpers::connect_all(boot_services) {
-            log::error!("connect_all failed: {:?}", e);
+        if let Err(e) = interleave_connect_and_dispatch(boot_services, dxe_dispatch) {
+            log::error!("interleave_connect_and_dispatch failed: {:?}", e);
         }
 
         if let Err(e) = helpers::signal_bds_phase_entry(boot_services) {
@@ -132,12 +165,119 @@ mod tests {
     extern crate alloc;
 
     use super::*;
-    use alloc::sync::Arc;
+    use alloc::{boxed::Box, sync::Arc};
     use core::sync::atomic::{AtomicBool, Ordering};
-    use patina::device_path::{node_defs::EndEntire, paths::DevicePathBuf};
+    use patina::{
+        boot_services::{MockBootServices, boxed::BootServicesBox},
+        device_path::{node_defs::EndEntire, paths::DevicePathBuf},
+    };
 
     fn test_device_path() -> DevicePathBuf {
         DevicePathBuf::from_device_path_node_iter(core::iter::once(EndEntire))
+    }
+
+    // Tests for interleave_connect_and_dispatch
+
+    struct MockDxeDispatcher {
+        results: spin::Mutex<alloc::collections::VecDeque<patina::error::Result<bool>>>,
+    }
+
+    impl MockDxeDispatcher {
+        fn new(results: &[patina::error::Result<bool>]) -> Self {
+            Self { results: spin::Mutex::new(results.iter().cloned().collect()) }
+        }
+    }
+
+    impl DxeDispatch for MockDxeDispatcher {
+        fn dispatch(&self) -> patina::error::Result<bool> {
+            self.results.lock().pop_front().expect("MockDxeDispatcher: unexpected dispatch call")
+        }
+    }
+
+    fn leaked_boot_services_for_box() -> &'static MockBootServices {
+        Box::leak(Box::new({
+            let mut m = MockBootServices::new();
+            m.expect_free_pool().returning(|_| Ok(()));
+            m
+        }))
+    }
+
+    fn mock_handle_buffer(
+        handle_addrs: &[usize],
+        boot_services: &'static MockBootServices,
+    ) -> BootServicesBox<'static, [efi::Handle], MockBootServices> {
+        let handles: Vec<efi::Handle> = handle_addrs.iter().map(|&a| a as efi::Handle).collect();
+        let leaked = handles.leak();
+        // SAFETY: leaked is a valid pointer+length from Vec::leak.
+        unsafe { BootServicesBox::from_raw_parts_mut(leaked.as_mut_ptr(), leaked.len(), boot_services) }
+    }
+
+    #[test]
+    fn test_interleave_single_round_no_drivers_dispatched() {
+        let box_mock = leaked_boot_services_for_box();
+        let mut boot_mock = MockBootServices::new();
+
+        boot_mock.expect_locate_handle_buffer().returning(move |_| Ok(mock_handle_buffer(&[1], box_mock)));
+        boot_mock.expect_connect_controller().returning(|_, _, _, _| Ok(()));
+
+        let dxe_mock = MockDxeDispatcher::new(&[Ok(false)]);
+
+        let result = interleave_connect_and_dispatch(&boot_mock, &dxe_mock);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_interleave_multiple_rounds() {
+        let box_mock = leaked_boot_services_for_box();
+        let mut boot_mock = MockBootServices::new();
+
+        boot_mock.expect_locate_handle_buffer().returning(move |_| Ok(mock_handle_buffer(&[1], box_mock)));
+        boot_mock.expect_connect_controller().returning(|_, _, _, _| Ok(()));
+
+        let dxe_mock = MockDxeDispatcher::new(&[Ok(true), Ok(false)]);
+
+        let result = interleave_connect_and_dispatch(&boot_mock, &dxe_mock);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_interleave_connect_failure_propagates() {
+        let mut boot_mock = MockBootServices::new();
+
+        boot_mock.expect_locate_handle_buffer().returning(|_| Err(efi::Status::NOT_FOUND));
+
+        let dxe_mock = MockDxeDispatcher::new(&[]);
+
+        let result = interleave_connect_and_dispatch(&boot_mock, &dxe_mock);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_interleave_dispatch_failure_propagates() {
+        let box_mock = leaked_boot_services_for_box();
+        let mut boot_mock = MockBootServices::new();
+
+        boot_mock.expect_locate_handle_buffer().returning(move |_| Ok(mock_handle_buffer(&[1], box_mock)));
+        boot_mock.expect_connect_controller().returning(|_, _, _, _| Ok(()));
+
+        let dxe_mock = MockDxeDispatcher::new(&[Err(EfiError::DeviceError)]);
+
+        let result = interleave_connect_and_dispatch(&boot_mock, &dxe_mock);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_interleave_stops_at_max_rounds() {
+        let box_mock = leaked_boot_services_for_box();
+        let mut boot_mock = MockBootServices::new();
+
+        boot_mock.expect_locate_handle_buffer().returning(move |_| Ok(mock_handle_buffer(&[1], box_mock)));
+        boot_mock.expect_connect_controller().returning(|_, _, _, _| Ok(()));
+
+        let dxe_mock = MockDxeDispatcher::new(&[Ok(true); 10]);
+
+        let result = interleave_connect_and_dispatch(&boot_mock, &dxe_mock);
+        assert!(result.is_ok());
     }
 
     #[test]


### PR DESCRIPTION
## Description

Interleave controller connection with DXE driver dispatch during device
enumeration. Connecting controllers can discover new firmware volumes
(e.g., PCI option ROMs) that contain drivers for devices behind that
controller. Those drivers must be dispatched before the next round of
enumeration, otherwise the devices they serve will not be found.

`SimpleBootManager` uses `interleave_connect_and_dispatch()` to alternate
between connecting controllers and dispatching newly-discovered drivers
until both stabilize. The `DxeDispatch` service trait (from #1421) is
consumed via dependency injection.

Note: `interleave_connect_and_dispatch()` currently uses `connect_all()`
which connects every controller on every round. This is functional but
inefficient for platforms with large device topologies — a future
optimization could connect only newly-discovered controllers.

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [x] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

- Built SBSA DXE core binary with `BootDispatcher` + `SimpleBootManager` replacing TianoCore BdsDxe
- Booted Windows ARM64 under QEMU SBSA-ref emulation with Patina BDS handling the full boot flow
- Verified interleaving: controller connection discovered AHCI device, partial device path expanded to full path, Windows bootloader loaded, ExitBootServices completed

## Integration Instructions

Depends on #1421 (`DxeDispatch` service trait) for platform binary integration.

Remove TianoCore `BdsDxe.inf` from platform DSC/FDF since the `BootDispatcher` provides the BDS architectural protocol.