### PR TITLE
patina: Use correct FPDT record types for MODULE_DB_END_ID

### DIFF
--- a/sdk/patina/src/performance/measurement.rs
+++ b/sdk/patina/src/performance/measurement.rs
@@ -508,6 +508,7 @@ mod tests {
         performance::{
             globals::set_perf_measurement_mask,
             logging::*,
+            record::PerformanceRecord,
             table::{FirmwarePerformanceVariable, MockFirmwareBasicBootPerfTable},
         },
         runtime_services::MockRuntimeServices,
@@ -803,5 +804,58 @@ mod tests {
 
         let combined = start_image | load_image | driver_binding_support;
         assert_eq!(combined, 7);
+    }
+
+    /// Validates that each KnownPerfId maps to the FPDT record type expected by the EDK2
+    /// Dp.c parser (ShellPkg/DynamicCommand/DpDynamicCommand/Dp.c). A mismatch causes
+    /// ASSERT(FALSE) in the C parser at runtime.
+    #[test]
+    fn test_known_perf_id_record_types_match_edk2_dp() {
+        let guid = crate::guids::ZERO;
+
+        // Expected mappings derived from the switch/case in Dp.c:
+        //   FPDT_GUID_EVENT_TYPE           (0x1010): MODULE_START_ID, MODULE_END_ID
+        //   FPDT_GUID_QWORD_EVENT_TYPE     (0x1013): MODULE_LOADIMAGE_*, MODULE_DB_START, MODULE_DB_SUPPORT_*, MODULE_DB_STOP_*
+        //   FPDT_GUID_QWORD_STRING_EVENT   (0x1014): MODULE_DB_END_ID only
+        //   FPDT_DYNAMIC_STRING_EVENT_TYPE (0x1011): any (no assert)
+        //   FPDT_DUAL_GUID_STRING_EVENT    (0x1012): any (no assert)
+        let expected: &[(u16, u16)] = &[
+            (KnownPerfId::ModuleStart.as_u16(), GuidEventRecord::TYPE),
+            (KnownPerfId::ModuleEnd.as_u16(), GuidEventRecord::TYPE),
+            (KnownPerfId::ModuleLoadImageStart.as_u16(), GuidQwordEventRecord::TYPE),
+            (KnownPerfId::ModuleLoadImageEnd.as_u16(), GuidQwordEventRecord::TYPE),
+            (KnownPerfId::ModuleDbStart.as_u16(), GuidQwordEventRecord::TYPE),
+            (KnownPerfId::ModuleDbEnd.as_u16(), GuidQwordStringEventRecord::TYPE),
+            (KnownPerfId::ModuleDbSupportStart.as_u16(), GuidQwordEventRecord::TYPE),
+            (KnownPerfId::ModuleDbSupportEnd.as_u16(), GuidQwordEventRecord::TYPE),
+            (KnownPerfId::ModuleDbStopStart.as_u16(), GuidQwordEventRecord::TYPE),
+            (KnownPerfId::ModuleDbStopEnd.as_u16(), GuidQwordEventRecord::TYPE),
+        ];
+
+        for &(perf_id, expected_type) in expected {
+            let record: Box<dyn PerformanceRecord> = match KnownPerfId::try_from(perf_id).unwrap() {
+                KnownPerfId::ModuleStart | KnownPerfId::ModuleEnd => {
+                    Box::new(GuidEventRecord::new(perf_id, 0, 0, guid))
+                }
+                KnownPerfId::ModuleLoadImageStart | KnownPerfId::ModuleLoadImageEnd => {
+                    Box::new(GuidQwordEventRecord::new(perf_id, 0, 0, guid, 0))
+                }
+                KnownPerfId::ModuleDbStart
+                | KnownPerfId::ModuleDbSupportStart
+                | KnownPerfId::ModuleDbSupportEnd
+                | KnownPerfId::ModuleDbStopStart
+                | KnownPerfId::ModuleDbStopEnd => Box::new(GuidQwordEventRecord::new(perf_id, 0, 0, guid, 0)),
+                KnownPerfId::ModuleDbEnd => Box::new(GuidQwordStringEventRecord::new(perf_id, 0, 0, guid, 0, "")),
+                _ => continue,
+            };
+            assert_eq!(
+                record.record_type(),
+                expected_type,
+                "KnownPerfId 0x{:02X} should produce record type 0x{:04X}, got 0x{:04X}",
+                perf_id,
+                expected_type,
+                record.record_type()
+            );
+        }
     }
 }

--- a/sdk/patina/src/performance/measurement.rs
+++ b/sdk/patina/src/performance/measurement.rs
@@ -281,10 +281,10 @@ where
             fbpt.lock().add_record(record)?;
         }
         KnownPerfId::ModuleDbStart
-        | KnownPerfId::ModuleDbEnd
         | KnownPerfId::ModuleDbSupportStart
         | KnownPerfId::ModuleDbSupportEnd
-        | KnownPerfId::ModuleDbStopStart => {
+        | KnownPerfId::ModuleDbStopStart
+        | KnownPerfId::ModuleDbStopEnd => {
             let module_handle = caller_identifier.as_handle().ok_or(EfiError::InvalidParameter)?;
             let Ok(guid) = get_module_guid_from_handle(boot_services, module_handle) else {
                 log::error!("Performance: Could not find the guid for module handle: {module_handle:?}");
@@ -293,10 +293,10 @@ where
             let record = GuidQwordEventRecord::new(perf_id, 0, timestamp, guid, address as u64);
             fbpt.lock().add_record(record)?;
         }
-        KnownPerfId::ModuleDbStopEnd => {
+        KnownPerfId::ModuleDbEnd => {
             let module_handle = caller_identifier.as_handle().ok_or(EfiError::InvalidParameter)?;
             let Ok(guid) = get_module_guid_from_handle(boot_services, module_handle) else {
-                log::error!("Performance Lib: Could not find the guid for module handle: {module_handle:?}");
+                log::error!("Performance: Could not find the guid for module handle: {module_handle:?}");
                 return Err(EfiError::InvalidParameter.into());
             };
             let module_name = "";


### PR DESCRIPTION
## Description

The patina implementation uses QWORD String event type for MODULE_DB_STOP_END_ID instead of MODULE_DB_END_ID, which is causing asserts when parsing the FDPT as this in unexpected. This commit fixes this to be consistent with the EDKII implementation.

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Tested on Q35 by parsing from shell with `dp`

## Integration Instructions

N/A
