### PR TITLE
.github: Pass head-sha to QEMU validation workflows

### DIFF
--- a/.github/workflows/patina-qemu-pr-validation-pending.yml
+++ b/.github/workflows/patina-qemu-pr-validation-pending.yml
@@ -34,5 +34,6 @@ jobs:
     name: Run
     uses: OpenDevicePartnership/patina-devops/.github/workflows/PatinaQemuPrValidationPending.yml@patina_e2e_plat_validation
     with:
+      head-sha: ${{ github.event.pull_request.head.sha }}
       pr-number: ${{ github.event.pull_request.number }}
     secrets: inherit

--- a/.github/workflows/patina-qemu-pr-validation.yml
+++ b/.github/workflows/patina-qemu-pr-validation.yml
@@ -121,6 +121,7 @@ jobs:
     if: needs.prepare.result == 'success' && needs.prepare.outputs.skip != 'true'
     uses: OpenDevicePartnership/patina-devops/.github/workflows/PatinaQemuPrValidation.yml@patina_e2e_plat_validation
     with:
-      pr-number: ${{ fromJSON(needs.prepare.outputs.pr_number) }}
+      head-sha: ${{ github.event.workflow_run.head_sha }}
       patina-ref: ${{ github.event.workflow_run.head_sha }}
+      pr-number: ${{ fromJSON(needs.prepare.outputs.pr_number) }}
     secrets: inherit


### PR DESCRIPTION
## Description

A new `head-sha` input parameter was added to the QEMU validation workflows. This allows the workflow to have access to the head SHA of the PR, which is useful for applying status check results.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

- patina fork

## Integration Instructions

- N/A - Only impacts local workflows in repo CI
