### PR TITLE
pecoff: Miscellaneous fixes/updates for load_resource_section [Rebase & FF]

### DIFF
--- a/patina_dxe_core/src/pecoff.rs
+++ b/patina_dxe_core/src/pecoff.rs
@@ -453,7 +453,7 @@ pub fn load_resource_section(pe_info: &UefiPeInfo, image: &[u8]) -> error::Resul
 
                     let name_start_offset =
                         directory_entry.name_offset() as usize + core::mem::size_of::<DirectoryString>();
-                    let name_end_offset = name_start_offset + (resource_directory_string.length as usize * 2);
+                    let name_end_offset = name_start_offset + (resource_directory_string.length as usize) * 2;
                     let string_val = resource_section
                         .get(name_start_offset..name_end_offset)
                         .ok_or(error::Error::Goblin(goblin::error::Error::BufferTooShort(name_end_offset, "bytes")))?;


### PR DESCRIPTION
## Description

**pecoff: Fix resource string offset and UTF-16LE comparison**

The HII string lookup in `load_resource_section` calculated the string
data offset as `name_offset + 1`, but `DirectoryString` has a
2-byte length field (followed by the string data), so the correct
offset is `name_offset + sizeof(DirectoryString)`.

"Resource Directory String" is defined here in the PE/COFF spec:

https://learn.microsoft.com/windows/win32/debug/pe-format#resource-directory-string

The comparison constant used was `[0x00, 0x48, 0x00, 0x49, 0x00, 0x49]`
which matched the shifted byte sequence from the wrong offset instead
of the correct UTF-16LE bytes for "HII" which is:
`[0x48, 0x00, 0x49, 0x00, 0x49, 0x00]`.

---

**pecoff: Advance iteration in resource directory parsing**

Today, the code in `load_resource_section` iterates the number of
named entry times but doesn't actually update the `directory_entry`
to the offset for the current iteration. This change makes that
adjustment.

This worked before because images with HII resource sections either
had a sinlge section or the HII section was the first section.

I couldn't find any existing images that have more than one resource
directory entry, so I had to create a simple section with two entries
in the unit test.

---

**pecoff: Prevent potential overflow in load_resource_section**

Since `resource_directory_string.length` is a `u16`, a `.length`
value of > 32767 could cause an overflow when multiplied by 2
since the multiplication done before the cast to `usize`.

This change updates the code to perform the multiplication after the
cast to `usize` which is the type the result is assigned to
(the type of `name_end_offset`).

---

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [x] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

- `cargo make all`
- Q35 and SBSA boot to EFI shell

## Integration Instructions

- N/A