### PR TITLE
.github: Add integration changes for PR validation status check

### DIFF
--- a/.github/workflows/patina-qemu-pr-validation-post.yml
+++ b/.github/workflows/patina-qemu-pr-validation-post.yml
@@ -20,8 +20,9 @@ permissions:
 
 jobs:
   post-process:
-    if: github.event.workflow_run.conclusion != 'cancelled'
     uses: OpenDevicePartnership/patina-devops/.github/workflows/PatinaQemuPrValidationPost.yml@patina_e2e_plat_validation
     with:
+      conclusion: ${{ github.event.workflow_run.conclusion }}
+      head-sha: ${{ github.event.workflow_run.head_sha }}
       triggering-run-id: ${{ fromJSON(github.event.workflow_run.id) }}
     secrets: inherit


### PR DESCRIPTION
## Description

Contributes to https://github.com/OpenDevicePartnership/patina-devops/issues/108

Passes `head-sha` and `conclusion` args to the QEMU post-processing workflow.

This allows the post-processing workflow to set commit status including cases like when the workflow is cancelled.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

- Run successful, cancelled, and failing Patina QEMU PR Validation scenarios on fork

## Integration Instructions

- N/A