### PR TITLE
patina_internal_cpu: Remove redundant architecture cfg gates

### DIFF
--- a/core/patina_internal_cpu/src/cpu/aarch64/cpu.rs
+++ b/core/patina_internal_cpu/src/cpu/aarch64/cpu.rs
@@ -7,7 +7,7 @@
 //! SPDX-License-Identifier: Apache-2.0
 //!
 use crate::cpu::Cpu;
-#[cfg(all(not(test), target_arch = "aarch64"))]
+#[cfg(not(test))]
 use core::arch::asm;
 use patina::{
     error::EfiError,
@@ -48,7 +48,7 @@ impl EfiCpuAarch64 {
             }
         }
 
-        #[cfg(all(not(test), target_arch = "aarch64"))]
+        #[cfg(not(test))]
         {
             // we have a data barrier after all cache lines have had the operation performed on them as an optimization
             // SAFETY: a data barrier has no impact on safety invariants.
@@ -59,7 +59,7 @@ impl EfiCpuAarch64 {
     }
 
     fn clean_data_entry_by_mva(&self, _mva: efi::PhysicalAddress) {
-        #[cfg(all(not(test), target_arch = "aarch64"))]
+        #[cfg(not(test))]
         {
             // SAFETY: Cleaning the data cache has no impact on safety invariants.
             unsafe {
@@ -69,7 +69,7 @@ impl EfiCpuAarch64 {
     }
 
     fn invalidate_data_cache_entry_by_mva(&self, _mva: efi::PhysicalAddress) {
-        #[cfg(all(not(test), target_arch = "aarch64"))]
+        #[cfg(not(test))]
         {
             // SAFETY: Invalidating the data cache does not impact safety checks. It
             // does have the potential to corrupt memory if used incorrectly, but the caller is
@@ -81,7 +81,7 @@ impl EfiCpuAarch64 {
     }
 
     fn clean_and_invalidate_data_entry_by_mva(&self, _mva: efi::PhysicalAddress) {
-        #[cfg(all(not(test), target_arch = "aarch64"))]
+        #[cfg(not(test))]
         {
             // SAFETY: Cleaning and invalidating the data cache does not impact safety invariants.
             unsafe {
@@ -92,7 +92,7 @@ impl EfiCpuAarch64 {
 
     fn data_cache_line_len(&self) -> u64 {
         cfg_if::cfg_if! {
-            if #[cfg(all(not(test), target_arch = "aarch64"))]  {
+            if #[cfg(not(test))]  {
                 // SAFETY: Reading ctr_el0 has no impact on safety invariants.
                 let ctr_el0 = unsafe {
                     let ctr_el0: u64;
@@ -101,7 +101,7 @@ impl EfiCpuAarch64 {
                 };
                 4 << ((ctr_el0 >> 16) & 0xf)
             } else {
-                // For test mode or non-aarch64 platforms, return 64 bytes
+                // For test mode, return 64 bytes
                 64_u64
             }
         }
@@ -111,7 +111,7 @@ impl EfiCpuAarch64 {
     // This routine only does bare-metal hardware access, so no coverage.
     #[coverage(off)]
     pub fn sleep() {
-        #[cfg(all(not(test), target_arch = "aarch64"))]
+        #[cfg(not(test))]
         {
             // SAFETY: The caller is expected to ensure that they want to wait for an interrupt
             unsafe {

--- a/core/patina_internal_cpu/src/cpu/x64/cpu.rs
+++ b/core/patina_internal_cpu/src/cpu/x64/cpu.rs
@@ -62,13 +62,13 @@ impl EfiCpuX64 {
     }
 
     fn initialize_gdt(&self) {
-        #[cfg(all(not(test), target_arch = "x86_64"))]
+        #[cfg(not(test))]
         gdt::init();
     }
 
     // X64 related asm functions
     fn asm_wbinvd(&self) {
-        #[cfg(all(not(test), target_arch = "x86_64"))]
+        #[cfg(not(test))]
         {
             // SAFETY: The caller is expected to ensure that they want to write back and invalidate the cache
             unsafe {
@@ -78,7 +78,7 @@ impl EfiCpuX64 {
     }
 
     fn asm_invd(&self) {
-        #[cfg(all(not(test), target_arch = "x86_64"))]
+        #[cfg(not(test))]
         {
             // SAFETY: The caller is expected to ensure that they want to invalidate the cache without writing back
             unsafe {
@@ -96,7 +96,7 @@ impl EfiCpuX64 {
     // This routine only does bare-metal hardware access, so no coverage.
     #[coverage(off)]
     pub fn sleep() {
-        #[cfg(all(not(test), target_arch = "x86_64"))]
+        #[cfg(not(test))]
         {
             // SAFETY: The caller is expected to ensure that they want to halt the CPU until the next interrupt
             unsafe {
@@ -110,7 +110,7 @@ impl EfiCpuX64 {
     }
 
     fn initialize_fpu(&self) {
-        #[cfg(all(not(test), target_arch = "x86_64"))]
+        #[cfg(not(test))]
         // SAFETY: This assembly writes only hard coded values to CR4 register, and MMX and FPU control words. No
         // inputs are used that could violate memory safety.
         unsafe {

--- a/core/patina_internal_cpu/src/interrupts/aarch64.rs
+++ b/core/patina_internal_cpu/src/interrupts/aarch64.rs
@@ -78,7 +78,7 @@ impl super::EfiExceptionStackTrace for ExceptionContextAArch64 {
 #[allow(unused)]
 pub fn enable_interrupts() {
     cfg_if::cfg_if! {
-        if #[cfg(all(not(test), target_arch = "aarch64"))]  {
+        if #[cfg(not(test))]  {
             write_sysreg!(reg daifclr, imm 0x02, "isb sy");
         } else {
             unimplemented!()
@@ -90,7 +90,7 @@ pub fn enable_interrupts() {
 #[allow(unused)]
 pub fn disable_interrupts() {
     cfg_if::cfg_if! {
-        if #[cfg(all(not(test), target_arch = "aarch64"))]  {
+        if #[cfg(not(test))]  {
             write_sysreg!(reg daifset, imm 0x02, "isb sy");
         } else {
             unimplemented!()
@@ -102,7 +102,7 @@ pub fn disable_interrupts() {
 #[allow(unused)]
 pub fn get_interrupt_state() -> Result<bool, EfiError> {
     cfg_if::cfg_if! {
-        if #[cfg(all(not(test), target_arch = "aarch64"))]  {
+        if #[cfg(not(test))]  {
             let daif = read_sysreg!(daif);
             Ok(daif & 0x80 == 0)
         } else {

--- a/core/patina_internal_cpu/src/interrupts/aarch64/interrupt_manager.rs
+++ b/core/patina_internal_cpu/src/interrupts/aarch64/interrupt_manager.rs
@@ -20,7 +20,7 @@ use crate::interrupts::{
 };
 
 cfg_if::cfg_if! {
-    if #[cfg(all(not(test), target_arch = "aarch64"))] {
+    if #[cfg(not(test))] {
         use core::arch::global_asm;
         use patina::{read_sysreg, write_sysreg};
         use crate::interrupts::aarch64::gic_manager::get_current_el;
@@ -67,7 +67,7 @@ impl InterruptManager for InterruptsAarch64 {}
 #[coverage(off)]
 fn enable_fiq() {
     cfg_if::cfg_if! {
-        if #[cfg(all(not(test), target_arch = "aarch64"))]  {
+        if #[cfg(not(test))]  {
             write_sysreg!(reg daifclr, imm 0x01, "isb sy");
         } else {
             unimplemented!()
@@ -78,7 +78,7 @@ fn enable_fiq() {
 #[coverage(off)]
 fn disable_fiq() {
     cfg_if::cfg_if! {
-        if #[cfg(all(not(test), target_arch = "aarch64"))]  {
+        if #[cfg(not(test))]  {
             write_sysreg!(reg daifset, imm 0x01, "isb sy");
         } else {
             unimplemented!()
@@ -89,7 +89,7 @@ fn disable_fiq() {
 #[coverage(off)]
 fn get_fiq_state() -> Result<bool, EfiError> {
     cfg_if::cfg_if! {
-        if #[cfg(all(not(test), target_arch = "aarch64"))]  {
+        if #[cfg(not(test))]  {
             let daif = read_sysreg!(daif);
             Ok(daif & 0x40 == 0)
         } else {
@@ -101,7 +101,7 @@ fn get_fiq_state() -> Result<bool, EfiError> {
 #[coverage(off)]
 fn enable_async_abort() {
     cfg_if::cfg_if! {
-        if #[cfg(all(not(test), target_arch = "aarch64"))]  {
+        if #[cfg(not(test))]  {
             write_sysreg!(reg daifclr, imm 0x04, "isb sy");
         } else {
             unimplemented!()
@@ -112,7 +112,7 @@ fn enable_async_abort() {
 #[coverage(off)]
 fn initialize_exception() -> Result<(), EfiError> {
     // Set the stack pointer for EL0 to be used for synchronous exceptions
-    #[cfg(all(not(test), target_arch = "aarch64"))]
+    #[cfg(not(test))]
     {
         // SAFETY: We are using the address of a symbol defined in assembly as the stack pointer for EL0.
         let mut sp_el0_reg = unsafe { &sp_el0_end as *const _ as u64 };
@@ -125,7 +125,7 @@ fn initialize_exception() -> Result<(), EfiError> {
     }
 
     // Program VBar
-    #[cfg(all(not(test), target_arch = "aarch64"))]
+    #[cfg(not(test))]
     {
         // SAFETY: We are using the address of the exception handlers as the vector base address.
         let vec_base = unsafe { &exception_handlers_start as *const _ as u64 };


### PR DESCRIPTION
## Description

The aarch64 and x64 modules are already gated by `target_arch` at the parent module level, so the inner `#[cfg(all(not(test), target_arch = "aarch64/x86_64"))]` checks simplify to just `#[cfg(not(test))]`.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

- `cargo make all`

## Integration Instructions

- N/A