### PR TITLE
Components: Print Before Dispatching Components

### DIFF
--- a/patina_dxe_core/src/component_dispatcher.rs
+++ b/patina_dxe_core/src/component_dispatcher.rs
@@ -223,10 +223,7 @@ impl ComponentDispatcher {
             let name = component.metadata().name();
             log::trace!("Dispatch Start: Id = [{name:?}]");
             !match component.run(&mut self.storage) {
-                Ok(true) => {
-                    log::info!("Dispatched: Id = [{name:?}] Status = [Success]");
-                    true
-                }
+                Ok(true) => true,
                 Ok(false) => false,
                 Err(err) => {
                     log_debug_assert!("Dispatched: Id = [{name:?}] Status = [Failed] Error = [{err:?}]");

--- a/sdk/patina/src/component/struct_component.rs
+++ b/sdk/patina/src/component/struct_component.rs
@@ -89,6 +89,7 @@ where
             "{} `input` is `None` during run. Did this component already run?",
             core::any::type_name::<Self>()
         );
+        log::info!("Dispatching {}", self.metadata.name());
         self.func.run(&mut self.input, param_value).map(|_| true)
     }
 


### PR DESCRIPTION
## Description

Currently, Patina only prints after dispatching a component. However, it is more valuable in debug logs to print before dispatching a component so that if it crashes or hangs, it is easy to tell from the log which component it was.

This changes Patina to print before dispatching a component and to drop the print that prints after dispatching a component if it successfully returns and only log/debug_assert if the component returns with a failure.

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Running Q35 and seeing the dispatch print occur before the component is dispatched:

<img width="895" height="45" alt="image" src="https://github.com/user-attachments/assets/6dd8aebc-a88b-4743-b884-59b2bddaaded" />

and seeing the failure print/debug_assert when a component fails:

<img width="1103" height="341" alt="image" src="https://github.com/user-attachments/assets/bd58899d-a6ee-4327-a212-51355e19ddc7" />

Previously this was seen:

<img width="1094" height="64" alt="image" src="https://github.com/user-attachments/assets/67f63a82-12ae-4686-b981-6148fbcc0281" />

## Integration Instructions

N/A.
