### PR TITLE
[REBASE & FF] Move Architectural Interfaces to SDK

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -16,7 +16,7 @@ The workspace is organized into four top-level areas:
 
 Crate dependency rules are strict. Components depend on `sdk/` only - never on each other or on `core/`. The SDK
 depends only on generic external crates. Core crates may depend on each other and on the SDK. See
-[code_organization.md](docs/src/dev/code_organization.md) for the full dependency matrix.
+`docs/src/dev/code_organization.md` for the full dependency matrix.
 
 ## Build and Test Commands
 
@@ -31,7 +31,7 @@ All commands go through `cargo make`. Never run raw `cargo` commands.
 - `cargo make coverage` - Generate test coverage reports
 - `cargo make doc` - Build documentation
 
-See [Makefile.toml](Makefile.toml) for the complete command list.
+See `Makefile.toml` for the complete command list.
 
 ## Module Organization
 
@@ -49,7 +49,7 @@ See [Makefile.toml](Makefile.toml) for the complete command list.
 // src/memory.rs
 ```
 
-See [component requirements](docs/src/component/requirements.md) for crate layout standards.
+See `docs/src/component/requirements.md` for crate layout standards.
 
 ## Safety Conventions
 
@@ -64,7 +64,7 @@ See [component requirements](docs/src/component/requirements.md) for crate layou
   itself cannot verify internally. If the function validates all inputs before the
   unsafe operation, it can remain safe.
 
-See [unsafe.md](docs/src/dev/principles/unsafe.md) for the full safety philosophy
+See `docs/src/dev/principles/unsafe.md` for the full safety philosophy
 (software safety vs. hardware safety distinctions).
 
 ## Error Handling
@@ -77,7 +77,7 @@ See [unsafe.md](docs/src/dev/principles/unsafe.md) for the full safety philosoph
 - Use `expect("descriptive message")` over bare `unwrap()`. Reserve `unwrap()` for
   test code only.
 
-See [error-handling.md](docs/src/dev/principles/error-handling.md) for error
+See `docs/src/dev/principles/error-handling.md` for error
 propagation patterns and examples.
 
 ## Component Model
@@ -98,8 +98,8 @@ A component only executes when all its declared dependencies are available.
 - Use the **stored dependencies** pattern: store all dependency references as fields in
   the component struct. The entry point stores references; methods use them.
 
-See [component interface](docs/src/component/interface.md) and
-[getting started](docs/src/component/getting_started.md) for details and examples.
+See `docs/src/component/interface.md` and
+`docs/src/component/getting_started.md` for details and examples.
 
 ## Mocking and Testing
 
@@ -109,18 +109,18 @@ See [component interface](docs/src/component/interface.md) and
 - Prefer `mockall` for trait mocking in unit tests. Use `#[automock]` on traits to generate mocks.
 - Use `pretty_assertions` for readable test diffs.
 
-See [testing.md](docs/src/dev/testing.md) for the full testing strategy.
+See `docs/src/dev/testing.md` for the full testing strategy.
 
 ## Trait Design
 
 Traits serve as **abstraction points** - not code reuse mechanisms. Use crates for
-code reuse (see [reuse.md](docs/src/dev/principles/reuse.md)).
+code reuse (see `docs/src/dev/principles/reuse.md`).
 
 - Define traits to represent swappable behavior (e.g., `BootServices`, `SerialIO`).
 - Implementations can vary per platform without affecting consumers.
 - Keep traits focused on a single responsibility (Interface Segregation).
 
-See [abstractions.md](docs/src/dev/principles/abstractions.md) for the full trait
+See `docs/src/dev/principles/abstractions.md` for the full trait
 design philosophy.
 
 ## Documentation Standards
@@ -133,7 +133,7 @@ design philosophy.
   should be self-evident. In cases where there is unavoidable ambiguity, add these sections
   to provide clarity.
 
-See [documenting.md](docs/src/dev/documenting.md) for templates and style guides.
+See `docs/src/dev/documenting.md` for templates and style guides.
 
 ## UEFI-Specific Guidelines
 
@@ -142,9 +142,9 @@ See [documenting.md](docs/src/dev/documenting.md) for templates and style guides
 - Do not use `TplMutex` for interior mutability on non-shared data.
 - No memory allocation or deallocation after `ExitBootServices`.
 
-See [synchronization.md](docs/src/dxe_core/synchronization.md),
-[memory management](docs/src/dxe_core/memory_management.md), and
-[platform requirements](docs/src/integrate/patina_dxe_core_requirements.md).
+See `docs/src/dxe_core/synchronization.md`,
+`docs/src/dxe_core/memory_management.md`, and
+`docs/src/integrate/patina_dxe_core_requirements.md`.
 
 ## Hardware Access
 
@@ -155,7 +155,7 @@ insert spurious reads through references, which can clear interrupt status bits,
 FIFO entries, or trigger other device side-effects. MMIO must be accessed exclusively
 through raw pointers with volatile operations.
 
