### PR TITLE
Safety & UB Updates [Rebase & FF]

### DIFF
--- a/components/patina_mm/src/config.rs
+++ b/components/patina_mm/src/config.rs
@@ -406,11 +406,13 @@ impl CommunicateBuffer {
 
         let header_slice = &self.as_slice()[..Self::MESSAGE_START_OFFSET];
 
-        // SAFETY: Buffer size validated, BinaryGuid is repr(transparent) over repr(C) efi::Guid at offset 0
-        let memory_guid = unsafe { core::ptr::read(header_slice.as_ptr() as *const patina::BinaryGuid) };
+        // SAFETY: Buffer size validated, BinaryGuid is repr(transparent) over repr(C) efi::Guid at offset 0.
+        // read_unaligned is used because the buffer may not be aligned to the type's requirements.
+        let memory_guid = unsafe { core::ptr::read_unaligned(header_slice.as_ptr() as *const patina::BinaryGuid) };
 
-        // SAFETY: Buffer size validated, usize at offset 16 after Guid
-        let memory_message_length = unsafe { core::ptr::read(header_slice.as_ptr().add(16) as *const usize) };
+        // SAFETY: Buffer size validated, usize at offset 16 after Guid.
+        // read_unaligned is used because the buffer may not be aligned to usize requirements.
+        let memory_message_length = unsafe { core::ptr::read_unaligned(header_slice.as_ptr().add(16) as *const usize) };
 
         // Verify that thee recipient matches
         match self.private_recipient {

--- a/patina_dxe_core/src/pi_dispatcher/fv.rs
+++ b/patina_dxe_core/src/pi_dispatcher/fv.rs
@@ -178,7 +178,10 @@ impl<P: PlatformInfo> FvProtocolData<P> {
             bytes_to_read = block_size.saturating_sub(offset);
         }
 
-        let lba_start = (physical_address as usize).saturating_add(lba_base_addr).saturating_add(offset) as *mut u8;
+        let lba_start = (physical_address as usize)
+            .checked_add(lba_base_addr)
+            .and_then(|addr| addr.checked_add(offset))
+            .ok_or(EfiError::InvalidParameter)? as *mut u8;
         // SAFETY: lba_start is calculated from the base address of a valid FV, plus an offset and offset+num_bytes.
         // consistency of this data is guaranteed by checks on instantiation of the VolumeRef.
         // The FV data is expected to be 'static (i.e. permanently mapped) for the lifetime of the system.

--- a/patina_dxe_core/src/runtime.rs
+++ b/patina_dxe_core/src/runtime.rs
@@ -46,26 +46,28 @@ impl RuntimeData {
 
         // SAFETY: The protocol is identified by it's GUID and should be a valid
         //         pointer to a EFI_RUNTIME_ARCH_PROTOCOL structure.
+        //         Raw pointers are used throughout to avoid creating aliasing &mut references
+        //         when the list is empty (where prev == &mut image_head).
         unsafe {
             // Update the image links
-            let mut prev = &mut (*self.runtime_arch_ptr).image_head;
+            let mut prev: *mut _ = ptr::addr_of_mut!((*self.runtime_arch_ptr).image_head);
             for entry in self.runtime_images.iter_mut() {
-                prev.forward_link = (&mut entry.link) as *mut _;
-                entry.link.back_link = prev as *mut _;
-                prev = &mut entry.link;
+                (*prev).forward_link = ptr::addr_of_mut!(entry.link);
+                entry.link.back_link = prev;
+                prev = ptr::addr_of_mut!(entry.link);
             }
-            prev.forward_link = &mut (*self.runtime_arch_ptr).image_head as *mut _;
-            (*self.runtime_arch_ptr).image_head.back_link = prev as *mut _;
+            (*prev).forward_link = ptr::addr_of_mut!((*self.runtime_arch_ptr).image_head);
+            (*self.runtime_arch_ptr).image_head.back_link = prev;
 
             // Update the event links
-            let mut prev = &mut (*self.runtime_arch_ptr).event_head;
+            let mut prev: *mut _ = ptr::addr_of_mut!((*self.runtime_arch_ptr).event_head);
             for entry in self.runtime_events.iter_mut() {
-                prev.forward_link = (&mut entry.link) as *mut _;
-                entry.link.back_link = prev as *mut _;
-                prev = &mut entry.link;
+                (*prev).forward_link = ptr::addr_of_mut!(entry.link);
+                entry.link.back_link = prev;
+                prev = ptr::addr_of_mut!(entry.link);
             }
-            prev.forward_link = &mut (*self.runtime_arch_ptr).event_head as *mut _;
-            (*self.runtime_arch_ptr).event_head.back_link = prev as *mut _;
+            (*prev).forward_link = ptr::addr_of_mut!((*self.runtime_arch_ptr).event_head);
+            (*self.runtime_arch_ptr).event_head.back_link = prev;
         }
     }
 }

--- a/patina_dxe_core/src/tpl_mutex.rs
+++ b/patina_dxe_core/src/tpl_mutex.rs
@@ -112,17 +112,17 @@ impl<T: ?Sized + fmt::Display> fmt::Display for TplGuard<'_, T> {
     }
 }
 
