### PR TITLE
Add Safe MMIO Docs and Example [Rebase & FF]

### DIFF
--- a/core/patina_internal_cpu/Cargo.toml
+++ b/core/patina_internal_cpu/Cargo.toml
@@ -32,7 +32,6 @@ patina_mtrr = { workspace = true }
 
 [target.'cfg(all(target_arch="aarch64"))'.dependencies]
 arm-gic = { workspace = true }
-safe-mmio = {workspace = true }
 
 [dev-dependencies]
 x86_64 = { workspace = true, features = [

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -25,6 +25,8 @@
 - [Documenting](dev/documenting.md)
   - [Quick Reference](dev/documenting/reference.md)
 - [Formatting](dev/formatting.md)
+- [Hardware Access](dev/hardware_access.md)
+  - [Memory-Mapped I/O (MMIO)](dev/hardware_access/mmio.md)
 - [Other Resources](dev/other.md)
 - [Process for Unstable Features](dev/unstable.md)
 - [RFC Template](rfc/template.md)

--- a/docs/src/dev/hardware_access.md
+++ b/docs/src/dev/hardware_access.md
@@ -1,0 +1,7 @@
+# Hardware Access
+
+Patina components access hardware through several mechanisms, each with Rust-specific safety considerations that
+differ from traditional C firmware. This section covers the supported access methods, the crates Patina uses for
+each, and the pitfalls to avoid.
+
+- [Memory-Mapped I/O (MMIO)](hardware_access/mmio.md)

--- a/docs/src/dev/hardware_access/mmio.md
+++ b/docs/src/dev/hardware_access/mmio.md
@@ -3,6 +3,14 @@
 This page explains the soundness problems with naive MMIO access in Rust and why Patina uses the
 [`safe-mmio`](https://crates.io/crates/safe-mmio) crate.
 
+The `patina` crate re-exports `safe-mmio` through a `patina::mmio` wrapper module. All Patina code should
+import from `patina::mmio` rather than depending on `safe-mmio` directly. This:
+
+1. Allows consumers to use the crate without adding `safe-mmio` as a direct dependency.
+2. Reduces the likelihood of the same crate being compiled multiple times with different versions.
+
+Crates that already depend on `patina` should not add `safe-mmio` to their own `Cargo.toml`.
+
 ## The Problem with References to MMIO Space
 
 In C, casting an address to a pointer and performing volatile reads/writes is the standard way to access device

--- a/docs/src/dev/hardware_access/mmio.md
+++ b/docs/src/dev/hardware_access/mmio.md
@@ -1,0 +1,55 @@
+# Memory-Mapped I/O (MMIO)
+
+This page explains the soundness problems with naive MMIO access in Rust and why Patina uses the
+[`safe-mmio`](https://crates.io/crates/safe-mmio) crate.
+
+## The Problem with References to MMIO Space
+
+In C, casting an address to a pointer and performing volatile reads/writes is the standard way to access device
+registers. In Rust, it might seem natural to create a reference (`&T` or `&mut T`) to a `#[repr(C)]` struct
+laid out over the register block. However, **creating a Rust reference to MMIO space is unsound**.
+
+The Rust compiler is free to insert additional reads through any `&T` reference at any time. For normal memory this
+is harmless, but for MMIO registers an extra read can clear an interrupt status, pop a byte from a FIFO, or trigger
+other device side-effects. More details are [documented](https://github.com/rust-embedded/volatile-register/issues/10)
+and [tracked by the Rust Embedded Working Group](https://github.com/rust-embedded/wg/issues/791).
+
+Because this is part of Rust's reference semantics, MMIO must be accessed exclusively through raw pointers combined
+with volatile operations.
+
+## Why `safe-mmio`
+
+Patina uses the [`safe-mmio`](https://github.com/google/safe-mmio) crate because it directly addresses the following
+concerns:
+
+1. **No references to MMIO space.** `UniqueMmioPointer<T>` is a unique owned pointer to the registers of some MMIO
+   device. It never creates a `&T` to device memory, eliminating potential for undefined behavior.
+
+2. **Read side-effect distinction.** The crate separates read-with-side-effects (`ReadOnly` and `ReadWrite`
+   requires `&mut UniqueMmioPointer`) from pure reads (`ReadPure` and `ReadPureWrite` allows `&UniqueMmioPointer`
+   or `&SharedMmioPointer`). This encodes at the type level whether a read is safe to perform.
+
+3. **Correct codegen on AArch64.** On AArch64, `read_volatile`/`write_volatile` can emit instructions that cannot be
+   virtualized. `safe-mmio` works around this by using inline assembly to emit the correct MMIO instructions on
+   AArch64.
+
+### Field Wrapper Types
+
+The below table is provided for quick Patina developer reference. See the
+[safe-mmio documentation](https://docs.rs/safe-mmio/latest/safe_mmio) for full API details.
+
+| Wrapper                                                                                           | Read | Write | Read Requires `&mut` | Notes                             |
+|---------------------------------------------------------------------------------------------------|------|-------|----------------------|-----------------------------------|
+| [`ReadPure<T>`](https://docs.rs/safe-mmio/latest/safe_mmio/fields/struct.ReadPure.html)           | yes  | no    | no                   | Pure read, no device side-effects |
+| [`ReadOnly<T>`](https://docs.rs/safe-mmio/latest/safe_mmio/fields/struct.ReadOnly.html)           | yes  | no    | yes                  | Read has device side-effects      |
+| [`WriteOnly<T>`](https://docs.rs/safe-mmio/latest/safe_mmio/fields/struct.WriteOnly.html)         | no   | yes   | n/a                  | Write-only register               |
+| [`ReadWrite<T>`](https://docs.rs/safe-mmio/latest/safe_mmio/fields/struct.ReadWrite.html)         | yes  | yes   | yes                  | Read has side-effects             |
+| [`ReadPureWrite<T>`](https://docs.rs/safe-mmio/latest/safe_mmio/fields/struct.ReadPureWrite.html) | yes  | yes   | no (for read)        | Read is pure, write allowed       |
+
+See [safe-mmio usage instructions](https://github.com/google/safe-mmio?tab=readme-ov-file#usage) for examples of how
+to define register blocks and access registers.
+
+## Further Reading
+
+- [`safe-mmio` README](https://github.com/google/safe-mmio) — full API overview and comparison with other MMIO crates
+- [`safe-mmio` docs.rs](https://docs.rs/safe-mmio) — API reference

--- a/sdk/patina/Cargo.toml
+++ b/sdk/patina/Cargo.toml
@@ -39,6 +39,7 @@ mu_rust_helpers = { workspace = true, optional = true }
 num-traits = { workspace = true }
 indoc = { workspace = true }
 fallible-streaming-iterator = { workspace = true }
+safe-mmio = { workspace = true }
 linkme = { workspace = true }
 scroll = { workspace = true }
 uuid = { workspace = true }

--- a/sdk/patina/src/lib.rs
+++ b/sdk/patina/src/lib.rs
@@ -60,3 +60,10 @@ pub mod serial;
 pub mod tpl_mutex;
 #[cfg(any(test, feature = "alloc"))]
 pub mod uefi_protocol;
+
+/// Re-export of the [`safe-mmio`](https://crates.io/crates/safe-mmio) crate.
+///
+/// Consumers should use `patina::mmio` instead of depending on `safe-mmio` directly.
+pub mod mmio {
+    pub use safe_mmio::*;
+}

--- a/sdk/patina/src/serial/uart.rs
+++ b/sdk/patina/src/serial/uart.rs
@@ -125,11 +125,29 @@ cfg_if::cfg_if! {
 
 cfg_if::cfg_if! {
     if #[cfg(any(feature = "doc", all(target_os = "uefi", target_arch = "aarch64")))] {
-        mod uart_pl011 {
-            pub const FLAG_REGISTER_OFFSET: usize = 0x18;
-            pub const FR_BUSY: u8 = 1 << 3;
-            pub const FR_RXFE: u8 = 1 << 4;
-            pub const FR_TXFF: u8 = 1 << 5;
+        use core::ptr::NonNull;
+        use safe_mmio::{field, fields::{ReadPure, ReadWrite}, UniqueMmioPointer};
+
+        /// PL011 flag register bit: UART busy.
+        const FR_BUSY: u8 = 1 << 3;
+        /// PL011 flag register bit: receive FIFO empty.
+        const FR_RXFE: u8 = 1 << 4;
+        /// PL011 flag register bit: transmit FIFO full.
+        const FR_TXFF: u8 = 1 << 5;
+
+        /// PL011 MMIO register block.
+        ///
+        /// Models the Data Register (DR) at offset 0x00 and the Flag Register (FR) at offset 0x18.
+        /// Intermediate registers are represented as reserved padding.
+        #[repr(C)]
+        struct Pl011Registers {
+            /// Data Register: reading pops from receive FIFO (side-effect), writing pushes to
+            /// transmit FIFO.
+            dr: ReadWrite<u8>,
+            /// Reserved registers between DR (0x00) and FR (0x18).
+            _reserved: [u8; 0x17],
+            /// Flag Register: reading has no side-effects (pure status bits).
+            fr: ReadPure<u8>,
         }
 
         /// An interface for writing to a UartPl011 device.
@@ -145,52 +163,54 @@ cfg_if::cfg_if! {
             ///
             /// # Safety
             ///
-            /// The given base address must point to the 8 MMIO control registers of a
+            /// The given base address must point to the MMIO control registers of a
             /// PL011 device, which must be mapped into the address space of the process
             /// as device memory and not have any other aliases.
             pub const fn new(base_address: usize) -> Self {
                 Self { base_address }
             }
 
+            /// Returns a [`UniqueMmioPointer`] to the PL011 register block.
+            ///
+            /// # Safety
+            ///
+            /// The caller must ensure that no other `UniqueMmioPointer` to the same
+            /// MMIO region exists for the duration of the returned pointer's use.
+            unsafe fn registers(&self) -> UniqueMmioPointer<'_, Pl011Registers> {
+                // SAFETY: The base address is required by the safety contract of new() to point
+                // to a PL011 register block that is mapped as device memory.
+                unsafe {
+                    UniqueMmioPointer::new(NonNull::new(self.base_address as *mut Pl011Registers).unwrap())
+                }
+            }
+
             /// Writes a single byte to the UART.
             pub fn write_byte(&self, byte: u8) {
-                // Wait until there is room in the TX buffer.
-                while self.read_flag_register() & uart_pl011::FR_TXFF != 0 {}
+                // SAFETY: Exclusive MMIO access is given by calling `UartPl011::new`.
+                let mut regs = unsafe { self.registers() };
 
-                // SAFETY: We know that the base address points to the control
-                // registers of a PL011 device which is appropriately mapped.
-                unsafe {
-                    // Write to the TX buffer.
-                    self.get_base().write_volatile(byte);
-                }
+                // Wait until there is room in the TX buffer.
+                while field!(regs, fr).read() & FR_TXFF != 0 {}
+
+                // Write to the TX buffer.
+                field!(regs, dr).write(byte);
 
                 // Wait until the UART is no longer busy.
-                while self.read_flag_register() & uart_pl011::FR_BUSY != 0 {}
+                while field!(regs, fr).read() & FR_BUSY != 0 {}
             }
 
             /// Reads a single byte from the UART.
             pub fn read_byte(&self) -> Option<u8> {
-                // Wait until the RX buffer is not empty.
-                if self.read_flag_register() & uart_pl011::FR_RXFE != 0 {
+                // SAFETY: Exclusive MMIO access is given by calling `UartPl011::new`.
+                let mut regs = unsafe { self.registers() };
+
+                // Check if the RX buffer is empty.
+                if field!(regs, fr).read() & FR_RXFE != 0 {
                     return None;
                 }
 
-                // SAFETY: We know that the base address points to the control
-                // registers of a PL011 device which is appropriately mapped.
-                unsafe {
-                    // Read from the RX buffer.
-                    Some(self.get_base().read_volatile())
-                }
-            }
-
-            fn read_flag_register(&self) -> u8 {
-                // SAFETY: We know that the base address points to the control
-                // registers of a PL011 device which is appropriately mapped.
-                unsafe { self.get_base().add(uart_pl011::FLAG_REGISTER_OFFSET).read_volatile() }
-            }
-
-            fn get_base(&self) -> *mut u8 {
-                self.base_address as *mut u8
+                // Read from the RX buffer.
+                Some(field!(regs, dr).read())
             }
         }
 

--- a/sdk/patina/src/serial/uart.rs
+++ b/sdk/patina/src/serial/uart.rs
@@ -126,7 +126,7 @@ cfg_if::cfg_if! {
 cfg_if::cfg_if! {
     if #[cfg(any(feature = "doc", all(target_os = "uefi", target_arch = "aarch64")))] {
         use core::ptr::NonNull;
-        use safe_mmio::{field, fields::{ReadPure, ReadWrite}, UniqueMmioPointer};
+        use crate::mmio::{field, fields::{ReadPure, ReadWrite}, UniqueMmioPointer};
 
         /// PL011 flag register bit: UART busy.
         const FR_BUSY: u8 = 1 << 3;


### PR DESCRIPTION
## Description

Resolves #1461 

**docs: Add MMIO documentation and example**

Adds a new "Hardware Access" section to the developer documentation
to host guides and conventions for accessing hardware in Patina.

Right now, this includes a new page on Memory-Mapped I/O (MMIO) that
explains why MMIO must be accessed through raw pointers in Rust, and
why we're using the safe-mmio crate to do so.

---

**sdk/patina: Replace raw volatile MMIO with safe-mmio in PL011 UART**

Replace raw pointer volatile reads/writes for the PL011 UART code with
safe-mmio abstractions.

ARM PrimeCell UART (PL011) register properties taken from:

https://developer.arm.com/documentation/ddi0183/g/programmers-model/summary-of-registers

---

**Re-export safe-mmio as patina::mmio**

Since the `patina` crate serves as the underlying SDK, this change
allows consumers to use `patina::mmio` instead of depending on
`safe-mmio` directly for the reasons stated in the mmio.md file
update.

---

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [x] Includes documentation?

## How This Was Tested

- `cargo make all`
- `mdbook build ./docs`
- QEMU SBSA boot to EFI shell with serial output

## Integration Instructions

- N/A