-Patina uses the [`safe-mmio`](https://github.com/google/safe-mmio) crate for all MMIO
+Patina uses the `https://github.com/google/safe-mmio` crate for all MMIO
 access. `safe-mmio` provides `UniqueMmioPointer<T>` which never creates a `&T` to device
 memory. Its field wrapper types encode read side-effect semantics at the type level:
 
@@ -163,8 +163,14 @@ memory. Its field wrapper types encode read side-effect semantics at the type le
 - `ReadOnly<T>` / `ReadWrite<T>` — reads have side-effects (require `&mut` access).
 - `WriteOnly<T>` — write-only register.
 
-See [mmio.md](docs/src/dev/hardware_access/mmio.md) for the full rationale, wrapper
+See `docs/src/dev/hardware_access/mmio.md` for the full rationale, wrapper
 reference table, and links to `safe-mmio` documentation.
+
+### Architectural Interfaces
+
+Minimize the use of inline assembly. Generally, architectural interfaces accessed through
+inline assembly should be wrapped in safe Rust abstractions in the SDK. The exception to
+this is if the interface is not generally applicable.
 
 ## Dependency Management
 
@@ -172,11 +178,11 @@ reference table, and links to `safe-mmio` documentation.
   security advisories, and allowed sources.
 - Use workspace-level dependency declarations in the root `Cargo.toml` for consistency.
 - Evaluate new dependencies against the criteria in
-  [dependency-management.md](docs/src/dev/principles/dependency-management.md).
+  `docs/src/dev/principles/dependency-management.md`.
 
 ## Formatting
 
-Formatting is enforced by `rustfmt` via [rustfmt.toml](rustfmt.toml). Always run
+Formatting is enforced by `rustfmt` via `rustfmt.toml`. Always run
 `cargo make fmt` after editing code.
 
 ## Common Anti-Patterns

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,7 +57,6 @@ time = { version = "0.3.47" }
 uart_16550 = { version = "^0.3.2" }
 corosensei = { version = "0.3.3", default-features = false }
 uuid = { version = "1.8", default-features = false }
-x86_64 = { version = "=0.15.2", default-features = false }
 zerocopy = { version = "0.8" }
 zerocopy-derive = { version = "0.8" }
 

--- a/components/patina_mm/Cargo.toml
+++ b/components/patina_mm/Cargo.toml
@@ -25,11 +25,6 @@ mockall = { workspace = true }
 patina = { workspace = true, features = ["mockall"] }
 patina_dxe_core = { path = "../../patina_dxe_core"}
 
-[target.'cfg(target_arch="x86_64")'.dependencies]
-x86_64 = { workspace = true, features = [
-  "instructions",
-] }
-
 [features]
 doc = []
 mockall = ["dep:mockall", "std"]

--- a/components/patina_mm/src/component/sw_mmi_manager.rs
+++ b/components/patina_mm/src/component/sw_mmi_manager.rs
@@ -118,14 +118,7 @@ unsafe impl SwMmiTrigger for SwMmiManager {
                         //    initialized upholding its safety contract.
                         // 3. This service is only registered after platform initialization (entry_point completion)
                         // 4. Writing to the SMI command port is the defined mechanism for triggering software MMIs
-                        unsafe {
-                            core::arch::asm!(
-                                "out dx, al",
-                                in("dx") _port,
-                                in("al") _cmd_port_value,
-                                options(nostack, nomem, preserves_flags)
-                            );
-                        }
+                        unsafe { patina::arch::x64::io_out8(_port, _cmd_port_value) };
                         log::trace!(target: "sw_mmi", "SMI command port write completed");
                     } else {
                         log::trace!(target: "sw_mmi", "SMI command port write skipped (not on target platform)");
@@ -151,14 +144,7 @@ unsafe impl SwMmiTrigger for SwMmiManager {
                         //     initialized upholding its safety contract.
                         // 3. This service is only registered after platform initialization (entry_point completion)
                         // 4. Writing to the SMI data port is the defined mechanism for passing data to MMI handlers
-                        unsafe {
-                            core::arch::asm!(
-                                "out dx, al",
-                                in("dx") _port,
-                                in("al") _data_port_value,
-                                options(nostack, nomem, preserves_flags)
-                            );
-                        }
+                        unsafe { patina::arch::x64::io_out8(_port, _data_port_value) };
                         log::trace!(target: "sw_mmi", "SMI data port write completed");
                     } else {
                         log::trace!(target: "sw_mmi", "SMI data port write skipped (not on target platform)");

--- a/components/patina_mm/src/component/sw_mmi_manager.rs
+++ b/components/patina_mm/src/component/sw_mmi_manager.rs
@@ -22,9 +22,6 @@ use patina::component::{
     service::{IntoService, Service},
 };
 
-#[cfg(all(target_arch = "x86_64", any(target_os = "uefi", feature = "doc")))]
-use x86_64::instructions::port;
-
 #[cfg(any(test, feature = "mockall"))]
 use mockall::automock;
 
@@ -121,7 +118,14 @@ unsafe impl SwMmiTrigger for SwMmiManager {
                         //    initialized upholding its safety contract.
                         // 3. This service is only registered after platform initialization (entry_point completion)
                         // 4. Writing to the SMI command port is the defined mechanism for triggering software MMIs
-                        unsafe { port::Port::new(_port).write(_cmd_port_value); }
+                        unsafe {
+                            core::arch::asm!(
+                                "out dx, al",
+                                in("dx") _port,
+                                in("al") _cmd_port_value,
+                                options(nostack, nomem, preserves_flags)
+                            );
+                        }
                         log::trace!(target: "sw_mmi", "SMI command port write completed");
                     } else {
                         log::trace!(target: "sw_mmi", "SMI command port write skipped (not on target platform)");
@@ -147,7 +151,14 @@ unsafe impl SwMmiTrigger for SwMmiManager {
                         //     initialized upholding its safety contract.
                         // 3. This service is only registered after platform initialization (entry_point completion)
                         // 4. Writing to the SMI data port is the defined mechanism for passing data to MMI handlers
-                        unsafe { port::Port::new(_port).write(_data_port_value); }
+                        unsafe {
+                            core::arch::asm!(
+                                "out dx, al",
+                                in("dx") _port,
+                                in("al") _data_port_value,
+                                options(nostack, nomem, preserves_flags)
+                            );
+                        }
                         log::trace!(target: "sw_mmi", "SMI data port write completed");
                     } else {
                         log::trace!(target: "sw_mmi", "SMI data port write skipped (not on target platform)");

--- a/core/patina_internal_cpu/Cargo.toml
+++ b/core/patina_internal_cpu/Cargo.toml
@@ -24,20 +24,12 @@ cfg-if = { workspace = true }
 patina_stacktrace = { workspace = true }
 
 [target.'cfg(all(target_arch="x86_64"))'.dependencies]
-x86_64 = { workspace = true, features = [
-    "instructions",
-    "abi_x86_interrupt",
-] }
 patina_mtrr = { workspace = true }
 
 [target.'cfg(all(target_arch="aarch64"))'.dependencies]
 arm-gic = { workspace = true }
 
 [dev-dependencies]
-x86_64 = { workspace = true, features = [
-    "instructions",
-    "abi_x86_interrupt",
-] }
 mockall = { workspace = true }
 serial_test = { workspace = true }
 

--- a/core/patina_internal_cpu/src/cpu.rs
+++ b/core/patina_internal_cpu/src/cpu.rs
@@ -22,7 +22,7 @@ mod aarch64;
 #[cfg(not(target_os = "uefi"))]
 mod stub;
 #[cfg(target_arch = "x86_64")]
-mod x64;
+pub(crate) mod x64;
 
 cfg_if::cfg_if! {
     if #[cfg(not(target_os = "uefi"))] {

--- a/core/patina_internal_cpu/src/cpu/x64.rs
+++ b/core/patina_internal_cpu/src/cpu/x64.rs
@@ -7,7 +7,7 @@
 //! SPDX-License-Identifier: Apache-2.0
 //!
 mod cpu;
-mod gdt;
+pub(crate) mod gdt;
 
 #[allow(unused)]
 pub use cpu::EfiCpuX64;

--- a/core/patina_internal_cpu/src/cpu/x64/gdt.rs
+++ b/core/patina_internal_cpu/src/cpu/x64/gdt.rs
@@ -8,252 +8,264 @@
 //!
 #![cfg_attr(test, allow(dead_code))]
 #![cfg_attr(test, allow(unused_imports))]
-use core::ptr::addr_of;
+use core::ptr::{addr_of, addr_of_mut};
 use lazy_static::lazy_static;
 use patina::base::SIZE_4GB;
-use x86_64::{
-    VirtAddr,
-    instructions::{
-        segmentation::{CS, DS, ES, FS, GS, SS, Segment},
-        tables::load_tss,
-    },
-    structures::{
-        gdt::{Descriptor, DescriptorFlags, GlobalDescriptorTable, SegmentSelector},
-        tss::TaskStateSegment,
-    },
+
+struct GdtEntry {
+    limit15_0: u16,
+    base15_0: u16,
+    base23_16: u8,
+    type_: u8,
+    limit19_16_and_flags: u8,
+    base31_24: u8,
+}
+
+// SAFETY: This also automatically defines the Into trait for u64. This is safe to do
+// but any malformed GdtEntries will cause general protection faults. Only the defaults
+// defined here should be used.
+impl From<GdtEntry> for u64 {
+    fn from(entry: GdtEntry) -> Self {
+        (entry.limit15_0 as u64)
+            | ((entry.base15_0 as u64) << 16)
+            | ((entry.base23_16 as u64) << 32)
+            | ((entry.type_ as u64) << 40)
+            | ((entry.limit19_16_and_flags as u64) << 48)
+            | ((entry.base31_24 as u64) << 56)
+    }
+}
+
+const NULL_SEL: GdtEntry = GdtEntry {
+    limit15_0: 0,
+    base15_0: 0,
+    base23_16: 0,
+    type_: 0, // NULL
+    limit19_16_and_flags: 0,
+    base31_24: 0,
 };
 
-pub const DOUBLE_FAULT_IST_INDEX: u16 = 0;
+const LINEAR_SEL: GdtEntry = GdtEntry {
+    limit15_0: 0xffff,
+    base15_0: 0x0000,
+    base23_16: 0x00,
+    type_: 0x92,                // present, ring 0, data, read/write
+    limit19_16_and_flags: 0xCF, // page-granular, 32-bit
+    base31_24: 0x00,
+};
 
-// 0xcf92000000ffff
-pub const LINEAR_SEL: DescriptorFlags = DescriptorFlags::from_bits_truncate(
-    // 0xFFFF
-    DescriptorFlags::LIMIT_0_15.bits()     // 0xFFFF
-    // 0x2 [41]
-    | DescriptorFlags::WRITABLE.bits()          // 41
-    // 0x9 [47, 44]
-    | DescriptorFlags::USER_SEGMENT.bits()      // 44
-    | DescriptorFlags::PRESENT.bits()           // 47
-    // 0xF [51, 50, 49, 48]
-    | DescriptorFlags::LIMIT_16_19.bits()       // 0xF << 48
-    // 0xC [55, 54]
-    | DescriptorFlags::DEFAULT_SIZE.bits()      // 54
-    | DescriptorFlags::GRANULARITY.bits(), // 55
-);
+const LINEAR_CODE_SEL: GdtEntry = GdtEntry {
+    limit15_0: 0xffff,
+    base15_0: 0x0000,
+    base23_16: 0x00,
+    type_: 0x9F,                // present, ring 0, code, execute/read, conforming, accessed
+    limit19_16_and_flags: 0xCF, // page-granular, 32-bit
+    base31_24: 0x00,
+};
 
-// 0xcf9f000000ffff
-pub const LINEAR_CODE_SEL: DescriptorFlags = DescriptorFlags::from_bits_truncate(
-    // 0xFFFF
-    DescriptorFlags::LIMIT_0_15.bits()     // 0xFFFF
-    // 0xF [43, 42, 41, 40]
-    | DescriptorFlags::ACCESSED.bits()          // 40
-    | DescriptorFlags::WRITABLE.bits()          // 41
-    | DescriptorFlags::CONFORMING.bits()        // 42
-    | DescriptorFlags::EXECUTABLE.bits()        // 43
-    // 0x9 [47, 44]
-    | DescriptorFlags::USER_SEGMENT.bits()      // 44
-    | DescriptorFlags::PRESENT.bits()           // 47
-    // 0xF [51, 50, 49, 48]
-    | DescriptorFlags::LIMIT_16_19.bits()       // 0xF << 48
-    // 0xC [55, 54]
-    | DescriptorFlags::DEFAULT_SIZE.bits()      // 54
-    | DescriptorFlags::GRANULARITY.bits(), // 55
-);
+const SYS_DATA_SEL: GdtEntry = GdtEntry {
+    limit15_0: 0xffff,
+    base15_0: 0x0000,
+    base23_16: 0x00,
+    type_: 0x93,                // present, ring 0, data, read/write, accessed
+    limit19_16_and_flags: 0xCF, // page-granular, 32-bit
+    base31_24: 0x00,
+};
 
-// 0xcf93000000ffff
-pub const SYS_DATA_SEL: DescriptorFlags = DescriptorFlags::from_bits_truncate(
-    // 0xFFFF
-    DescriptorFlags::LIMIT_0_15.bits()     // 0xFFFF
-    // 0x3 [41, 40]
-    | DescriptorFlags::ACCESSED.bits()          // 40
-    | DescriptorFlags::WRITABLE.bits()          // 41
-    // 0x9 [47, 44]
-    | DescriptorFlags::USER_SEGMENT.bits()      // 44
-    | DescriptorFlags::PRESENT.bits()           // 47
-    // 0xF [51, 50, 49, 48]
-    | DescriptorFlags::LIMIT_16_19.bits()       // 0xF << 48
-    // 0xC [55, 54]
-    | DescriptorFlags::DEFAULT_SIZE.bits()      // 54
-    | DescriptorFlags::GRANULARITY.bits(), // 55
-);
+const SYS_CODE_SEL: GdtEntry = GdtEntry {
+    limit15_0: 0xffff,
+    base15_0: 0x0000,
+    base23_16: 0x00,
+    type_: 0x9A,                // present, ring 0, code, execute/read
+    limit19_16_and_flags: 0xCF, // page-granular, 32-bit
+    base31_24: 0x00,
+};
 
-// 0xcf9a000000ffff
-pub const SYS_CODE_SEL: DescriptorFlags = DescriptorFlags::from_bits_truncate(
-    // 0xFFFF
-    DescriptorFlags::LIMIT_0_15.bits()     // 0xFFFF
-    // 0xA [43, 41]
-    | DescriptorFlags::WRITABLE.bits()          // 41
-    | DescriptorFlags::EXECUTABLE.bits()        // 43
-    // 0x9 [47, 44]
-    | DescriptorFlags::USER_SEGMENT.bits()      // 44
-    | DescriptorFlags::PRESENT.bits()           // 47
-    // 0xF [51, 50, 49, 48]
-    | DescriptorFlags::LIMIT_16_19.bits()       // 0xF << 48
-    // 0xC [55, 54]
-    | DescriptorFlags::DEFAULT_SIZE.bits()      // 54
-    | DescriptorFlags::GRANULARITY.bits(), // 55
-);
+const SYS_CODE16_SEL: GdtEntry = GdtEntry {
+    limit15_0: 0xffff,
+    base15_0: 0x0000,
+    base23_16: 0x00,
+    type_: 0x9A,                // present, ring 0, code, execute/read
+    limit19_16_and_flags: 0x8F, // page-granular, 16-bit
+    base31_24: 0x00,
+};
 
-// 0x8f9a000000ffff
-pub const SYS_CODE16_SEL: DescriptorFlags = DescriptorFlags::from_bits_truncate(
-    // 0xFFFF
-    DescriptorFlags::LIMIT_0_15.bits()    // 0xFFFF
-    // 0xA [43, 41]
-    | DescriptorFlags::WRITABLE.bits()          // 41
-    | DescriptorFlags::EXECUTABLE.bits()        // 43
-    // 0x9 [47, 44]
-    | DescriptorFlags::USER_SEGMENT.bits()      // 44
-    | DescriptorFlags::PRESENT.bits()           // 47
-    // 0xF [51, 50, 49, 48]
-    | DescriptorFlags::LIMIT_16_19.bits()       // 0xF << 48
-    // 0x8 [55]
-    | DescriptorFlags::GRANULARITY.bits(), // 55
-);
+const LINEAR_DATA64_SEL: GdtEntry = GdtEntry {
+    limit15_0: 0xffff,
+    base15_0: 0x0000,
+    base23_16: 0x00,
+    type_: 0x92,                // present, ring 0, data, read/write
+    limit19_16_and_flags: 0xCF, // page-granular, 32-bit
+    base31_24: 0x00,
+};
 
-// 0xcf92000000ffff
-pub const LINEAR_DATA64_SEL: DescriptorFlags = DescriptorFlags::from_bits_truncate(
-    // 0xFFFF
-    DescriptorFlags::LIMIT_0_15.bits()     // 0xFFFF
-    // 0x2 [41]
-    | DescriptorFlags::WRITABLE.bits()          // 41
-    // 0x9 [47, 44]
-    | DescriptorFlags::USER_SEGMENT.bits()      // 44
-    | DescriptorFlags::PRESENT.bits()           // 47
-    // 0xF [51, 50, 49, 48]
-    | DescriptorFlags::LIMIT_16_19.bits()       // 0xF << 48
-    // 0xC [55, 54]
-    | DescriptorFlags::DEFAULT_SIZE.bits()      // 54
-    | DescriptorFlags::GRANULARITY.bits(), // 55
-);
+const LINEAR_CODE64_SEL: GdtEntry = GdtEntry {
+    limit15_0: 0xffff,
+    base15_0: 0x0000,
+    base23_16: 0x00,
+    type_: 0x9A,                // present, ring 0, code, execute/read
+    limit19_16_and_flags: 0xAF, // page-granular, 64-bit code
+    base31_24: 0x00,
+};
 
-// 0xaf9a000000ffff
-pub const LINEAR_CODE64_SEL: DescriptorFlags = DescriptorFlags::from_bits_truncate(
-    // 0xFFFF
-    DescriptorFlags::LIMIT_0_15.bits()     // 0xFFFF
-    // 0xA [43, 41]
-    | DescriptorFlags::WRITABLE.bits()          // 41
-    | DescriptorFlags::EXECUTABLE.bits()        // 43
-    // 0x9 [47, 44]
-    | DescriptorFlags::USER_SEGMENT.bits()      // 44
-    | DescriptorFlags::PRESENT.bits()           // 47
-    // 0xF [51, 50, 49, 48]
-    | DescriptorFlags::LIMIT_16_19.bits()       // 0xF << 48
-    // 0xa [55, 53]
-    | DescriptorFlags::LONG_MODE.bits()         // 53
-    | DescriptorFlags::GRANULARITY.bits(), // 55
-);
+const SPARE5_SEL: GdtEntry = GdtEntry {
+    limit15_0: 0x0000,
+    base15_0: 0x0000,
+    base23_16: 0x00,
+    type_: 0x00,
+    limit19_16_and_flags: 0x00,
+    base31_24: 0x00,
+};
 
-// 0x0
-pub const SPARE5_SEL: DescriptorFlags = DescriptorFlags::from_bits_truncate(0);
+/// Size of the 64-bit TSS structure in bytes.
+const TSS_SIZE: usize = 104;
 
-lazy_static! {
-    static ref TSS: TaskStateSegment = {
-        let mut tss = TaskStateSegment::new();
-        tss.interrupt_stack_table[DOUBLE_FAULT_IST_INDEX as usize] = {
-            const STACK_SIZE: usize = 4096 * 5;
-            static mut STACK: [u8; STACK_SIZE] = [0; STACK_SIZE];
+/// Byte offset of IST1 within the TSS (DOUBLE_FAULT_IST_INDEX 0 maps to IST1).
+const TSS_IST1_OFFSET: usize = 36;
 
-            VirtAddr::from_ptr(addr_of!(STACK)) + STACK_SIZE as u64
-        };
-        tss
-    };
+const STACK_SIZE: usize = 4096 * 5;
+
+const GDT_ENTRY_COUNT: usize = 11;
+
+// Segment selector values (GDT index * 8, RPL = 0)
+pub(crate) const CODE_SELECTOR: u16 = 7 * 8; // LINEAR_CODE64_SEL at index 7
+const DATA_SELECTOR: u16 = 6 * 8; // LINEAR_DATA64_SEL at index 6
+const TSS_SELECTOR: u16 = 8 * 8; // TSS descriptor at index 8
+
+static mut DOUBLE_FAULT_STACK: [u8; STACK_SIZE] = [0; STACK_SIZE];
+static mut TSS: [u8; TSS_SIZE] = [0; TSS_SIZE];
+
+/// Build a 128-bit (two u64) TSS system segment descriptor from base address and limit.
+fn tss_descriptor(base: u64, limit: u32) -> (u64, u64) {
+    let low: u64 =
+        // Limit [15:0]
+        (limit as u64 & 0xFFFF)
+        // Base [15:0] at bits 16..31
+        | ((base & 0xFFFF) << 16)
+        // Base [23:16] at bits 32..39
+        | (((base >> 16) & 0xFF) << 32)
+        // Type = 0x9 (64-bit TSS Available) at bits 40..43
+        | (0x9u64 << 40)
+        // Present bit at bit 47
+        | (1u64 << 47)
+        // Limit [19:16] at bits 48..51
+        | ((((limit >> 16) as u64) & 0xF) << 48)
+        // Base [31:24] at bits 56..63
+        | (((base >> 24) & 0xFF) << 56);
+    // High 8 bytes: Base [63:32]
+    let high: u64 = base >> 32;
+    (low, high)
 }
 
 lazy_static! {
-    static ref GDT: (GlobalDescriptorTable::<11>, Selectors) = {
-        let mut gdt = GlobalDescriptorTable::<11>::empty();
+    static ref GDT: [u64; GDT_ENTRY_COUNT] = {
+        // Initialize TSS with double-fault stack in IST1
+        // SAFETY: Single-threaded initialization guaranteed by lazy_static.
+        unsafe {
+            let ist_addr = addr_of!(DOUBLE_FAULT_STACK) as u64 + STACK_SIZE as u64;
+            let ist_bytes = ist_addr.to_ne_bytes();
+            core::ptr::copy_nonoverlapping(
+                ist_bytes.as_ptr(),
+                addr_of_mut!(TSS).cast::<u8>().add(TSS_IST1_OFFSET),
+                8,
+            );
+        }
 
-        // We need a valid 32 bit code segment for MpServices as they start in real mode, go through protected mode,
-        // then switch to long mode. It also must come before the TSS entry as the MpDxe C code matches the TSS
-        // selector to the code selector, even though it is not.
-        gdt.append(Descriptor::UserSegment(LINEAR_SEL.bits()));
-        gdt.append(Descriptor::UserSegment(LINEAR_CODE_SEL.bits()));
-        gdt.append(Descriptor::UserSegment(SYS_DATA_SEL.bits()));
-        gdt.append(Descriptor::UserSegment(SYS_CODE_SEL.bits()));
-        gdt.append(Descriptor::UserSegment(SYS_CODE16_SEL.bits()));
-        // Always load 64-bit code & data segments
-        let data_selector = gdt.append(Descriptor::UserSegment(LINEAR_DATA64_SEL.bits()));
-        let code_selector = gdt.append(Descriptor::UserSegment(LINEAR_CODE64_SEL.bits()));
-        let tss_selector = gdt.append(Descriptor::tss_segment(&TSS));
-        gdt.append(Descriptor::UserSegment(SPARE5_SEL.bits()));
-        (gdt, Selectors { code_selector, data_selector, tss_selector })
+        let tss_base = addr_of!(TSS) as u64;
+        let (tss_low, tss_high) = tss_descriptor(tss_base, (TSS_SIZE - 1) as u32);
+
+        // We need valid 32-bit code segments for MpServices as they start in real mode, go through
+        // protected mode, then switch to long mode. They must come before the TSS entry as the
+        // MpDxe C code matches the TSS selector to the code selector, even though it is not.
+        [
+            NULL_SEL.into(),
+            LINEAR_SEL.into(),
+            LINEAR_CODE_SEL.into(),
+            SYS_DATA_SEL.into(),
+            SYS_CODE_SEL.into(),
+            SYS_CODE16_SEL.into(),
+            LINEAR_DATA64_SEL.into(),
+            LINEAR_CODE64_SEL.into(),
+            tss_low,
+            tss_high,
+            SPARE5_SEL.into(),
+        ]
     };
 }
 
-struct Selectors {
-    code_selector: SegmentSelector,
-    data_selector: SegmentSelector,
-    tss_selector: SegmentSelector,
+#[repr(C, packed)]
+struct GdtPointer {
+    limit: u16,
+    base: u64,
 }
 
+#[coverage(off)]
 pub fn init() {
-    if &GDT.0 as *const _ as usize >= SIZE_4GB {
+    let gdt_ptr = GDT.as_ptr() as usize;
+    if gdt_ptr >= SIZE_4GB {
         panic!("GDT above 4GB, MP services will fail");
     }
-    GDT.0.load();
+
+    let gdtr = GdtPointer { limit: (core::mem::size_of::<[u64; GDT_ENTRY_COUNT]>() - 1) as u16, base: gdt_ptr as u64 };
 
     // SAFETY: We are constructing a well known GDT that maps all segments in a flat map
     unsafe {
-        CS::set_reg(GDT.1.code_selector);
+        core::arch::asm!("lgdt [{}]", in(reg) &gdtr, options(nostack, preserves_flags));
+
+        // Reload CS via a far return
+        core::arch::asm!(
+            "push {sel}",
+            "lea {tmp}, [rip + 2f]",
+            "push {tmp}",
+            "retfq",
+            "2:",
+            sel = in(reg) CODE_SELECTOR as u64,
+            tmp = lateout(reg) _,
+            options(preserves_flags),
+        );
 
         // These segments need to be valid, but can be all the same. Program them to the same GDT entry,
         // following what the C codebase does, as these are unused in long mode.
-        SS::set_reg(GDT.1.data_selector);
-        DS::set_reg(GDT.1.data_selector);
-        ES::set_reg(GDT.1.data_selector);
-        FS::set_reg(GDT.1.data_selector);
-        GS::set_reg(GDT.1.data_selector);
-        load_tss(GDT.1.tss_selector);
+        core::arch::asm!("mov ss, {0:x}", in(reg) DATA_SELECTOR, options(nostack, preserves_flags));
+        core::arch::asm!("mov ds, {0:x}", in(reg) DATA_SELECTOR, options(nostack, preserves_flags));
+        core::arch::asm!("mov es, {0:x}", in(reg) DATA_SELECTOR, options(nostack, preserves_flags));
+        core::arch::asm!("mov fs, {0:x}", in(reg) DATA_SELECTOR, options(nostack, preserves_flags));
+        core::arch::asm!("mov gs, {0:x}", in(reg) DATA_SELECTOR, options(nostack, preserves_flags));
+
+        // Load TSS
+        core::arch::asm!("ltr {0:x}", in(reg) TSS_SELECTOR, options(nostack, preserves_flags));
     }
-    log::info!("Loaded GDT @ {:p}", &GDT.0);
-    log::info!("GDT is: {:?}", GDT.0);
+
+    log::info!("Loaded GDT @ {:p}", GDT.as_ptr());
 }
 
 #[cfg(test)]
 #[coverage(off)]
 mod tests {
-    use super::{
-        GDT, LINEAR_CODE_SEL, LINEAR_CODE64_SEL, LINEAR_DATA64_SEL, LINEAR_SEL, SPARE5_SEL, SYS_CODE_SEL,
-        SYS_CODE16_SEL, SYS_DATA_SEL,
-    };
+    use super::*;
 
     #[test]
     pub fn test_dxe_default_entries() {
-        println!("{:?}", GDT.0.entries()[8]);
-
-        for (i, entry) in GDT.0.entries().iter().enumerate() {
+        for (i, &entry) in GDT.iter().enumerate() {
             match i {
-                0 => assert_eq!(entry.raw(), 0),
-                1 => assert_eq!(entry.raw(), LINEAR_SEL.bits()),
-                2 => assert_eq!(entry.raw(), LINEAR_CODE_SEL.bits()),
-                3 => assert_eq!(entry.raw(), SYS_DATA_SEL.bits()),
-                4 => assert_eq!(entry.raw(), SYS_CODE_SEL.bits()),
-                5 => assert_eq!(entry.raw(), SYS_CODE16_SEL.bits()),
-                6 => assert_eq!(entry.raw(), LINEAR_DATA64_SEL.bits()),
-                7 => assert_eq!(entry.raw(), LINEAR_CODE64_SEL.bits()),
+                0 => assert_eq!(entry, NULL_SEL.into()),
+                1 => assert_eq!(entry, LINEAR_SEL.into()),
+                2 => assert_eq!(entry, LINEAR_CODE_SEL.into()),
+                3 => assert_eq!(entry, SYS_DATA_SEL.into()),
+                4 => assert_eq!(entry, SYS_CODE_SEL.into()),
+                5 => assert_eq!(entry, SYS_CODE16_SEL.into()),
+                6 => assert_eq!(entry, LINEAR_DATA64_SEL.into()),
+                7 => assert_eq!(entry, LINEAR_CODE64_SEL.into()),
                 8 => assert!(
-                    entry.raw() & 0xFF > 0                                          // Limit > 0
-                    && ((entry.raw() & (((1 << 4) - 1) << 40)) >> 40  == 0x9)       // Type is 9 (TSS Available)
-                    && entry.raw() & (0x1 << 47) > 0, // Present set
+                    entry & 0xFF > 0                                          // Limit > 0
+                    && ((entry & (((1 << 4) - 1) << 40)) >> 40  == 0x9)       // Type is 9 (TSS Available)
+                    && entry & (0x1 << 47) > 0, // Present set
                     "TSS Segment Descriptor is Not Valid"
                 ),
-                9 => assert!(entry.raw() & 0xFFFFFFFF > 0, "TSS Segment Descriptor Base must be set"), // TSS segment limit > 0
-                10 => assert_eq!(entry.raw(), SPARE5_SEL.bits()),
+                9 => assert!(entry & 0xFFFFFFFF > 0, "TSS Segment Descriptor Base must be set"), // TSS segment limit > 0
+                10 => assert_eq!(entry, SPARE5_SEL.into()),
                 _ => panic!("Unexpected GDT entry"),
             }
         }
-        assert_eq!(GDT.0.entries().len(), 11);
-    }
-
-    #[test]
-    fn test_dxe_default_segment_values() {
-        assert_eq!(LINEAR_SEL.bits(), 0xcf92000000ffff);
-        assert_eq!(LINEAR_CODE_SEL.bits(), 0xcf9f000000ffff);
-        assert_eq!(SYS_DATA_SEL.bits(), 0xcf93000000ffff);
-        assert_eq!(SYS_CODE_SEL.bits(), 0xcf9a000000ffff);
-        assert_eq!(SYS_CODE16_SEL.bits(), 0x8f9a000000ffff);
-        assert_eq!(LINEAR_DATA64_SEL.bits(), 0xcf92000000ffff);
-        assert_eq!(LINEAR_CODE64_SEL.bits(), 0xaf9a000000ffff);
-        assert_eq!(SPARE5_SEL.bits(), 0x0);
+        assert_eq!(GDT.len(), 11);
     }
 }

--- a/core/patina_internal_cpu/src/interrupts/x64/idt.rs
+++ b/core/patina_internal_cpu/src/interrupts/x64/idt.rs
@@ -7,13 +7,8 @@
 //! SPDX-License-Identifier: Apache-2.0
 //!
 
-use core::arch::global_asm;
-use lazy_static::lazy_static;
+use core::{arch::global_asm, cell::UnsafeCell};
 use patina::base::SIZE_4GB;
-use x86_64::{
-    VirtAddr,
-    structures::idt::{InterruptDescriptorTable, InterruptStackFrame},
-};
 
 global_asm!(include_str!("interrupt_handler.asm"));
 // Use efiapi for the consistent calling convention.
@@ -21,78 +16,119 @@ unsafe extern "efiapi" {
     fn AsmGetVectorAddress(index: usize) -> u64;
 }
 
-// The x86_64 crate requires the IDT to be static, which makes sense as the IDT
-// can live beyond any code lifetime.
-lazy_static! {
-    static ref IDT: InterruptDescriptorTable = {
-        let mut idt = InterruptDescriptorTable::new();
+/// A single 16-byte gate descriptor in the IDT.
+#[derive(Clone, Copy)]
+#[repr(C)]
+struct IdtEntry {
+    offset_low: u16,
+    selector: u16,
+    ist: u8,
+    type_attr: u8,
+    offset_mid: u16,
+    offset_high: u32,
+    reserved: u32,
+}
 
-        // Initialize all of the index-able well-known entries.
-        for vector in [0, 1, 2, 3, 4, 5, 6, 7, 9, 16, 19, 20, 28] {
-            // SAFETY: We are constructing the well known IDT handlers which must be present in the IDT
-            unsafe { idt[vector].set_handler_addr(get_vector_address(vector.into())) };
-        }
+impl IdtEntry {
+    const fn empty() -> Self {
+        Self { offset_low: 0, selector: 0, ist: 0, type_attr: 0, offset_mid: 0, offset_high: 0, reserved: 0 }
+    }
 
-        // Intentionally use direct function for double fault. This allows for
-        // more robust diagnostics of the exception stack. Currently this also
-        // means external caller cannot register for double fault call backs.
-        // Fix it: Below line is excluded from std builds because rustc fails to
-        //        compile with following error "offset is not a multiple of 16"
-        // SAFETY: We are adding a double fault handler to our static IDT that already exists
-        unsafe { idt.double_fault.set_handler_addr(VirtAddr::new(double_fault_handler as *const () as u64)).set_stack_index(0); }
+    /// Configure this entry as a present interrupt gate (DPL 0) pointing to `addr`.
+    fn set_handler(&mut self, addr: u64, selector: u16, ist_index: u8) {
+        self.offset_low = addr as u16;
+        self.offset_mid = (addr >> 16) as u16;
+        self.offset_high = (addr >> 32) as u32;
+        self.selector = selector;
+        self.ist = ist_index & 0x7;
+        self.type_attr = 0x8E; // Present | DPL 0 | Interrupt Gate
+        self.reserved = 0;
+    }
+}
 
-        // Initialize the error code vectors. the x86_64 crate does not allow these
-        // to be indexed.
-        // SAFETY: We are using a static IDT and configuring all exception handlers
-        unsafe {
-            idt.invalid_tss.set_handler_addr(get_vector_address(10));
-            idt.segment_not_present.set_handler_addr(get_vector_address(11));
-            idt.stack_segment_fault.set_handler_addr(get_vector_address(12));
-            idt.general_protection_fault.set_handler_addr(get_vector_address(13));
-            idt.page_fault.set_handler_addr(get_vector_address(14));
-            idt.alignment_check.set_handler_addr(get_vector_address(17));
-            idt.cp_protection_exception.set_handler_addr(get_vector_address(19));
-            idt.vmm_communication_exception.set_handler_addr(get_vector_address(29));
-            idt.security_exception.set_handler_addr(get_vector_address(30));
-        }
+/// The 256-entry x86-64 Interrupt Descriptor Table.
+#[repr(C, align(16))]
+struct Idt {
+    entries: [IdtEntry; 256],
+}
 
-        // Initialize generic interrupts.
-        for vector in 32..=255 {
-            // SAFETY: We are using a static IDT and configuring the expected list of generic interrupts
-            unsafe { idt[vector].set_handler_addr(get_vector_address(vector.into())) };
-        }
+struct StaticIdt(UnsafeCell<Idt>);
 
-        idt
-    };
+// SAFETY: IDT initialization and loading is serialized during early CPU init before
+// interrupts are enabled and before concurrent access is possible.
+unsafe impl Sync for StaticIdt {}
+
+/// Pointer structure passed to the `lidt` instruction.
+#[repr(C, packed)]
+struct Idtr {
+    limit: u16,
+    base: u64,
 }
 
 /// Gets the address of the assembly entry point for the given vector index.
-fn get_vector_address(index: usize) -> VirtAddr {
-    // Verify the index is in [0-255]
+fn get_vector_address(index: usize) -> u64 {
     if index >= 256 {
         panic!("Invalid vector index! 0x{index:#X?}");
     }
-
-    // SAFETY: We have validated we are using the architecturally guaranteed indices
-    unsafe { VirtAddr::from_ptr(AsmGetVectorAddress(index) as *const ()) }
+    // SAFETY: Index has been validated to be in [0, 255].
+    unsafe { AsmGetVectorAddress(index) }
 }
 
+static IDT: StaticIdt = StaticIdt(UnsafeCell::new(Idt { entries: [IdtEntry::empty(); 256] }));
+
 pub fn initialize_idt() {
-    if &IDT as *const _ as usize >= SIZE_4GB {
-        // TODO: Come back and ensure the IDT is below 4GB
+    let cs = crate::cpu::x64::gdt::CODE_SELECTOR;
+    // SAFETY: There is only path to access the IDT and it is not possible to have concurrent access.
+    let idt = unsafe { &mut *IDT.0.get() };
+
+    // Point every vector at its corresponding assembly handler.
+    for vector in 0..=255usize {
+        idt.entries[vector].set_handler(get_vector_address(vector), cs, 0);
+    }
+
+    // Override double fault (vector 8): use a direct Rust handler and IST 1
+    // for more robust diagnostics when the normal interrupt stack is corrupt.
+    idt.entries[8].set_handler(double_fault_handler as *const () as u64, cs, 1);
+
+    if IDT.0.get() as usize >= SIZE_4GB {
         panic!("IDT above 4GB, MP services will fail");
     }
     #[cfg(target_os = "uefi")]
-    IDT.load();
+    {
+        let idtr = Idtr { limit: (core::mem::size_of::<Idt>() - 1) as u16, base: IDT.0.get() as *mut Idt as u64 };
+        // SAFETY: Loading our fully initialized IDT.
+        unsafe { core::arch::asm!("lidt [{}]", in(reg) &idtr, options(nostack)) };
+    }
     log::info!("Loaded IDT");
+}
+
+/// Stack frame pushed by the CPU on interrupt/exception entry.
+#[repr(C)]
+struct InterruptStackFrame {
+    rip: u64,
+    cs: u64,
+    rflags: u64,
+    rsp: u64,
+    ss: u64,
+}
+
+impl core::fmt::Debug for InterruptStackFrame {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("InterruptStackFrame")
+            .field("rip", &format_args!("{:#X}", self.rip))
+            .field("cs", &format_args!("{:#X}", self.cs))
+            .field("rflags", &format_args!("{:#X}", self.rflags))
+            .field("rsp", &format_args!("{:#X}", self.rsp))
+            .field("ss", &format_args!("{:#X}", self.ss))
+            .finish()
+    }
 }
 
 /// Handler for double faults.
 ///
-/// Handler for double faults that is configured to run as a direct interrupt
-/// handler without using the normal handler assembly or stack. This is done to
-/// increase the diagnosability of faults in the interrupt handling code.
-///
+/// Configured to run as a direct interrupt handler without using the normal
+/// handler assembly or stack. This is done to increase the diagnosability of
+/// faults in the interrupt handling code.
 extern "x86-interrupt" fn double_fault_handler(stack_frame: InterruptStackFrame, _error_code: u64) {
-    panic!("EXCEPTION: DOUBLE FAULT\n{stack_frame:#X?}");
+    panic!("EXCEPTION: DOUBLE FAULT\n{stack_frame:#?}");
 }

--- a/core/patina_internal_cpu/src/interrupts/x64/idt.rs
+++ b/core/patina_internal_cpu/src/interrupts/x64/idt.rs
@@ -54,8 +54,8 @@ struct Idt {
 
 struct StaticIdt(UnsafeCell<Idt>);
 
-// SAFETY: IDT initialization and loading is serialized during early CPU init before
-// interrupts are enabled and before concurrent access is possible.
+// SAFETY: IDT initialization and loading is serialized during early CPU init and concurrent
+// access is not possible
 unsafe impl Sync for StaticIdt {}
 
 /// Pointer structure passed to the `lidt` instruction.
@@ -83,12 +83,10 @@ pub fn initialize_idt() {
 
     // Point every vector at its corresponding assembly handler.
     for vector in 0..=255usize {
-        idt.entries[vector].set_handler(get_vector_address(vector), cs, 0);
+        // Use IST 1 for double fault (vector 8) to ensure it has a valid stack
+        let ist_index = if vector == 8 { 1 } else { 0 };
+        idt.entries[vector].set_handler(get_vector_address(vector), cs, ist_index);
     }
-
-    // Override double fault (vector 8): use a direct Rust handler and IST 1
-    // for more robust diagnostics when the normal interrupt stack is corrupt.
-    idt.entries[8].set_handler(double_fault_handler as *const () as u64, cs, 1);
 
     if IDT.0.get() as usize >= SIZE_4GB {
         panic!("IDT above 4GB, MP services will fail");
@@ -100,35 +98,4 @@ pub fn initialize_idt() {
         unsafe { core::arch::asm!("lidt [{}]", in(reg) &idtr, options(nostack)) };
     }
     log::info!("Loaded IDT");
-}
-
-/// Stack frame pushed by the CPU on interrupt/exception entry.
-#[repr(C)]
-struct InterruptStackFrame {
-    rip: u64,
-    cs: u64,
-    rflags: u64,
-    rsp: u64,
-    ss: u64,
-}
-
-impl core::fmt::Debug for InterruptStackFrame {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("InterruptStackFrame")
-            .field("rip", &format_args!("{:#X}", self.rip))
-            .field("cs", &format_args!("{:#X}", self.cs))
-            .field("rflags", &format_args!("{:#X}", self.rflags))
-            .field("rsp", &format_args!("{:#X}", self.rsp))
-            .field("ss", &format_args!("{:#X}", self.ss))
-            .finish()
-    }
-}
-
-/// Handler for double faults.
-///
-/// Configured to run as a direct interrupt handler without using the normal
-/// handler assembly or stack. This is done to increase the diagnosability of
-/// faults in the interrupt handling code.
-extern "x86-interrupt" fn double_fault_handler(stack_frame: InterruptStackFrame, _error_code: u64) {
-    panic!("EXCEPTION: DOUBLE FAULT\n{stack_frame:#?}");
 }

--- a/core/patina_internal_cpu/src/interrupts/x64/interrupt_manager.rs
+++ b/core/patina_internal_cpu/src/interrupts/x64/interrupt_manager.rs
@@ -46,6 +46,8 @@ impl InterruptsX64 {
         crate::interrupts::x64::idt::initialize_idt();
 
         // Register some default handlers.
+        self.register_exception_handler(8, HandlerType::UefiRoutine(double_fault_handler))
+            .expect("Failed to install default exception handler!");
         self.register_exception_handler(13, HandlerType::UefiRoutine(general_protection_fault_handler))
             .expect("Failed to install default exception handler!");
         self.register_exception_handler(14, HandlerType::UefiRoutine(page_fault_handler))
@@ -56,6 +58,31 @@ impl InterruptsX64 {
 }
 
 impl InterruptManager for InterruptsX64 {}
+
+#[coverage(off)]
+/// Default handler for double faults.
+extern "efiapi" fn double_fault_handler(_exception_type: isize, context: EfiSystemContext) {
+    // SAFETY: We don't have any choice here, we are in an exception and have to do our best
+    // to report. The system is dead anyway.
+    let x64_context = unsafe { context.system_context_x64.as_ref().unwrap() };
+    log::error!("EXCEPTION: DOUBLE FAULT");
+    log::error!("Instruction Pointer: {:#X?}", x64_context.rip);
+    log::error!("Code Segment: {:#X?}", x64_context.cs);
+    log::error!("RFLAGS: {:#X?}", x64_context.rflags);
+    log::error!("Stack Segment: {:#X?}", x64_context.ss);
+    log::error!("Stack Pointer: {:#X?}", x64_context.rsp);
+    log::error!("Data Segment: {:#X?}", x64_context.ds);
+    log::error!("Paging Enable: {}", x64_context.cr0 & 0x80000000 != 0);
+    log::error!("Protection Enable: {}", x64_context.cr0 & 0x00000001 != 0);
+    log::error!("Page Directory Base: {:#X?}", x64_context.cr3);
+    log::error!("Control Flags (cr4): {:#X?}", x64_context.cr4);
+
+    log::error!("");
+
+    (x64_context as &ExceptionContextX64).dump_system_context_registers();
+
+    panic!("EXCEPTION: Double Fault");
+}
 
 #[coverage(off)]
 /// Default handler for GP faults.

--- a/docs/src/dev/hardware_access.md
+++ b/docs/src/dev/hardware_access.md
@@ -5,3 +5,14 @@ differ from traditional C firmware. This section covers the supported access met
 each, and the pitfalls to avoid.
 
 - [Memory-Mapped I/O (MMIO)](hardware_access/mmio.md)
+
+## Architectural Interfaces
+
+Various parts of Patina need to access architectural interfaces, e.g. I/O Ports on x86 or reading system registers
+on AArch64. Patina has consolidated generally applicable functions in the Patina SDK's arch module. Developers
+should prefer using interfaces from there and adding new ones as needed. However, if the architectural interface is
+not widely applicable, it should be contained within the module that uses it.
+
+The goal is to limit the use of inline assembly code, particularly around interfaces that need very specific patterns
+to operate correctly. Instead, well used and tested interfaces provided by the SDK should be used so that safety
+invariants can be maintained.

--- a/patina_dxe_core/Cargo.toml
+++ b/patina_dxe_core/Cargo.toml
@@ -54,7 +54,6 @@ zerocopy-derive = { workspace = true }
 
 [target.'cfg(all(target_arch="aarch64"))'.dependencies]
 arm-gic = { workspace = true }
-aarch64-cpu = { version = "11.0.0", optional = false }
 
 [features]
 default = []

--- a/patina_dxe_core/src/cpu/perf_timer.rs
+++ b/patina_dxe_core/src/cpu/perf_timer.rs
@@ -61,9 +61,11 @@ impl Default for PerfTimer {
 fn arch_cpu_count() -> u64 {
     #[cfg(target_arch = "x86_64")]
     {
-        use core::arch::x86_64;
+        let lo: u32;
+        let hi: u32;
         // SAFETY: _rdtsc only reads the TSC on x86_64. No invariants are required for safety.
-        unsafe { x86_64::_rdtsc() }
+        unsafe { core::arch::asm!("rdtsc", out("eax") lo, out("edx") hi, options(nostack, nomem)) };
+        ((hi as u64) << 32) | lo as u64
     }
     #[cfg(target_arch = "aarch64")]
     {
@@ -83,28 +85,28 @@ pub(crate) fn arch_perf_frequency() -> u64 {
     // Try to get TSC frequency from CPUID (most Intel and AMD platforms).
     #[cfg(target_arch = "x86_64")]
     {
-        use core::arch::{x86_64, x86_64::CpuidResult};
-
-        // SAFETY: The `cpuid` instruction is guaranteed to be supported on all x86_64 processors.
-        //
         // `#[allow(unused_unsafe)]` is used here to simultaneously support Rust <= 1.93 toolchains
         // that consider __cpuid unsafe and Rust >= 1.94 (or >= nightly-2025-12-27) toolchains that
         // consider __cpuid safe.
         #[allow(unused_unsafe)]
-        let CpuidResult { eax, ebx, ecx, .. } = unsafe { x86_64::__cpuid(0x15) };
+        // SAFETY: Calling cpuid does not violate memory safety
+        let core::arch::x86_64::CpuidResult { eax, ebx, ecx, .. } = unsafe { core::arch::x86_64::__cpuid(0x15) };
         if eax != 0 && ebx != 0 && ecx != 0 {
-            // CPUID 0x15 gives TSC_frequency = (ECX * EAX) / EBX.
+            // CPUID 0x15 gives TSC_frequency = (ECX * EBX) / EAX.
             // Most modern x86 platforms support this leaf.
             return (ecx as u64 * ebx as u64) / eax as u64;
         }
 
-        // SAFETY: The `cpuid` instruction is guaranteed to be supported on all x86_64 processors.
+        // CPUID 0x16 gives base frequency in MHz in EAX.
+        // This is supported on some older x86 platforms.
+        // This is a nominal frequency and is less accurate for reflecting actual operating conditions.
         //
         // `#[allow(unused_unsafe)]` is used here to simultaneously support Rust <= 1.93 toolchains
         // that consider __cpuid unsafe and Rust >= 1.94 (or >= nightly-2025-12-27) toolchains that
         // consider __cpuid safe.
         #[allow(unused_unsafe)]
-        let CpuidResult { eax, .. } = unsafe { x86_64::__cpuid(0x16) };
+        // SAFETY: Calling cpuid does not violate memory safety
+        let core::arch::x86_64::CpuidResult { eax, .. } = unsafe { core::arch::x86_64::__cpuid(0x16) };
         if eax != 0 {
             // CPUID 0x16 gives base frequency in MHz in EAX.
             // This is supported on some older x86 platforms.

--- a/patina_dxe_core/src/cpu/perf_timer.rs
+++ b/patina_dxe_core/src/cpu/perf_timer.rs
@@ -61,16 +61,11 @@ impl Default for PerfTimer {
 fn arch_cpu_count() -> u64 {
     #[cfg(target_arch = "x86_64")]
     {
-        let lo: u32;
-        let hi: u32;
-        // SAFETY: _rdtsc only reads the TSC on x86_64. No invariants are required for safety.
-        unsafe { core::arch::asm!("rdtsc", out("eax") lo, out("edx") hi, options(nostack, nomem)) };
-        ((hi as u64) << 32) | lo as u64
+        patina::arch::x64::rdtsc()
     }
     #[cfg(target_arch = "aarch64")]
     {
-        use aarch64_cpu::registers::{self, Readable};
-        registers::CNTPCT_EL0.get()
+        patina::read_sysreg!(CNTPCT_EL0)
     }
 }
 

--- a/sdk/patina/Cargo.toml
+++ b/sdk/patina/Cargo.toml
@@ -51,7 +51,6 @@ zerocopy = { workspace = true }
 zerocopy-derive = { workspace = true }
 
 [target.'cfg(target_arch="x86_64")'.dependencies]
-x86_64 = { workspace = true, features = ["instructions"] }
 uart_16550 = { workspace = true }
 
 [dev-dependencies]

--- a/sdk/patina/src/arch.rs
+++ b/sdk/patina/src/arch.rs
@@ -9,3 +9,6 @@
 
 #[cfg(all(not(test), target_arch = "aarch64"))]
 pub mod aarch64;
+
+#[cfg(all(not(test), target_arch = "x86_64"))]
+pub mod x64;

--- a/sdk/patina/src/arch/x64.rs
+++ b/sdk/patina/src/arch/x64.rs
@@ -1,0 +1,37 @@
+//! x64-specific architectural helpers for Patina.
+//!
+//! ## License
+//!
+//! Copyright (c) Microsoft Corporation.
+//!
+//! SPDX-License-Identifier: Apache-2.0
+//!
+
+/// Writes a byte to an x64 I/O port.
+///
+/// # Safety
+///
+/// The caller must ensure `port` is valid for byte writes on this platform and
+/// that the side effects are safe in the current execution context.
+#[coverage(off)]
+pub unsafe fn io_out8(port: u16, value: u8) {
+    // SAFETY: Guaranteed by caller.
+    unsafe {
+        core::arch::asm!(
+            "out dx, al",
+            in("dx") port,
+            in("al") value,
+            options(nostack, nomem, preserves_flags)
+        );
+    }
+}
+
+/// Reads the time-stamp counter.
+#[coverage(off)]
+pub fn rdtsc() -> u64 {
+    let lo: u32;
+    let hi: u32;
+    // SAFETY: `rdtsc` reads a CPU counter and does not violate memory safety.
+    unsafe { core::arch::asm!("rdtsc", out("eax") lo, out("edx") hi, options(nostack, nomem)) };
+    ((hi as u64) << 32) | lo as u64
+}

--- a/sdk/patina/src/serial/uart.rs
+++ b/sdk/patina/src/serial/uart.rs
@@ -31,7 +31,26 @@ cfg_if::cfg_if! {
 
         use uart_16550::MmioSerialPort;
         use uart_16550::SerialPort as IoSerialPort;
-        use x86_64::instructions::interrupts;
+
+        /// Runs `f` with CPU interrupts disabled, restoring the previous interrupt state afterward.
+        fn without_interrupts<F, R>(f: F) -> R
+        where
+            F: FnOnce() -> R,
+        {
+            let flags: u64;
+            // SAFETY: Reading RFLAGS and disabling interrupts around the closure is safe because we restore
+            // interrupts afterwards, but only if they were previously enabled.
+            unsafe {
+                core::arch::asm!("pushfq; pop {0}; cli", out(reg) flags, options(nomem));
+            }
+            let result = f();
+            // Restore interrupts only if they were previously enabled (IF bit).
+            if flags & (1 << 9) != 0 {
+                // SAFETY: Re-enabling interrupts that were enabled before.
+                unsafe { core::arch::asm!("sti", options(nostack, nomem)); }
+            }
+            result
+        }
 
         /// An interface for writing to a Uart16550 device.
         #[derive(Debug)]
@@ -71,7 +90,7 @@ cfg_if::cfg_if! {
                     Uart16550::Io { base } => {
                         // SAFETY: The base address is provided during Uart16550 construction and is assumed to be valid for I/O port access.
                         let mut serial_port = unsafe { IoSerialPort::new(*base) };
-                        interrupts::without_interrupts(|| {
+                        without_interrupts(|| {
                             for b in buffer {
                                 serial_port.send(*b);
                             }
@@ -80,7 +99,7 @@ cfg_if::cfg_if! {
                     Uart16550::Mmio { base, reg_stride } => {
                         // SAFETY: The base address and stride are provided during Uart16550 construction and are assumed to be valid for MMIO access.
                         let mut serial_port = unsafe { MmioSerialPort::new_with_stride(*base, *reg_stride) };
-                        interrupts::without_interrupts(|| {
+                        without_interrupts(|| {
                             for b in buffer {
                                 serial_port.send(*b);
                             }

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -16,14 +16,6 @@ url = "https://raw.githubusercontent.com/google/supply-chain/main/audits.toml"
 [imports.mozilla]
 url = "https://raw.githubusercontent.com/mozilla/supply-chain/main/audits.toml"
 
-[[exemptions.aarch64-cpu]]
-version = "10.0.0"
-criteria = "safe-to-deploy"
-
-[[exemptions.aarch64-cpu]]
-version = "11.2.0"
-criteria = "safe-to-deploy"
-
 [[exemptions.aho-corasick]]
 version = "1.1.4"
 criteria = "safe-to-run"


### PR DESCRIPTION
## Description

This contains three commits:

Drop x86_64 crate
--
Patina has light usage of the x86_64 crate and the main usage is for the IDT and GDT, where a different, simplified design is desired.

This updates all consumers to not use the crate and drops the crate.

Use Standard Exception Handler for #DF
--
Currently, a feature from x86_64 was being used to have special handling for a double fault. However, this is not required as we can use our standard exception handler and identify this is a double fault.

This commit drops use of the feature and instead handles the #DF as we normally do.

Move Architectural Interfaces to SDK's Arch Mod
--
Centralize architectural interfaces in the SDK instead of sprinkling them around the code.

As a result, the aarch64-cpu crate is no longer required.

This also fixes hyperlinks in the copilot-instructions.md doc.

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [x] Includes documentation?

## How This Was Tested

Booting to Windows and Linux on Q35 and SBSA. Booting to Windows on a physical Intel device. On Q35 and the physical Intel device, connecting the debugger to confirm the IDT changes are working correctly.

Tested the #DF changes by generating a double fault on Q35 and a physical Intel platform by changing RSP to a bad value then generating a #PF.

## Integration Instructions

N/A.