-impl<'a, T: ?Sized> Deref for TplGuard<'a, T> {
+impl<T: ?Sized> Deref for TplGuard<'_, T> {
     type Target = T;
-    fn deref(&self) -> &'a T {
+    fn deref(&self) -> &T {
         // SAFETY: data is only accessible through the guard, which guarantees mutual exclusion since no higher TPL can
         // obtain the lock without panic, and no code at equal or lower TPL can interrupt while the lock is held.
         unsafe { self.mutex.data.get().as_ref().expect("TplMutex data pointer should not be null") }
     }
 }
 
-impl<'a, T: ?Sized> DerefMut for TplGuard<'a, T> {
-    fn deref_mut(&mut self) -> &'a mut T {
+impl<T: ?Sized> DerefMut for TplGuard<'_, T> {
+    fn deref_mut(&mut self) -> &mut T {
         // SAFETY: data is only accessible through the guard, which guarantees mutual exclusion since no higher TPL can
         // obtain the lock without panic, and no code at equal or lower TPL can interrupt while the lock is held.
         unsafe { self.mutex.data.get().as_mut().expect("TplMutex data pointer should not be null") }

--- a/sdk/patina/src/boot_services.rs
+++ b/sdk/patina/src/boot_services.rs
@@ -229,7 +229,7 @@ pub trait BootServices {
                 notify_tpl,
                 mem::transmute::<
                     Option<extern "efiapi" fn(*mut c_void, T)>,
-                    extern "efiapi" fn(*mut c_void, *mut <T as c_ptr::CPtr<'_>>::Type),
+                    Option<extern "efiapi" fn(*mut c_void, *mut <T as c_ptr::CPtr<'_>>::Type)>,
                 >(notify_function),
                 notify_context.into_ptr() as *mut <T as CPtr>::Type,
                 event_group,
@@ -246,7 +246,7 @@ pub trait BootServices {
         &self,
         event_type: EventType,
         notify_tpl: Tpl,
-        notify_function: EventNotifyCallback<*mut T>,
+        notify_function: Option<EventNotifyCallback<*mut T>>,
         notify_context: *mut T,
         event_group: &'static efi::Guid,
     ) -> Result<efi::Event, efi::Status>;
@@ -1029,7 +1029,7 @@ impl BootServices for StandardBootServices {
         &self,
         event_type: EventType,
         notify_tpl: Tpl,
-        notify_function: EventNotifyCallback<*mut T>,
+        notify_function: Option<EventNotifyCallback<*mut T>>,
         notify_context: *mut T,
         event_group: &'static efi::Guid,
     ) -> Result<efi::Event, efi::Status> {
@@ -1041,10 +1041,9 @@ impl BootServices for StandardBootServices {
             notify_tpl.into(),
             // Safety: Transmuting function pointer types with matching ABIs and compatible signatures.
             // Both are extern "efiapi" callbacks - the generic parameter T is erased to c_void for FFI.
-            // Wrapping in Option as the UEFI interface expects an optional callback.
             unsafe {
                 mem::transmute::<
-                    extern "efiapi" fn(*mut c_void, *mut T),
+                    Option<extern "efiapi" fn(*mut c_void, *mut T)>,
                     Option<extern "efiapi" fn(*mut c_void, *mut c_void)>,
                 >(notify_function)
             },

--- a/sdk/patina/src/boot_services.rs
+++ b/sdk/patina/src/boot_services.rs
@@ -523,10 +523,10 @@ pub trait BootServices {
             }
             Some(i) => Ok(i),
             None => {
-                static ZERO_SIZE_TYPE: () = ();
-                // SAFETY: Zero-sized types (ZSTs) don't require valid memory addresses.
-                // ZERO_SIZE_TYPE provides a stable address for the cast to maintain type safety.
-                Ok(unsafe { (ptr::addr_of!(ZERO_SIZE_TYPE) as *mut T).as_mut().unwrap() })
+                // SAFETY: T is a ZST (size == 0). NonNull::dangling() returns a well-aligned,
+                // non-null pointer. For ZSTs, reads/writes are zero-sized accesses. Each call
+                // produces its own reference, avoiding aliasing violations.
+                Ok(unsafe { NonNull::<T>::dangling().as_mut() })
             }
         }
     }
@@ -606,10 +606,10 @@ pub trait BootServices {
             }
             Some(i) => Ok(i),
             None => {
-                static ZERO_SIZE_TYPE: () = ();
-                // SAFETY: Zero-sized types (ZSTs) don't require valid memory addresses.
-                // ZERO_SIZE_TYPE provides a stable address for the cast to maintain type safety.
-                Ok(unsafe { (ptr::addr_of!(ZERO_SIZE_TYPE) as *mut T).as_mut().unwrap() })
+                // SAFETY: T is a ZST (size == 0). NonNull::dangling() returns a well-aligned,
+                // non-null pointer. For ZSTs, reads/writes are zero-sized accesses. Each call
+                // produces its own reference, avoiding aliasing violations.
+                Ok(unsafe { NonNull::<T>::dangling().as_mut() })
             }
         }
     }
@@ -746,10 +746,10 @@ pub trait BootServices {
             }
             Some(i) => Ok(i),
             None => {
-                static ZERO_SIZE_TYPE: () = ();
-                // SAFETY: Zero-sized types (ZSTs) don't require valid memory addresses.
-                // ZERO_SIZE_TYPE provides a stable address for the cast to maintain type safety.
-                Ok(unsafe { (ptr::addr_of!(ZERO_SIZE_TYPE) as *mut T).as_mut().unwrap() })
+                // SAFETY: T is a ZST (size == 0). NonNull::dangling() returns a well-aligned,
+                // non-null pointer. For ZSTs, reads/writes are zero-sized accesses. Each call
+                // produces its own reference, avoiding aliasing violations.
+                Ok(unsafe { NonNull::<T>::dangling().as_mut() })
             }
         }
     }

--- a/sdk/patina/src/component/service.rs
+++ b/sdk/patina/src/component/service.rs
@@ -354,27 +354,16 @@ impl<T: ?Sized + 'static> Deref for Service<T> {
             if let Some(service) = service.downcast_ref() {
                 service
             } else {
-                // Using core::hint::unreachable_unchecked() here results in the compiler optimizing away this entire
-                // code path, and will result in UB if the path is reached. This code path truly is unreachable as we
-                // (as patina developers) control all ways of instantiating a Service type.
+                // All construction paths (mock, from, initialize) guarantee that the downcast will succeed.
+                // unreachable! is used here instead of unreachable_unchecked to avoid UB if this invariant is
+                // ever violated (e.g., via the public From<&'static dyn Any> impl with a mismatched type).
                 //
-                // The performance impact of using this over unreachable! or panic! is about 25% improved performance
-                // in benchmarks.
-                //
-                // # SAFETY
-                // - The `Service` type tightly couples the underlying type to the `dyn Any` type for downcasting.
-                // - All ways of instantiating a `Service` type are tightly controlled to ensure that this downcast is
-                //   valid and will never fail including:
-                //   - The `mock` function, which requires a `Box<dyn T>` which is then manually leaked, ensuring the
-                //     underlying type is always available and the correct type.
-                //   - The `from` function, which is passed data from `Storage`, that is guaranteed to be the correct
-                //     type as it is generated via the `IntoService` macro and out of the hands of the user.
-                //   - The `initialize` function, which consumes another `Service` type, which has the same guarantees
-                //     as above.
-                // - If the Service is uninitialized, it will panic at the normal unreachable! macro call below.
-                // SAFETY: Service value was validated to be initialized in the Some(v) match arm.
-                // unreachable_unchecked provides optimizer hints for the impossible None case.
-                unsafe { core::hint::unreachable_unchecked() }
+                // However, this is a potential point for performance improvement in the future as the component
+                // infrastructure evolves and the number of components increases.
+                unreachable!(
+                    "Service downcast failed — this indicates a type mismatch in Service<{}> construction",
+                    core::any::type_name::<T>()
+                )
             }
         } else {
             // We use unreachable! here instead of panic! as this provides compiler hints to the optimizer. We cannot

--- a/sdk/patina/src/pi/fw_fs.rs
+++ b/sdk/patina/src/pi/fw_fs.rs
@@ -14,7 +14,7 @@
 //!
 //! SPDX-License-Identifier: Apache-2.0
 //!
-use core::{fmt, mem, num::Wrapping, slice};
+use core::{fmt, mem, num::Wrapping, ptr, slice};
 
 pub mod ffs;
 pub mod fv;
@@ -183,8 +183,8 @@ impl<'a> FirmwareVolume<'a> {
             Err(efi::Status::INVALID_PARAMETER)?;
         }
 
-        // SAFETY: Buffer size was validated to contain the full Header
-        let fv_header = unsafe { &*(buffer.as_ptr() as *const fv::Header) };
+        // SAFETY: Buffer size was validated to contain the full Header.
+        let fv_header = unsafe { ptr::read_unaligned(buffer.as_ptr() as *const fv::Header) };
 
         // signature: must be ASCII '_FVH'
         if fv_header.signature != u32::from_le_bytes(*b"_FVH") {

--- a/sdk/patina/src/pi/hob/hob_list.rs
+++ b/sdk/patina/src/pi/hob/hob_list.rs
@@ -311,6 +311,11 @@ impl<'a> HobList<'a> {
                 }
             }
             let next_hob = hob_header as usize + current_header.length as usize;
+            // Guard against malformed HOBs: length must advance past the header to avoid infinite
+            // loops, and the addition must not overflow the address space.
+            if (current_header.length as usize) < mem::size_of::<header::Hob>() || next_hob < hob_header as usize {
+                break;
+            }
             hob_header = next_hob as *const header::Hob;
         }
     }

