### PR TITLE
[REBASE & FF] Add Ability To Hide Debugger Monitor Commands

### DIFF
--- a/core/patina_debugger/src/debugger.rs
+++ b/core/patina_debugger/src/debugger.rs
@@ -439,7 +439,7 @@ impl<T: SerialIO> Debugger for PatinaDebugger<T> {
     fn add_monitor_command(
         &'static self,
         command: &'static str,
-        description: &'static str,
+        description: Option<&'static str>,
         callback: Box<crate::MonitorCommandFn>,
     ) {
         if !self.enabled() {

--- a/core/patina_debugger/src/lib.rs
+++ b/core/patina_debugger/src/lib.rs
@@ -42,7 +42,7 @@
 //!     patina_debugger::set_debugger(&DEBUGGER);
 //!
 //!     // Setup a custom monitor command for this platform.
-//!     patina_debugger::add_monitor_command("my_command", "Description of my_command", |args, writer| {
+//!     patina_debugger::add_monitor_command("my_command", Some("Description of my_command"), |args, writer| {
 //!         // Parse the arguments from _args, which is a SplitWhitespace iterator.
 //!         let _ = write!(writer, "Executed my_command with args: {:?}", args);
 //!     });
@@ -177,7 +177,7 @@ trait Debugger: Sync {
     fn add_monitor_command(
         &'static self,
         command: &'static str,
-        description: &'static str,
+        description: Option<&'static str>,
         callback: alloc::boxed::Box<MonitorCommandFn>,
     );
 }
@@ -297,14 +297,14 @@ pub fn initialized() -> bool {
 /// ## Example
 ///
 /// ```rust
-/// patina_debugger::add_monitor_command("my_command", "Description of my_command", |args, writer| {
+/// patina_debugger::add_monitor_command("my_command", Some("Description of my_command"), |args, writer| {
 ///     // Parse the arguments from _args, which is a SplitWhitespace iterator.
 ///     let _ = write!(writer, "Executed my_command with args: {:?}", args);
 /// });
 /// ```
 ///
 #[cfg(feature = "alloc")]
-pub fn add_monitor_command<F>(cmd: &'static str, description: &'static str, function: F)
+pub fn add_monitor_command<F>(cmd: &'static str, description: Option<&'static str>, function: F)
 where
     F: Fn(&mut core::str::SplitWhitespace<'_>, &mut dyn core::fmt::Write) + Send + Sync + 'static,
 {
@@ -320,14 +320,14 @@ where
 /// ## Example
 ///
 /// ```rust
-/// patina_debugger::add_monitor_command("my_command", "Description of my_command", |args, writer| {
+/// patina_debugger::add_monitor_command("my_command", Some("Description of my_command"), |args, writer| {
 ///     // Parse the arguments from _args, which is a SplitWhitespace iterator.
 ///     let _ = write!(writer, "Executed my_command with args: {:?}", args);
 /// });
 /// ```
 ///
 #[cfg(not(feature = "alloc"))]
-pub fn add_monitor_command<F>(cmd: &'static str, _description: &'static str, _function: F)
+pub fn add_monitor_command<F>(cmd: &'static str, _description: Option<&'static str>, _function: F)
 where
     F: Fn(&mut core::str::SplitWhitespace<'_>, &mut dyn core::fmt::Write) + Send + Sync + 'static,
 {

--- a/core/patina_debugger/src/system/alloc.rs
+++ b/core/patina_debugger/src/system/alloc.rs
@@ -38,7 +38,7 @@ impl SystemState {
     pub fn add_monitor_command(
         &mut self,
         command: &'static str,
-        description: &'static str,
+        description: Option<&'static str>,
         callback: Box<MonitorCommandFn>,
     ) {
         let monitor = MonitorCallback { command, description, callback };
@@ -49,7 +49,11 @@ impl SystemState {
 impl SystemStateTrait for SystemState {
     fn dump_monitor_commands(&self, out: &mut dyn core::fmt::Write) {
         for cmd in &self.monitor_commands {
-            let _ = writeln!(out, "    {} - {}", cmd.command, cmd.description);
+            if let Some(description) = cmd.description {
+                let _ = writeln!(out, "    {} - {}", cmd.command, description);
+            } else {
+                continue;
+            }
         }
     }
 
@@ -134,8 +138,9 @@ struct ModuleInfo {
 struct MonitorCallback {
     /// The monitor command string that triggers the callback.
     command: &'static str,
-    /// The description of the monitor command.
-    description: &'static str,
+    /// The description of the monitor command. If `None`, the command is hidden
+    /// from the default help listing.
+    description: Option<&'static str>,
     /// The callback function that will be invoked when the command is executed.
     /// See [MonitorCommandFn] for more details on the function signature.
     callback: Box<MonitorCommandFn>,
@@ -200,7 +205,7 @@ mod tests {
         let callback: Box<MonitorCommandFn> = Box::new(|args, out| {
             let _ = writeln!(out, "Executed with args: {:?}", args.collect::<Vec<_>>());
         });
-        system_state.add_monitor_command(command, description, callback);
+        system_state.add_monitor_command(command, Some(description), callback);
 
         let mut out = String::new();
         let args = &mut "arg1 arg2".split_whitespace();
@@ -220,7 +225,7 @@ mod tests {
         let callback: Box<MonitorCommandFn> = Box::new(move |_args, out| {
             let _ = writeln!(out, "Captured state: {}", x);
         });
-        system_state.add_monitor_command(command, description, callback);
+        system_state.add_monitor_command(command, Some(description), callback);
 
         let mut out = String::new();
         let args = &mut "arg1 arg2".split_whitespace();
@@ -233,8 +238,8 @@ mod tests {
     #[test]
     fn test_dump_monitor_commands() {
         let mut state = SystemState::new();
-        state.add_monitor_command("cmd_a", "Description A", Box::new(|_, _| {}));
-        state.add_monitor_command("cmd_b", "Description B", Box::new(|_, _| {}));
+        state.add_monitor_command("cmd_a", Some("Description A"), Box::new(|_, _| {}));
+        state.add_monitor_command("cmd_b", Some("Description B"), Box::new(|_, _| {}));
 
         let mut out = String::new();
         state.dump_monitor_commands(&mut out);
@@ -288,5 +293,23 @@ mod tests {
         let printed = state.dump_modules(&mut out, 10, usize::MAX);
         assert_eq!(printed, 0);
         assert!(out.is_empty());
+    }
+
+    #[test]
+    fn test_hidden_monitor_command() {
+        let mut system_state = SystemState::new();
+        let command = "hidden_command";
+        let callback: Box<MonitorCommandFn> = Box::new(|_args, out| {
+            let _ = writeln!(out, "Hidden command was executed!");
+        });
+        system_state.add_monitor_command(command, None, callback);
+
+        let mut out = String::new();
+        system_state.dump_monitor_commands(&mut out);
+        assert!(!out.contains("hidden_command"));
+
+        let args = &mut "".split_whitespace();
+        system_state.handle_monitor_command(command, args, &mut out);
+        assert!(out.contains("Hidden command was executed!"));
     }
 }

--- a/patina_dxe_core/src/debugger_reload.rs
+++ b/patina_dxe_core/src/debugger_reload.rs
@@ -37,7 +37,9 @@ const ARCH_ALLOCATION_STRATEGY: PageAllocationStrategy = PageAllocationStrategy:
 /// Initializes the debugger reload command subsystem.
 pub fn initialize_debugger_reload(hob_list: *const c_void) {
     HOB_LIST_ADDRESS.store(hob_list as usize, core::sync::atomic::Ordering::Relaxed);
-    patina_debugger::add_monitor_command("reload", "Used to reload the core", reload_monitor);
+    // This is not intended to be called by a user so hide it from the monitor command list. UefiExt will call this
+    // automatically.
+    patina_debugger::add_monitor_command("reload", None, reload_monitor);
 }
 
 /// Tears down the debugger reload command subsystem.

--- a/patina_dxe_core/src/lib.rs
+++ b/patina_dxe_core/src/lib.rs
@@ -454,10 +454,6 @@ impl<P: PlatformInfo> Core<P> {
 
         // Add custom monitor commands to the debugger before initializing so that
         // they are available in the initial breakpoint.
-        patina_debugger::add_monitor_command("gcd", "Prints the GCD", false, |_, out| {
-            let _ = write!(out, "GCD -\n{GCD}");
-        });
-
         #[cfg(feature = "debugger_reload")]
         debugger_reload::initialize_debugger_reload(physical_hob_list);
 

--- a/patina_dxe_core/src/lib.rs
+++ b/patina_dxe_core/src/lib.rs
@@ -454,7 +454,7 @@ impl<P: PlatformInfo> Core<P> {
 
         // Add custom monitor commands to the debugger before initializing so that
         // they are available in the initial breakpoint.
-        patina_debugger::add_monitor_command("gcd", "Prints the GCD", |_, out| {
+        patina_debugger::add_monitor_command("gcd", "Prints the GCD", false, |_, out| {
             let _ = write!(out, "GCD -\n{GCD}");
         });
 

--- a/patina_dxe_core/src/pi_dispatcher.rs
+++ b/patina_dxe_core/src/pi_dispatcher.rs
@@ -196,9 +196,13 @@ impl<P: PlatformInfo> PiDispatcher<P> {
             core::ptr::write_volatile(&mut (*ptr).crc32, crc32);
         }
 
-        patina_debugger::add_monitor_command("system_table_ptr", "Prints the system table pointer", move |_, out| {
-            let _ = write!(out, "{address:x}");
-        });
+        patina_debugger::add_monitor_command(
+            "system_table_ptr",
+            Some("Prints the system table pointer"),
+            move |_, out| {
+                let _ = write!(out, "{address:x}");
+            },
+        );
     }
 
     /// Installs any firmware volumes from FV HOBs in the hob list


### PR DESCRIPTION
## Description

 patina_debugger: Allow Hidden Monitor Cmds
--
Patina adds some monitor cmds that are not intended to be run by a user, such as the reload cmd. UefiExt is expected to run this in response to the !loadcore cmd.

However, the monitor help will show this as a valid command for a user to run, which is confusing. This hides that command as well as generically providing a mechanism to do so.

Drop GCD Debugger Monitor Cmd
--
A more advanced GCD command is available as of UefiExt v0.5.0. Drop the monitor cmd.

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Tested by connecting Q35 and a physical Intel platform to the debugger and confirming the reload and gcd monitor cmds do not show up any longer but that !loadcore still works.

## Integration Instructions

Upgrade to the latest [UefiExt release](https://github.com/microsoft/uefi_debug_tools/releases) to ensure the UefiExt GCD command is available.
