### PR TITLE
Drop abi_x86_interrupt Unstable Feature

### DIFF
--- a/core/patina_internal_cpu/src/lib.rs
+++ b/core/patina_internal_cpu/src/lib.rs
@@ -9,7 +9,6 @@
 //! SPDX-License-Identifier: Apache-2.0
 //!
 #![cfg_attr(all(not(feature = "std"), not(test)), no_std)]
-#![feature(abi_x86_interrupt)]
 #![feature(coverage_attribute)]
 
 pub mod cpu;


### PR DESCRIPTION
## Description

The need for this feature was dropped in f0132a3b3cf5a3899a327825dec0faa689015d8d, however, the feature was not removed. Remove it.

Closes #812 

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

N/A.

## Integration Instructions

N/A.