--- a/sdk/patina_macro/src/smbios_record_macro.rs
+++ b/sdk/patina_macro/src/smbios_record_macro.rs
@@ -195,24 +195,12 @@ pub(crate) fn smbios_record_derive(item: TokenStream) -> TokenStream {
             },
         )
     } else {
-        (
-            quote! {
-                fn string_pool(&self) -> &[alloc::string::String] {
-                    &[]
-                }
-
-                fn string_pool_mut(&mut self) -> &mut alloc::vec::Vec<alloc::string::String> {
-                    // Return a dummy mutable reference - this should never be used
-                    static mut EMPTY: alloc::vec::Vec<alloc::string::String> = alloc::vec::Vec::new();
-                    unsafe { &mut EMPTY }
-                }
-            },
-            quote! {
-                fn validate(&self) -> core::result::Result<(), #crate_path::error::SmbiosError> {
-                    Ok(())
-                }
-            },
+        return syn::Error::new(
+            record.item.span(),
+            "Missing #[string_pool] field. All SMBIOS records must have a `#[string_pool] pub string_pool: Vec<String>` field \
+             for trait conformance, even if the record has no strings (use an empty Vec).",
         )
+        .to_compile_error();
     };
 
     // Generate serialize_strings helper
@@ -384,6 +372,24 @@ mod tests {
         // Non-[u8; N] arrays are serialized via IntoBytes, not copied directly
         assert!(!output_str.contains("compile_error"));
         assert!(output_str.contains("IntoBytes"));
+    }
+
+    #[test]
+    fn test_missing_string_pool_field() {
+        let input = quote! {
+            #[derive(SmbiosRecord)]
+            #[smbios(record_type = 0x80)]
+            pub struct TestRecord {
+                pub header: SmbiosTableHeader,
+                pub field: u8,
+            }
+        };
+
+        let output = smbios_record_derive(input);
+        let output_str = output.to_string();
+        // Should error about missing string_pool field
+        assert!(output_str.contains("compile_error"));
+        assert!(output_str.contains("string_pool"));
     }
 
     #[test]


