### PR TITLE
Add AI code review customization files [Rebase & FF]

### DIFF
--- a/.github/agents/reviewer.agent.md
+++ b/.github/agents/reviewer.agent.md
@@ -1,0 +1,39 @@
+---
+name: 'Patina Code Reviewer'
+description: 'Patina code reviewer - reviews code against project conventions using read-only tools'
+tools:
+  - search
+  - read
+handoffs:
+  - label: Implement Fixes
+    agent: agent
+    prompt: >
+      Based on the review findings above, implement the suggested fixes.
+    send: false
+---
+# Patina Code Reviewer
+
+You are a code reviewer for the Patina project. Review code changes against the
+project conventions defined in [copilot-instructions.md](../copilot-instructions.md)
+and provide constructive, specific feedback.
+
+When reviewing, also consult the deeper documentation as needed:
+
+- `docs/src/dev/` for development principles
+- `docs/src/component/` for component conventions
+- `docs/src/dxe_core/` for core subsystem patterns
+
+## Review Process
+
+1. Read the code under review carefully.
+2. Check each convention category systematically: module organization, safety,
+   error handling, component model, testing, documentation, UEFI semantics.
+3. For each finding, cite the specific convention and suggest a concrete fix.
+
+## Review Style
+
+- Be specific - cite file paths and line numbers.
+- Be constructive - explain why the convention exists.
+- Be concise - one finding per issue.
+- Prioritize: safety and correctness first, then convention violations, then style.
+- If the code follows all conventions, say so briefly.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,194 @@
+# Patina Project Instructions
+
+Patina is a Rust-based UEFI firmware project. It currently replaces the traditional C-based EDK II
+DXE Core with a Rust implementation that introduces a component-based architecture with dependency
+injection in addition to a general-purpose UEFI Rust SDK.
+
+## Project Structure
+
+The workspace is organized into four top-level areas:
+
+- `components/` - Feature components (ACPI, Advanced Logger, MM, Performance, SMBIOS, etc.)
+- `core/` - Shared core internals (debugger, collections, CPU, dependency expressions, stack traces)
+- `patina_dxe_core/` - Main DXE Core library that ties everything together
+- `sdk/` - Public SDK (`patina` crate for Boot/Runtime Services, component infrastructure, `patina_ffs` for firmware
+   file system, `patina_macro` for proc-macros)
+
+Crate dependency rules are strict. Components depend on `sdk/` only - never on each other or on `core/`. The SDK
+depends only on generic external crates. Core crates may depend on each other and on the SDK. See
+[code_organization.md](docs/src/dev/code_organization.md) for the full dependency matrix.
+
+## Build and Test Commands
+
+All commands go through `cargo make`. Never run raw `cargo` commands.
+
+- `cargo make check` - Type-check all code
+- `cargo make fmt` - Format code (run after every edit)
+- `cargo make clippy` - Lint with clippy
+- `cargo make test` - Run all unit tests
+- `cargo make all` - Full PR readiness (fmt-check, deny, cspell, clippy, build, test, coverage, doc)
+- `cargo make build-x64` / `cargo make build-aarch64` - Build for UEFI targets
+- `cargo make coverage` - Generate test coverage reports
+- `cargo make doc` - Build documentation
+
+See [Makefile.toml](Makefile.toml) for the complete command list.
+
+## Module Organization
+
+- Never use `mod.rs` files. Use named module files (e.g., `my_module.rs`) instead.
+- No public definitions directly in `lib.rs` - only public module declarations.
+- Break implementations into logical files with clean namespaces.
+- Crate naming: `patina_` prefix for public crates, `patina_internal_` for internal
+  crates, `_macro` suffix for proc-macro crates.
+
+```rust
+// WRONG: using mod.rs
+// src/memory/mod.rs
+
+// CORRECT: using named module file
+// src/memory.rs
+```
+
+See [component requirements](docs/src/component/requirements.md) for crate layout standards.
+
+## Safety Conventions
+
+- Prefer `zerocopy` for binary data and memory layouts over manual unsafe pointer/slice
+  operations. `zerocopy` provides safe, zero-cost abstractions for interpreting byte
+  buffers as typed data.
+- Minimize `unsafe` code. Constrain it within safe abstraction wrappers.
+- Document preconditions, postconditions, and invariants for every `unsafe` block.
+- Prefer fallible constructors returning `Result` over constructors that silently
+  handle invalid input or panic.
+- Mark functions `unsafe` only when the caller must uphold a contract the function
+  itself cannot verify internally. If the function validates all inputs before the
+  unsafe operation, it can remain safe.
+
+See [unsafe.md](docs/src/dev/principles/unsafe.md) for the full safety philosophy
+(software safety vs. hardware safety distinctions).
+
+## Error Handling
+
+- Prefer `Result` return types. Avoid panics in production code.
+- At UEFI ABI boundaries (`extern "efiapi"` functions), use `efi::Status`.
+- Internally, use domain-specific Rust error types with `Debug`, `Display`, and `Error`
+  trait implementations.
+- Implement `From<>` conversions at error type boundaries to create clean error chains.
+- Use `expect("descriptive message")` over bare `unwrap()`. Reserve `unwrap()` for
+  test code only.
+
+See [error-handling.md](docs/src/dev/principles/error-handling.md) for error
+propagation patterns and examples.
+
+## Component Model
+
+Patina uses dependency injection through component entry point function signatures.
+A component only executes when all its declared dependencies are available.
+
+- Define components with the `#[component]` attribute macro on an `impl` block.
+  The impl must contain `fn entry_point(self, ...) -> Result<()>`.
+- Register service implementations with `#[derive(IntoService)]` and `#[service(dyn Trait)]`.
+- Param types: `Config<T>`, `ConfigMut<T>`, `Service<T>`, `Hob<T>`, `Commands`,
+  `Handle`, `StandardBootServices`, `StandardRuntimeServices`, `&Storage`/`&mut Storage`,
+  `Option<P>`, tuples.
+- `ConfigMut<T>` components run first (config is unlocked); calling `lock()` makes the
+  value immutable and enables `Config<T>` components to execute.
+- `Service<dyn Trait>` is preferred over `Service<ConcreteType>` for mockability. Use
+  a concrete wrapper struct only when generic method signatures are needed.
+- Use the **stored dependencies** pattern: store all dependency references as fields in
+  the component struct. The entry point stores references; methods use them.
+
+See [component interface](docs/src/component/interface.md) and
+[getting started](docs/src/component/getting_started.md) for details and examples.
+
+## Mocking and Testing
+
+- Target ≥80% code coverage. Patch coverage ≥80% is a required PR check.
+  - Write tests to cover critical logic and edge cases, not just to hit coverage numbers.
+- Test naming: prefix with `test_<component_name>_` or `test_<service_name>_`.
+- Prefer `mockall` for trait mocking in unit tests. Use `#[automock]` on traits to generate mocks.
+- Use `pretty_assertions` for readable test diffs.
+
+See [testing.md](docs/src/dev/testing.md) for the full testing strategy.
+
+## Trait Design
+
+Traits serve as **abstraction points** - not code reuse mechanisms. Use crates for
+code reuse (see [reuse.md](docs/src/dev/principles/reuse.md)).
+
+- Define traits to represent swappable behavior (e.g., `BootServices`, `SerialIO`).
+- Implementations can vary per platform without affecting consumers.
+- Keep traits focused on a single responsibility (Interface Segregation).
+
+See [abstractions.md](docs/src/dev/principles/abstractions.md) for the full trait
+design philosophy.
+
+## Documentation Standards
+
+- All public items must be documented. Set `#[deny(missing_docs)]` in component crates.
+- Use `///` doc comments with these sections as appropriate: **Examples**, **Errors**,
+  **Safety**, **Panics**.
+- Document **traits**, not their implementations.
+- In most cases, do not add `# Arguments` or `# Returns` sections - the function signature
+  should be self-evident. In cases where there is unavoidable ambiguity, add these sections
+  to provide clarity.
+
+See [documenting.md](docs/src/dev/documenting.md) for templates and style guides.
+
+## UEFI-Specific Guidelines
+
+- Use `TplMutex` for synchronization in shared state. Do not use non-TPL-aware
+  primitives like `spin::Mutex`. Keep critical sections narrow.
+- Do not use `TplMutex` for interior mutability on non-shared data.
+- No memory allocation or deallocation after `ExitBootServices`.
+
+See [synchronization.md](docs/src/dxe_core/synchronization.md),
+[memory management](docs/src/dxe_core/memory_management.md), and
+[platform requirements](docs/src/integrate/patina_dxe_core_requirements.md).
+
+## Hardware Access
+
+### Memory-Mapped I/O (MMIO)
+
+Do not create Rust references (`&T` or `&mut T`) to MMIO space. The compiler may
+insert spurious reads through references, which can clear interrupt status bits, pop
+FIFO entries, or trigger other device side-effects. MMIO must be accessed exclusively
+through raw pointers with volatile operations.
+
+Patina uses the [`safe-mmio`](https://github.com/google/safe-mmio) crate for all MMIO
+access. `safe-mmio` provides `UniqueMmioPointer<T>` which never creates a `&T` to device
+memory. Its field wrapper types encode read side-effect semantics at the type level:
+
+- `ReadPure<T>` / `ReadPureWrite<T>` — reads have no side-effects (shared access OK).
+- `ReadOnly<T>` / `ReadWrite<T>` — reads have side-effects (require `&mut` access).
+- `WriteOnly<T>` — write-only register.
+
+See [mmio.md](docs/src/dev/hardware_access/mmio.md) for the full rationale, wrapper
+reference table, and links to `safe-mmio` documentation.
+
+## Dependency Management
+
+- All external dependencies are vetted via `cargo-deny` for license compatibility,
+  security advisories, and allowed sources.
+- Use workspace-level dependency declarations in the root `Cargo.toml` for consistency.
+- Evaluate new dependencies against the criteria in
+  [dependency-management.md](docs/src/dev/principles/dependency-management.md).
+
+## Formatting
+
+Formatting is enforced by `rustfmt` via [rustfmt.toml](rustfmt.toml). Always run
+`cargo make fmt` after editing code.
+
+## Common Anti-Patterns
+
+Flag these patterns during review:
+
+1. Using `mod.rs` instead of named module files
+2. Raw slice/pointer manipulation where `zerocopy` would work
+3. Unnecessary `unsafe` without a safe abstraction wrapper
+4. `unwrap()` in production code (outside of tests)
+5. Cross-component dependencies (components must only depend on `sdk/`)
+6. Adding public type definitions directly in `lib.rs`
+7. Missing documentation on public items
+8. Using non-TPL-aware synchronization primitives for shared state
+9. Creating Rust references (`&T`/`&mut T`) to MMIO space instead of using `safe-mmio`

--- a/.github/instructions/components.instructions.md
+++ b/.github/instructions/components.instructions.md
@@ -1,0 +1,96 @@
+---
+name: 'Patina Component Conventions'
+description: 'Coding conventions and patterns for Patina component crates'
+applyTo: 'components/**'
+---
+# Patina Component Conventions
+
+These conventions apply to all crates under `components/`. For project-wide rules,
+see [copilot-instructions.md](../copilot-instructions.md).
+
+## Component Architecture
+
+Components use dependency injection through their entry point function signature.
+The entry point declares what the component needs and the dispatcher provides it.
+
+- Apply the `#[component]` attribute macro on an `impl` block for the component struct.
+- The impl block must contain a method named `entry_point` that takes `self` and
+  returns `patina::error::Result<()>`.
+- Parameters in the entry point define dependencies - the component will not execute
+  until all dependencies are satisfied.
+
+```rust
+use patina::{
+    component::{component, params::Config},
+    error::Result,
+};
+
+struct MyComponent;
+
+#[component]
+impl MyComponent {
+    fn entry_point(self, config: Config<MyConfig>) -> Result<()> {
+        // Component logic using injected dependencies
+        Ok(())
+    }
+}
+```
+
+Services are registered via `#[derive(IntoService)]` with a `#[service(dyn Trait)]`
+attribute:
+
+```rust
+use patina::component::service::IntoService;
+
+#[derive(IntoService)]
+#[service(dyn MyTrait)]
+pub struct MyServiceImpl {
+    // ...
+}
+```
+
+## Stored Dependencies Pattern
+
+Components must store all dependency references as fields in the component struct
+rather than passing them through call chains. This avoids memory copies and enables
+safe reuse in UEFI's memory-constrained environment.
+
+- **Initialization phase:** Store all dependency references in struct fields.
+- **Execution phase:** Use stored references via methods - no additional parameter
+  resolution needed.
+- Use `Service<T>` for service references (these are `Clone` with static lifetimes).
+- Use `Option<T>` for optional dependencies to handle unavailable services gracefully.
+
+## Parameter Semantics
+
+See [component interface](../../docs/src/component/interface.md) for the full parameter
+reference table, availability rules, and detailed descriptions of each parameter type.
+
+## Crate Layout
+
+Follow the standardized layout from [component requirements](../../docs/src/component/requirements.md):
+
+1. No public definitions in `lib.rs` - only public module declarations.
+2. **Required:** `component` module containing the crate's component(s).
+3. **Optional modules** (as needed):
+   - `config` - Configuration types registered via `.with_config`
+   - `error` - Domain-specific error types for services
+   - `hob` - GUID HOB type definitions
+   - `service` - Service trait definitions and implementations
+
+## Component Dependencies
+
+Components must only depend on crates in `sdk/` and generic external crates. Never
+depend on other component crates or `core/` crates. This keeps components loosely
+coupled and independently maintainable.
+
+## Testing Components
+
+- Test names must be prefixed with `test_<component_name>_` (snake_case).
+- Use `Config::mock(value)`, `Service::mock(impl)`, `Hob::mock(data)`, and
+  `Commands::mock()` for unit testing component entry points.
+- Mock service traits with `#[automock]` from `mockall`. Use extension traits for
+  any utility methods that call base trait methods.
+
+See [component interface](../../docs/src/component/interface.md) for the full
+parameter specification and examples.

--- a/.github/prompts/review.prompt.md
+++ b/.github/prompts/review.prompt.md
@@ -1,0 +1,63 @@
+---
+description: 'Review code changes against Patina project conventions and standards'
+tools:
+  - search
+  - read
+---
+# Patina Code Review
+
+Review the provided code against Patina project conventions. For each issue found,
+cite the specific convention being violated and suggest a concrete fix.
+
+## Review Checklist
+
+Work through each category below. Report findings grouped by category. If a
+category has no issues, skip it silently. Apply the conventions from
+[copilot-instructions.md](../copilot-instructions.md).
+
+### 1. Module Organization
+
+- No `mod.rs` files; no public definitions in `lib.rs`; correct crate naming.
+
+### 2. Safety
+
+- Raw pointer/slice work where `zerocopy` would suffice.
+- `unsafe` blocks missing documented invariants or missing safe wrappers.
+- Functions marked `unsafe` that could validate inputs internally.
+
+### 3. Error Handling
+
+- `unwrap()` in non-test code.
+- Missing `Result` returns, missing `From<>` conversions at error boundaries.
+
+### 4. Component Model
+
+- Correct use of dependency injection, stored dependencies pattern, and parameter
+  types (`Config`/`ConfigMut`/`Service<dyn Trait>`).
+- Components depending on anything outside `sdk/`.
+
+### 5. Testing
+
+- New logic missing tests; incorrect test naming.
+- Default methods on `#[automock]` traits instead of extension traits.
+
+### 6. Documentation
+
+- Public items missing doc comments.
+- `unsafe` functions missing `# Safety`; fallible functions missing `# Errors`.
+
+### 7. UEFI-Specific
+
+- Non-TPL-aware synchronization primitives.
+- Possible allocation after `ExitBootServices`.
+
+## Output Format
+
+For each finding, use this format:
+
+**[Category] Issue title**
+- **File:** `path/to/file.rs:line`
+- **Convention:** Brief description of the rule being violated
+- **Suggestion:** Concrete fix or code example
+
+Conclude with a summary: total findings by category and an overall assessment.

--- a/docs/src/component/interface.md
+++ b/docs/src/component/interface.md
@@ -83,14 +83,19 @@ reference the `Param` trait's [Type Implementations][patina] for a complete list
 in the function interface of a component.
 
 <!-- markdownlint-disable -->
-| Param                        | Description                                                                                                                       |
-|------------------------------|-----------------------------------------------------------------------------------------------------------------------------------|
-| Config\<T\>                  | An immutable config value that will only be available once the underlying data has been locked.                                   |
-| ConfigMut\<T\>               | A mutable config value that will only be available while the underlying data is unlocked.                                         |
-| Hob\<T\>                     | A parsed, immutable, GUID HOB (Hand-Off Block) that is automatically parsed and registered.                                       |
-| Service\<T\>                 | A wrapper for producing and consuming services of a particular interface, `T`, that is agnostic to the underlying implementation. |
-| (P1, P2, ...)                | A Tuple where each entry implements `Param`. Useful when you need more parameters than the current parameter limit.               |
-| Option\<P\>                  | An Option, where P implements `Param`. Affects each param type differently. See [Option](#optionp) section for more details.       |
+| Param                        | Available When                   | Description                                                                                                       |
+|------------------------------|----------------------------------|-------------------------------------------------------------------------------------------------------------------|
+| Config\<T\>                  | After config is locked           | An immutable config value that will only be available once the underlying data has been locked.                   |
+| ConfigMut\<T\>               | While config is unlocked         | A mutable config value that will only be available while the underlying data is unlocked.                         |
+| Hob\<T\>                     | If GUID HOB exists in HOB list   | A parsed, immutable, GUID HOB (Hand-Off Block) that is automatically parsed and registered.                       |
+| Service\<T\>                 | After service is registered      | A wrapper for producing and consuming services of a particular interface, `T`, that is agnostic to the underlying implementation. |
+| Commands                     | Always                           | A deferred command queue for registering services and configs without conflicting with other params. See [Commands](#commands) section. |
+| Handle                       | After image handle is set        | The DXE Core's image handle. See [Handle](#handle) section.                                                       |
+| StandardBootServices         | After boot services init         | UEFI Boot Services access. See [StandardBootServices](#standardbootservices) section.                             |
+| StandardRuntimeServices      | After runtime services init      | UEFI Runtime Services access. See [StandardRuntimeServices](#standardruntimeservices) section.                    |
+| &Storage / &mut Storage      | Always                           | Direct storage access. Conflicts with `Config`/`ConfigMut` params. See [Storage Access](#storage-access) section. |
+| (P1, P2, ...)                | When all inner params available  | A Tuple where each entry implements `Param`. Useful when you need more parameters than the current parameter limit. |
+| Option\<P\>                  | Immediately                      | An Option, where P implements `Param`. Affects each param type differently. See [Option](#optionp) section.       |
 <!-- markdownlint-enable -->
 
 ``` admonish warning
@@ -190,6 +195,93 @@ allows them stash it for their own needs post component execution.
 ```
 
 This type comes with a `mock(...)` method to make unit testing simple.
+
+### Commands
+
+`Commands` is a deferred command queue that allows a component to register services and configuration values without
+conflicting with other parameters like `Config<T>` or `ConfigMut<T>`. Instead of modifying `Storage` directly during
+component execution, the changes are queued and applied after the component finishes.
+
+```rust
+# extern crate patina;
+use patina::{
+    component::{component, params::Commands},
+    error::Result,
+};
+
+# struct MyServiceImpl;
+# use patina::component::service::IntoService;
+# #[derive(Debug, IntoService)]
+# #[service(dyn core::fmt::Debug)]
+# struct DebugService;
+
+pub struct MyComponent;
+
+#[component]
+impl MyComponent {
+    fn entry_point(self, mut cmds: Commands) -> Result<()> {
+        cmds.add_config(42i32);
+        cmds.add_service(DebugService);
+        Ok(())
+    }
+}
+```
+
+A `mock()` method is available to simplify writing unit tests.
+
+### Handle
+
+`Handle` provides the DXE Core's image handle for use cases when it is needed.
+
+```admonish warning
+This handle is the DXE Core's image handle, shared across all components. It should not be used as a
+`DriverBindingHandle` in `EFI_DRIVER_BINDING_PROTOCOL`, as multiple components sharing the same agent handle will
+conflict with protocol open/close tracking in the UEFI driver model.
+```
+
+`Handle` implements `Deref` to the underlying `r_efi::efi::Handle`, so it can be dereferenced directly.
+
+This type comes with a `mock(...)` method to make unit testing simple.
+
+### StandardBootServices
+
+`StandardBootServices` provides immutable access to UEFI Boot Services functions. It is available once boot services
+have been initialized. Each component receives its own cloned instance.
+
+```rust
+# extern crate patina;
+use patina::{
+    boot_services::StandardBootServices,
+    component::component,
+    error::Result,
+};
+
+pub struct MyComponent;
+
+#[component]
+impl MyComponent {
+    fn entry_point(self, bs: StandardBootServices) -> Result<()> {
+        // Use boot services functions...
+        Ok(())
+    }
+}
+```
+
+### StandardRuntimeServices
+
+`StandardRuntimeServices` provides immutable access to UEFI Runtime Services functions. It is available once runtime
+services have been initialized, which typically occurs later in the boot process than boot services.
+
+### Storage Access
+
+`&Storage` and `&mut Storage` provide direct access to the component storage. They have some conflict rules:
+
+- `&Storage` conflicts with `ConfigMut<T>` and `&mut Storage`.
+- `&mut Storage` conflicts with `Config<T>`, `ConfigMut<T>`, `&Storage`, and other `&mut Storage` parameters.
+
+Because of these conflicts, prefer using `Commands` for registering services and configs, and use the typed `Config<T>`
+/ `ConfigMut<T>` / `Service<T>` parameters for reading values. Direct storage access is only needed for advanced use
+cases.
 
 ### Option\<P\>
 

--- a/docs/src/dev/documenting.md
+++ b/docs/src/dev/documenting.md
@@ -215,10 +215,10 @@ Function documentation should be available for functions of a public type (assoc
 and any public functions. At least one example is required for each function in addition to the
 other sections mentioned below.
 
-Do not provide an arguments section, the name and type of the argument should make it self-evident.
-
-Do not provide a Returns section, this should be captured in the longer description and the return
-type makes the possible return value self-evident.
+An "arguments and "return" section should only be provided in circumstances where it clarifies
+ambiguity in the function signature. In most cases, the code should be written in such a way that
+normal Rust conventions make the arguments and return type self-evident so that the documentation
+can focus on describing the behavior of the function and any non-obvious details.
 
 ```rust
 # extern crate goblin;


### PR DESCRIPTION
## Description

Closes #1453 

Adds project-level AI customization files to support AI-assisted code review.

These files encode Patina's domain-specific conventions so that AI reviewers can flag violations locally, prior to human review.

The files are layered:

1. Always-on instructions (.github/copilot-instructions.md): Covers global conventions across the codebase.

2. File-based instructions (.github/instructions/): Currently, provides component-specific instructions in components.instructions.md(applyTo: components/**) to supplement the global instructions. These load only when editing matching files to minimize token cost.

3. Review prompt file (.github/prompts/review.prompt.md): A reusable /review slash command that defines a structured review checklist. This is to provide a convenient way to reliably perform the same set of review steps. Delegates convention details to the always-on instructions to avoid duplication.

4. Reviewer agent (.github/agents/reviewer.agent.md): A read-only review persona restricted to `search` and `read` tool sets (no edit or execute tools). Includes a handoff to the default agent for implementing fixes after review.

References:

- VS Code Customization Overview: https://code.visualstudio.com/docs/copilot/concepts/customization
- Custom Instructions: https://code.visualstudio.com/docs/copilot/customization/custom-instructions
- Prompt Files: https://code.visualstudio.com/docs/copilot/customization/prompt-files
- Custom Agents: https://code.visualstudio.com/docs/copilot/customization/custom-agents

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

- Use the "Patina Code Reviewer" locally

## Integration Instructions

- N/A

---

This PR is in draft as it serves as a starting open to changes from others before publishing for broader review.