### PR DESCRIPTION
## Description

Fixes some safety and undefined behavior (UB) issues.

Reported by Claude with a UB/safety focused prompt. Manually filtered out less severe issues, false positives, and made fixes.

---

**boot_services: Fix UB in create_event_ex() Option<fn> transmute**

create_event_ex() transmuted Option<extern fn> to extern fn, dropping
the Option wrapper. Passing None would produce a null function pointer
typed as fn(...) which is instant UB since fn pointers are guaranteed
non-null.

Align create_event_ex() with create_event() by preserving the Option
wrapper through the transmute chain. Update create_event_ex_unchecked()
to accept Option<EventNotifyCallback> matching create_event_unchecked().

---

**patina_dxe_core: Fix TplGuard Deref lifetime unsoundness**

TplGuard's Deref and DerefMut returned references with the mutex's
lifetime ('a) instead of the guard's lifetime. This allowed extracting
references that outlive the guard, accessing mutex-protected data
without the lock held.

Tie the returned reference lifetime to &self (the guard) instead of
'a (the mutex), matching the correct pattern used in sdk/patina's
TplMutexGuard.

---

**patina_macro: Reject records without #[string_pool] at compile time**

The SmbiosRecordStructure trait requires string_pool_mut() to return
&mut Vec<String>. Records without a `#[string_pool]` field previously
used a static mut Vec which was mutable aliasing UB.

Replace with a compile-time error requiring all records to declare a
`#[string_pool]` field for trait conformance, even if never populated.
This makes the invalid state unrepresentable rather than deferring to
runtime.

----

**patina_sdk: Replace unreachable_unchecked() with unreachable in Service Deref**

The downcast failure path used unreachable_unchecked() which is UB if
reached. While all intended construction paths guarantee correct types,
the public From<&'static dyn Any> impl accepts any dyn Any, creating a
reachable path to UB. Replace with unreachable! which provides a safe
panic with a diagnostic message if the invariant is ever violated.

---

**boot_services: Use NonNull::dangling for ZST protocol references**

The ZST protocol path returned &'static mut T from a shared static (),
creating aliasing &mut references across concurrent callers.

Use NonNull::dangling() instead, which gives each caller a unique
aligned pointer without shared state.

---

**runtime: Use raw pointers for linked list manipulation to avoid aliasing**

When the runtime image/event lists are empty, the previous code created
two &mut references to the same image_head/event_head field on the same
line.

Follow the advice in https://rust-unofficial.github.io/too-many-lists/fifth-stacked-borrows.html#managing-stacked-borrows
and use pointers with addr_of_mut! throughout the list code.

---

**fv: Use checked arithmetic for FV read address calculation**

saturating_add() silently produces usize::MAX on overflow instead of
returning an error. A malformed FV with large LBA values could trigger
this, leading to a wild pointer in from_raw_parts().

Switch to checked_add and propagate InvalidParameter on overflow.

---

**fw_fs: Use read_unaligned() for FV header parsing from byte buffer**

The byte buffer has alignment 1 but fv::Header contains u32/u64 fields
requiring higher alignment. Creating a reference via &*(ptr as *const
fv::Header) is UB on unaligned data.

Use ptr::read_unaligned() to safely copy the header out of the buffer,
matching the approach used in patina_ffs.

---

**hob_list: Guard against zero-length or overflowing HOB entries**

A malformed HOB with length 0 causes an infinite loop, and a very
large length can wrap the pointer on 32-bit targets. Break out of
the parsing loop if the length is too small to contain a HOB header
or if the pointer addition overflows.

---

**patina_mm: Use read_unaligned() for communicate buffer header parsing**

The communicate buffer header fields were read with ptr::read() which
requires aligned pointers. The buffer comes from firmware memory that
may not be aligned to BinaryGuid or usize requirements depending on
the platform. Switch to ptr::read_unaligned() to be correct regardless
of alignment.

---

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

- `cargo make all`

## Integration Instructions

- N/A