### PR TITLE
patina_smbios: Add SMBIOS types

### DIFF
--- a/components/patina_samples/src/smbios_platform.rs
+++ b/components/patina_samples/src/smbios_platform.rs
@@ -41,7 +41,8 @@ use patina_smbios::{
     smbios_record::{
         SmbiosRecordStructure, Type0PlatformFirmwareInformation, Type1SystemInformation, Type2BaseboardInformation,
         Type3SystemEnclosure,
-    }, smbios_types::*,
+    },
+    smbios_types::*,
 };
 
 /// Example custom vendor-specific OEM record (Type 0x80)
@@ -161,14 +162,19 @@ impl SmbiosExampleComponent {
             bios_starting_address_segment: 0xE800,
             firmware_release_date: 3,
             firmware_rom_size: 0xFF, // 16MB
-            characteristics: BiosCharacteristics::new(false,false,false, false, false, true, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, 0, 0),   // PCI supported
-            characteristics_ext1: BiosCharacteristicsExt1::new(true, true, false, false, false, false, false, true),
-            characteristics_ext2: BiosCharacteristicsExt2::new(true, false, false, true, false),
+            characteristics: BiosCharacteristics::new().with_pci_supported(true),
+            characteristics_ext1: BiosCharacteristicsExt1::new()
+                .with_acpi_supported(true)
+                .with_usb_legacy_supported(true)
+                .with_smart_battery_supported(true),
+            characteristics_ext2: BiosCharacteristicsExt2::new()
+                .with_bios_boot_specification_supported(true)
+                .with_uefi_spec_supported(true),
             system_bios_major_release: 1,
             system_bios_minor_release: 0,
             embedded_controller_major_release: 0xFF,
             embedded_controller_minor_release: 0xFF,
-            extended_bios_rom_size: ExtendedBiosRomSize::new(0,0),
+            extended_bios_rom_size: ExtendedBiosRomSize::new(),
             string_pool: vec![
                 String::from("Example Firmware Vendor"),
                 String::from("1.0.0"),
@@ -229,7 +235,7 @@ impl SmbiosExampleComponent {
             version: 3,
             serial_number: 4,
             asset_tag: 5,
-            feature_flags: FeatureFlags::new(true, true, false, false, false), // Board is a hosting board
+            feature_flags: FeatureFlags::new().with_hosting_board(true).with_require_aux_board(true),
             location_in_chassis: 6,
             chassis_handle: 0x0003,
             board_type: BoardType::Motherboard, // Motherboard
@@ -264,8 +270,8 @@ impl SmbiosExampleComponent {
             version: 2,
             serial_number: 3,
             asset_tag_number: 4,
-            bootup_state: BootUpState::Desktop,
-            power_supply_state: PowerSupplyState::CentralProcessor,
+            bootup_state: BootUpState::Safe,
+            power_supply_state: PowerSupplyState::Safe,
             thermal_state: ThermalState::Safe,
             security_status: SecurityStatus::Unknown,
             oem_defined: 0x00000000,

--- a/components/patina_samples/src/smbios_platform.rs
+++ b/components/patina_samples/src/smbios_platform.rs
@@ -41,7 +41,7 @@ use patina_smbios::{
     smbios_record::{
         SmbiosRecordStructure, Type0PlatformFirmwareInformation, Type1SystemInformation, Type2BaseboardInformation,
         Type3SystemEnclosure,
-    },
+    }, smbios_types::*,
 };
 
 /// Example custom vendor-specific OEM record (Type 0x80)
@@ -161,14 +161,14 @@ impl SmbiosExampleComponent {
             bios_starting_address_segment: 0xE800,
             firmware_release_date: 3,
             firmware_rom_size: 0xFF, // 16MB
-            characteristics: 0x08,   // PCI supported
-            characteristics_ext1: 0x03,
-            characteristics_ext2: 0x03,
+            characteristics: BiosCharacteristics::new(false,false,false, false, false, true, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, 0, 0),   // PCI supported
+            characteristics_ext1: BiosCharacteristicsExt1::new(true, true, false, false, false, false, false, true),
+            characteristics_ext2: BiosCharacteristicsExt2::new(true, false, false, true, false),
             system_bios_major_release: 1,
             system_bios_minor_release: 0,
             embedded_controller_major_release: 0xFF,
             embedded_controller_minor_release: 0xFF,
-            extended_bios_rom_size: 0,
+            extended_bios_rom_size: ExtendedBiosRomSize::new(0,0),
             string_pool: vec![
                 String::from("Example Firmware Vendor"),
                 String::from("1.0.0"),
@@ -196,7 +196,7 @@ impl SmbiosExampleComponent {
             version: 3,
             serial_number: 4,
             uuid: [0x12, 0x34, 0x56, 0x78, 0x9A, 0xBC, 0xDE, 0xF0, 0x12, 0x34, 0x56, 0x78, 0x9A, 0xBC, 0xDE, 0xF0],
-            wake_up_type: 0x06, // Power switch
+            wake_up_type: WakeUpType::PowerSwitch, // Power switch
             sku_number: 5,
             family: 6,
             string_pool: vec![
@@ -229,10 +229,10 @@ impl SmbiosExampleComponent {
             version: 3,
             serial_number: 4,
             asset_tag: 5,
-            feature_flags: 0x01, // Board is a hosting board
+            feature_flags: FeatureFlags::new(true, true, false, false, false), // Board is a hosting board
             location_in_chassis: 6,
             chassis_handle: 0x0003,
-            board_type: 0x0A, // Motherboard
+            board_type: BoardType::Motherboard, // Motherboard
             contained_object_handles: 0,
             string_pool: vec![
                 String::from("Example Corporation"),
@@ -264,10 +264,10 @@ impl SmbiosExampleComponent {
             version: 2,
             serial_number: 3,
             asset_tag_number: 4,
-            bootup_state: 0x03,
-            power_supply_state: 0x03,
-            thermal_state: 0x03,
-            security_status: 0x02,
+            bootup_state: BootUpState::Desktop,
+            power_supply_state: PowerSupplyState::CentralProcessor,
+            thermal_state: ThermalState::Safe,
+            security_status: SecurityStatus::Unknown,
             oem_defined: 0x00000000,
             height: 0x00,
             number_of_power_cords: 0x01,

--- a/components/patina_samples/src/smbios_platform.rs
+++ b/components/patina_samples/src/smbios_platform.rs
@@ -202,7 +202,7 @@ impl SmbiosExampleComponent {
             version: 3,
             serial_number: 4,
             uuid: [0x12, 0x34, 0x56, 0x78, 0x9A, 0xBC, 0xDE, 0xF0, 0x12, 0x34, 0x56, 0x78, 0x9A, 0xBC, 0xDE, 0xF0],
-            wake_up_type: WakeUpType::PowerSwitch, // Power switch
+            wake_up_type: WakeUpType::PowerSwitch,
             sku_number: 5,
             family: 6,
             string_pool: vec![
@@ -238,7 +238,7 @@ impl SmbiosExampleComponent {
             feature_flags: FeatureFlags::new().with_hosting_board(true).with_require_aux_board(true),
             location_in_chassis: 6,
             chassis_handle: 0x0003,
-            board_type: BoardType::Motherboard, // Motherboard
+            board_type: BoardType::Motherboard,
             contained_object_handles: 0,
             string_pool: vec![
                 String::from("Example Corporation"),

--- a/components/patina_smbios/Cargo.toml
+++ b/components/patina_smbios/Cargo.toml
@@ -16,6 +16,7 @@ r-efi = { workspace = true }
 spin = { workspace = true }
 zerocopy = { workspace = true }
 zerocopy-derive = { workspace = true }
+bitfield = "0.17.0"
 
 [dev-dependencies]
 mockall = { workspace = true }

--- a/components/patina_smbios/Cargo.toml
+++ b/components/patina_smbios/Cargo.toml
@@ -16,7 +16,7 @@ r-efi = { workspace = true }
 spin = { workspace = true }
 zerocopy = { workspace = true }
 zerocopy-derive = { workspace = true }
-bitfield = "0.17.0"
+bitfield-struct = { workspace = true }
 
 [dev-dependencies]
 mockall = { workspace = true }

--- a/components/patina_smbios/src/lib.rs
+++ b/components/patina_smbios/src/lib.rs
@@ -325,6 +325,7 @@ pub mod component;
 pub mod error;
 pub mod service;
 pub mod smbios_record;
+pub mod smbios_types;
 
 mod manager;
 

--- a/components/patina_smbios/src/service.rs
+++ b/components/patina_smbios/src/service.rs
@@ -696,14 +696,18 @@ mod tests {
             bios_starting_address_segment: 0xE800,
             firmware_release_date: 3,
             firmware_rom_size: 0xFF,
-            characteristics: smbios_types::BiosCharacteristics::from_bits(0x08),
-            characteristics_ext1: smbios_types::BiosCharacteristicsExt1::from_bits(0x03),
-            characteristics_ext2: smbios_types::BiosCharacteristicsExt2::from_bits(0x03),
+            characteristics: smbios_types::BiosCharacteristics::new().with_pci_supported(true),
+            characteristics_ext1: smbios_types::BiosCharacteristicsExt1::new()
+                .with_acpi_supported(true)
+                .with_usb_legacy_supported(true),
+            characteristics_ext2: smbios_types::BiosCharacteristicsExt2::new()
+                .with_bios_boot_specification_supported(true)
+                .with_fn_network_service_boot_supported(true),
             system_bios_major_release: 1,
             system_bios_minor_release: 0,
             embedded_controller_major_release: 0xFF,
             embedded_controller_minor_release: 0xFF,
-            extended_bios_rom_size: smbios_types::ExtendedBiosRomSize::from_bits(0),
+            extended_bios_rom_size: smbios_types::ExtendedBiosRomSize::new(),
             string_pool: vec![String::from("Vendor"), String::from("1.0"), String::from("2025")],
         };
 
@@ -809,14 +813,18 @@ mod tests {
             bios_starting_address_segment: 0xE800,
             firmware_release_date: 3,
             firmware_rom_size: 0xFF,
-            characteristics: smbios_types::BiosCharacteristics::from_bits(0x08),
-            characteristics_ext1: smbios_types::BiosCharacteristicsExt1::from_bits(0x03),
-            characteristics_ext2: smbios_types::BiosCharacteristicsExt2::from_bits(0x03),
+            characteristics: smbios_types::BiosCharacteristics::new().with_pci_supported(true),
+            characteristics_ext1: smbios_types::BiosCharacteristicsExt1::new()
+                .with_acpi_supported(true)
+                .with_usb_legacy_supported(true),
+            characteristics_ext2: smbios_types::BiosCharacteristicsExt2::new()
+                .with_bios_boot_specification_supported(true)
+                .with_fn_network_service_boot_supported(true),
             system_bios_major_release: 1,
             system_bios_minor_release: 0,
             embedded_controller_major_release: 0xFF,
             embedded_controller_minor_release: 0xFF,
-            extended_bios_rom_size: smbios_types::ExtendedBiosRomSize::from_bits(0),
+            extended_bios_rom_size: smbios_types::ExtendedBiosRomSize::new(),
             string_pool: vec![String::from("Vendor"), String::from("1.0"), String::from("01/01/2025")],
         };
 
@@ -842,14 +850,18 @@ mod tests {
             bios_starting_address_segment: 0xE800,
             firmware_release_date: 3,
             firmware_rom_size: 0xFF,
-            characteristics: smbios_types::BiosCharacteristics::from_bits(0x08),
-            characteristics_ext1: smbios_types::BiosCharacteristicsExt1::from_bits(0x03),
-            characteristics_ext2: smbios_types::BiosCharacteristicsExt2::from_bits(0x03),
+            characteristics: smbios_types::BiosCharacteristics::new().with_pci_supported(true),
+            characteristics_ext1: smbios_types::BiosCharacteristicsExt1::new()
+                .with_acpi_supported(true)
+                .with_usb_legacy_supported(true),
+            characteristics_ext2: smbios_types::BiosCharacteristicsExt2::new()
+                .with_bios_boot_specification_supported(true)
+                .with_fn_network_service_boot_supported(true),
             system_bios_major_release: 1,
             system_bios_minor_release: 0,
             embedded_controller_major_release: 0xFF,
             embedded_controller_minor_release: 0xFF,
-            extended_bios_rom_size: smbios_types::ExtendedBiosRomSize::from_bits(0),
+            extended_bios_rom_size: smbios_types::ExtendedBiosRomSize::new(),
             string_pool: vec![String::from("Vendor"), String::from("1.0"), String::from("01/01/2025")],
         };
 
@@ -873,14 +885,18 @@ mod tests {
             bios_starting_address_segment: 0xE800,
             firmware_release_date: 3,
             firmware_rom_size: 0xFF,
-            characteristics: smbios_types::BiosCharacteristics::from_bits(0x08),
-            characteristics_ext1: smbios_types::BiosCharacteristicsExt1::from_bits(0x03),
-            characteristics_ext2: smbios_types::BiosCharacteristicsExt2::from_bits(0x03),
+            characteristics: smbios_types::BiosCharacteristics::new().with_pci_supported(true),
+            characteristics_ext1: smbios_types::BiosCharacteristicsExt1::new()
+                .with_acpi_supported(true)
+                .with_usb_legacy_supported(true),
+            characteristics_ext2: smbios_types::BiosCharacteristicsExt2::new()
+                .with_bios_boot_specification_supported(true)
+                .with_fn_network_service_boot_supported(true),
             system_bios_major_release: 1,
             system_bios_minor_release: 0,
             embedded_controller_major_release: 0xFF,
             embedded_controller_minor_release: 0xFF,
-            extended_bios_rom_size: smbios_types::ExtendedBiosRomSize::from_bits(0),
+            extended_bios_rom_size: smbios_types::ExtendedBiosRomSize::new(),
             string_pool: vec![String::from("Vendor"), String::from("1.0"), String::from("01/01/2025")],
         };
 
@@ -954,14 +970,18 @@ mod tests {
             bios_starting_address_segment: 0xE800,
             firmware_release_date: 3,
             firmware_rom_size: 0xFF,
-            characteristics: smbios_types::BiosCharacteristics::from_bits(0x08),
-            characteristics_ext1: smbios_types::BiosCharacteristicsExt1::from_bits(0x03),
-            characteristics_ext2: smbios_types::BiosCharacteristicsExt2::from_bits(0x03),
+            characteristics: smbios_types::BiosCharacteristics::new().with_pci_supported(true),
+            characteristics_ext1: smbios_types::BiosCharacteristicsExt1::new()
+                .with_acpi_supported(true)
+                .with_usb_legacy_supported(true),
+            characteristics_ext2: smbios_types::BiosCharacteristicsExt2::new()
+                .with_bios_boot_specification_supported(true)
+                .with_fn_network_service_boot_supported(true),
             system_bios_major_release: 1,
             system_bios_minor_release: 0,
             embedded_controller_major_release: 0xFF,
             embedded_controller_minor_release: 0xFF,
-            extended_bios_rom_size: smbios_types::ExtendedBiosRomSize::from_bits(0),
+            extended_bios_rom_size: smbios_types::ExtendedBiosRomSize::new(),
             string_pool: vec![String::from("Vendor"), String::from("1.0"), String::from("01/01/2025")],
         };
 

--- a/components/patina_smbios/src/service.rs
+++ b/components/patina_smbios/src/service.rs
@@ -356,6 +356,7 @@ mod tests {
     use std::format;
 
     use crate::smbios_record::{SmbiosRecordStructure, Type0PlatformFirmwareInformation, Type127EndOfTable};
+    use crate::smbios_types;
     use mockall::predicate::*;
     use patina::{
         boot_services::{MockBootServices, tpl::Tpl},
@@ -693,14 +694,14 @@ mod tests {
             bios_starting_address_segment: 0xE800,
             firmware_release_date: 3,
             firmware_rom_size: 0xFF,
-            characteristics: 0x08,
-            characteristics_ext1: 0x03,
-            characteristics_ext2: 0x03,
+            characteristics: smbios_types::BiosCharacteristics(0x08),
+            characteristics_ext1: smbios_types::BiosCharacteristicsExt1(0x03),
+            characteristics_ext2: smbios_types::BiosCharacteristicsExt2(0x03),
             system_bios_major_release: 1,
             system_bios_minor_release: 0,
             embedded_controller_major_release: 0xFF,
             embedded_controller_minor_release: 0xFF,
-            extended_bios_rom_size: 0,
+            extended_bios_rom_size: smbios_types::ExtendedBiosRomSize(0),
             string_pool: vec![String::from("Vendor"), String::from("1.0"), String::from("2025")],
         };
 
@@ -806,14 +807,14 @@ mod tests {
             bios_starting_address_segment: 0xE800,
             firmware_release_date: 3,
             firmware_rom_size: 0xFF,
-            characteristics: 0x08,
-            characteristics_ext1: 0x03,
-            characteristics_ext2: 0x03,
+            characteristics: smbios_types::BiosCharacteristics(0x08),
+            characteristics_ext1: smbios_types::BiosCharacteristicsExt1(0x03),
+            characteristics_ext2: smbios_types::BiosCharacteristicsExt2(0x03),
             system_bios_major_release: 1,
             system_bios_minor_release: 0,
             embedded_controller_major_release: 0xFF,
             embedded_controller_minor_release: 0xFF,
-            extended_bios_rom_size: 0,
+            extended_bios_rom_size: smbios_types::ExtendedBiosRomSize(0),
             string_pool: vec![String::from("Vendor"), String::from("1.0"), String::from("01/01/2025")],
         };
 
@@ -839,14 +840,14 @@ mod tests {
             bios_starting_address_segment: 0xE800,
             firmware_release_date: 3,
             firmware_rom_size: 0xFF,
-            characteristics: 0x08,
-            characteristics_ext1: 0x03,
-            characteristics_ext2: 0x03,
+            characteristics: smbios_types::BiosCharacteristics(0x08),
+            characteristics_ext1: smbios_types::BiosCharacteristicsExt1(0x03),
+            characteristics_ext2: smbios_types::BiosCharacteristicsExt2(0x03),
             system_bios_major_release: 1,
             system_bios_minor_release: 0,
             embedded_controller_major_release: 0xFF,
             embedded_controller_minor_release: 0xFF,
-            extended_bios_rom_size: 0,
+            extended_bios_rom_size: smbios_types::ExtendedBiosRomSize(0),
             string_pool: vec![String::from("Vendor"), String::from("1.0"), String::from("01/01/2025")],
         };
 
@@ -870,14 +871,14 @@ mod tests {
             bios_starting_address_segment: 0xE800,
             firmware_release_date: 3,
             firmware_rom_size: 0xFF,
-            characteristics: 0x08,
-            characteristics_ext1: 0x03,
-            characteristics_ext2: 0x03,
+            characteristics: smbios_types::BiosCharacteristics(0x08),
+            characteristics_ext1: smbios_types::BiosCharacteristicsExt1(0x03),
+            characteristics_ext2: smbios_types::BiosCharacteristicsExt2(0x03),
             system_bios_major_release: 1,
             system_bios_minor_release: 0,
             embedded_controller_major_release: 0xFF,
             embedded_controller_minor_release: 0xFF,
-            extended_bios_rom_size: 0,
+            extended_bios_rom_size: smbios_types::ExtendedBiosRomSize(0),
             string_pool: vec![String::from("Vendor"), String::from("1.0"), String::from("01/01/2025")],
         };
 
@@ -951,14 +952,14 @@ mod tests {
             bios_starting_address_segment: 0xE800,
             firmware_release_date: 3,
             firmware_rom_size: 0xFF,
-            characteristics: 0x08,
-            characteristics_ext1: 0x03,
-            characteristics_ext2: 0x03,
+            characteristics: smbios_types::BiosCharacteristics(0x08),
+            characteristics_ext1: smbios_types::BiosCharacteristicsExt1(0x03),
+            characteristics_ext2: smbios_types::BiosCharacteristicsExt2(0x03),
             system_bios_major_release: 1,
             system_bios_minor_release: 0,
             embedded_controller_major_release: 0xFF,
             embedded_controller_minor_release: 0xFF,
-            extended_bios_rom_size: 0,
+            extended_bios_rom_size: smbios_types::ExtendedBiosRomSize(0),
             string_pool: vec![String::from("Vendor"), String::from("1.0"), String::from("01/01/2025")],
         };
 

--- a/components/patina_smbios/src/service.rs
+++ b/components/patina_smbios/src/service.rs
@@ -355,8 +355,10 @@ mod tests {
     use alloc::string::String;
     use std::format;
 
-    use crate::smbios_record::{SmbiosRecordStructure, Type0PlatformFirmwareInformation, Type127EndOfTable};
-    use crate::smbios_types;
+    use crate::{
+        smbios_record::{SmbiosRecordStructure, Type0PlatformFirmwareInformation, Type127EndOfTable},
+        smbios_types,
+    };
     use mockall::predicate::*;
     use patina::{
         boot_services::{MockBootServices, tpl::Tpl},
@@ -694,14 +696,14 @@ mod tests {
             bios_starting_address_segment: 0xE800,
             firmware_release_date: 3,
             firmware_rom_size: 0xFF,
-            characteristics: smbios_types::BiosCharacteristics(0x08),
-            characteristics_ext1: smbios_types::BiosCharacteristicsExt1(0x03),
-            characteristics_ext2: smbios_types::BiosCharacteristicsExt2(0x03),
+            characteristics: smbios_types::BiosCharacteristics::from_bits(0x08),
+            characteristics_ext1: smbios_types::BiosCharacteristicsExt1::from_bits(0x03),
+            characteristics_ext2: smbios_types::BiosCharacteristicsExt2::from_bits(0x03),
             system_bios_major_release: 1,
             system_bios_minor_release: 0,
             embedded_controller_major_release: 0xFF,
             embedded_controller_minor_release: 0xFF,
-            extended_bios_rom_size: smbios_types::ExtendedBiosRomSize(0),
+            extended_bios_rom_size: smbios_types::ExtendedBiosRomSize::from_bits(0),
             string_pool: vec![String::from("Vendor"), String::from("1.0"), String::from("2025")],
         };
 
@@ -807,14 +809,14 @@ mod tests {
             bios_starting_address_segment: 0xE800,
             firmware_release_date: 3,
             firmware_rom_size: 0xFF,
-            characteristics: smbios_types::BiosCharacteristics(0x08),
-            characteristics_ext1: smbios_types::BiosCharacteristicsExt1(0x03),
-            characteristics_ext2: smbios_types::BiosCharacteristicsExt2(0x03),
+            characteristics: smbios_types::BiosCharacteristics::from_bits(0x08),
+            characteristics_ext1: smbios_types::BiosCharacteristicsExt1::from_bits(0x03),
+            characteristics_ext2: smbios_types::BiosCharacteristicsExt2::from_bits(0x03),
             system_bios_major_release: 1,
             system_bios_minor_release: 0,
             embedded_controller_major_release: 0xFF,
             embedded_controller_minor_release: 0xFF,
-            extended_bios_rom_size: smbios_types::ExtendedBiosRomSize(0),
+            extended_bios_rom_size: smbios_types::ExtendedBiosRomSize::from_bits(0),
             string_pool: vec![String::from("Vendor"), String::from("1.0"), String::from("01/01/2025")],
         };
 
@@ -840,14 +842,14 @@ mod tests {
             bios_starting_address_segment: 0xE800,
             firmware_release_date: 3,
             firmware_rom_size: 0xFF,
-            characteristics: smbios_types::BiosCharacteristics(0x08),
-            characteristics_ext1: smbios_types::BiosCharacteristicsExt1(0x03),
-            characteristics_ext2: smbios_types::BiosCharacteristicsExt2(0x03),
+            characteristics: smbios_types::BiosCharacteristics::from_bits(0x08),
+            characteristics_ext1: smbios_types::BiosCharacteristicsExt1::from_bits(0x03),
+            characteristics_ext2: smbios_types::BiosCharacteristicsExt2::from_bits(0x03),
             system_bios_major_release: 1,
             system_bios_minor_release: 0,
             embedded_controller_major_release: 0xFF,
             embedded_controller_minor_release: 0xFF,
-            extended_bios_rom_size: smbios_types::ExtendedBiosRomSize(0),
+            extended_bios_rom_size: smbios_types::ExtendedBiosRomSize::from_bits(0),
             string_pool: vec![String::from("Vendor"), String::from("1.0"), String::from("01/01/2025")],
         };
 
@@ -871,14 +873,14 @@ mod tests {
             bios_starting_address_segment: 0xE800,
             firmware_release_date: 3,
             firmware_rom_size: 0xFF,
-            characteristics: smbios_types::BiosCharacteristics(0x08),
-            characteristics_ext1: smbios_types::BiosCharacteristicsExt1(0x03),
-            characteristics_ext2: smbios_types::BiosCharacteristicsExt2(0x03),
+            characteristics: smbios_types::BiosCharacteristics::from_bits(0x08),
+            characteristics_ext1: smbios_types::BiosCharacteristicsExt1::from_bits(0x03),
+            characteristics_ext2: smbios_types::BiosCharacteristicsExt2::from_bits(0x03),
             system_bios_major_release: 1,
             system_bios_minor_release: 0,
             embedded_controller_major_release: 0xFF,
             embedded_controller_minor_release: 0xFF,
-            extended_bios_rom_size: smbios_types::ExtendedBiosRomSize(0),
+            extended_bios_rom_size: smbios_types::ExtendedBiosRomSize::from_bits(0),
             string_pool: vec![String::from("Vendor"), String::from("1.0"), String::from("01/01/2025")],
         };
 
@@ -952,14 +954,14 @@ mod tests {
             bios_starting_address_segment: 0xE800,
             firmware_release_date: 3,
             firmware_rom_size: 0xFF,
-            characteristics: smbios_types::BiosCharacteristics(0x08),
-            characteristics_ext1: smbios_types::BiosCharacteristicsExt1(0x03),
-            characteristics_ext2: smbios_types::BiosCharacteristicsExt2(0x03),
+            characteristics: smbios_types::BiosCharacteristics::from_bits(0x08),
+            characteristics_ext1: smbios_types::BiosCharacteristicsExt1::from_bits(0x03),
+            characteristics_ext2: smbios_types::BiosCharacteristicsExt2::from_bits(0x03),
             system_bios_major_release: 1,
             system_bios_minor_release: 0,
             embedded_controller_major_release: 0xFF,
             embedded_controller_minor_release: 0xFF,
-            extended_bios_rom_size: smbios_types::ExtendedBiosRomSize(0),
+            extended_bios_rom_size: smbios_types::ExtendedBiosRomSize::from_bits(0),
             string_pool: vec![String::from("Vendor"), String::from("1.0"), String::from("01/01/2025")],
         };
 

--- a/components/patina_smbios/src/smbios_record.rs
+++ b/components/patina_smbios/src/smbios_record.rs
@@ -544,7 +544,7 @@ pub struct Type7CacheInformation {
     /// Cache speed in nanoseconds
     pub cache_speed: u8,
     /// Error correction type
-    pub error_correction_type: ErrorCorrectionType,
+    pub error_correction_type: CacheErrorCorrectionType,
     /// System cache type
     pub system_cache_type: SystemCacheType,
     /// Associativity
@@ -578,7 +578,7 @@ pub struct Type16PhysicalMemoryArray {
     /// Function for which the array is used (renamed from `use` to avoid Rust keyword)
     pub use_field: MemoryArrayUse,
     /// Primary hardware error correction or detection method
-    pub memory_error_correction: ErrorCorrectionType,
+    pub memory_error_correction: MemoryArrayErrorCorrectionType,
     /// Maximum capacity in KB (0x80000000 = use extended_maximum_capacity)
     pub maximum_capacity: u32,
     /// Handle of the error information structure (0xFFFE = not provided)
@@ -777,14 +777,18 @@ mod tests {
             bios_starting_address_segment: 0xE800,
             firmware_release_date: 3,
             firmware_rom_size: 0xFF,
-            characteristics: smbios_types::BiosCharacteristics::from_bits(0x08),
-            characteristics_ext1: smbios_types::BiosCharacteristicsExt1::from_bits(0x03),
-            characteristics_ext2: smbios_types::BiosCharacteristicsExt2::from_bits(0x03),
+            characteristics: smbios_types::BiosCharacteristics::new().with_pci_supported(true),
+            characteristics_ext1: smbios_types::BiosCharacteristicsExt1::new()
+                .with_acpi_supported(true)
+                .with_usb_legacy_supported(true),
+            characteristics_ext2: smbios_types::BiosCharacteristicsExt2::new()
+                .with_bios_boot_specification_supported(true)
+                .with_fn_network_service_boot_supported(true),
             system_bios_major_release: 1,
             system_bios_minor_release: 0,
             embedded_controller_major_release: 0xFF,
             embedded_controller_minor_release: 0xFF,
-            extended_bios_rom_size: smbios_types::ExtendedBiosRomSize::from_bits(0),
+            extended_bios_rom_size: smbios_types::ExtendedBiosRomSize::new(),
             string_pool: vec![String::from("Vendor"), String::from("Version"), String::from("Date")],
         };
 
@@ -802,14 +806,18 @@ mod tests {
             bios_starting_address_segment: 0xE800,
             firmware_release_date: 3,
             firmware_rom_size: 0xFF,
-            characteristics: smbios_types::BiosCharacteristics::from_bits(0x08),
-            characteristics_ext1: smbios_types::BiosCharacteristicsExt1::from_bits(0x03),
-            characteristics_ext2: smbios_types::BiosCharacteristicsExt2::from_bits(0x03),
+            characteristics: smbios_types::BiosCharacteristics::new().with_pci_supported(true),
+            characteristics_ext1: smbios_types::BiosCharacteristicsExt1::new()
+                .with_acpi_supported(true)
+                .with_usb_legacy_supported(true),
+            characteristics_ext2: smbios_types::BiosCharacteristicsExt2::new()
+                .with_bios_boot_specification_supported(true)
+                .with_fn_network_service_boot_supported(true),
             system_bios_major_release: 1,
             system_bios_minor_release: 0,
             embedded_controller_major_release: 0xFF,
             embedded_controller_minor_release: 0xFF,
-            extended_bios_rom_size: smbios_types::ExtendedBiosRomSize::from_bits(0),
+            extended_bios_rom_size: smbios_types::ExtendedBiosRomSize::new(),
             string_pool: vec![String::from("x").repeat(SMBIOS_STRING_MAX_LENGTH + 1)],
         };
 
@@ -874,7 +882,7 @@ mod tests {
             version: 3,
             serial_number: 4,
             asset_tag: 5,
-            feature_flags: smbios_types::FeatureFlags::from_bits(0x01),
+            feature_flags: smbios_types::FeatureFlags::new().with_hosting_board(true),
             location_in_chassis: 6,
             chassis_handle: 0x0003,
             board_type: smbios_types::BoardType::Motherboard,
@@ -948,10 +956,10 @@ mod tests {
             version: 2,
             serial_number: 3,
             asset_tag_number: 4,
-            bootup_state: smbios_types::BootUpState::Safe, // 0x03
-            power_supply_state: smbios_types::PowerSupplyState::Safe, // 0x03
-            thermal_state: smbios_types::ThermalState::Safe, // 0x03
-            security_status: smbios_types::SecurityStatus::NoneStatus, // 0x03
+            bootup_state: smbios_types::BootUpState::Safe,
+            power_supply_state: smbios_types::PowerSupplyState::Safe,
+            thermal_state: smbios_types::ThermalState::Safe,
+            security_status: smbios_types::SecurityStatus::NoneStatus,
             oem_defined: 0,
             height: 0, // Unspecified
             number_of_power_cords: 1,
@@ -981,10 +989,10 @@ mod tests {
             version: 2,
             serial_number: 3,
             asset_tag_number: 4,
-            bootup_state: smbios_types::BootUpState::Safe, // 0x03
-            power_supply_state: smbios_types::PowerSupplyState::Safe, // 0x03
-            thermal_state: smbios_types::ThermalState::Safe, // 0x03
-            security_status: smbios_types::SecurityStatus::NoneStatus, // 0x03
+            bootup_state: smbios_types::BootUpState::Safe,
+            power_supply_state: smbios_types::PowerSupplyState::Safe,
+            thermal_state: smbios_types::ThermalState::Safe,
+            security_status: smbios_types::SecurityStatus::NoneStatus,
             oem_defined: 0,
             height: 0,
             number_of_power_cords: 1,
@@ -1018,10 +1026,10 @@ mod tests {
             version: 3,
             serial_number: 4,
             asset_tag: 5,
-            feature_flags: smbios_types::FeatureFlags::from_bits(0),
+            feature_flags: smbios_types::FeatureFlags::new(),
             location_in_chassis: 6,
             chassis_handle: 0,
-            board_type: smbios_types::BoardType::Unknown, // 0x00 in org
+            board_type: smbios_types::BoardType::Unknown,
             contained_object_handles: 0,
             string_pool: vec![
                 String::from("Board Manufacturer"),
@@ -1042,17 +1050,17 @@ mod tests {
         let type4 = Type4ProcessorInformation {
             header: SmbiosTableHeader { record_type: 4, length: 0, handle: 0x0400 },
             socket_designation: 1,
-            processor_type: smbios_types::ProcessorTypeData::CentralProcessor, // 0x03
-            processor_family: 0xFE,                                            // 0xFE
+            processor_type: smbios_types::ProcessorTypeData::CentralProcessor,
+            processor_family: 0xFE,
             processor_manufacturer: 2,
             processor_id: [0u8; 8],
             processor_version: 3,
-            voltage: smbios_types::ProcessorVoltage::from_bits(0x80),
+            voltage: smbios_types::ProcessorVoltage::new().with_processor_voltage_indicate_legacy(true),
             external_clock: 100,
             max_speed: 3000,
             current_speed: 2400,
-            status: smbios_types::ProcessorInformationStatus::from_bits(0x41),
-            processor_upgrade: smbios_types::ProcessorUpgrade::Unknown, // 0x02
+            status: smbios_types::ProcessorInformationStatus::new().with_cpu_status(1).with_cpu_socket_populated(true),
+            processor_upgrade: smbios_types::ProcessorUpgrade::Unknown,
             l1_cache_handle: 0xFFFF,
             l2_cache_handle: 0xFFFF,
             l3_cache_handle: 0xFFFF,
@@ -1062,7 +1070,7 @@ mod tests {
             core_count: 4,
             core_enabled: 4,
             thread_count: 8,
-            processor_characteristics: smbios_types::ProcessorCharacteristics::from_bits(0x04),
+            processor_characteristics: smbios_types::ProcessorCharacteristics::new().with_capable_64bit(true),
             processor_family2: smbios_types::ProcessorFamilyData::ARMv8,
             core_count2: 4,
             core_enabled2: 4,
@@ -1088,17 +1096,17 @@ mod tests {
         let type4 = Type4ProcessorInformation {
             header: SmbiosTableHeader { record_type: 4, length: 0, handle: 0x0400 },
             socket_designation: 1,
-            processor_type: smbios_types::ProcessorTypeData::CentralProcessor, // 0x03
-            processor_family: 0xFE,                                            // 0xFE
+            processor_type: smbios_types::ProcessorTypeData::CentralProcessor,
+            processor_family: 0xFE,
             processor_manufacturer: 2,
             processor_id: [0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08],
             processor_version: 3,
-            voltage: smbios_types::ProcessorVoltage::from_bits(0x80),
+            voltage: smbios_types::ProcessorVoltage::new().with_processor_voltage_indicate_legacy(true),
             external_clock: 100,
             max_speed: 3000,
             current_speed: 2400,
-            status: smbios_types::ProcessorInformationStatus::from_bits(0x41),
-            processor_upgrade: smbios_types::ProcessorUpgrade::Unknown, // 0x02
+            status: smbios_types::ProcessorInformationStatus::new().with_cpu_status(1).with_cpu_socket_populated(true),
+            processor_upgrade: smbios_types::ProcessorUpgrade::Unknown,
             l1_cache_handle: 0x0001,
             l2_cache_handle: 0x0002,
             l3_cache_handle: 0xFFFF,
@@ -1108,7 +1116,7 @@ mod tests {
             core_count: 4,
             core_enabled: 4,
             thread_count: 8,
-            processor_characteristics: smbios_types::ProcessorCharacteristics::from_bits(0x04),
+            processor_characteristics: smbios_types::ProcessorCharacteristics::new().with_capable_64bit(true),
             processor_family2: smbios_types::ProcessorFamilyData::ARMv8,
             core_count2: 4,
             core_enabled2: 4,
@@ -1136,17 +1144,19 @@ mod tests {
         let type7 = Type7CacheInformation {
             header: SmbiosTableHeader { record_type: 7, length: 0, handle: 0x0700 },
             socket_designation: 1,
-            cache_configuration: smbios_types::CacheConfiguration::from_bits(0x0180), // L1, enabled, write-back
-            maximum_cache_size: smbios_types::CacheSize::from_bits(64),
-            installed_size: smbios_types::CacheSize::from_bits(64),
-            supported_sram_type: smbios_types::CacheSramTypeData::from_bits(0x0002),
-            current_sram_type: smbios_types::CacheSramTypeData::from_bits(0x0002),
+            cache_configuration: smbios_types::CacheConfiguration::new()
+                .with_enabled_disabled(true)
+                .with_operational_mode(1),
+            maximum_cache_size: smbios_types::CacheSize::new().with_max_size(64),
+            installed_size: smbios_types::CacheSize::new().with_max_size(64),
+            supported_sram_type: smbios_types::CacheSramTypeData::new().with_unknown(true),
+            current_sram_type: smbios_types::CacheSramTypeData::new().with_unknown(true),
             cache_speed: 0,
-            error_correction_type: smbios_types::ErrorCorrectionType::Unknown, // 0x02
-            system_cache_type: smbios_types::SystemCacheType::Data,            // 0x04
-            associativity: smbios_types::AssociativityField::SetAssociative4Way, // 0x05
-            maximum_cache_size2: smbios_types::CacheSize2::from_bits(64),
-            installed_size2: smbios_types::CacheSize2::from_bits(64),
+            error_correction_type: smbios_types::CacheErrorCorrectionType::Unknown,
+            system_cache_type: smbios_types::SystemCacheType::Data,
+            associativity: smbios_types::AssociativityField::SetAssociative4Way,
+            maximum_cache_size2: smbios_types::CacheSize2::new().with_max_size(64),
+            installed_size2: smbios_types::CacheSize2::new().with_max_size(64),
             string_pool: vec![String::from("L1 Data Cache")],
         };
 
@@ -1161,17 +1171,19 @@ mod tests {
         let type7 = Type7CacheInformation {
             header: SmbiosTableHeader { record_type: 7, length: 0, handle: 0x0700 },
             socket_designation: 1,
-            cache_configuration: smbios_types::CacheConfiguration::from_bits(0x0180),
-            maximum_cache_size: smbios_types::CacheSize::from_bits(64),
-            installed_size: smbios_types::CacheSize::from_bits(64),
-            supported_sram_type: smbios_types::CacheSramTypeData::from_bits(0x0002),
-            current_sram_type: smbios_types::CacheSramTypeData::from_bits(0x0002),
+            cache_configuration: smbios_types::CacheConfiguration::new()
+                .with_enabled_disabled(true)
+                .with_operational_mode(1),
+            maximum_cache_size: smbios_types::CacheSize::new().with_max_size(64),
+            installed_size: smbios_types::CacheSize::new().with_max_size(64),
+            supported_sram_type: smbios_types::CacheSramTypeData::new().with_unknown(true),
+            current_sram_type: smbios_types::CacheSramTypeData::new().with_unknown(true),
             cache_speed: 0,
-            error_correction_type: smbios_types::ErrorCorrectionType::Unknown, // 0x02
-            system_cache_type: smbios_types::SystemCacheType::Data,            // 0x04
-            associativity: smbios_types::AssociativityField::SetAssociative4Way, // 0x05
-            maximum_cache_size2: smbios_types::CacheSize2::from_bits(64),
-            installed_size2: smbios_types::CacheSize2::from_bits(64),
+            error_correction_type: smbios_types::CacheErrorCorrectionType::Unknown,
+            system_cache_type: smbios_types::SystemCacheType::Data,
+            associativity: smbios_types::AssociativityField::SetAssociative4Way,
+            maximum_cache_size2: smbios_types::CacheSize2::new().with_max_size(64),
+            installed_size2: smbios_types::CacheSize2::new().with_max_size(64),
             string_pool: vec![String::from("L1 Data Cache")],
         };
 
@@ -1191,11 +1203,11 @@ mod tests {
     fn test_type16_new() {
         let type16 = Type16PhysicalMemoryArray {
             header: SmbiosTableHeader { record_type: 16, length: 0, handle: 0x1000 },
-            location: smbios_types::MemoryArrayLocation::SystemBoard, // 0x03
-            use_field: smbios_types::MemoryArrayUse::SystemMemory,    // 0x03
-            memory_error_correction: smbios_types::ErrorCorrectionType::MutliBitEcc, // 0x06
-            maximum_capacity: 0x00800000,                             // 8 GB in KB
-            memory_error_information_handle: 0xFFFE,                  // Not provided
+            location: smbios_types::MemoryArrayLocation::SystemBoard,
+            use_field: smbios_types::MemoryArrayUse::SystemMemory,
+            memory_error_correction: smbios_types::MemoryArrayErrorCorrectionType::MultiBitEcc,
+            maximum_capacity: 0x00800000,            // 8 GB in KB
+            memory_error_information_handle: 0xFFFE, // Not provided
             number_of_memory_devices: 2,
             extended_maximum_capacity: 0,
             string_pool: vec![],
@@ -1212,9 +1224,9 @@ mod tests {
     fn test_type16_to_bytes() {
         let type16 = Type16PhysicalMemoryArray {
             header: SmbiosTableHeader { record_type: 16, length: 0, handle: 0x1000 },
-            location: smbios_types::MemoryArrayLocation::SystemBoard, // 0x03
-            use_field: smbios_types::MemoryArrayUse::SystemMemory,    // 0x03
-            memory_error_correction: smbios_types::ErrorCorrectionType::MutliBitEcc, // 0x06
+            location: smbios_types::MemoryArrayLocation::SystemBoard,
+            use_field: smbios_types::MemoryArrayUse::SystemMemory,
+            memory_error_correction: smbios_types::MemoryArrayErrorCorrectionType::MultiBitEcc,
             maximum_capacity: 0x00800000,
             memory_error_information_handle: 0xFFFE,
             number_of_memory_devices: 2,
@@ -1242,26 +1254,26 @@ mod tests {
             memory_error_information_handle: 0xFFFE,
             total_width: 64,
             data_width: 64,
-            size: 0x1000,                                      // 4096 MB
-            form_factor: smbios_types::MemoryFormFactor::Dimm, // 0x09
+            size: 0x1000, // 4096 MB
+            form_factor: smbios_types::MemoryFormFactor::Dimm,
             device_set: 0,
             device_locator: 1,
             bank_locator: 2,
-            memory_type: smbios_types::MemoryDeviceType::Ddr4, // 0x1A
-            type_detail: smbios_types::MemoryDeviceTypeDetails::from_bits(0x0080), // Synchronous
+            memory_type: smbios_types::MemoryDeviceType::Ddr4,
+            type_detail: smbios_types::MemoryDeviceTypeDetails::new().with_synchronous(true),
             speed: 3200,
             manufacturer: 3,
             serial_number: 4,
             asset_tag: 5,
             part_number: 6,
-            attributes: smbios_types::MemoryDeviceAttributes::from_bits(0x02), // Dual rank
+            attributes: smbios_types::MemoryDeviceAttributes::new().with_rank(2),
             extended_size: 0,
             configured_memory_clock_speed: 3200,
             minimum_voltage: 1200,
             maximum_voltage: 1200,
             configured_voltage: 1200,
-            memory_technology: smbios_types::MemoryDeviceTechnology::Unknown, // 0x02
-            memory_operating_mode_capability: smbios_types::MemoryCapability::from_bits(0x0004), // Volatile
+            memory_technology: smbios_types::MemoryDeviceTechnology::Unknown,
+            memory_operating_mode_capability: smbios_types::MemoryCapability::new().with_unknown(true),
             firmware_version: 7,
             module_manufacturer_id: 0x012C,
             module_product_id: 0,
@@ -1304,25 +1316,25 @@ mod tests {
             total_width: 64,
             data_width: 64,
             size: 0x1000,
-            form_factor: smbios_types::MemoryFormFactor::Dimm, // 0x09
+            form_factor: smbios_types::MemoryFormFactor::Dimm,
             device_set: 0,
             device_locator: 1,
             bank_locator: 2,
-            memory_type: smbios_types::MemoryDeviceType::Ddr4, // 0x1A
-            type_detail: smbios_types::MemoryDeviceTypeDetails::from_bits(0x0080),
+            memory_type: smbios_types::MemoryDeviceType::Ddr4,
+            type_detail: smbios_types::MemoryDeviceTypeDetails::new().with_synchronous(true),
             speed: 3200,
             manufacturer: 3,
             serial_number: 4,
             asset_tag: 5,
             part_number: 6,
-            attributes: smbios_types::MemoryDeviceAttributes::from_bits(0x02),
+            attributes: smbios_types::MemoryDeviceAttributes::new().with_rank(2),
             extended_size: 0,
             configured_memory_clock_speed: 3200,
             minimum_voltage: 1200,
             maximum_voltage: 1200,
             configured_voltage: 1200,
-            memory_technology: smbios_types::MemoryDeviceTechnology::Unknown, // 0x02
-            memory_operating_mode_capability: smbios_types::MemoryCapability::from_bits(0x0004),
+            memory_technology: smbios_types::MemoryDeviceTechnology::Unknown,
+            memory_operating_mode_capability: smbios_types::MemoryCapability::new().with_unknown(true),
             firmware_version: 7,
             module_manufacturer_id: 0x012C,
             module_product_id: 0,
@@ -1414,7 +1426,7 @@ mod tests {
             version: 0,
             serial_number: 0,
             uuid: [0; 16],
-            wake_up_type: smbios_types::WakeUpType::PowerSwitch, // 0x06
+            wake_up_type: smbios_types::WakeUpType::PowerSwitch,
             sku_number: 0,
             family: 0,
             string_pool: vec![],

--- a/components/patina_smbios/src/smbios_record.rs
+++ b/components/patina_smbios/src/smbios_record.rs
@@ -469,8 +469,8 @@ pub struct Type4ProcessorInformation {
     pub socket_designation: u8,
     /// Processor type
     pub processor_type: ProcessorTypeData,
-    /// Processor family
-    pub processor_family: ProcessorFamilyData,
+    /// Processor family (BYTE; set to 0xFE to indicate the value is in `processor_family2`)
+    pub processor_family: u8,
     /// Processor manufacturer string index
     pub processor_manufacturer: u8,
     /// Processor ID (PROCESSOR_ID_DATA: 2x u32 = 8 bytes)
@@ -765,8 +765,7 @@ impl Default for Type127EndOfTable {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::smbios_types;
-    use crate::service::SMBIOS_STRING_MAX_LENGTH;
+    use crate::{service::SMBIOS_STRING_MAX_LENGTH, smbios_types};
     use alloc::vec;
 
     #[test]
@@ -778,14 +777,14 @@ mod tests {
             bios_starting_address_segment: 0xE800,
             firmware_release_date: 3,
             firmware_rom_size: 0xFF,
-            characteristics: smbios_types::BiosCharacteristics(0x08),
-            characteristics_ext1: smbios_types::BiosCharacteristicsExt1(0x03),
-            characteristics_ext2: smbios_types::BiosCharacteristicsExt2(0x03),
+            characteristics: smbios_types::BiosCharacteristics::from_bits(0x08),
+            characteristics_ext1: smbios_types::BiosCharacteristicsExt1::from_bits(0x03),
+            characteristics_ext2: smbios_types::BiosCharacteristicsExt2::from_bits(0x03),
             system_bios_major_release: 1,
             system_bios_minor_release: 0,
             embedded_controller_major_release: 0xFF,
             embedded_controller_minor_release: 0xFF,
-            extended_bios_rom_size: smbios_types::ExtendedBiosRomSize(0),
+            extended_bios_rom_size: smbios_types::ExtendedBiosRomSize::from_bits(0),
             string_pool: vec![String::from("Vendor"), String::from("Version"), String::from("Date")],
         };
 
@@ -803,14 +802,14 @@ mod tests {
             bios_starting_address_segment: 0xE800,
             firmware_release_date: 3,
             firmware_rom_size: 0xFF,
-            characteristics: smbios_types::BiosCharacteristics(0x08),
-            characteristics_ext1: smbios_types::BiosCharacteristicsExt1(0x03),
-            characteristics_ext2: smbios_types::BiosCharacteristicsExt2(0x03),
+            characteristics: smbios_types::BiosCharacteristics::from_bits(0x08),
+            characteristics_ext1: smbios_types::BiosCharacteristicsExt1::from_bits(0x03),
+            characteristics_ext2: smbios_types::BiosCharacteristicsExt2::from_bits(0x03),
             system_bios_major_release: 1,
             system_bios_minor_release: 0,
             embedded_controller_major_release: 0xFF,
             embedded_controller_minor_release: 0xFF,
-            extended_bios_rom_size: smbios_types::ExtendedBiosRomSize(0),
+            extended_bios_rom_size: smbios_types::ExtendedBiosRomSize::from_bits(0),
             string_pool: vec![String::from("x").repeat(SMBIOS_STRING_MAX_LENGTH + 1)],
         };
 
@@ -875,7 +874,7 @@ mod tests {
             version: 3,
             serial_number: 4,
             asset_tag: 5,
-            feature_flags: smbios_types::FeatureFlags(0x01),
+            feature_flags: smbios_types::FeatureFlags::from_bits(0x01),
             location_in_chassis: 6,
             chassis_handle: 0x0003,
             board_type: smbios_types::BoardType::Motherboard,
@@ -949,10 +948,10 @@ mod tests {
             version: 2,
             serial_number: 3,
             asset_tag_number: 4,
-            bootup_state: smbios_types::BootUpState::Desktop,          // 0x03
-            power_supply_state: smbios_types::PowerSupplyState::CentralProcessor, // 0x03
-            thermal_state: smbios_types::ThermalState::Safe,          // 0x03
-            security_status: smbios_types::SecurityStatus::_None,     // 0x03
+            bootup_state: smbios_types::BootUpState::Safe, // 0x03
+            power_supply_state: smbios_types::PowerSupplyState::Safe, // 0x03
+            thermal_state: smbios_types::ThermalState::Safe, // 0x03
+            security_status: smbios_types::SecurityStatus::NoneStatus, // 0x03
             oem_defined: 0,
             height: 0, // Unspecified
             number_of_power_cords: 1,
@@ -982,10 +981,10 @@ mod tests {
             version: 2,
             serial_number: 3,
             asset_tag_number: 4,
-            bootup_state: smbios_types::BootUpState::Desktop,          // 0x03
-            power_supply_state: smbios_types::PowerSupplyState::CentralProcessor, // 0x03
-            thermal_state: smbios_types::ThermalState::Safe,          // 0x03
-            security_status: smbios_types::SecurityStatus::_None,     // 0x03
+            bootup_state: smbios_types::BootUpState::Safe, // 0x03
+            power_supply_state: smbios_types::PowerSupplyState::Safe, // 0x03
+            thermal_state: smbios_types::ThermalState::Safe, // 0x03
+            security_status: smbios_types::SecurityStatus::NoneStatus, // 0x03
             oem_defined: 0,
             height: 0,
             number_of_power_cords: 1,
@@ -1019,7 +1018,7 @@ mod tests {
             version: 3,
             serial_number: 4,
             asset_tag: 5,
-            feature_flags: smbios_types::FeatureFlags(0),
+            feature_flags: smbios_types::FeatureFlags::from_bits(0),
             location_in_chassis: 6,
             chassis_handle: 0,
             board_type: smbios_types::BoardType::Unknown, // 0x00 in org
@@ -1044,15 +1043,15 @@ mod tests {
             header: SmbiosTableHeader { record_type: 4, length: 0, handle: 0x0400 },
             socket_designation: 1,
             processor_type: smbios_types::ProcessorTypeData::CentralProcessor, // 0x03
-            processor_family: smbios_types::ProcessorFamilyData::IndicatorFamily2,   // 0xFE
+            processor_family: 0xFE,                                            // 0xFE
             processor_manufacturer: 2,
             processor_id: [0u8; 8],
             processor_version: 3,
-            voltage: smbios_types::ProcessorVoltage(0x80),
+            voltage: smbios_types::ProcessorVoltage::from_bits(0x80),
             external_clock: 100,
             max_speed: 3000,
             current_speed: 2400,
-            status: smbios_types::ProcessorInformationStatus(0x41),
+            status: smbios_types::ProcessorInformationStatus::from_bits(0x41),
             processor_upgrade: smbios_types::ProcessorUpgrade::Unknown, // 0x02
             l1_cache_handle: 0xFFFF,
             l2_cache_handle: 0xFFFF,
@@ -1063,7 +1062,7 @@ mod tests {
             core_count: 4,
             core_enabled: 4,
             thread_count: 8,
-            processor_characteristics: smbios_types::ProcessorCharacteristics(0x04),
+            processor_characteristics: smbios_types::ProcessorCharacteristics::from_bits(0x04),
             processor_family2: smbios_types::ProcessorFamilyData::ARMv8,
             core_count2: 4,
             core_enabled2: 4,
@@ -1090,15 +1089,15 @@ mod tests {
             header: SmbiosTableHeader { record_type: 4, length: 0, handle: 0x0400 },
             socket_designation: 1,
             processor_type: smbios_types::ProcessorTypeData::CentralProcessor, // 0x03
-            processor_family: smbios_types::ProcessorFamilyData::IndicatorFamily2,   // 0xFE
+            processor_family: 0xFE,                                            // 0xFE
             processor_manufacturer: 2,
             processor_id: [0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08],
             processor_version: 3,
-            voltage: smbios_types::ProcessorVoltage(0x80),
+            voltage: smbios_types::ProcessorVoltage::from_bits(0x80),
             external_clock: 100,
             max_speed: 3000,
             current_speed: 2400,
-            status: smbios_types::ProcessorInformationStatus(0x41),
+            status: smbios_types::ProcessorInformationStatus::from_bits(0x41),
             processor_upgrade: smbios_types::ProcessorUpgrade::Unknown, // 0x02
             l1_cache_handle: 0x0001,
             l2_cache_handle: 0x0002,
@@ -1109,7 +1108,7 @@ mod tests {
             core_count: 4,
             core_enabled: 4,
             thread_count: 8,
-            processor_characteristics: smbios_types::ProcessorCharacteristics(0x04),
+            processor_characteristics: smbios_types::ProcessorCharacteristics::from_bits(0x04),
             processor_family2: smbios_types::ProcessorFamilyData::ARMv8,
             core_count2: 4,
             core_enabled2: 4,
@@ -1137,17 +1136,17 @@ mod tests {
         let type7 = Type7CacheInformation {
             header: SmbiosTableHeader { record_type: 7, length: 0, handle: 0x0700 },
             socket_designation: 1,
-            cache_configuration: smbios_types::CacheConfiguration(0x0180), // L1, enabled, write-back
-            maximum_cache_size: smbios_types::CacheSize(64),
-            installed_size: smbios_types::CacheSize(64),
-            supported_sram_type: smbios_types::CacheSramTypeData(0x0002),
-            current_sram_type: smbios_types::CacheSramTypeData(0x0002),
+            cache_configuration: smbios_types::CacheConfiguration::from_bits(0x0180), // L1, enabled, write-back
+            maximum_cache_size: smbios_types::CacheSize::from_bits(64),
+            installed_size: smbios_types::CacheSize::from_bits(64),
+            supported_sram_type: smbios_types::CacheSramTypeData::from_bits(0x0002),
+            current_sram_type: smbios_types::CacheSramTypeData::from_bits(0x0002),
             cache_speed: 0,
             error_correction_type: smbios_types::ErrorCorrectionType::Unknown, // 0x02
-            system_cache_type: smbios_types::SystemCacheType::Data,              // 0x04
+            system_cache_type: smbios_types::SystemCacheType::Data,            // 0x04
             associativity: smbios_types::AssociativityField::SetAssociative4Way, // 0x05
-            maximum_cache_size2: smbios_types::CacheSize2(64),
-            installed_size2: smbios_types::CacheSize2(64),
+            maximum_cache_size2: smbios_types::CacheSize2::from_bits(64),
+            installed_size2: smbios_types::CacheSize2::from_bits(64),
             string_pool: vec![String::from("L1 Data Cache")],
         };
 
@@ -1162,17 +1161,17 @@ mod tests {
         let type7 = Type7CacheInformation {
             header: SmbiosTableHeader { record_type: 7, length: 0, handle: 0x0700 },
             socket_designation: 1,
-            cache_configuration: smbios_types::CacheConfiguration(0x0180),
-            maximum_cache_size: smbios_types::CacheSize(64),
-            installed_size: smbios_types::CacheSize(64),
-            supported_sram_type: smbios_types::CacheSramTypeData(0x0002),
-            current_sram_type: smbios_types::CacheSramTypeData(0x0002),
+            cache_configuration: smbios_types::CacheConfiguration::from_bits(0x0180),
+            maximum_cache_size: smbios_types::CacheSize::from_bits(64),
+            installed_size: smbios_types::CacheSize::from_bits(64),
+            supported_sram_type: smbios_types::CacheSramTypeData::from_bits(0x0002),
+            current_sram_type: smbios_types::CacheSramTypeData::from_bits(0x0002),
             cache_speed: 0,
             error_correction_type: smbios_types::ErrorCorrectionType::Unknown, // 0x02
-            system_cache_type: smbios_types::SystemCacheType::Data,              // 0x04
+            system_cache_type: smbios_types::SystemCacheType::Data,            // 0x04
             associativity: smbios_types::AssociativityField::SetAssociative4Way, // 0x05
-            maximum_cache_size2: smbios_types::CacheSize2(64),
-            installed_size2: smbios_types::CacheSize2(64),
+            maximum_cache_size2: smbios_types::CacheSize2::from_bits(64),
+            installed_size2: smbios_types::CacheSize2::from_bits(64),
             string_pool: vec![String::from("L1 Data Cache")],
         };
 
@@ -1192,11 +1191,11 @@ mod tests {
     fn test_type16_new() {
         let type16 = Type16PhysicalMemoryArray {
             header: SmbiosTableHeader { record_type: 16, length: 0, handle: 0x1000 },
-            location: smbios_types::MemoryArrayLocation::SystemBoard,            // 0x03
-            use_field: smbios_types::MemoryArrayUse::SystemMemory,                // 0x03
+            location: smbios_types::MemoryArrayLocation::SystemBoard, // 0x03
+            use_field: smbios_types::MemoryArrayUse::SystemMemory,    // 0x03
             memory_error_correction: smbios_types::ErrorCorrectionType::MutliBitEcc, // 0x06
-            maximum_capacity: 0x00800000,            // 8 GB in KB
-            memory_error_information_handle: 0xFFFE, // Not provided
+            maximum_capacity: 0x00800000,                             // 8 GB in KB
+            memory_error_information_handle: 0xFFFE,                  // Not provided
             number_of_memory_devices: 2,
             extended_maximum_capacity: 0,
             string_pool: vec![],
@@ -1213,8 +1212,8 @@ mod tests {
     fn test_type16_to_bytes() {
         let type16 = Type16PhysicalMemoryArray {
             header: SmbiosTableHeader { record_type: 16, length: 0, handle: 0x1000 },
-            location: smbios_types::MemoryArrayLocation::SystemBoard,            // 0x03
-            use_field: smbios_types::MemoryArrayUse::SystemMemory,                // 0x03
+            location: smbios_types::MemoryArrayLocation::SystemBoard, // 0x03
+            use_field: smbios_types::MemoryArrayUse::SystemMemory,    // 0x03
             memory_error_correction: smbios_types::ErrorCorrectionType::MutliBitEcc, // 0x06
             maximum_capacity: 0x00800000,
             memory_error_information_handle: 0xFFFE,
@@ -1243,26 +1242,26 @@ mod tests {
             memory_error_information_handle: 0xFFFE,
             total_width: 64,
             data_width: 64,
-            size: 0x1000,      // 4096 MB
-            form_factor: smbios_types::MemoryFormFactor::Dimm,     // 0x09
+            size: 0x1000,                                      // 4096 MB
+            form_factor: smbios_types::MemoryFormFactor::Dimm, // 0x09
             device_set: 0,
             device_locator: 1,
             bank_locator: 2,
-            memory_type: smbios_types::MemoryDeviceType::Ddr4,     // 0x1A
-            type_detail: smbios_types::MemoryDeviceTypeDetails(0x0080), // Synchronous
+            memory_type: smbios_types::MemoryDeviceType::Ddr4, // 0x1A
+            type_detail: smbios_types::MemoryDeviceTypeDetails::from_bits(0x0080), // Synchronous
             speed: 3200,
             manufacturer: 3,
             serial_number: 4,
             asset_tag: 5,
             part_number: 6,
-            attributes: smbios_types::MemoryDeviceAttributes(0x02), // Dual rank
+            attributes: smbios_types::MemoryDeviceAttributes::from_bits(0x02), // Dual rank
             extended_size: 0,
             configured_memory_clock_speed: 3200,
             minimum_voltage: 1200,
             maximum_voltage: 1200,
             configured_voltage: 1200,
             memory_technology: smbios_types::MemoryDeviceTechnology::Unknown, // 0x02
-            memory_operating_mode_capability: smbios_types::MemoryCapability(0x0004), // Volatile
+            memory_operating_mode_capability: smbios_types::MemoryCapability::from_bits(0x0004), // Volatile
             firmware_version: 7,
             module_manufacturer_id: 0x012C,
             module_product_id: 0,
@@ -1305,25 +1304,25 @@ mod tests {
             total_width: 64,
             data_width: 64,
             size: 0x1000,
-            form_factor: smbios_types::MemoryFormFactor::Dimm,     // 0x09
+            form_factor: smbios_types::MemoryFormFactor::Dimm, // 0x09
             device_set: 0,
             device_locator: 1,
             bank_locator: 2,
-            memory_type: smbios_types::MemoryDeviceType::Ddr4,     // 0x1A
-            type_detail: smbios_types::MemoryDeviceTypeDetails(0x0080),
+            memory_type: smbios_types::MemoryDeviceType::Ddr4, // 0x1A
+            type_detail: smbios_types::MemoryDeviceTypeDetails::from_bits(0x0080),
             speed: 3200,
             manufacturer: 3,
             serial_number: 4,
             asset_tag: 5,
             part_number: 6,
-            attributes: smbios_types::MemoryDeviceAttributes(0x02),
+            attributes: smbios_types::MemoryDeviceAttributes::from_bits(0x02),
             extended_size: 0,
             configured_memory_clock_speed: 3200,
             minimum_voltage: 1200,
             maximum_voltage: 1200,
             configured_voltage: 1200,
             memory_technology: smbios_types::MemoryDeviceTechnology::Unknown, // 0x02
-            memory_operating_mode_capability: smbios_types::MemoryCapability(0x0004),
+            memory_operating_mode_capability: smbios_types::MemoryCapability::from_bits(0x0004),
             firmware_version: 7,
             module_manufacturer_id: 0x012C,
             module_product_id: 0,

--- a/components/patina_smbios/src/smbios_record.rs
+++ b/components/patina_smbios/src/smbios_record.rs
@@ -238,6 +238,7 @@ extern crate alloc;
 use crate::{
     error::SmbiosError,
     service::{SMBIOS_HANDLE_PI_RESERVED, SmbiosTableHeader},
+    smbios_types::*,
 };
 use alloc::{string::String, vec::Vec};
 
@@ -308,11 +309,11 @@ pub struct Type0PlatformFirmwareInformation {
     /// Firmware ROM size
     pub firmware_rom_size: u8,
     /// BIOS characteristics
-    pub characteristics: u64,
+    pub characteristics: BiosCharacteristics,
     /// BIOS characteristics extension byte 1
-    pub characteristics_ext1: u8,
+    pub characteristics_ext1: BiosCharacteristicsExt1,
     /// BIOS characteristics extension byte 2
-    pub characteristics_ext2: u8,
+    pub characteristics_ext2: BiosCharacteristicsExt2,
     /// System BIOS major release
     pub system_bios_major_release: u8,
     /// System BIOS minor release
@@ -322,7 +323,7 @@ pub struct Type0PlatformFirmwareInformation {
     /// Embedded controller firmware minor release
     pub embedded_controller_minor_release: u8,
     /// Extended BIOS ROM size
-    pub extended_bios_rom_size: u16,
+    pub extended_bios_rom_size: ExtendedBiosRomSize,
 
     /// String pool containing the actual string content.
     ///
@@ -359,7 +360,7 @@ pub struct Type1SystemInformation {
     /// UUID bytes
     pub uuid: [u8; 16],
     /// Wake-up type
-    pub wake_up_type: u8,
+    pub wake_up_type: WakeUpType,
     /// SKU number string index
     pub sku_number: u8,
     /// Family string index
@@ -395,13 +396,13 @@ pub struct Type2BaseboardInformation {
     /// Asset tag string index
     pub asset_tag: u8,
     /// Feature flags
-    pub feature_flags: u8,
+    pub feature_flags: FeatureFlags,
     /// Location in chassis string index
     pub location_in_chassis: u8,
     /// Chassis handle
     pub chassis_handle: u16,
     /// Board type
-    pub board_type: u8,
+    pub board_type: BoardType,
     /// Number of contained object handles
     pub contained_object_handles: u8,
 
@@ -435,13 +436,13 @@ pub struct Type3SystemEnclosure {
     /// Asset tag number string index
     pub asset_tag_number: u8,
     /// Boot-up state
-    pub bootup_state: u8,
+    pub bootup_state: BootUpState,
     /// Power supply state
-    pub power_supply_state: u8,
+    pub power_supply_state: PowerSupplyState,
     /// Thermal state
-    pub thermal_state: u8,
+    pub thermal_state: ThermalState,
     /// Security status
-    pub security_status: u8,
+    pub security_status: SecurityStatus,
     /// OEM-defined
     pub oem_defined: u32,
     /// Height
@@ -467,9 +468,9 @@ pub struct Type4ProcessorInformation {
     /// Socket designation string index
     pub socket_designation: u8,
     /// Processor type
-    pub processor_type: u8,
+    pub processor_type: ProcessorTypeData,
     /// Processor family
-    pub processor_family: u8,
+    pub processor_family: ProcessorFamilyData,
     /// Processor manufacturer string index
     pub processor_manufacturer: u8,
     /// Processor ID (PROCESSOR_ID_DATA: 2x u32 = 8 bytes)
@@ -477,7 +478,7 @@ pub struct Type4ProcessorInformation {
     /// Processor version string index
     pub processor_version: u8,
     /// Voltage
-    pub voltage: u8,
+    pub voltage: ProcessorVoltage,
     /// External clock frequency in MHz
     pub external_clock: u16,
     /// Max speed in MHz
@@ -485,9 +486,9 @@ pub struct Type4ProcessorInformation {
     /// Current speed in MHz
     pub current_speed: u16,
     /// Status
-    pub status: u8,
+    pub status: ProcessorInformationStatus,
     /// Processor upgrade
-    pub processor_upgrade: u8,
+    pub processor_upgrade: ProcessorUpgrade,
     /// L1 cache handle
     pub l1_cache_handle: u16,
     /// L2 cache handle
@@ -507,9 +508,9 @@ pub struct Type4ProcessorInformation {
     /// Thread count
     pub thread_count: u8,
     /// Processor characteristics
-    pub processor_characteristics: u16,
+    pub processor_characteristics: ProcessorCharacteristics,
     /// Processor family 2
-    pub processor_family2: u16,
+    pub processor_family2: ProcessorFamilyData,
     /// Core count 2 (SMBIOS 3.0+)
     pub core_count2: u16,
     /// Core enabled 2 (SMBIOS 3.0+)
@@ -531,27 +532,27 @@ pub struct Type7CacheInformation {
     /// Socket designation string index
     pub socket_designation: u8,
     /// Cache configuration
-    pub cache_configuration: u16,
+    pub cache_configuration: CacheConfiguration,
     /// Maximum cache size (in KB)
-    pub maximum_cache_size: u16,
+    pub maximum_cache_size: CacheSize,
     /// Installed size (in KB)
-    pub installed_size: u16,
+    pub installed_size: CacheSize,
     /// Supported SRAM type (bitfield)
-    pub supported_sram_type: u16,
+    pub supported_sram_type: CacheSramTypeData,
     /// Current SRAM type (bitfield)
-    pub current_sram_type: u16,
+    pub current_sram_type: CacheSramTypeData,
     /// Cache speed in nanoseconds
     pub cache_speed: u8,
     /// Error correction type
-    pub error_correction_type: u8,
+    pub error_correction_type: ErrorCorrectionType,
     /// System cache type
-    pub system_cache_type: u8,
+    pub system_cache_type: SystemCacheType,
     /// Associativity
-    pub associativity: u8,
+    pub associativity: AssociativityField,
     /// Maximum cache size 2 (SMBIOS 3.1+)
-    pub maximum_cache_size2: u32,
+    pub maximum_cache_size2: CacheSize2,
     /// Installed cache size 2 (SMBIOS 3.1+)
-    pub installed_cache_size2: u32,
+    pub installed_size2: CacheSize2,
 
     /// String pool
     #[string_pool]
@@ -559,9 +560,6 @@ pub struct Type7CacheInformation {
 }
 
 /// Type 16: Physical Memory Array
-///
-/// Describes the attributes of a physical memory array, including the number
-/// of memory devices it contains, the maximum capacity, and the error correction type.
 ///
 /// # Important: Not C-Compatible
 ///
@@ -576,11 +574,11 @@ pub struct Type16PhysicalMemoryArray {
     /// SMBIOS table header
     pub header: SmbiosTableHeader,
     /// Location of the memory array
-    pub location: u8,
+    pub location: MemoryArrayLocation,
     /// Function for which the array is used (renamed from `use` to avoid Rust keyword)
-    pub use_field: u8,
+    pub use_field: MemoryArrayUse,
     /// Primary hardware error correction or detection method
-    pub memory_error_correction: u8,
+    pub memory_error_correction: ErrorCorrectionType,
     /// Maximum capacity in KB (0x80000000 = use extended_maximum_capacity)
     pub maximum_capacity: u32,
     /// Handle of the error information structure (0xFFFE = not provided)
@@ -623,7 +621,7 @@ pub struct Type17MemoryDevice {
     /// Size of the memory device (0x7FFF = use extended_size, 0xFFFF = unknown)
     pub size: u16,
     /// Form factor of the memory device
-    pub form_factor: u8,
+    pub form_factor: MemoryFormFactor,
     /// Device set number (0 = not part of a set, 0xFF = unknown)
     pub device_set: u8,
     /// Device locator string index
@@ -631,9 +629,9 @@ pub struct Type17MemoryDevice {
     /// Bank locator string index
     pub bank_locator: u8,
     /// Memory type
-    pub memory_type: u8,
+    pub memory_type: MemoryDeviceType,
     /// Type detail bitmask
-    pub type_detail: u16,
+    pub type_detail: MemoryDeviceTypeDetails,
     /// Speed in MT/s (0 = unknown)
     pub speed: u16,
     /// Manufacturer string index
@@ -645,7 +643,7 @@ pub struct Type17MemoryDevice {
     /// Part number string index
     pub part_number: u8,
     /// Attributes (bits 3:0 = rank, bits 7:4 = reserved)
-    pub attributes: u8,
+    pub attributes: MemoryDeviceAttributes,
     /// Extended size in MB (valid when size = 0x7FFF)
     pub extended_size: u32,
     /// Configured memory clock speed in MT/s (0 = unknown)
@@ -657,9 +655,9 @@ pub struct Type17MemoryDevice {
     /// Configured voltage in mV (0 = unknown)
     pub configured_voltage: u16,
     /// Memory technology
-    pub memory_technology: u8,
+    pub memory_technology: MemoryDeviceTechnology,
     /// Memory operating mode capability bitmask
-    pub memory_operating_mode_capability: u16,
+    pub memory_operating_mode_capability: MemoryCapability,
     /// Firmware version string index
     pub firmware_version: u8,
     /// Module manufacturer ID (JEDEC)
@@ -767,6 +765,7 @@ impl Default for Type127EndOfTable {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::smbios_types;
     use crate::service::SMBIOS_STRING_MAX_LENGTH;
     use alloc::vec;
 
@@ -779,14 +778,14 @@ mod tests {
             bios_starting_address_segment: 0xE800,
             firmware_release_date: 3,
             firmware_rom_size: 0xFF,
-            characteristics: 0x08,
-            characteristics_ext1: 0x03,
-            characteristics_ext2: 0x03,
+            characteristics: smbios_types::BiosCharacteristics(0x08),
+            characteristics_ext1: smbios_types::BiosCharacteristicsExt1(0x03),
+            characteristics_ext2: smbios_types::BiosCharacteristicsExt2(0x03),
             system_bios_major_release: 1,
             system_bios_minor_release: 0,
             embedded_controller_major_release: 0xFF,
             embedded_controller_minor_release: 0xFF,
-            extended_bios_rom_size: 0,
+            extended_bios_rom_size: smbios_types::ExtendedBiosRomSize(0),
             string_pool: vec![String::from("Vendor"), String::from("Version"), String::from("Date")],
         };
 
@@ -804,14 +803,14 @@ mod tests {
             bios_starting_address_segment: 0xE800,
             firmware_release_date: 3,
             firmware_rom_size: 0xFF,
-            characteristics: 0x08,
-            characteristics_ext1: 0x03,
-            characteristics_ext2: 0x03,
+            characteristics: smbios_types::BiosCharacteristics(0x08),
+            characteristics_ext1: smbios_types::BiosCharacteristicsExt1(0x03),
+            characteristics_ext2: smbios_types::BiosCharacteristicsExt2(0x03),
             system_bios_major_release: 1,
             system_bios_minor_release: 0,
             embedded_controller_major_release: 0xFF,
             embedded_controller_minor_release: 0xFF,
-            extended_bios_rom_size: 0,
+            extended_bios_rom_size: smbios_types::ExtendedBiosRomSize(0),
             string_pool: vec![String::from("x").repeat(SMBIOS_STRING_MAX_LENGTH + 1)],
         };
 
@@ -827,7 +826,7 @@ mod tests {
             version: 3,
             serial_number: 4,
             uuid: [0; 16],
-            wake_up_type: 0x06,
+            wake_up_type: smbios_types::WakeUpType::PowerSwitch,
             sku_number: 5,
             family: 6,
             string_pool: vec![
@@ -854,7 +853,7 @@ mod tests {
             version: 3,
             serial_number: 4,
             uuid: [0; 16],
-            wake_up_type: 0x06,
+            wake_up_type: smbios_types::WakeUpType::PowerSwitch,
             sku_number: 5,
             family: 6,
             string_pool: vec![String::from("Initial")],
@@ -876,10 +875,10 @@ mod tests {
             version: 3,
             serial_number: 4,
             asset_tag: 5,
-            feature_flags: 0x01,
+            feature_flags: smbios_types::FeatureFlags(0x01),
             location_in_chassis: 6,
             chassis_handle: 0x0003,
-            board_type: 0x0A,
+            board_type: smbios_types::BoardType::Motherboard,
             contained_object_handles: 0,
             string_pool: vec![
                 String::from("Manufacturer"),
@@ -928,7 +927,7 @@ mod tests {
             version: 3,
             serial_number: 4,
             uuid: [0; 16],
-            wake_up_type: 0x06,
+            wake_up_type: smbios_types::WakeUpType::PowerSwitch,
             sku_number: 5,
             family: 6,
             string_pool: vec![String::from("Valid")],
@@ -950,10 +949,10 @@ mod tests {
             version: 2,
             serial_number: 3,
             asset_tag_number: 4,
-            bootup_state: 0x03,       // Safe
-            power_supply_state: 0x03, // Safe
-            thermal_state: 0x03,      // Safe
-            security_status: 0x03,    // None
+            bootup_state: smbios_types::BootUpState::Desktop,          // 0x03
+            power_supply_state: smbios_types::PowerSupplyState::CentralProcessor, // 0x03
+            thermal_state: smbios_types::ThermalState::Safe,          // 0x03
+            security_status: smbios_types::SecurityStatus::_None,     // 0x03
             oem_defined: 0,
             height: 0, // Unspecified
             number_of_power_cords: 1,
@@ -983,10 +982,10 @@ mod tests {
             version: 2,
             serial_number: 3,
             asset_tag_number: 4,
-            bootup_state: 0x03,
-            power_supply_state: 0x03,
-            thermal_state: 0x03,
-            security_status: 0x03,
+            bootup_state: smbios_types::BootUpState::Desktop,          // 0x03
+            power_supply_state: smbios_types::PowerSupplyState::CentralProcessor, // 0x03
+            thermal_state: smbios_types::ThermalState::Safe,          // 0x03
+            security_status: smbios_types::SecurityStatus::_None,     // 0x03
             oem_defined: 0,
             height: 0,
             number_of_power_cords: 1,
@@ -1020,10 +1019,10 @@ mod tests {
             version: 3,
             serial_number: 4,
             asset_tag: 5,
-            feature_flags: 0,
+            feature_flags: smbios_types::FeatureFlags(0),
             location_in_chassis: 6,
             chassis_handle: 0,
-            board_type: 0,
+            board_type: smbios_types::BoardType::Unknown, // 0x00 in org
             contained_object_handles: 0,
             string_pool: vec![
                 String::from("Board Manufacturer"),
@@ -1044,17 +1043,17 @@ mod tests {
         let type4 = Type4ProcessorInformation {
             header: SmbiosTableHeader { record_type: 4, length: 0, handle: 0x0400 },
             socket_designation: 1,
-            processor_type: 0x03,   // Central Processor
-            processor_family: 0xFE, // Use Family2
+            processor_type: smbios_types::ProcessorTypeData::CentralProcessor, // 0x03
+            processor_family: smbios_types::ProcessorFamilyData::IndicatorFamily2,   // 0xFE
             processor_manufacturer: 2,
             processor_id: [0u8; 8],
             processor_version: 3,
-            voltage: 0x80,
+            voltage: smbios_types::ProcessorVoltage(0x80),
             external_clock: 100,
             max_speed: 3000,
             current_speed: 2400,
-            status: 0x41,
-            processor_upgrade: 0x02,
+            status: smbios_types::ProcessorInformationStatus(0x41),
+            processor_upgrade: smbios_types::ProcessorUpgrade::Unknown, // 0x02
             l1_cache_handle: 0xFFFF,
             l2_cache_handle: 0xFFFF,
             l3_cache_handle: 0xFFFF,
@@ -1064,8 +1063,8 @@ mod tests {
             core_count: 4,
             core_enabled: 4,
             thread_count: 8,
-            processor_characteristics: 0x04,
-            processor_family2: 0x0101,
+            processor_characteristics: smbios_types::ProcessorCharacteristics(0x04),
+            processor_family2: smbios_types::ProcessorFamilyData::ARMv8,
             core_count2: 4,
             core_enabled2: 4,
             thread_count2: 8,
@@ -1090,17 +1089,17 @@ mod tests {
         let type4 = Type4ProcessorInformation {
             header: SmbiosTableHeader { record_type: 4, length: 0, handle: 0x0400 },
             socket_designation: 1,
-            processor_type: 0x03,
-            processor_family: 0xFE,
+            processor_type: smbios_types::ProcessorTypeData::CentralProcessor, // 0x03
+            processor_family: smbios_types::ProcessorFamilyData::IndicatorFamily2,   // 0xFE
             processor_manufacturer: 2,
             processor_id: [0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08],
             processor_version: 3,
-            voltage: 0x80,
+            voltage: smbios_types::ProcessorVoltage(0x80),
             external_clock: 100,
             max_speed: 3000,
             current_speed: 2400,
-            status: 0x41,
-            processor_upgrade: 0x02,
+            status: smbios_types::ProcessorInformationStatus(0x41),
+            processor_upgrade: smbios_types::ProcessorUpgrade::Unknown, // 0x02
             l1_cache_handle: 0x0001,
             l2_cache_handle: 0x0002,
             l3_cache_handle: 0xFFFF,
@@ -1110,8 +1109,8 @@ mod tests {
             core_count: 4,
             core_enabled: 4,
             thread_count: 8,
-            processor_characteristics: 0x04,
-            processor_family2: 0x0101,
+            processor_characteristics: smbios_types::ProcessorCharacteristics(0x04),
+            processor_family2: smbios_types::ProcessorFamilyData::ARMv8,
             core_count2: 4,
             core_enabled2: 4,
             thread_count2: 8,
@@ -1138,17 +1137,17 @@ mod tests {
         let type7 = Type7CacheInformation {
             header: SmbiosTableHeader { record_type: 7, length: 0, handle: 0x0700 },
             socket_designation: 1,
-            cache_configuration: 0x0180, // L1, enabled, write-back
-            maximum_cache_size: 64,
-            installed_size: 64,
-            supported_sram_type: 0x0002,
-            current_sram_type: 0x0002,
+            cache_configuration: smbios_types::CacheConfiguration(0x0180), // L1, enabled, write-back
+            maximum_cache_size: smbios_types::CacheSize(64),
+            installed_size: smbios_types::CacheSize(64),
+            supported_sram_type: smbios_types::CacheSramTypeData(0x0002),
+            current_sram_type: smbios_types::CacheSramTypeData(0x0002),
             cache_speed: 0,
-            error_correction_type: 0x02,
-            system_cache_type: 0x04, // Data
-            associativity: 0x05,     // 4-way
-            maximum_cache_size2: 64,
-            installed_cache_size2: 64,
+            error_correction_type: smbios_types::ErrorCorrectionType::Unknown, // 0x02
+            system_cache_type: smbios_types::SystemCacheType::Data,              // 0x04
+            associativity: smbios_types::AssociativityField::SetAssociative4Way, // 0x05
+            maximum_cache_size2: smbios_types::CacheSize2(64),
+            installed_size2: smbios_types::CacheSize2(64),
             string_pool: vec![String::from("L1 Data Cache")],
         };
 
@@ -1163,17 +1162,17 @@ mod tests {
         let type7 = Type7CacheInformation {
             header: SmbiosTableHeader { record_type: 7, length: 0, handle: 0x0700 },
             socket_designation: 1,
-            cache_configuration: 0x0180,
-            maximum_cache_size: 64,
-            installed_size: 64,
-            supported_sram_type: 0x0002,
-            current_sram_type: 0x0002,
+            cache_configuration: smbios_types::CacheConfiguration(0x0180),
+            maximum_cache_size: smbios_types::CacheSize(64),
+            installed_size: smbios_types::CacheSize(64),
+            supported_sram_type: smbios_types::CacheSramTypeData(0x0002),
+            current_sram_type: smbios_types::CacheSramTypeData(0x0002),
             cache_speed: 0,
-            error_correction_type: 0x02,
-            system_cache_type: 0x04,
-            associativity: 0x05,
-            maximum_cache_size2: 64,
-            installed_cache_size2: 64,
+            error_correction_type: smbios_types::ErrorCorrectionType::Unknown, // 0x02
+            system_cache_type: smbios_types::SystemCacheType::Data,              // 0x04
+            associativity: smbios_types::AssociativityField::SetAssociative4Way, // 0x05
+            maximum_cache_size2: smbios_types::CacheSize2(64),
+            installed_size2: smbios_types::CacheSize2(64),
             string_pool: vec![String::from("L1 Data Cache")],
         };
 
@@ -1193,9 +1192,9 @@ mod tests {
     fn test_type16_new() {
         let type16 = Type16PhysicalMemoryArray {
             header: SmbiosTableHeader { record_type: 16, length: 0, handle: 0x1000 },
-            location: 0x03,                          // System board
-            use_field: 0x03,                         // System memory
-            memory_error_correction: 0x06,           // Multi-bit ECC
+            location: smbios_types::MemoryArrayLocation::SystemBoard,            // 0x03
+            use_field: smbios_types::MemoryArrayUse::SystemMemory,                // 0x03
+            memory_error_correction: smbios_types::ErrorCorrectionType::MutliBitEcc, // 0x06
             maximum_capacity: 0x00800000,            // 8 GB in KB
             memory_error_information_handle: 0xFFFE, // Not provided
             number_of_memory_devices: 2,
@@ -1214,9 +1213,9 @@ mod tests {
     fn test_type16_to_bytes() {
         let type16 = Type16PhysicalMemoryArray {
             header: SmbiosTableHeader { record_type: 16, length: 0, handle: 0x1000 },
-            location: 0x03,
-            use_field: 0x03,
-            memory_error_correction: 0x06,
+            location: smbios_types::MemoryArrayLocation::SystemBoard,            // 0x03
+            use_field: smbios_types::MemoryArrayUse::SystemMemory,                // 0x03
+            memory_error_correction: smbios_types::ErrorCorrectionType::MutliBitEcc, // 0x06
             maximum_capacity: 0x00800000,
             memory_error_information_handle: 0xFFFE,
             number_of_memory_devices: 2,
@@ -1245,25 +1244,25 @@ mod tests {
             total_width: 64,
             data_width: 64,
             size: 0x1000,      // 4096 MB
-            form_factor: 0x09, // DIMM
+            form_factor: smbios_types::MemoryFormFactor::Dimm,     // 0x09
             device_set: 0,
             device_locator: 1,
             bank_locator: 2,
-            memory_type: 0x1A,   // DDR4
-            type_detail: 0x0080, // Synchronous
+            memory_type: smbios_types::MemoryDeviceType::Ddr4,     // 0x1A
+            type_detail: smbios_types::MemoryDeviceTypeDetails(0x0080), // Synchronous
             speed: 3200,
             manufacturer: 3,
             serial_number: 4,
             asset_tag: 5,
             part_number: 6,
-            attributes: 0x02, // Dual rank
+            attributes: smbios_types::MemoryDeviceAttributes(0x02), // Dual rank
             extended_size: 0,
             configured_memory_clock_speed: 3200,
             minimum_voltage: 1200,
             maximum_voltage: 1200,
             configured_voltage: 1200,
-            memory_technology: 0x02,                  // DRAM
-            memory_operating_mode_capability: 0x0004, // Volatile
+            memory_technology: smbios_types::MemoryDeviceTechnology::Unknown, // 0x02
+            memory_operating_mode_capability: smbios_types::MemoryCapability(0x0004), // Volatile
             firmware_version: 7,
             module_manufacturer_id: 0x012C,
             module_product_id: 0,
@@ -1306,25 +1305,25 @@ mod tests {
             total_width: 64,
             data_width: 64,
             size: 0x1000,
-            form_factor: 0x09,
+            form_factor: smbios_types::MemoryFormFactor::Dimm,     // 0x09
             device_set: 0,
             device_locator: 1,
             bank_locator: 2,
-            memory_type: 0x1A,
-            type_detail: 0x0080,
+            memory_type: smbios_types::MemoryDeviceType::Ddr4,     // 0x1A
+            type_detail: smbios_types::MemoryDeviceTypeDetails(0x0080),
             speed: 3200,
             manufacturer: 3,
             serial_number: 4,
             asset_tag: 5,
             part_number: 6,
-            attributes: 0x02,
+            attributes: smbios_types::MemoryDeviceAttributes(0x02),
             extended_size: 0,
             configured_memory_clock_speed: 3200,
             minimum_voltage: 1200,
             maximum_voltage: 1200,
             configured_voltage: 1200,
-            memory_technology: 0x02,
-            memory_operating_mode_capability: 0x0004,
+            memory_technology: smbios_types::MemoryDeviceTechnology::Unknown, // 0x02
+            memory_operating_mode_capability: smbios_types::MemoryCapability(0x0004),
             firmware_version: 7,
             module_manufacturer_id: 0x012C,
             module_product_id: 0,
@@ -1416,7 +1415,7 @@ mod tests {
             version: 0,
             serial_number: 0,
             uuid: [0; 16],
-            wake_up_type: 0x06,
+            wake_up_type: smbios_types::WakeUpType::PowerSwitch, // 0x06
             sku_number: 0,
             family: 0,
             string_pool: vec![],

--- a/components/patina_smbios/src/smbios_types.rs
+++ b/components/patina_smbios/src/smbios_types.rs
@@ -14,8 +14,6 @@
 //!
 //! SPDX-License-Identifier: Apache-2.0
 
-#![allow(missing_docs)]
-
 extern crate alloc;
 
 use bitfield_struct::bitfield;
@@ -25,40 +23,73 @@ use zerocopy::{Immutable, IntoBytes, KnownLayout};
 #[bitfield(u64)]
 #[derive(IntoBytes, Immutable, KnownLayout)]
 pub struct BiosCharacteristics {
+    /// Reserved bits.
     #[bits(2)]
     pub reserved: u8,
+    /// Unknown.
     pub unknown: bool,
+    /// BIOS characteristics are not supported.
     pub bios_characteristics_unsupported: bool,
+    /// ISA is supported.
     pub isa_supported: bool,
+    /// MCA is supported.
     pub mca_supported: bool,
+    /// EISA is supported.
     pub eisa_supported: bool,
+    /// PCI is supported.
     pub pci_supported: bool,
+    /// PC Card (PCMCIA) is supported.
     pub pcmcia_supported: bool,
+    /// Plug and Play is supported.
     pub plug_play_supported: bool,
+    /// APM is supported.
     pub apm_supported: bool,
+    /// BIOS is upgradeable (Flash).
     pub bios_is_upgradable: bool,
+    /// BIOS shadowing is allowed.
     pub bios_shadowing_allowed: bool,
+    /// VL-VESA is supported.
     pub vlvesa_supported: bool,
+    /// ESCD support is available.
     pub escd_supported: bool,
+    /// Boot from CD is supported.
     pub cd_boot_supported: bool,
+    /// Selectable boot is supported.
     pub selectable_boot_supported: bool,
+    /// BIOS ROM is socketed.
     pub bios_rom_socketed: bool,
+    /// Boot from PC Card (PCMCIA) is supported.
     pub pc_card_boot_supported: bool,
+    /// EDD specification is supported.
     pub edd_spec_supported: bool,
+    /// Japanese floppy for NEC 9800 1.2 MB (3.5", 1K bytes/sector, 360 RPM) is supported.
     pub japanese_nec_9800_supported: bool,
+    /// Japanese floppy for Toshiba 1.2 MB (3.5", 360 RPM) is supported.
     pub japanese_toshiba_supported: bool,
+    /// 5.25" / 360 KB floppy services are supported.
     pub kb_525_360_supported: bool,
-    pub mb_535_12_supported: bool,
+    /// 5.25" / 1.2 MB floppy services are supported.
+    pub mb_525_12_supported: bool,
+    /// 3.5" / 720 KB floppy services are supported.
     pub mb_35_720_supported: bool,
+    /// 3.5" / 2.88 MB floppy services are supported.
     pub mb_35_288_supported: bool,
+    /// Print Screen service is supported.
     pub print_screen_supported: bool,
+    /// 8042 keyboard services are supported.
     pub keyboard_8042_supported: bool,
+    /// Serial services are supported.
     pub serial_services_supported: bool,
+    /// Printer services are supported.
     pub printer_services_supported: bool,
+    /// CGA/Mono video services are supported.
     pub cga_mono_video_supported: bool,
+    /// NEC PC-98 system.
     pub nec_pc_98: bool,
+    /// Reserved for BIOS vendor.
     #[bits(16)]
     pub reserved_bios_vendor: u16,
+    /// Reserved for system vendor.
     #[bits(16)]
     pub reserved_system_vendor: u16,
 }
@@ -67,13 +98,21 @@ pub struct BiosCharacteristics {
 #[bitfield(u8)]
 #[derive(IntoBytes, Immutable, KnownLayout)]
 pub struct BiosCharacteristicsExt1 {
+    /// ACPI is supported.
     pub acpi_supported: bool,
+    /// USB Legacy is supported.
     pub usb_legacy_supported: bool,
+    /// AGP is supported.
     pub agp_supported: bool,
-    pub i20_supported: bool,
+    /// I2O boot is supported.
+    pub i2o_supported: bool,
+    /// LS-120 SuperDisk boot is supported.
     pub superdisk_boot_supported: bool,
+    /// ATAPI ZIP drive boot is supported.
     pub zip_drive_boot_supported: bool,
+    /// 1394 boot is supported.
     pub boot_1394_supported: bool,
+    /// Smart battery is supported.
     pub smart_battery_supported: bool,
 }
 
@@ -81,11 +120,17 @@ pub struct BiosCharacteristicsExt1 {
 #[bitfield(u8)]
 #[derive(IntoBytes, Immutable, KnownLayout)]
 pub struct BiosCharacteristicsExt2 {
+    /// BIOS Boot Specification is supported.
     pub bios_boot_specification_supported: bool,
+    /// Function-key initiated network service boot is supported.
     pub fn_network_service_boot_supported: bool,
+    /// Enable Targeted Content Distribution.
     pub enable_targeted_content_distribution: bool,
+    /// UEFI Specification is supported.
     pub uefi_spec_supported: bool,
+    /// SMBIOS table describes a virtual machine.
     pub smbios_describes_vm: bool,
+    /// Reserved bits.
     #[bits(3)]
     pub reserved: u8,
 }
@@ -94,8 +139,10 @@ pub struct BiosCharacteristicsExt2 {
 #[bitfield(u16)]
 #[derive(IntoBytes, Immutable, KnownLayout)]
 pub struct ExtendedBiosRomSize {
+    /// ROM size value.
     #[bits(14)]
     pub size: u16,
+    /// Unit encoding: 0b00 = megabytes, 0b01 = gigabytes.
     #[bits(2)]
     pub unit: u8,
 }
@@ -104,14 +151,23 @@ pub struct ExtendedBiosRomSize {
 #[repr(u8)]
 #[derive(Copy, Clone, Debug, IntoBytes, Immutable, KnownLayout)]
 pub enum WakeUpType {
+    /// Reserved.
     Reserved = 0x00,
+    /// Other.
     Other = 0x01,
+    /// Unknown.
     Unknown = 0x02,
+    /// APM timer.
     ApmTimer = 0x03,
+    /// Modem ring.
     ModemRing = 0x04,
+    /// LAN remote.
     LanRemote = 0x05,
+    /// Power switch.
     PowerSwitch = 0x06,
+    /// PCI PME#.
     PciPme = 0x07,
+    /// AC power restored.
     AcPowerRestored = 0x08,
 }
 
@@ -119,11 +175,17 @@ pub enum WakeUpType {
 #[bitfield(u8)]
 #[derive(IntoBytes, Immutable, KnownLayout)]
 pub struct FeatureFlags {
+    /// Board is a hosting board (e.g. motherboard).
     pub hosting_board: bool,
+    /// Board requires at least one daughter board / auxiliary card.
     pub require_aux_board: bool,
+    /// Board is removable.
     pub removable_board: bool,
+    /// Board is replaceable.
     pub replaceable_board: bool,
+    /// Board is hot-swappable.
     pub hot_swappable_board: bool,
+    /// Reserved bits.
     #[bits(3)]
     pub reserved: u8,
 }
@@ -132,18 +194,31 @@ pub struct FeatureFlags {
 #[repr(u8)]
 #[derive(Copy, Clone, Debug, IntoBytes, Immutable, KnownLayout)]
 pub enum BoardType {
+    /// Unknown.
     Unknown = 0x01,
+    /// Other.
     Other = 0x02,
+    /// Server blade.
     ServerBlade = 0x03,
+    /// Connectivity switch.
     ConnectivitySwitch = 0x04,
+    /// System management module.
     SystemManagementModule = 0x05,
+    /// Processor module.
     ProcessorModule = 0x06,
+    /// I/O module.
     IoModule = 0x07,
+    /// Memory module.
     MemoryModule = 0x08,
+    /// Daughter board.
     DaughterBoard = 0x09,
+    /// Motherboard (includes processor, memory, and I/O).
     Motherboard = 0x0A,
+    /// Processor/memory module.
     ProcessorMemoryModule = 0x0B,
+    /// Processor/I/O module.
     ProcessorIoModule = 0x0C,
+    /// Interconnect board.
     InterconnectBoard = 0x0D,
 }
 
@@ -153,11 +228,17 @@ pub enum BoardType {
 #[repr(u8)]
 #[derive(Copy, Clone, Debug, IntoBytes, Immutable, KnownLayout)]
 pub enum BootUpState {
+    /// Other.
     Other = 0x01,
+    /// Unknown.
     Unknown = 0x02,
+    /// Safe.
     Safe = 0x03,
+    /// Warning.
     Warning = 0x04,
+    /// Critical.
     Critical = 0x05,
+    /// Non-recoverable.
     NonRecoverable = 0x06,
 }
 
@@ -167,11 +248,17 @@ pub enum BootUpState {
 #[repr(u8)]
 #[derive(Copy, Clone, Debug, IntoBytes, Immutable, KnownLayout)]
 pub enum PowerSupplyState {
+    /// Other.
     Other = 0x01,
+    /// Unknown.
     Unknown = 0x02,
+    /// Safe.
     Safe = 0x03,
+    /// Warning.
     Warning = 0x04,
+    /// Critical.
     Critical = 0x05,
+    /// Non-recoverable.
     NonRecoverable = 0x06,
 }
 
@@ -179,11 +266,17 @@ pub enum PowerSupplyState {
 #[repr(u8)]
 #[derive(Copy, Clone, Debug, IntoBytes, Immutable, KnownLayout)]
 pub enum ThermalState {
+    /// Other.
     Other = 0x01,
+    /// Unknown.
     Unknown = 0x02,
+    /// Safe.
     Safe = 0x03,
+    /// Warning.
     Warning = 0x04,
+    /// Critical.
     Critical = 0x05,
+    /// Non-recoverable.
     NonRecoverable = 0x06,
 }
 
@@ -193,10 +286,15 @@ pub enum ThermalState {
 #[repr(u8)]
 #[derive(Copy, Clone, Debug, IntoBytes, Immutable, KnownLayout)]
 pub enum SecurityStatus {
+    /// Other.
     Other = 0x01,
+    /// Unknown.
     Unknown = 0x02,
+    /// No security status; named `NoneStatus` to avoid the reserved `None` keyword.
     NoneStatus = 0x03,
+    /// External interface locked out.
     ExternalInterfaceLockedOut = 0x04,
+    /// External interface enabled.
     ExternalInterfaceEnabled = 0x05,
 }
 
@@ -204,8 +302,10 @@ pub enum SecurityStatus {
 #[bitfield(u8)]
 #[derive(IntoBytes, Immutable, KnownLayout)]
 pub struct ContainedElementType {
+    /// Type value (SMBIOS record type if `type_select == true`, otherwise baseboard type).
     #[bits(7)]
     pub r#type: u8,
+    /// Type selector: `false` = baseboard type (Type 2 enumeration), `true` = SMBIOS record type.
     pub type_select: bool,
 }
 
@@ -213,8 +313,11 @@ pub struct ContainedElementType {
 #[repr(C, packed)]
 #[derive(Copy, Clone, Debug, IntoBytes, Immutable, KnownLayout)]
 pub struct ContainedElements {
+    /// Type of contained element.
     pub contained_element_type: ContainedElementType,
+    /// Minimum number of this contained element type.
     pub contained_element_minimum: u8,
+    /// Maximum number of this contained element type.
     pub contained_element_maximum: u8,
 }
 
@@ -232,11 +335,17 @@ impl Default for ContainedElements {
 #[repr(u8)]
 #[derive(Copy, Clone, Debug, IntoBytes, Immutable, KnownLayout)]
 pub enum ProcessorTypeData {
+    /// Other.
     ProcessorOther = 0x01,
+    /// Unknown.
     ProcessorUnknown = 0x02,
+    /// Central processor.
     CentralProcessor = 0x03,
+    /// Math processor.
     MathProcessor = 0x04,
+    /// DSP processor.
     DspProcessor = 0x05,
+    /// Video processor.
     VideoProcessor = 0x06,
 }
 
@@ -249,252 +358,496 @@ pub enum ProcessorTypeData {
 #[repr(u16)]
 #[derive(Copy, Clone, Debug, IntoBytes, Immutable, KnownLayout)]
 pub enum ProcessorFamilyData {
+    /// Other.
     Other = 0x01,
+    /// Unknown.
     Unknown = 0x02,
+    /// 8086.
     Processor8086 = 0x03,
+    /// 80286.
     Processor80286 = 0x04,
+    /// Intel386™ processor.
     Intel386 = 0x05,
+    /// Intel486™ processor.
     Intel486 = 0x06,
+    /// 8087.
     Processor8087 = 0x07,
+    /// 80287.
     Processor80287 = 0x08,
+    /// 80387.
     Processor80387 = 0x09,
+    /// 80487.
     Processor80487 = 0x0A,
+    /// Intel® Pentium® processor.
     Pentium = 0x0B,
+    /// Pentium® Pro processor.
     PentiumPro = 0x0C,
+    /// Pentium® II processor.
     PentiumII = 0x0D,
+    /// Pentium® processor with MMX™ technology.
     PentiumMMX = 0x0E,
+    /// Intel® Celeron® processor.
     Celeron = 0x0F,
+    /// Pentium® II Xeon™ processor.
     PentiumIIXeon = 0x10,
+    /// Pentium® III processor.
     PentiumIII = 0x11,
+    /// M1 family.
     M1Family = 0x12,
+    /// M2 family.
     M2Family = 0x13,
+    /// Intel® Celeron® M processor.
     IntelCeleronM = 0x14,
+    /// Intel® Pentium® 4 HT processor.
     IntelPentium4Ht = 0x15,
+    /// Intel® processor.
     IntelProcessor = 0x16,
+    /// AMD Duron™ processor family.
     AmdDuron = 0x18,
+    /// K5 family.
     K5Family = 0x19,
+    /// K6 family.
     K6Family = 0x1A,
+    /// K6-2.
     K6_2 = 0x1B,
+    /// K6-3.
     K6_3 = 0x1C,
+    /// AMD Athlon™ processor family.
     AmdAthlon = 0x1D,
+    /// AMD29000 family.
     Amd29000 = 0x1E,
+    /// K6-2+.
     K6_2Plus = 0x1F,
+    /// Power PC family.
     PowerPC = 0x20,
+    /// Power PC 601.
     PowerPC601 = 0x21,
+    /// Power PC 603.
     PowerPC603 = 0x22,
+    /// Power PC 603+.
     PowerPC603Plus = 0x23,
+    /// Power PC 604.
     PowerPC604 = 0x24,
+    /// Power PC 620.
     PowerPC620 = 0x25,
+    /// Power PC x704.
     PowerPCx704 = 0x26,
+    /// Power PC 750.
     PowerPC750 = 0x27,
+    /// Intel® Core™ Duo processor.
     IntelCoreDuo = 0x28,
+    /// Intel® Core™ Duo mobile processor.
     IntelCoreDuoMobile = 0x29,
+    /// Intel® Core™ Solo mobile processor.
     IntelCoreSoloMobile = 0x2A,
+    /// Intel® Atom™ processor.
     IntelAtom = 0x2B,
+    /// Intel® Core™ M processor.
     IntelCoreM = 0x2C,
+    /// Intel® Core™ m3 processor.
     IntelCorem3 = 0x2D,
+    /// Intel® Core™ m5 processor.
     IntelCorem5 = 0x2E,
+    /// Intel® Core™ m7 processor.
     IntelCorem7 = 0x2F,
+    /// Alpha family.
     Alpha = 0x30,
+    /// Alpha 21064.
     Alpha21064 = 0x31,
+    /// Alpha 21066.
     Alpha21066 = 0x32,
+    /// Alpha 21164.
     Alpha21164 = 0x33,
+    /// Alpha 21164PC.
     Alpha21164PC = 0x34,
+    /// Alpha 21164a.
     Alpha21164a = 0x35,
+    /// Alpha 21264.
     Alpha21264 = 0x36,
+    /// Alpha 21364.
     Alpha21364 = 0x37,
+    /// AMD Turion™ II Ultra Dual-Core Mobile M processor family.
     AmdTurionIIUltraDualCoreMobileM = 0x38,
+    /// AMD Turion™ II Dual-Core Mobile M processor family.
     AmdTurionIIDualCoreMobileM = 0x39,
+    /// AMD Athlon™ II Dual-Core M processor family.
     AmdAthlonIIDualCoreM = 0x3A,
+    /// AMD Opteron™ 6100 Series processor.
     AmdOpteron6100Series = 0x3B,
+    /// AMD Opteron™ 4100 Series processor.
     AmdOpteron4100Series = 0x3C,
+    /// AMD Opteron™ 6200 Series processor.
     AmdOpteron6200Series = 0x3D,
+    /// AMD Opteron™ 4200 Series processor.
     AmdOpteron4200Series = 0x3E,
+    /// AMD FX™ Series processor.
     AmdFxSeries = 0x3F,
+    /// MIPS family.
     MipsFamily = 0x40,
+    /// MIPS R4000.
     MipsR4000 = 0x41,
+    /// MIPS R4200.
     MipsR4200 = 0x42,
+    /// MIPS R4400.
     MipsR4400 = 0x43,
+    /// MIPS R4600.
     MipsR4600 = 0x44,
+    /// MIPS R10000.
     MipsR10000 = 0x45,
+    /// AMD C-Series processor.
     AmdCSeries = 0x46,
+    /// AMD E-Series processor.
     AmdESeries = 0x47,
+    /// AMD A-Series processor.
     AmdASeries = 0x48,
+    /// AMD G-Series processor.
     AmdGSeries = 0x49,
+    /// AMD Z-Series processor.
     AmdZSeries = 0x4A,
+    /// AMD R-Series processor.
     AmdRSeries = 0x4B,
+    /// AMD Opteron™ 4300 Series processor.
     AmdOpteron4300 = 0x4C,
+    /// AMD Opteron™ 6300 Series processor.
     AmdOpteron6300 = 0x4D,
+    /// AMD Opteron™ 3300 Series processor.
     AmdOpteron3300 = 0x4E,
+    /// AMD FirePro™ Series processor.
     AmdFireProSeries = 0x4F,
+    /// SPARC family.
     Sparc = 0x50,
+    /// SuperSPARC.
     SuperSparc = 0x51,
+    /// microSPARC II.
     MicroSparcII = 0x52,
+    /// microSPARC IIep.
     MicroSparcIIep = 0x53,
+    /// UltraSPARC.
     UltraSparc = 0x54,
+    /// UltraSPARC II.
     UltraSparcII = 0x55,
+    /// UltraSPARC IIi.
     UltraSparcIii = 0x56,
+    /// UltraSPARC III.
     UltraSparcIII = 0x57,
+    /// UltraSPARC IIIi.
     UltraSparcIIIi = 0x58,
+    /// 68040.
     Processor68040 = 0x60,
+    /// 68xxx.
     Processor68xxx = 0x61,
+    /// 68000.
     Processor68000 = 0x62,
+    /// 68010.
     Processor68010 = 0x63,
+    /// 68020.
     Processor68020 = 0x64,
+    /// 68030.
     Processor68030 = 0x65,
+    /// AMD Athlon™ X4 Quad-Core processor.
     AmdAthlonX4QuadCore = 0x66,
+    /// AMD Opteron™ X1000 Series processor.
     AmdOpteronX1000Series = 0x67,
+    /// AMD Opteron™ X2000 Series APU.
     AmdOpteronX2000Series = 0x68,
+    /// AMD Opteron™ A-Series processor.
     AmdOpteronASeries = 0x69,
+    /// AMD Opteron™ X3000 Series APU.
     AmdOpteronX3000Series = 0x6A,
+    /// AMD Zen processor family.
     AmdZen = 0x6B,
+    /// Hobbit family.
     HobbitFamily = 0x70,
+    /// Crusoe™ TM5000 family.
     CrusoeTM5000 = 0x78,
+    /// Crusoe™ TM3000 family.
     CrusoeTM3000 = 0x79,
+    /// Efficeon™ TM8000 family.
     EfficeonTM8000 = 0x7A,
+    /// Weitek.
     Weitek = 0x80,
+    /// Itanium™ processor.
     Itanium = 0x82,
+    /// AMD Athlon™ 64 processor family.
     AmdAthlon64 = 0x83,
+    /// AMD Opteron™ processor family.
     AmdOpteron = 0x84,
+    /// AMD Sempron™ processor family.
     AmdSempron = 0x85,
+    /// AMD Turion™ 64 Mobile Technology.
     AmdTurion64Mobile = 0x86,
+    /// Dual-Core AMD Opteron™ processor family.
     DualCoreAmdOpteron = 0x87,
+    /// AMD Athlon™ 64 X2 Dual-Core processor family.
     AmdAthlon64X2DualCore = 0x88,
+    /// AMD Turion™ 64 X2 Mobile Technology.
     AmdTurion64X2Mobile = 0x89,
+    /// Quad-Core AMD Opteron™ processor family.
     QuadCoreAmdOpteron = 0x8A,
+    /// Third-Generation AMD Opteron™ processor family.
     ThirdGenerationAmdOpteron = 0x8B,
+    /// AMD Phenom™ FX Quad-Core processor family.
     AmdPhenomFxQuadCore = 0x8C,
+    /// AMD Phenom™ X4 Quad-Core processor family.
     AmdPhenomX4QuadCore = 0x8D,
+    /// AMD Phenom™ X2 Dual-Core processor family.
     AmdPhenomX2DualCore = 0x8E,
+    /// AMD Athlon™ X2 Dual-Core processor family.
     AmdAthlonX2DualCore = 0x8F,
+    /// PA-RISC family.
     Parisc = 0x90,
+    /// PA-RISC 8500.
     PaRisc8500 = 0x91,
+    /// PA-RISC 8000.
     PaRisc8000 = 0x92,
+    /// PA-RISC 7300LC.
     PaRisc7300LC = 0x93,
+    /// PA-RISC 7200.
     PaRisc7200 = 0x94,
+    /// PA-RISC 7100LC.
     PaRisc7100LC = 0x95,
+    /// PA-RISC 7100.
     PaRisc7100 = 0x96,
+    /// V30 family.
     V30Family = 0xA0,
+    /// Quad-Core Intel® Xeon® processor 3200 Series.
     QuadCoreIntelXeon3200Series = 0xA1,
+    /// Dual-Core Intel® Xeon® processor 3000 Series.
     DualCoreIntelXeon3000Series = 0xA2,
+    /// Quad-Core Intel® Xeon® processor 5300 Series.
     QuadCoreIntelXeon5300Series = 0xA3,
+    /// Dual-Core Intel® Xeon® processor 5100 Series.
     DualCoreIntelXeon5100Series = 0xA4,
+    /// Dual-Core Intel® Xeon® processor 5000 Series.
     DualCoreIntelXeon5000Series = 0xA5,
+    /// Dual-Core Intel® Xeon® processor LV.
     DualCoreIntelXeonLV = 0xA6,
+    /// Dual-Core Intel® Xeon® processor ULV.
     DualCoreIntelXeonULV = 0xA7,
+    /// Dual-Core Intel® Xeon® processor 7100 Series.
     DualCoreIntelXeon7100Series = 0xA8,
+    /// Quad-Core Intel® Xeon® processor 5400 Series.
     QuadCoreIntelXeon5400Series = 0xA9,
+    /// Quad-Core Intel® Xeon® processor.
     QuadCoreIntelXeon = 0xAA,
+    /// Dual-Core Intel® Xeon® processor 5200 Series.
     DualCoreIntelXeon5200Series = 0xAB,
+    /// Dual-Core Intel® Xeon® processor 7200 Series.
     DualCoreIntelXeon7200Series = 0xAC,
+    /// Quad-Core Intel® Xeon® processor 7300 Series.
     QuadCoreIntelXeon7300Series = 0xAD,
+    /// Quad-Core Intel® Xeon® processor 7400 Series.
     QuadCoreIntelXeon7400Series = 0xAE,
+    /// Multi-Core Intel® Xeon® processor 7400 Series.
     MultiCoreIntelXeon7400Series = 0xAF,
+    /// Pentium® III Xeon™ processor.
     PentiumIIIXeon = 0xB0,
+    /// Pentium® III processor with Intel® SpeedStep™ technology.
     PentiumIIISpeedStep = 0xB1,
+    /// Pentium® 4 processor.
     Pentium4 = 0xB2,
+    /// Intel® Xeon® processor.
     IntelXeon = 0xB3,
+    /// AS400 family.
     As400 = 0xB4,
+    /// Intel® Xeon™ processor MP.
     IntelXeonMP = 0xB5,
+    /// AMD Athlon™ XP processor family.
     AMDAthlonXP = 0xB6,
+    /// AMD Athlon™ MP processor family.
     AMDAthlonMP = 0xB7,
+    /// Intel® Itanium® 2 processor.
     IntelItanium2 = 0xB8,
+    /// Intel® Pentium® M processor.
     IntelPentiumM = 0xB9,
+    /// Intel® Celeron® D processor.
     IntelCeleronD = 0xBA,
+    /// Intel® Pentium® D processor.
     IntelPentiumD = 0xBB,
+    /// Intel® Pentium® Processor Extreme Edition.
     IntelPentiumEx = 0xBC,
+    /// Intel® Core™ Solo Processor.
     IntelCoreSolo = 0xBD,
+    /// Reserved.
     Reserved = 0xBE,
+    /// Intel® Core™ 2 Processor.
     IntelCore2 = 0xBF,
+    /// Intel® Core™ 2 Solo processor.
     IntelCore2Solo = 0xC0,
+    /// Intel® Core™ 2 Extreme processor.
     IntelCore2Extreme = 0xC1,
+    /// Intel® Core™ 2 Quad processor.
     IntelCore2Quad = 0xC2,
+    /// Intel® Core™ 2 Extreme mobile processor.
     IntelCore2ExtremeMobile = 0xC3,
+    /// Intel® Core™ 2 Duo mobile processor.
     IntelCore2DuoMobile = 0xC4,
+    /// Intel® Core™ 2 Solo mobile processor.
     IntelCore2SoloMobile = 0xC5,
+    /// Intel® Core™ i7 processor.
     IntelCoreI7 = 0xC6,
+    /// Dual-Core Intel® Celeron® processor.
     DualCoreIntelCeleron = 0xC7,
+    /// IBM390 family.
     Ibm390 = 0xC8,
+    /// G4.
     G4 = 0xC9,
+    /// G5.
     G5 = 0xCA,
+    /// ESA/390 G6.
     EsaG6 = 0xCB,
+    /// z/Architecture base.
     ZArchitecture = 0xCC,
+    /// Intel® Core™ i5 processor.
     IntelCoreI5 = 0xCD,
+    /// Intel® Core™ i3 processor.
     IntelCoreI3 = 0xCE,
+    /// Intel® Core™ i9 processor.
     IntelCoreI9 = 0xCF,
+    /// Intel® Xeon® D processor.
     IntelXeonD = 0xD0,
+    /// VIA C7™-M processor family.
     ViaC7M = 0xD2,
+    /// VIA C7™-D processor family.
     ViaC7D = 0xD3,
+    /// VIA C7™ processor family.
     ViaC7 = 0xD4,
+    /// VIA Eden™ processor family.
     ViaEden = 0xD5,
+    /// Multi-Core Intel® Xeon® processor.
     MultiCoreIntelXeon = 0xD6,
+    /// Dual-Core Intel® Xeon® processor 3xxx Series.
     DualCoreIntelXeon3Series = 0xD7,
+    /// Quad-Core Intel® Xeon® processor 3xxx Series.
     QuadCoreIntelXeon3Series = 0xD8,
+    /// VIA Nano™ processor family.
     ViaNano = 0xD9,
+    /// Dual-Core Intel® Xeon® processor 5xxx Series.
     DualCoreIntelXeon5Series = 0xDA,
+    /// Quad-Core Intel® Xeon® processor 5xxx Series.
     QuadCoreIntelXeon5Series = 0xDB,
+    /// Dual-Core Intel® Xeon® processor 7xxx Series.
     DualCoreIntelXeon7Series = 0xDD,
+    /// Quad-Core Intel® Xeon® processor 7xxx Series.
     QuadCoreIntelXeon7Series = 0xDE,
+    /// Multi-Core Intel® Xeon® processor 7xxx Series.
     MultiCoreIntelXeon7Series = 0xDF,
+    /// Multi-Core Intel® Xeon® processor 3400 Series.
     MultiCoreIntelXeon3400Series = 0xE0,
+    /// AMD Opteron™ 3000 Series processor.
     AmdOpteron3000Series = 0xE4,
+    /// AMD Sempron™ II processor.
     AmdSempronII = 0xE5,
+    /// Embedded AMD Opteron™ Quad-Core processor family.
     EmbeddedAmdOpteronQuadCore = 0xE6,
+    /// AMD Phenom™ Triple-Core processor family.
     AmdPhenomTripleCore = 0xE7,
+    /// AMD Turion™ Ultra Dual-Core Mobile processor family.
     AmdTurionUltraDualCoreMobile = 0xE8,
+    /// AMD Turion™ Dual-Core Mobile processor family.
     AmdTurionDualCoreMobile = 0xE9,
+    /// AMD Athlon™ Dual-Core processor family.
     AmdAthlonDualCore = 0xEA,
+    /// AMD Sempron™ SI processor family.
     AmdSempronSI = 0xEB,
+    /// AMD Phenom™ II processor family.
     AmdPhenomII = 0xEC,
+    /// AMD Athlon™ II processor family.
     AmdAthlonII = 0xED,
+    /// Six-Core AMD Opteron™ processor family.
     SixCoreAmdOpteron = 0xEE,
+    /// AMD Sempron™ M processor family.
     AmdSempronM = 0xEF,
+    /// i860.
     I860 = 0xFA,
+    /// i960.
     I960 = 0xFB,
     /// Use this u8 marker (0xFE) in `processor_family` to indicate that the
     /// real value is in `processor_family2`.
     IndicatorFamily2 = 0xFE,
+    /// Reserved.
     Reserved1 = 0xFF,
+    /// ARMv7.
     ARMv7 = 0x0100,
+    /// ARMv8.
     ARMv8 = 0x0101,
+    /// ARMv9.
     ARMv9 = 0x0102,
+    /// SH-3.
     Sh3 = 0x0103,
+    /// SH-4.
     Sh4 = 0x0104,
+    /// ARM.
     Arm = 0x0118,
+    /// StrongARM.
     StrongARM = 0x0119,
+    /// 6x86.
     Processor6x86 = 0x012C,
+    /// MediaGX.
     MediaGX = 0x012D,
+    /// MII.
     Mii = 0x012E,
+    /// WinChip.
     WinChip = 0x0140,
+    /// DSP.
     Dsp = 0x015E,
+    /// Video processor.
     VideoProcessor = 0x01F4,
+    /// RISC-V RV32.
     RiscvRV32 = 0x0200,
+    /// RISC-V RV64.
     RiscVRV64 = 0x0201,
+    /// RISC-V RV128.
     RiscVRV128 = 0x0202,
+    /// LoongArch.
     LoongArch = 0x0258,
+    /// Loongson™ 1 processor.
     Loongson1 = 0x0259,
+    /// Loongson™ 2 processor.
     Loongson2 = 0x025A,
+    /// Loongson™ 3 processor.
     Loongson3 = 0x025B,
+    /// Loongson™ 2K processor.
     Loongson2K = 0x025C,
+    /// Loongson™ 3A processor.
     Loongson3A = 0x025D,
+    /// Loongson™ 3B processor.
     Loongson3B = 0x025E,
+    /// Loongson™ 3C processor.
     Loongson3C = 0x025F,
+    /// Loongson™ 3D processor.
     Loongson3D = 0x0260,
+    /// Loongson™ 3E processor.
     Loongson3E = 0x0261,
+    /// Dual-Core Loongson™ 2K processor 2xxx Series.
     DualCoreLoongson2K = 0x0262,
+    /// Quad-Core Loongson™ 3A processor 5xxx Series.
     QuadCoreLoongson3A = 0x026C,
+    /// Multi-Core Loongson™ 3A processor 5xxx Series.
     MultiCoreLoongson3A = 0x026D,
+    /// Quad-Core Loongson™ 3B processor 5xxx Series.
     QuadCoreLoongson3B = 0x026E,
+    /// Multi-Core Loongson™ 3B processor 5xxx Series.
     MultiCoreLoongson3B = 0x026F,
+    /// Multi-Core Loongson™ 3C processor 5xxx Series.
     MultiCoreLoongson3C = 0x0270,
+    /// Multi-Core Loongson™ 3D processor 5xxx Series.
     MultiCoreLoongson3D = 0x0271,
+    /// Intel® Core™ 3 processor.
     IntelCore3 = 0x0300,
+    /// Intel® Core™ 5 processor.
     IntelCore5 = 0x0301,
+    /// Intel® Core™ 7 processor.
     IntelCore7 = 0x0302,
+    /// Intel® Core™ 9 processor.
     IntelCore9 = 0x0303,
+    /// Intel® Core™ Ultra 3 processor.
     IntelCoreUltra3 = 0x0304,
+    /// Intel® Core™ Ultra 5 processor.
     IntelCoreUltra5 = 0x0305,
+    /// Intel® Core™ Ultra 7 processor.
     IntelCoreUltra7 = 0x0306,
+    /// Intel® Core™ Ultra 9 processor.
     IntelCoreUltra9 = 0x0307,
 }
 
@@ -502,93 +855,181 @@ pub enum ProcessorFamilyData {
 #[repr(u8)]
 #[derive(Copy, Clone, Debug, IntoBytes, Immutable, KnownLayout)]
 pub enum ProcessorUpgrade {
+    /// Other.
     Other = 0x01,
+    /// Unknown.
     Unknown = 0x02,
+    /// Daughter board.
     DaughterBoard = 0x03,
+    /// ZIF socket.
     ZIFSocket = 0x04,
+    /// Replaceable piggy back.
     ReplaceablePiggyBack = 0x05,
+    /// No upgrade.
     NoUpgrade = 0x06,
+    /// LIF socket.
     LIFSocket = 0x07,
+    /// Slot 1.
     Slot1 = 0x08,
+    /// Slot 2.
     Slot2 = 0x09,
+    /// 370-pin socket.
     Pin370Socket = 0x0A,
+    /// Slot A.
     SlotA = 0x0B,
+    /// Slot M.
     SlotM = 0x0C,
+    /// Socket 423.
     Socket423 = 0x0D,
+    /// Socket A (Socket 462).
     SocketA = 0x0E,
+    /// Socket 478.
     Socket478 = 0x0F,
+    /// Socket 754.
     Socket754 = 0x10,
+    /// Socket 940.
     Socket940 = 0x11,
+    /// Socket 939.
     Socket939 = 0x12,
+    /// Socket mPGA604.
     SocketmPGA604 = 0x13,
+    /// Socket LGA771.
     SocketLGA771 = 0x14,
+    /// Socket LGA775.
     SocketLGA775 = 0x15,
+    /// Socket S1.
     SocketS1 = 0x16,
+    /// Socket AM2.
     SocketAM2 = 0x17,
+    /// Socket F (1207).
     SocketF1207 = 0x18,
+    /// Socket LGA1366.
     SocketLGA1366 = 0x19,
+    /// Socket G34.
     SocketG34 = 0x1A,
+    /// Socket AM3.
     SocketAM3 = 0x1B,
+    /// Socket C32.
     SocketC32 = 0x1C,
+    /// Socket LGA1156.
     SocketLGA1156 = 0x1D,
+    /// Socket LGA1567.
     SocketLGA1567 = 0x1E,
+    /// Socket PGA988A.
     SocketPGA988A = 0x1F,
+    /// Socket BGA1288.
     SocketBGA1288 = 0x20,
+    /// Socket rPGA988B.
     SocketrPGA988B = 0x21,
+    /// Socket BGA1023.
     SocketBGA1023 = 0x22,
+    /// Socket BGA1224.
     SocketBGA1224 = 0x23,
+    /// Socket LGA1155.
     SocketLGA1155 = 0x24,
+    /// Socket LGA1356.
     SocketLGA1356 = 0x25,
+    /// Socket LGA2011.
     SocketLGA2011 = 0x26,
+    /// Socket FS1.
     SocketFS1 = 0x27,
+    /// Socket FS2.
     SocketFS2 = 0x28,
+    /// Socket FM1.
     SocketFM1 = 0x29,
+    /// Socket FM2.
     SocketFM2 = 0x2A,
+    /// Socket LGA2011-3.
     SocketLGA2011_3 = 0x2B,
+    /// Socket LGA1356-3.
     SocketLGA1356_3 = 0x2C,
+    /// Socket LGA1150.
     SocketLGA1150 = 0x2D,
+    /// Socket BGA1168.
     SocketBGA1168 = 0x2E,
+    /// Socket BGA1234.
     SocketBGA1234 = 0x2F,
+    /// Socket BGA1364.
     SocketBGA1364 = 0x30,
+    /// Socket AM4.
     SocketAM4 = 0x31,
+    /// Socket LGA1151.
     SocketLGA1151 = 0x32,
+    /// Socket BGA1356.
     SocketBGA1356 = 0x33,
+    /// Socket BGA1440.
     SocketBGA1440 = 0x34,
+    /// Socket BGA1515.
     SocketBGA1515 = 0x35,
+    /// Socket LGA3647-1.
     SocketLGA3647_1 = 0x36,
+    /// Socket SP3.
     SocketSP3 = 0x37,
+    /// Socket SP3r2.
     SocketSP3r2 = 0x38,
+    /// Socket LGA2066.
     SocketLGA2066 = 0x39,
+    /// Socket BGA1392.
     SocketBGA1392 = 0x3A,
+    /// Socket BGA1510.
     SocketBGA1510 = 0x3B,
+    /// Socket BGA1528.
     SocketBGA1528 = 0x3C,
+    /// Socket LGA4189.
     SocketLGA4189 = 0x3D,
+    /// Socket LGA1200.
     SocketLGA1200 = 0x3E,
+    /// Socket LGA4677.
     SocketLGA4677 = 0x3F,
+    /// Socket LGA1700.
     SocketLGA1700 = 0x40,
+    /// Socket BGA1744.
     SocketBGA1744 = 0x41,
+    /// Socket BGA1781.
     SocketBGA1781 = 0x42,
+    /// Socket BGA1211.
     SocketBGA1211 = 0x43,
+    /// Socket BGA2422.
     SocketBGA2422 = 0x44,
+    /// Socket LGA1211.
     SocketLGA1211 = 0x45,
+    /// Socket LGA2422.
     SocketLGA2422 = 0x46,
+    /// Socket LGA5773.
     SocketLGA5773 = 0x47,
+    /// Socket BGA5773.
     SocketBGA5773 = 0x48,
+    /// Socket AM5.
     SocketAM5 = 0x49,
+    /// Socket SP5.
     SocketSP5 = 0x4A,
+    /// Socket SP6.
     SocketSP6 = 0x4B,
+    /// Socket BGA883.
     SocketBGA883 = 0x4C,
+    /// Socket BGA1190.
     SocketBGA1190 = 0x4D,
+    /// Socket BGA4129.
     SocketBGA4129 = 0x4E,
+    /// Socket LGA4710.
     SocketLGA4710 = 0x4F,
+    /// Socket LGA7529.
     SocketLGA7529 = 0x50,
+    /// Socket BGA1964.
     SocketBGA1964 = 0x51,
+    /// Socket BGA1792.
     SocketBGA1792 = 0x52,
+    /// Socket BGA2049.
     SocketBGA2049 = 0x53,
+    /// Socket BGA2551.
     SocketBGA2551 = 0x54,
+    /// Socket LGA1851.
     SocketLGA1851 = 0x55,
+    /// Socket BGA2114.
     SocketBGA2114 = 0x56,
+    /// Socket BGA2833.
     SocketBGA2833 = 0x57,
+    /// Not available.
     NotAvailable = 0xFF,
 }
 
@@ -596,12 +1037,18 @@ pub enum ProcessorUpgrade {
 #[bitfield(u8)]
 #[derive(IntoBytes, Immutable, KnownLayout)]
 pub struct ProcessorVoltage {
+    /// 5 V voltage capability.
     pub processor_voltage_capability_5v: bool,
+    /// 3.3 V voltage capability.
     pub processor_voltage_capability_3_3v: bool,
+    /// 2.9 V voltage capability.
     pub processor_voltage_capability_2_9v: bool,
+    /// Reserved capability bit (must be zero).
     pub processor_voltage_capability_reserved: bool,
+    /// Reserved bits.
     #[bits(3)]
     pub processor_voltage_reserved: u8,
+    /// Set when the byte holds a legacy mode voltage (bits 0-3 are capabilities); clear when bits 0-6 hold the current voltage in tenths of a volt.
     pub processor_voltage_indicate_legacy: bool,
 }
 
@@ -609,11 +1056,15 @@ pub struct ProcessorVoltage {
 #[bitfield(u8)]
 #[derive(IntoBytes, Immutable, KnownLayout)]
 pub struct ProcessorInformationStatus {
+    /// CPU status: 0=unknown, 1=enabled, 2=disabled by user via BIOS, 3=disabled by BIOS (POST error), 4=idle, 7=other.
     #[bits(3)]
     pub cpu_status: u8,
+    /// Reserved bits.
     #[bits(3)]
     pub reserved: u8,
+    /// CPU socket populated.
     pub cpu_socket_populated: bool,
+    /// Reserved bit.
     pub reserved2: bool,
 }
 
@@ -621,16 +1072,27 @@ pub struct ProcessorInformationStatus {
 #[bitfield(u16)]
 #[derive(IntoBytes, Immutable, KnownLayout)]
 pub struct ProcessorCharacteristics {
+    /// Reserved.
     pub reserved: bool,
+    /// Unknown.
     pub unknown: bool,
+    /// 64-bit capable.
     pub capable_64bit: bool,
+    /// Multi-core.
     pub multi_core: bool,
+    /// Hardware thread.
     pub hardware_thread: bool,
+    /// Execute Protection.
     pub execute_protection: bool,
+    /// Enhanced Virtualization.
     pub enhanced_virtualization: bool,
+    /// Power/Performance Control.
     pub performance_control: bool,
+    /// 128-bit capable.
     pub capable_128bit: bool,
+    /// Arm64 SoC ID.
     pub arm64_soc_id: bool,
+    /// Reserved bits.
     #[bits(6)]
     pub reserved2: u8,
 }
@@ -639,15 +1101,22 @@ pub struct ProcessorCharacteristics {
 #[bitfield(u16)]
 #[derive(IntoBytes, Immutable, KnownLayout)]
 pub struct CacheConfiguration {
+    /// Cache level: 0 = L1, 1 = L2, etc.
     #[bits(3)]
     pub cache_level: u8,
+    /// Cache socketed.
     pub cache_socketed: bool,
+    /// Reserved.
     pub reserved: bool,
+    /// Cache location: 0 = internal, 1 = external, 3 = unknown.
     #[bits(2)]
     pub location: u8,
+    /// Enabled (true) / disabled (false).
     pub enabled_disabled: bool,
+    /// Operational mode: 0 = write-through, 1 = write-back, 2 = varies, 3 = unknown.
     #[bits(2)]
     pub operational_mode: u8,
+    /// Reserved bits.
     #[bits(6)]
     pub reserved2: u8,
 }
@@ -656,8 +1125,10 @@ pub struct CacheConfiguration {
 #[bitfield(u16)]
 #[derive(IntoBytes, Immutable, KnownLayout)]
 pub struct CacheSize {
+    /// Max cache size value (in units determined by `granularity`).
     #[bits(15)]
     pub max_size: u16,
+    /// Granularity: false = 1 KB, true = 64 KB.
     pub granularity: bool,
 }
 
@@ -665,8 +1136,10 @@ pub struct CacheSize {
 #[bitfield(u32)]
 #[derive(IntoBytes, Immutable, KnownLayout)]
 pub struct CacheSize2 {
+    /// Max cache size value (in units determined by `granularity`).
     #[bits(31)]
     pub max_size: u32,
+    /// Granularity: false = 1 KB, true = 64 KB.
     pub granularity: bool,
 }
 
@@ -674,13 +1147,21 @@ pub struct CacheSize2 {
 #[bitfield(u16)]
 #[derive(IntoBytes, Immutable, KnownLayout)]
 pub struct CacheSramTypeData {
+    /// Other.
     pub other: bool,
+    /// Unknown.
     pub unknown: bool,
+    /// Non-burst.
     pub non_burst: bool,
+    /// Burst.
     pub burst: bool,
+    /// Pipeline burst.
     pub pipeline_burst: bool,
+    /// Synchronous.
     pub synchronous: bool,
+    /// Asynchronous.
     pub asynchronous: bool,
+    /// Reserved bits.
     #[bits(9)]
     pub reserved: u16,
 }
@@ -688,23 +1169,34 @@ pub struct CacheSramTypeData {
 /// Cache Error Correction Type (Type 7, offset 0x10)
 #[repr(u8)]
 #[derive(Copy, Clone, Debug, IntoBytes, Immutable, KnownLayout)]
-pub enum ErrorCorrectionType {
+pub enum CacheErrorCorrectionType {
+    /// Other.
     Other = 0x01,
+    /// Unknown.
     Unknown = 0x02,
+    /// No ECC.
     NoEcc = 0x03,
+    /// Parity.
     Parity = 0x04,
+    /// Single-bit ECC.
     SingleBitEcc = 0x05,
-    MutliBitEcc = 0x06,
+    /// Multi-bit ECC.
+    MultiBitEcc = 0x06,
 }
 
 /// System Cache Type (Type 7, offset 0x11)
 #[repr(u8)]
 #[derive(Copy, Clone, Debug, IntoBytes, Immutable, KnownLayout)]
 pub enum SystemCacheType {
+    /// Other.
     Other = 0x01,
+    /// Unknown.
     Unknown = 0x02,
+    /// Instruction cache.
     Instruction = 0x03,
+    /// Data cache.
     Data = 0x04,
+    /// Unified cache.
     Unified = 0x05,
 }
 
@@ -712,19 +1204,33 @@ pub enum SystemCacheType {
 #[repr(u8)]
 #[derive(Copy, Clone, Debug, IntoBytes, Immutable, KnownLayout)]
 pub enum AssociativityField {
+    /// Other.
     Other = 0x01,
+    /// Unknown.
     Unknown = 0x02,
+    /// Direct-mapped.
     DirectMapped = 0x03,
+    /// 2-way set-associative.
     SetAssociative2Way = 0x04,
+    /// 4-way set-associative.
     SetAssociative4Way = 0x05,
+    /// Fully associative.
     FullyAssociative = 0x06,
+    /// 8-way set-associative.
     SetAssociative8Way = 0x07,
+    /// 16-way set-associative.
     SetAssociative16Way = 0x08,
+    /// 12-way set-associative.
     SetAssociative12Way = 0x09,
+    /// 24-way set-associative.
     SetAssociative24Way = 0x0A,
+    /// 32-way set-associative.
     SetAssociative32Way = 0x0B,
+    /// 48-way set-associative.
     SetAssociative48Way = 0x0C,
+    /// 64-way set-associative.
     SetAssociative64Way = 0x0D,
+    /// 20-way set-associative.
     SetAssociative20Way = 0x0E,
 }
 
@@ -732,83 +1238,161 @@ pub enum AssociativityField {
 #[repr(u8)]
 #[derive(Copy, Clone, Debug, IntoBytes, Immutable, KnownLayout)]
 pub enum SlotType {
+    /// Other.
     Other = 0x01,
+    /// Unknown.
     Unknown = 0x02,
+    /// ISA.
     Isa = 0x03,
+    /// MCA.
     Mca = 0x04,
+    /// EISA.
     Eisa = 0x05,
+    /// PCI.
     Pci = 0x06,
+    /// PC Card (PCMCIA).
     PcCard = 0x07,
+    /// VL-VESA.
     VlVesa = 0x08,
+    /// Proprietary.
     Proprietary = 0x09,
+    /// Processor card slot.
     ProcessorCardSlot = 0x0A,
-    ProprietaryMemroyCardSlot = 0x0B,
+    /// Proprietary memory card slot.
+    ProprietaryMemoryCardSlot = 0x0B,
+    /// I/O riser card slot.
     IoRiserCardSlot = 0x0C,
+    /// NuBus.
     NuBus = 0x0D,
+    /// PCI - 66 MHz capable.
     Pci66mhz = 0x0E,
+    /// AGP.
     Agp = 0x0F,
+    /// AGP 2X.
     Agp2x = 0x10,
+    /// AGP 4X.
     Agp4x = 0x11,
+    /// PCI-X.
     PciX = 0x12,
+    /// AGP 8X.
     Agp8x = 0x13,
+    /// M.2 Socket 1-DP (Mechanical Key A).
     M2Socket1DP = 0x14,
+    /// M.2 Socket 1-SD (Mechanical Key E).
     M2Socket1SD = 0x15,
+    /// M.2 Socket 2 (Mechanical Key B).
     M2Socket2 = 0x16,
+    /// M.2 Socket 3 (Mechanical Key M).
     M2Socket3 = 0x17,
+    /// MXM Type I.
     MxmTypeI = 0x18,
+    /// MXM Type II.
     MxmTypeII = 0x19,
+    /// MXM Type III (standard connector).
     MxmTypeIIIStandard = 0x1A,
+    /// MXM Type III-HE.
     MxmTypeIIIHe = 0x1B,
+    /// MXM Type IV.
     MxmTypeIV = 0x1C,
+    /// MXM 3.0 Type A.
     Mxm3TypeA = 0x1D,
+    /// MXM 3.0 Type B.
     Mxm3TypeB = 0x1E,
+    /// PCI Express Gen 2 SFF-8639 (U.2).
     PciExpressGen2Sff8629 = 0x1F,
+    /// PCI Express Gen 3 SFF-8639 (U.2).
     PciExpressGen3Sff8629 = 0x20,
+    /// PCI Express Mini 52-pin (CEM spec. 2.0) with bottom-side keep-outs.
     PciExpressMini52PinBottomSideKeepOuts = 0x21,
+    /// PCI Express Mini 52-pin (CEM spec. 2.0) without bottom-side keep-outs.
     PciExpressMini52Pin = 0x22,
+    /// PCI Express Mini 76-pin (CEM spec. 2.0).
     PciExpressMini76Pin = 0x23,
+    /// PCI Express Gen 4 SFF-8639 (U.2).
     PciExpressGen4Sff8639 = 0x24,
+    /// PCI Express Gen 5 SFF-8639 (U.2).
     PciExpressGen5Sff8639 = 0x25,
+    /// OCP NIC 3.0 Small Form Factor (SFF).
     OcpNic3SFF = 0x26,
+    /// OCP NIC 3.0 Large Form Factor (LFF).
     OcpNic3LFF = 0x27,
+    /// OCP NIC Prior to 3.0.
     OcpNicPrior = 0x28,
+    /// PC-98/C20.
     Pc98C20 = 0xA0,
+    /// PC-98/C24.
     Pc98C24 = 0xA1,
+    /// PC-98/E.
     Pc98E = 0xA2,
+    /// PC-98/Local Bus.
     Pc98LocalBus = 0xA3,
+    /// PC-98/Card.
     Pc98Card = 0xA4,
+    /// PCI Express (one of the undefined/general slot types).
     PciExpress = 0xA5,
+    /// PCI Express x1.
     PciExpressx1 = 0xA6,
+    /// PCI Express x2.
     PciExpressx2 = 0xA7,
+    /// PCI Express x4.
     PciExpressx4 = 0xA8,
+    /// PCI Express x8.
     PciExpressx8 = 0xA9,
+    /// PCI Express x16.
     PciExpressx16 = 0xAA,
+    /// PCI Express Gen 2.
     PciExpressGen2 = 0xAB,
+    /// PCI Express Gen 2 x1.
     PciExpressGen2x1 = 0xAC,
+    /// PCI Express Gen 2 x2.
     PciExpressGen2x2 = 0xAD,
+    /// PCI Express Gen 2 x4.
     PciExpressGen2x4 = 0xAE,
+    /// PCI Express Gen 2 x8.
     PciExpressGen2x8 = 0xAF,
+    /// PCI Express Gen 2 x16.
     PciExpressGen2x16 = 0xB0,
+    /// PCI Express Gen 3.
     PciExpressGen3 = 0xB1,
+    /// PCI Express Gen 3 x1.
     PciExpressGen3x1 = 0xB2,
+    /// PCI Express Gen 3 x2.
     PciExpressGen3x2 = 0xB3,
+    /// PCI Express Gen 3 x4.
     PciExpressGen3x4 = 0xB4,
+    /// PCI Express Gen 3 x8.
     PciExpressGen3x8 = 0xB5,
+    /// PCI Express Gen 3 x16.
     PciExpressGen3x16 = 0xB6,
+    /// PCI Express Gen 4.
     PciExpressGen4 = 0xB8,
+    /// PCI Express Gen 4 x1.
     PciExpressGen4x1 = 0xB9,
+    /// PCI Express Gen 4 x2.
     PciExpressGen4x2 = 0xBA,
+    /// PCI Express Gen 4 x4.
     PciExpressGen4x4 = 0xBB,
+    /// PCI Express Gen 4 x8.
     PciExpressGen4x8 = 0xBC,
+    /// PCI Express Gen 4 x16.
     PciExpressGen4x16 = 0xBD,
+    /// PCI Express Gen 5.
     PciExpressGen5 = 0xBE,
+    /// PCI Express Gen 5 x1.
     PciExpressGen5x1 = 0xBF,
+    /// PCI Express Gen 5 x2.
     PciExpressGen5x2 = 0xC0,
+    /// PCI Express Gen 5 x4.
     PciExpressGen5x4 = 0xC1,
+    /// PCI Express Gen 5 x8.
     PciExpressGen5x8 = 0xC2,
+    /// PCI Express Gen 5 x16.
     PciExpressGen5x16 = 0xC3,
+    /// PCI Express Gen 6 and beyond.
     PciExpressGen6 = 0xC4,
+    /// EDSFF E1.S, E1.L.
     EdsffE1SE1L = 0xC5,
+    /// EDSFF E3.S, E3.L.
     EdsffE3SE3L = 0xC6,
 }
 
@@ -816,19 +1400,33 @@ pub enum SlotType {
 #[repr(u8)]
 #[derive(Copy, Clone, Debug, IntoBytes, Immutable, KnownLayout)]
 pub enum SlotWidth {
+    /// Other.
     Other = 0x01,
+    /// Unknown.
     Unknown = 0x02,
+    /// 8-bit.
     Bit8 = 0x03,
+    /// 16-bit.
     Bit16 = 0x04,
+    /// 32-bit.
     Bit32 = 0x05,
+    /// 64-bit.
     Bit64 = 0x06,
+    /// 128-bit.
     Bit128 = 0x07,
+    /// 1x or x1.
     X1 = 0x08,
+    /// 2x or x2.
     X2 = 0x09,
+    /// 4x or x4.
     X4 = 0x0A,
+    /// 8x or x8.
     X8 = 0x0B,
+    /// 12x or x12.
     X12 = 0x0C,
+    /// 16x or x16.
     X16 = 0x0D,
+    /// 32x or x32.
     X32 = 0x0E,
 }
 
@@ -836,10 +1434,15 @@ pub enum SlotWidth {
 #[repr(u8)]
 #[derive(Copy, Clone, Debug, IntoBytes, Immutable, KnownLayout)]
 pub enum CurrentUsage {
+    /// Other.
     Other = 0x01,
+    /// Unknown.
     Unknown = 0x02,
+    /// Available.
     Available = 0x03,
+    /// In use.
     InUse = 0x04,
+    /// Unavailable.
     Unavailable = 0x05,
 }
 
@@ -847,11 +1450,17 @@ pub enum CurrentUsage {
 #[repr(u8)]
 #[derive(Copy, Clone, Debug, IntoBytes, Immutable, KnownLayout)]
 pub enum SlotLength {
+    /// Other.
     Other = 0x01,
+    /// Unknown.
     Unknown = 0x02,
+    /// Short length.
     ShortLength = 0x03,
+    /// Long length.
     LongLength = 0x04,
+    /// 2.5" drive form factor.
     DriveFF25 = 0x05,
+    /// 3.5" drive form factor.
     DriveFF35 = 0x06,
 }
 
@@ -859,13 +1468,21 @@ pub enum SlotLength {
 #[bitfield(u8)]
 #[derive(IntoBytes, Immutable, KnownLayout)]
 pub struct SlotCharacteristics1 {
+    /// Characteristics unknown.
     pub characteristics_unknown: bool,
+    /// Provides 5.0 V.
     pub provides_5_volts: bool,
+    /// Provides 3.3 V.
     pub provides_3_volts: bool,
+    /// Slot's opening is shared with another slot (e.g. PCI/EISA shared opening).
     pub shared_slot: bool,
+    /// PC Card slot supports PC Card-16.
     pub pc_supports_pccard16: bool,
+    /// PC Card slot supports CardBus.
     pub pc_supports_cardbus: bool,
+    /// PC Card slot supports Zoom Video.
     pub pc_supports_zoomvideo: bool,
+    /// PC Card slot supports Modem Ring Resume.
     pub pc_supports_modemringresume: bool,
 }
 
@@ -873,13 +1490,21 @@ pub struct SlotCharacteristics1 {
 #[bitfield(u8)]
 #[derive(IntoBytes, Immutable, KnownLayout)]
 pub struct SlotCharacteristics2 {
+    /// PCI slot supports Power Management Event (PME#) signal.
     pub pci_supports_pme: bool,
+    /// Slot supports hot-plug devices.
     pub supports_hotplug: bool,
+    /// PCI slot supports SMBus signal.
     pub pci_supports_smbus: bool,
+    /// PCIe slot supports bifurcation.
     pub pcie_supports_bifurcation: bool,
+    /// Slot supports async/surprise removal.
     pub supports_async_removal: bool,
+    /// Flexbus slot: CXL 1.0 capable.
     pub flexbus_slot1: bool,
+    /// Flexbus slot: CXL 2.0 capable.
     pub flexbus_slot2: bool,
+    /// Flexbus slot: CXL 3.0 capable (reserved per spec; vendor-defined).
     pub flexbus_slot3: bool,
 }
 
@@ -887,8 +1512,10 @@ pub struct SlotCharacteristics2 {
 #[bitfield(u8)]
 #[derive(IntoBytes, Immutable, KnownLayout)]
 pub struct DeviceFunctionNumber {
+    /// PCI function number.
     #[bits(3)]
     pub function_number: u8,
+    /// PCI device number.
     #[bits(5)]
     pub device_number: u8,
 }
@@ -897,9 +1524,13 @@ pub struct DeviceFunctionNumber {
 #[repr(C, packed)]
 #[derive(Copy, Clone, Debug, IntoBytes, Immutable, KnownLayout)]
 pub struct MiscSlotPeerGroup {
+    /// PCI segment group number.
     pub segment_group_num: u16,
+    /// PCI bus number for the peer slot.
     pub bus_num: u8,
+    /// PCI device/function number for the peer slot.
     pub dev_func_num: DeviceFunctionNumber,
+    /// Data bus width of the peer slot (matches `SlotWidth` byte values).
     pub data_bus_width: u8,
 }
 
@@ -907,20 +1538,35 @@ pub struct MiscSlotPeerGroup {
 #[repr(u8)]
 #[derive(Copy, Clone, Debug, IntoBytes, Immutable, KnownLayout)]
 pub enum MemoryArrayLocation {
+    /// Other.
     Other = 0x01,
+    /// Unknown.
     Unknown = 0x02,
+    /// System board or motherboard.
     SystemBoard = 0x03,
+    /// ISA add-on card.
     IsaAddOn = 0x04,
+    /// EISA add-on card.
     EisaAddOn = 0x05,
+    /// PCI add-on card.
     PciAddOn = 0x06,
+    /// MCA add-on card.
     McaAddOn = 0x07,
+    /// PCMCIA add-on card.
     PcmciaAddOn = 0x08,
+    /// Proprietary add-on card.
     ProprietaryAddOn = 0x09,
+    /// NuBus.
     NuBus = 0x0A,
+    /// PC-98/C20 add-on card.
     Pc98C20AddOn = 0xA0,
+    /// PC-98/C24 add-on card.
     Pc98C24AddOn = 0xA1,
+    /// PC-98/E add-on card.
     Pc98EAddOn = 0xA2,
+    /// PC-98/Local Bus add-on card.
     Pc98LocalAddOn = 0xA3,
+    /// CXL add-on card.
     CxlAddOn = 0xA4,
 }
 
@@ -928,25 +1574,39 @@ pub enum MemoryArrayLocation {
 #[repr(u8)]
 #[derive(Copy, Clone, Debug, IntoBytes, Immutable, KnownLayout)]
 pub enum MemoryArrayUse {
+    /// Other.
     Other = 0x01,
+    /// Unknown.
     Unknown = 0x02,
+    /// System memory.
     SystemMemory = 0x03,
+    /// Video memory.
     VideoMemory = 0x04,
+    /// Flash memory.
     FlashMemory = 0x05,
+    /// Non-volatile RAM.
     NonVolatileRam = 0x06,
+    /// Cache memory.
     CacheMemory = 0x07,
 }
 
 /// Memory Array Error Correction Types (Type 16, offset 0x06)
 #[repr(u8)]
 #[derive(Copy, Clone, Debug, IntoBytes, Immutable, KnownLayout)]
-pub enum ErrorCorrectionTypes {
+pub enum MemoryArrayErrorCorrectionType {
+    /// Other.
     Other = 0x01,
+    /// Unknown.
     Unknown = 0x02,
+    /// No ECC.
     NoEcc = 0x03,
+    /// Parity.
     Parity = 0x04,
+    /// Single-bit ECC.
     SingleBitEcc = 0x05,
+    /// Multi-bit ECC.
     MultiBitEcc = 0x06,
+    /// CRC.
     Crc = 0x07,
 }
 
@@ -954,24 +1614,43 @@ pub enum ErrorCorrectionTypes {
 #[repr(u8)]
 #[derive(Copy, Clone, Debug, IntoBytes, Immutable, KnownLayout)]
 pub enum MemoryFormFactor {
+    /// Other.
     Other = 0x01,
+    /// Unknown.
     Unknown = 0x02,
+    /// SIMM.
     Simm = 0x03,
+    /// SIP.
     Sip = 0x04,
+    /// Chip.
     Chip = 0x05,
+    /// DIP.
     Dip = 0x06,
+    /// ZIP.
     Zip = 0x07,
+    /// Proprietary card.
     ProprietaryCard = 0x08,
+    /// DIMM.
     Dimm = 0x09,
+    /// TSOP.
     Tsop = 0x0A,
+    /// Row of chips.
     RowOfChips = 0x0B,
+    /// RIMM.
     Rimm = 0x0C,
+    /// SODIMM.
     Sodimm = 0x0D,
+    /// SRIMM.
     Srimm = 0x0E,
+    /// FB-DIMM.
     FbDimm = 0x0F,
+    /// Die.
     Die = 0x10,
+    /// CAMM.
     Camm = 0x11,
+    /// CUDIMM.
     Cudimm = 0x12,
+    /// CSODIMM.
     Csodimm = 0x13,
 }
 
@@ -979,39 +1658,73 @@ pub enum MemoryFormFactor {
 #[repr(u8)]
 #[derive(Copy, Clone, Debug, IntoBytes, Immutable, KnownLayout)]
 pub enum MemoryDeviceType {
+    /// Other.
     Other = 0x01,
+    /// Unknown.
     Unknown = 0x02,
+    /// DRAM.
     Dram = 0x03,
+    /// EDRAM.
     Edram = 0x04,
+    /// VRAM.
     Vram = 0x05,
+    /// SRAM.
     Sram = 0x06,
+    /// RAM.
     Ram = 0x07,
+    /// ROM.
     Rom = 0x08,
+    /// FLASH.
     Flash = 0x09,
+    /// EEPROM.
     Eeprom = 0x0A,
+    /// FEPROM.
     Feprom = 0x0B,
+    /// EPROM.
     Eprom = 0x0C,
+    /// CDRAM.
     Cdram = 0x0D,
+    /// 3DRAM.
     ThreeDram = 0x0E,
+    /// SDRAM.
     Sdram = 0x0F,
+    /// SGRAM.
     Sgram = 0x10,
+    /// RDRAM.
     Rdram = 0x11,
+    /// DDR.
     Ddr = 0x12,
+    /// DDR2.
     Ddr2 = 0x13,
+    /// DDR2 FB-DIMM.
     Ddr2FbDimm = 0x14,
+    /// DDR3.
     Ddr3 = 0x18,
+    /// FBD2.
     Fbd2 = 0x19,
+    /// DDR4.
     Ddr4 = 0x1A,
+    /// LPDDR.
     Lpddr = 0x1B,
+    /// LPDDR2.
     Lpddr2 = 0x1C,
+    /// LPDDR3.
     Lpddr3 = 0x1D,
+    /// LPDDR4.
     Lpddr4 = 0x1E,
+    /// Logical non-volatile device.
     LogicalNonVolatileDevice = 0x1F,
+    /// HBM (High Bandwidth Memory).
     Hbm = 0x20,
+    /// HBM2.
     Hbm2 = 0x21,
+    /// DDR5.
     Ddr5 = 0x22,
+    /// LPDDR5.
     Lpddr5 = 0x23,
+    /// HBM3.
     Hbm3 = 0x24,
+    /// MRDIMM.
     Mrdimm = 0x25,
 }
 
@@ -1019,21 +1732,37 @@ pub enum MemoryDeviceType {
 #[bitfield(u16)]
 #[derive(IntoBytes, Immutable, KnownLayout)]
 pub struct MemoryDeviceTypeDetails {
+    /// Reserved.
     pub reserved: bool,
+    /// Other.
     pub other: bool,
+    /// Unknown.
     pub unknown: bool,
+    /// Fast-paged.
     pub fast_paged: bool,
+    /// Static column.
     pub static_column: bool,
+    /// Pseudo-static.
     pub pseudo_static: bool,
+    /// RAMBUS.
     pub rambus: bool,
+    /// Synchronous.
     pub synchronous: bool,
+    /// CMOS.
     pub cmos: bool,
+    /// EDO.
     pub edo: bool,
+    /// Window DRAM.
     pub window_dram: bool,
+    /// Cache DRAM.
     pub cache_dram: bool,
+    /// Non-volatile.
     pub nonvolatile: bool,
+    /// Registered (buffered).
     pub registered: bool,
+    /// Unbuffered (unregistered).
     pub unbuffered: bool,
+    /// LRDIMM.
     pub lr_dimm: bool,
 }
 
@@ -1041,21 +1770,30 @@ pub struct MemoryDeviceTypeDetails {
 #[repr(u8)]
 #[derive(Copy, Clone, Debug, IntoBytes, Immutable, KnownLayout)]
 pub enum MemoryDeviceTechnology {
+    /// Other.
     Other = 0x01,
+    /// Unknown.
     Unknown = 0x02,
+    /// DRAM.
     Dram = 0x03,
+    /// NVDIMM-N.
     NvdimmN = 0x04,
+    /// NVDIMM-F.
     NvdimmF = 0x05,
+    /// NVDIMM-P.
     NvdimmP = 0x06,
+    /// Intel® Optane™ persistent memory.
     IntelOptanePersistentMemory = 0x07,
 }
 
-/// Memory Device Attributes (Type 17, offset 0x21)
+/// Memory Device Attributes (Type 17, offset 0x1B)
 #[bitfield(u8)]
 #[derive(IntoBytes, Immutable, KnownLayout)]
 pub struct MemoryDeviceAttributes {
+    /// Memory rank.
     #[bits(4)]
     pub rank: u8,
+    /// Reserved bits.
     #[bits(4)]
     pub reserved: u8,
 }
@@ -1064,12 +1802,19 @@ pub struct MemoryDeviceAttributes {
 #[bitfield(u16)]
 #[derive(IntoBytes, Immutable, KnownLayout)]
 pub struct MemoryCapability {
+    /// Reserved.
     pub reserved: bool,
+    /// Other.
     pub other: bool,
+    /// Unknown.
     pub unknown: bool,
+    /// Volatile memory.
     pub volatile_memory: bool,
+    /// Byte-accessible persistent memory.
     pub byte_persistent_memory: bool,
+    /// Block-accessible persistent memory.
     pub block_persistent_memory: bool,
+    /// Reserved bits.
     #[bits(10)]
     pub reserved2: u16,
 }

--- a/components/patina_smbios/src/smbios_types.rs
+++ b/components/patina_smbios/src/smbios_types.rs
@@ -1,0 +1,1681 @@
+//! SMBIOS Types
+//!
+//! Defines the types used in SMBIOS Records 
+//!
+//! ## License
+//!
+//! Copyright (c) Microsoft Corporation.
+//!
+//! SPDX-License-Identifier: Apache-2.0
+
+use bitfield::bitfield;
+extern crate alloc;
+
+
+bitfield! {
+    ///
+    /// BIOS Characteristics
+    /// 
+    pub struct BiosCharacteristics (u64);
+    impl Debug;
+    pub reserved, set_reserved: 1, 0;
+    pub unknown, set_unknown: 2;
+    pub bios_characteristics_unsupported, set_bios_characteristics_unsupported: 3;
+    pub isa_supported, set_isa_supported: 4;
+    pub mca_supported, set_mca_supported: 5;
+    pub eisa_supported, set_eisa_supported: 6;
+    pub pci_supported, set_pci_supported: 7;
+    pub pcmcia_supported, set_pcmcia_supported: 8;
+    pub plug_play_supported, set_plug_play_supported: 9;
+    pub apm_supported, set_apm_supported: 10;
+    pub bios_is_upgradable, set_bios_is_upgradable: 11;
+    pub bios_shadowing_allowed, set_bios_shadowing_allowed: 12;
+    pub vlvesa_supported, set_vlvesa_supported: 13;
+    pub escd_supported, set_escd_supported: 14;
+    pub cd_boot_supported, set_cd_boot_supported: 15;
+    pub selectable_boot_supported, set_selectable_boot_supported: 16;
+    pub bios_rom_socketed, set_bios_rom_socketed: 17;
+    pub pc_card_boot_supported, set_pc_card_boot_supported: 18;
+    pub edd_spec_supported, set_edd_spec_supported: 19;
+    pub japanese_nec_9800_supported, set_japanese_nec_9800_supported: 20;
+    pub japanese_toshiba_supported, set_japanese_toshiba_supported: 21;
+    pub kb_525_360_supported, set_kb_525_360_supported: 22;
+    pub mb_535_12_supported, set_mb_535_12_supported: 23;
+    pub mb_35_720_supported, set_mb_35_720_supported: 24;
+    pub mb_35_288_supported, set_mb_35_288_supported: 25;
+    pub print_screen_supported, set_print_screen_supported: 26;
+    pub keyboard_8042_supported, set_keyboard_8042_supported: 27;
+    pub serial_services_supported, set_serial_services_supported: 28;
+    pub printer_services_supported, set_printer_services_supported: 29;
+    pub cga_mono_video_supported, set_cga_mono_video_supported: 30;
+    pub nec_pc_98, set_nec_pc_98: 31;
+    pub reserved_bios_vendor, set_reserved_bios_vendor: 47, 32;
+    pub reserved_system_vendor, set_reserved_system_vendor: 63, 48;
+}
+
+impl BiosCharacteristics {
+    pub fn new(
+        unknown: bool,
+        bios_characteristics_unsupported: bool,
+        isa_supported: bool,
+        mca_supported: bool,
+        eisa_supported: bool,
+        pci_supported: bool,
+        pcmcia_supported: bool,
+        plug_play_supported: bool,
+        apm_supported: bool,
+        bios_is_upgradable: bool,
+        bios_shadowing_allowed: bool,
+        vlvesa_supported: bool,
+        escd_supported: bool,
+        cd_boot_supported: bool,
+        selectable_boot_supported: bool,
+        bios_rom_socketed: bool,
+        pc_card_boot_supported: bool,
+        edd_spec_supported: bool,
+        japanese_nec_9800_supported: bool,
+        japanese_toshiba_supported: bool,
+        kb_525_360_supported: bool,
+        mb_535_12_supported: bool,
+        mb_35_720_supported: bool,
+        mb_35_288_supported: bool,
+        print_screen_supported: bool,
+        keyboard_8042_supported: bool,
+        serial_services_supported: bool,
+        printer_services_supported: bool,
+        cga_mono_video_supported: bool,
+        nec_pc_98: bool,
+        reserved_bios_vendor: u64,
+        reserved_system_vendor:u64,
+    ) -> Self{
+        let mut config = BiosCharacteristics(0);
+        config.set_reserved(0);
+        config.set_unknown(unknown);
+        config.set_bios_characteristics_unsupported(bios_characteristics_unsupported);
+        config.set_isa_supported(isa_supported);
+        config.set_mca_supported(mca_supported);
+        config.set_eisa_supported(eisa_supported);
+        config.set_pci_supported(pci_supported);
+        config.set_pcmcia_supported(pcmcia_supported);
+        config.set_plug_play_supported(plug_play_supported);
+        config.set_apm_supported(apm_supported);
+        config.set_bios_is_upgradable(bios_is_upgradable);
+        config.set_bios_shadowing_allowed(bios_shadowing_allowed);
+        config.set_vlvesa_supported(vlvesa_supported);
+        config.set_escd_supported(escd_supported);
+        config.set_cd_boot_supported(cd_boot_supported);
+        config.set_selectable_boot_supported(selectable_boot_supported);
+        config.set_bios_rom_socketed(bios_rom_socketed);
+        config.set_pc_card_boot_supported(pc_card_boot_supported);
+        config.set_edd_spec_supported(edd_spec_supported);
+        config.set_japanese_nec_9800_supported(japanese_nec_9800_supported);
+        config.set_japanese_toshiba_supported(japanese_toshiba_supported);
+        config.set_kb_525_360_supported(kb_525_360_supported);
+        config.set_mb_535_12_supported(mb_535_12_supported);
+        config.set_mb_35_720_supported(mb_35_720_supported);
+        config.set_mb_35_288_supported(mb_35_288_supported);
+        config.set_print_screen_supported(print_screen_supported);
+        config.set_keyboard_8042_supported(keyboard_8042_supported);
+        config.set_serial_services_supported(serial_services_supported);
+        config.set_printer_services_supported(printer_services_supported);
+        config.set_cga_mono_video_supported(cga_mono_video_supported);
+        config.set_nec_pc_98(nec_pc_98);
+        config.set_reserved_bios_vendor(reserved_bios_vendor);
+        config.set_reserved_system_vendor(reserved_system_vendor);
+        config
+    }
+}
+
+bitfield! {
+    ///
+    /// BIOS Characteristics Extension Byte 1
+    /// 
+    pub struct BiosCharacteristicsExt1 (u8);
+    impl Debug;
+    pub acpi_supported, set_acpi_supported: 0;
+    pub usb_legacy_supported, set_usb_legacy_supported: 1;
+    pub agp_supported, set_agp_supported: 2;
+    pub i20_supported, set_i20_supported: 3;
+    pub superdisk_boot_supported, set_superdisk_boot_supported: 4;
+    pub zip_drive_boot_supported, set_zip_drive_boot_supported: 5;
+    pub boot_1394_supported, set_boot_1394_supported: 6;
+    pub smart_battery_supported, set_smart_battery_supported: 7;
+}
+
+impl BiosCharacteristicsExt1 {
+    pub fn new(
+        acpi_supported: bool,
+        usb_legacy_supported: bool,
+        agp_supported: bool,
+        i20_supported: bool,
+        superdisk_boot_supported: bool,
+        zip_drive_boot_supported: bool,
+        boot_1394_supported: bool,
+        smart_battery_supported: bool,
+    ) -> Self{
+        let mut config = BiosCharacteristicsExt1(0);
+        config.set_acpi_supported(acpi_supported);
+        config.set_usb_legacy_supported(usb_legacy_supported);
+        config.set_agp_supported(agp_supported);
+        config.set_i20_supported(i20_supported);
+        config.set_superdisk_boot_supported(superdisk_boot_supported);
+        config.set_zip_drive_boot_supported(zip_drive_boot_supported);
+        config.set_boot_1394_supported(boot_1394_supported);
+        config.set_smart_battery_supported(smart_battery_supported);
+        config
+    }
+}
+
+bitfield! {
+    ///
+    /// BIOS Characteristics Extension Byte 2
+    /// 
+    pub struct BiosCharacteristicsExt2 (u8);
+    impl Debug;
+    pub bios_boot_specification_supported, set_bios_boot_specification_supported: 0;
+    pub fn_network_service_boot_supported, set_fn_network_service_boot_supported: 1;
+    pub enable_targeted_content_distribution, set_enable_targeted_content_distribution: 2;
+    pub uefi_spec_supported, set_uefi_spec_supported: 3;
+    pub smbios_describes_vm, set_smbios_describes_vm: 4;
+    pub reserved, set_reserved: 7, 5;
+}
+
+impl BiosCharacteristicsExt2 {
+    pub fn new(
+        bios_boot_specification_supported: bool,
+        fn_network_service_boot_supported: bool,
+        enable_targeted_content_distribution: bool,
+        uefi_spec_supported: bool,
+        smbios_describes_vm: bool,
+    ) -> Self{
+        let mut config = BiosCharacteristicsExt2(0);
+        config.set_bios_boot_specification_supported(bios_boot_specification_supported);
+        config.set_fn_network_service_boot_supported(fn_network_service_boot_supported);
+        config.set_enable_targeted_content_distribution(enable_targeted_content_distribution);
+        config.set_uefi_spec_supported(uefi_spec_supported);
+        config.set_smbios_describes_vm(smbios_describes_vm);
+        config.set_reserved(0);
+        config
+    }
+}
+
+bitfield! {
+    ///
+    /// Extended BIOS Rom Size
+    /// 
+    pub struct ExtendedBiosRomSize (u16);
+    impl Debug;
+    pub size, set_size: 13, 0;
+    pub unit, set_unit: 15, 14;
+}
+
+impl ExtendedBiosRomSize {
+    pub fn new(
+        size: u16,
+        unit: u16,
+    ) -> Self{
+        let mut config = ExtendedBiosRomSize(0);
+        config.set_size(size);
+        config.set_unit(unit);
+        config
+    }
+}
+
+
+
+///
+/// Wake Up Type
+/// 
+#[derive(Copy, Clone, Debug)]
+pub enum WakeUpType {
+    Reserved = 0x0,
+    Other,
+    Unknown,
+    ApmTimer,
+    ModemRing,
+    LanRemote,
+    PowerSwitch,
+    PciPme,
+    AcPowerRestored
+}
+
+bitfield! {
+    ///
+    /// Feature Flags
+    /// 
+    pub struct FeatureFlags (u8);
+    impl Debug;
+    pub hosting_board, set_hosting_board: 0;
+    pub require_aux_board, set_require_aux_board: 1;
+    pub removable_board, set_removable_board: 2;
+    pub replaceable_board, set_replaceable_board: 3;
+    pub hot_swappable_board, set_hot_swappable_board: 4;
+    pub reserved, set_reserved: 7, 5;
+}
+
+impl FeatureFlags {
+    pub fn new(
+        hosting_board: bool,
+        require_aux_board: bool,
+        removable_board: bool,
+        replaceable_board: bool,
+        hot_swappable_board: bool,
+    ) -> Self{
+        let mut config = FeatureFlags(0);
+        config.set_hosting_board(hosting_board);
+        config.set_require_aux_board(require_aux_board);
+        config.set_removable_board(removable_board);
+        config.set_replaceable_board(replaceable_board);
+        config.set_hot_swappable_board(hot_swappable_board);
+        config.set_reserved(0);
+        config
+    }
+}
+
+///
+/// Board Type
+/// 
+#[derive(Copy, Clone, Debug)]
+pub enum BoardType {
+    Unknown = 0x01,
+    Other,
+    ServerBlade,
+    ConnectivitySwitch,
+    SystemManagementModule,
+    ProcessorModule,
+    IoModule,
+    MemoryModule,
+    DaughterBoard,
+    Motherboard,
+    ProcessorMemoryModule,
+    ProcessorIoModule,
+    InterconnectBoard
+}
+
+///
+/// Boot Up State
+///
+#[derive(Copy, Clone, Debug)]
+pub enum BootUpState {
+    Other = 0x01,
+    Unknown,
+    Desktop,
+    LowProfileDesktop,
+    Pizzabox,
+    MiniTower,
+    Tower,
+    Portable,
+    Laptop,
+    Notebook,
+    HandHeld,
+    DockingStation,
+    AllInOne,
+    SubNotebook,
+    SpaceSaving,
+    LunchBox,
+    MainServerChassis,
+    ExpansionChassis,
+    SubChassis,
+    BusExpansionChassis,
+    PeripheralChassis,
+    RaidChassis,
+    RackMountChassis,
+    SealedCasePc,
+    MultiSystemChassis,
+    CompactPci,
+    AdvancedTca,
+    Blade,
+    BladeEnclosure,
+    Tablet,
+    Convertible,
+    Detachable,
+    IotGateway,
+    EmbeddedPc,
+    MiniPc,
+    StickPc
+}
+
+///
+/// Power Supply State
+///
+#[derive(Copy, Clone, Debug)]
+pub enum PowerSupplyState {
+    ProcessorOther = 0x01,
+    ProcessorUnknown,
+    CentralProcessor,
+    MathProcessor,
+    DspProcessor,
+    VideoProcessor,
+}
+
+///
+/// Thermal State
+///
+#[derive(Copy, Clone, Debug)]
+pub enum ThermalState {
+    Other = 0x01,
+    Unknown,
+    Safe,
+    Warning,
+    Critical,
+    NonRecoverable
+}
+
+///
+/// Security Status
+///
+#[derive(Copy, Clone, Debug)]
+pub enum SecurityStatus {
+    Other = 0x01,
+    Unknown,
+    _None,
+    ExternalInterfaceLockedOut,
+    ExternalInterfaceEnabled
+}
+
+bitfield! {
+    ///
+    /// Contained Elements - Contained Element Type
+    ///
+    #[derive(Copy, Clone)] 
+    pub struct  ContainedElementType(u8);
+    impl Debug;
+    pub _type, set_type : 6, 0;
+    pub type_select, set_type_select : 7;
+}
+
+impl ContainedElementType {
+    pub fn new(
+        _type: u8,
+        type_select: bool,
+    ) -> Self{
+        let mut config = ContainedElementType(0);
+        config.set_type(_type);
+        config.set_type_select(type_select);
+        config
+    }
+}
+
+///
+/// Contained Elements
+///
+#[derive(Copy, Clone, Debug)]
+pub struct ContainedElements {
+    pub contained_element_type: ContainedElementType,
+    pub contained_element_minimum: u8,
+    pub contained_element_maximum: u8,
+}
+
+impl Default for ContainedElements {
+    fn default() -> Self {
+        Self {
+            contained_element_type: ContainedElementType::new(0, false),
+            contained_element_minimum: 0,
+            contained_element_maximum: 0
+        }
+    }
+}
+
+///
+/// Processor Information
+///
+#[derive(Copy, Clone, Debug)]
+pub enum ProcessorTypeData {
+    ProcessorOther = 0x01,
+    ProcessorUnknown,
+    CentralProcessor,
+    MathProcessor,
+    DspProcessor,
+    VideoProcessor,
+}
+
+///
+/// Processor Information - Processor Family
+///
+#[derive(Copy, Clone, Debug)]
+pub enum ProcessorFamilyData {
+    Other = 0x01,
+    Unknown,
+    Processor8086,
+    Processor80286,
+    Intel386,
+    Intel486,
+    Processor8087,
+    Processor80287,
+    Processor80387,
+    Processor80487,
+    Pentium,
+    PentiumPro,
+    PentiumII,
+    PentiumMMX,
+    Celeron,
+    PentiumIIXeon,
+    PentiumIII,
+    M1Family,
+    M2Family,
+    IntelCeleronM,
+    IntelPentium4Ht,
+    IntelProcessor,
+    AmdDuron = 0x18,
+    K5Family,
+    K6Family,
+    K6_2,
+    K6_3,
+    AmdAthlon,
+    Amd29000,
+    K6_2Plus,
+    PowerPC,
+    PowerPC601,
+    PowerPC603,
+    PowerPC603Plus,
+    PowerPC604,
+    PowerPC620,
+    PowerPCx704,
+    PowerPC750,
+    IntelCoreDuo,
+    IntelCoreDuoMobile,
+    IntelCoreSoloMobile,
+    IntelAtom,
+    IntelCoreM,
+    IntelCorem3,
+    IntelCorem5,
+    IntelCorem7,
+    Alpha,
+    Alpha21064,
+    Alpha21066,
+    Alpha21164,
+    Alpha21164PC,
+    Alpha21164a,
+    Alpha21264,
+    Alpha21364,
+    AmdTurionIIUltraDualCoreMobileM,
+    AmdTurionIIDualCoreMobileM,
+    AmdAthlonIIDualCoreM,
+    AmdOpteron6100Series,
+    AmdOpteron4100Series,
+    AmdOpteron6200Series,
+    AmdOpteron4200Series,
+    AmdFxSeries,
+    MipsFamily,
+    MipsR4000,
+    MipsR4200,
+    MipsR4400,
+    MipsR4600,
+    MipsR10000,
+    AmdCSeries,
+    AmdESeries,
+    AmdASeries,
+    AmdGSeries,
+    AmdZSeries,
+    AmdRSeries,
+    AmdOpteron4300,
+    AmdOpteron6300,
+    AmdOpteron3300,
+    AmdFireProSeries,
+    Sparc,
+    SuperSparc,
+    MicroSparcII,
+    MicroSparcIIep,
+    UltraSparc,
+    UltraSparcII,
+    UltraSparcIii,
+    UltraSparcIII,
+    UltraSparcIIIi,
+    Processor68040 = 0x60,
+    Processor68xxx,
+    Processor68000,
+    Processor68010,
+    Processor68020,
+    Processor68030,
+    AmdAthlonX4QuadCore,
+    AmdOpteronX1000Series,
+    AmdOpteronX2000Series,
+    AmdOpteronASeries,
+    AmdOpteronX3000Series,
+    AmdZen,
+    HobbitFamily = 0x70,
+    CrusoeTM5000 = 0x78,
+    CrusoeTM3000,
+    EfficeonTM8000,
+    Weitek = 0x80,
+    Itanium = 0x82,
+    AmdAthlon64,
+    AmdOpteron,
+    AmdSempron,
+    AmdTurion64Mobile,
+    DualCoreAmdOpteron,
+    AmdAthlon64X2DualCore,
+    AmdTurion64X2Mobile,
+    QuadCoreAmdOpteron,
+    ThirdGenerationAmdOpteron,
+    AmdPhenomFxQuadCore,
+    AmdPhenomX4QuadCore,
+    AmdPhenomX2DualCore,
+    AmdAthlonX2DualCore,
+    Parisc,
+    PaRisc8500,
+    PaRisc8000,
+    PaRisc7300LC,
+    PaRisc7200,
+    PaRisc7100LC,
+    PaRisc7100,
+    V30Family = 0xA0,
+    QuadCoreIntelXeon3200Series,
+    DualCoreIntelXeon3000Series,
+    QuadCoreIntelXeon5300Series,
+    DualCoreIntelXeon5100Series,
+    DualCoreIntelXeon5000Series,
+    DualCoreIntelXeonLV,
+    DualCoreIntelXeonULV,
+    DualCoreIntelXeon7100Series,
+    QuadCoreIntelXeon5400Series,
+    QuadCoreIntelXeon,
+    DualCoreIntelXeon5200Series,
+    DualCoreIntelXeon7200Series,
+    QuadCoreIntelXeon7300Series,
+    QuadCoreIntelXeon7400Series,
+    MultiCoreIntelXeon7400Series,
+    PentiumIIIXeon,
+    PentiumIIISpeedStep,
+    Pentium4,
+    IntelXeon,
+    As400,
+    IntelXeonMP,
+    AMDAthlonXP,
+    AMDAthlonMP,
+    IntelItanium2,
+    IntelPentiumM,
+    IntelCeleronD,
+    IntelPentiumD,
+    IntelPentiumEx,
+    IntelCoreSolo,
+    Reserved,
+    IntelCore2,
+    IntelCore2Solo,
+    IntelCore2Extreme,
+    IntelCore2Quad,
+    IntelCore2ExtremeMobile,
+    IntelCore2DuoMobile,
+    IntelCore2SoloMobile,
+    IntelCoreI7,
+    DualCoreIntelCeleron,
+    Ibm390,
+    G4,
+    G5,
+    EsaG6,
+    ZArchitecture,
+    IntelCoreI5,
+    IntelCoreI3,
+    IntelCoreI9,
+    IntelXeonD,
+    ViaC7M = 0xD2,
+    ViaC7D,
+    ViaC7,
+    ViaEden,
+    MultiCoreIntelXeon,
+    DualCoreIntelXeon3Series,
+    QuadCoreIntelXeon3Series,
+    ViaNano,
+    DualCoreIntelXeon5Series,
+    QuadCoreIntelXeon5Series,
+    DualCoreIntelXeon7Series = 0xDD,
+    QuadCoreIntelXeon7Series,
+    MultiCoreIntelXeon7Series,
+    MultiCoreIntelXeon3400Series,
+    AmdOpteron3000Series = 0xE4,
+    AmdSempronII,
+    EmbeddedAmdOpteronQuadCore,
+    AmdPhenomTripleCore,
+    AmdTurionUltraDualCoreMobile,
+    AmdTurionDualCoreMobile,
+    AmdAthlonDualCore,
+    AmdSempronSI,
+    AmdPhenomII,
+    AmdAthlonII,
+    SixCoreAmdOpteron,
+    AmdSempronM,
+    I860 = 0xFA,
+    I960,
+    IndicatorFamily2 = 0xFE,
+    Reserved1,
+    ARMv7 = 0x0100,
+    ARMv8,
+    ARMv9,
+    Sh3,
+    Sh4,
+    Arm = 0x0118,
+    StrongARM,
+    Processor6x86 = 0x012C,
+    MediaGX,
+    Mii,
+    WinChip = 0x0140,
+    Dsp = 0x015E,
+    VideoProcessor = 0x01F4,
+    RiscvRV32 = 0x0200,
+    RiscVRV64,
+    RiscVRV128,
+    LoongArch = 0x0258,
+    Loongson1,
+    Loongson2,
+    Loongson3,
+    Loongson2K,
+    Loongson3A,
+    Loongson3B,
+    Loongson3C,
+    Loongson3D,
+    Loongson3E,
+    DualCoreLoongson2K,
+    QuadCoreLoongson3A = 0x026C,
+    MultiCoreLoongson3A,
+    QuadCoreLoongson3B,
+    MultiCoreLoongson3B,
+    MultiCoreLoongson3C,
+    MultiCoreLoongson3D,
+    IntelCore3 = 0x0300,
+    IntelCore5,
+    IntelCore7,
+    IntelCore9,
+    IntelCoreUltra3,
+    IntelCoreUltra5,
+    IntelCoreUltra7,
+    IntelCoreUltra9,
+}
+
+///
+/// Processor Information - Processor Upgrade
+///
+#[derive(Copy, Clone, Debug)]
+pub enum ProcessorUpgrade {
+    Other = 0x01,
+    Unknown,
+    DaughterBoard,
+    ZIFSocket,
+    ReplaceablePiggyBack,
+    None,
+    LIFSocket,
+    Slot1,
+    Slot2,
+    Pin370Socket,
+    SlotA,
+    SlotM,
+    Socket423,
+    SocketA, //  Socket 462
+    Socket478,
+    Socket754,
+    Socket940,
+    Socket939,
+    SocketmPGA604,
+    SocketLGA771,
+    SocketLGA775,
+    SocketS1,
+    SocketAM2,
+    SocketF1207,
+    SocketLGA1366,
+    SocketG34,
+    SocketAM3,
+    SocketC32,
+    SocketLGA1156,
+    SocketLGA1567,
+    SocketPGA988A,
+    SocketBGA1288,
+    SocketrPGA988B,
+    SocketBGA1023,
+    SocketBGA1224,
+    SocketLGA1155,
+    SocketLGA1356,
+    SocketLGA2011,
+    SocketFS1,
+    SocketFS2,
+    SocketFM1,
+    SocketFM2,
+    SocketLGA2011_3,
+    SocketLGA1356_3,
+    SocketLGA1150,
+    SocketBGA1168,
+    SocketBGA1234,
+    SocketBGA1364,
+    SocketAM4,
+    SocketLGA1151,
+    SocketBGA1356,
+    SocketBGA1440,
+    SocketBGA1515,
+    SocketLGA3647_1,
+    SocketSP3,
+    SocketSP3r2,
+    SocketLGA2066,
+    SocketBGA1392,
+    SocketBGA1510,
+    SocketBGA1528,
+    SocketLGA4189,
+    SocketLGA1200,
+    SocketLGA4677,
+    SocketLGA1700,
+    SocketBGA1744,
+    SocketBGA1781,
+    SocketBGA1211,
+    SocketBGA2422,
+    SocketLGA1211,
+    SocketLGA2422,
+    SocketLGA5773,
+    SocketBGA5773,
+    SocketAM5,
+    SocketSP5,
+    SocketSP6,
+    SocketBGA883,
+    SocketBGA1190,
+    SocketBGA4129,
+    SocketLGA4710,
+    SocketLGA7529,
+    SocketBGA1964, //ANS: check for the rest of list, not on 3.7
+    SocketBGA1792,
+    SocketBGA2049,
+    SocketBGA2551,
+    SocketLGA1851,
+    SocketBGA2114,
+    SocketBGA2833,
+    // Use this when no other valid enumeration is available.
+    // When this enumeration is used, Socket Type at offset 32h must be non-null.
+    NotAvailable = 0xFF,
+}
+
+bitfield! {
+    ///
+    /// Processor Information - Voltage
+    ///
+    pub struct ProcessorVoltage (u8);
+    impl Debug;
+    pub processor_voltage_capability_5v, set_processor_voltage_capability_5v: 0;
+    pub processor_voltage_capability_3_3v, set_processor_voltage_capability_3_3v: 1;
+    pub processor_voltage_capability_2_9v, set_processor_voltage_capability_2_9v: 2;
+    pub processor_voltage_capability_reserved, set_processor_voltage_capability_reserved: 3;
+    pub processor_voltage_reserved, set_processor_voltage_reserved: 6, 4;
+    pub processor_voltage_indicate_legacy, set_processor_voltage_indicate_legacy: 7;
+}
+
+impl ProcessorVoltage {
+    pub fn new(
+        processor_voltage_capability_5v: bool,
+        processor_voltage_capability_3_3v: bool,
+        processor_voltage_capability_2_9v: bool,
+        processor_voltage_capability_reserved: bool,
+        processor_voltage_reserved: u8,
+        processor_voltage_indicate_legacy: bool,
+    ) -> Self{
+        let mut config = ProcessorVoltage(0);
+        config.set_processor_voltage_capability_5v(processor_voltage_capability_5v);
+        config.set_processor_voltage_capability_3_3v(processor_voltage_capability_3_3v);
+        config.set_processor_voltage_capability_2_9v(processor_voltage_capability_2_9v);
+        config.set_processor_voltage_capability_reserved(processor_voltage_capability_reserved);
+        config.set_processor_voltage_reserved(processor_voltage_reserved);
+        config.set_processor_voltage_indicate_legacy(processor_voltage_indicate_legacy);
+        config
+    }
+}
+
+bitfield! {
+    ///
+    /// Processor Information - Status
+    ///
+    pub struct ProcessorInformationStatus (u8);
+    impl Debug;
+    pub cpu_status, set_cpu_status: 2, 0;
+    // reserved must be zero
+    pub reserved, set_reserved: 5, 3;
+    pub cpu_socket_populated, set_cpu_socket_populated: 6;
+    // reserved2 must be zero
+    pub reserved2, set_reserved2: 7;
+}
+
+impl ProcessorInformationStatus {
+    pub fn new(
+        cpu_status: u8,
+        cpu_socket_populated: bool,
+    ) -> Self{
+        let mut config = ProcessorInformationStatus(0);
+        config.set_cpu_status(cpu_status);
+        config.set_reserved(0);
+        config.set_cpu_socket_populated(cpu_socket_populated);
+        config.set_reserved2(false);
+        config
+    }
+}
+
+bitfield! {
+    ///
+    /// Processor Information - Status
+    ///
+    pub struct ProcessorCharacteristics (u16);
+    impl Debug;
+    pub reserved, set_reserved : 0;
+    pub unknown, set_unknown : 1;
+    pub _64bit_capable, set_64bit_capable : 2;
+    pub multi_core, set_multi_core : 3;
+    pub hardware_thread, set_hardware_thread : 4;
+    pub execute_protection, set_execute_protection : 5;
+    pub enhanced_virtualization, set_enhanced_virtualization : 6;
+    pub performance_control, set_performance_control : 7;
+    pub _128bit_capable, set_128bit_capable : 8;
+    pub arm64_soc_id, set_arm64_soc_id : 9;
+    pub reserved2, set_reserved2 : 15, 10;
+}
+
+impl ProcessorCharacteristics {
+    pub fn new(
+        unknown: bool,
+        _64bit_capable: bool,
+        multi_core: bool,
+        hardware_thread: bool,
+        execute_protection: bool,
+        enhanced_virtualization: bool,
+        performance_control: bool,
+        _128bit_capable: bool,
+        arm64_soc_id: bool,
+    ) -> Self{
+        let mut config = ProcessorCharacteristics(0);
+        config.set_reserved(false);
+        config.set_unknown(unknown);
+        config.set_64bit_capable(_64bit_capable);
+        config.set_multi_core(multi_core);
+        config.set_hardware_thread(hardware_thread);
+        config.set_execute_protection(execute_protection);
+        config.set_enhanced_virtualization(enhanced_virtualization);
+        config.set_performance_control(performance_control);
+        config.set_128bit_capable(_128bit_capable);
+        config.set_arm64_soc_id(arm64_soc_id);
+        config.set_reserved2(0);
+        config
+    }
+}
+
+bitfield! {
+    ///
+    /// Cache Information - Cache Configuration
+    ///
+    pub struct CacheConfiguration (u16);
+    impl Debug;
+    pub cache_level, set_cache_level: 2, 0;
+    pub cache_socketed, set_cache_socketed: 3;
+    // reserved must be zero
+    pub reserved, set_reserved: 4;
+    pub location, set_location: 6, 5;
+    pub enabled_disabled, set_enabled_disabled: 7;
+    pub operational_mode, set_operational_mode: 9, 8;
+    // reserved2 must be zero
+    pub reserved2, set_reserved2: 15, 10;
+}
+
+impl CacheConfiguration {
+    pub fn new(
+        cache_level: u16,
+        cache_socketed: bool,
+        location: u16,
+        enabled_disabled: bool,
+        operational_mode: u16,
+    ) -> Self {
+        let mut config = CacheConfiguration(0);
+        config.set_cache_level(cache_level);
+        config.set_cache_socketed(cache_socketed);
+        config.set_reserved(false); // reserved must be zero
+        config.set_location(location);
+        config.set_enabled_disabled(enabled_disabled);
+        config.set_operational_mode(operational_mode);
+        config.set_reserved2(0); // reserved2 must be zero
+        config
+    }
+}
+
+bitfield! {
+    ///
+    /// Cache Information - Cache Size
+    ///
+    pub struct CacheSize (u16);
+    impl Debug;
+    pub max_size, set_max_size : 14, 0;
+    pub granularity, set_granularity : 15;
+}
+
+impl CacheSize {
+    pub fn new(
+        max_size: u16,
+        granularity: bool,
+    ) -> Self {
+        let mut config = CacheSize(0);
+        config.set_max_size(max_size);
+        config.set_granularity(granularity);
+        config
+    }
+}
+
+bitfield! {
+    ///
+    /// Cache Information - Cache Size 2
+    ///
+    pub struct CacheSize2 (u32);
+    impl Debug;
+    pub max_size, set_max_size : 30, 0;
+    pub granularity, set_granularity : 31;
+}
+
+impl CacheSize2 {
+    pub fn new(
+        max_size: u32,
+        granularity: bool,
+    ) -> Self {
+        let mut config = CacheSize2(0);
+        config.set_max_size(max_size);
+        config.set_granularity(granularity);
+        config
+    }
+}
+
+bitfield! {
+    ///
+    /// Cache Information - SRAM Type
+    ///
+    pub struct CacheSramTypeData(u16);
+    impl Debug;
+    pub other, set_other: 0;
+    pub unknown, set_unknown: 1;
+    pub non_burst, set_non_burst: 2;
+    pub burst, set_burst: 3;
+    pub pipeline_burst, set_pipeline_burst: 4;
+    pub synchronous, set_synchronous: 5;
+    pub asynchronous, set_asynchronous: 6;
+    // reserved must be zero
+    pub reserved, set_reserved: 15, 7;
+}
+
+impl CacheSramTypeData {
+    pub fn new(
+        other: bool,
+        unknown: bool,
+        non_burst: bool,
+        burst: bool,
+        pipeline_burst: bool,
+        synchronous: bool,
+        asynchronous: bool,
+    ) -> Self {
+        let mut config = CacheSramTypeData(0);
+        config.set_other(other);
+        config.set_unknown(unknown);
+        config.set_non_burst(non_burst);
+        config.set_burst(burst);
+        config.set_pipeline_burst(pipeline_burst);
+        config.set_synchronous(synchronous);
+        config.set_asynchronous(asynchronous);
+        config.set_reserved(0);
+        config
+    }
+}
+
+///
+/// Cache Information - Error Correction Type
+///
+#[derive(Copy, Clone, Debug)]
+pub enum ErrorCorrectionType {
+    Other = 0x01,
+    Unknown,
+    None,
+    Parity,
+    SingleBitEcc,
+    MutliBitEcc,
+}
+
+///
+/// Cache Information - System Cache Type
+///
+#[derive(Copy, Clone, Debug)]
+pub enum SystemCacheType {
+    Other = 0x01,
+    Unknown,
+    Instruction,
+    Data,
+    Unified,
+}
+
+///
+/// Cache Information - Error Correction Type
+///
+#[derive(Copy, Clone, Debug)]
+pub enum AssociativityField {
+    Other = 0x01,
+    Unknown,
+    DirectMapped,
+    SetAssociative2Way,
+    SetAssociative4Way,
+    FullyAssociative,
+    SetAssociative8Way,
+    SetAssociative16Way,
+    SetAssociative12Way,
+    SetAssociative24Way,
+    SetAssociative32Way,
+    SetAssociative48Way,
+    SetAssociative64Way,
+    SetAssociative20Way,
+}
+
+///
+/// System Slots - Slot Type
+///
+#[derive(Copy, Clone, Debug)]
+pub enum SlotType {
+    Other = 0x01,
+    Unknown,
+    Isa,
+    Mca,
+    Eisa,
+    Pci,
+    PcCard,
+    VlVesa,
+    Proprietary,
+    ProcessorCardSlot,
+    ProprietaryMemroyCardSlot,
+    IoRiserCardSlot,
+    NuBus,
+    // 66MHz Capable PCI
+    Pci66mhz,
+    Agp,
+    Agp2x,
+    Agp4x,
+    PciX,
+    Agp8x,
+    M2Socket1DP,
+    M2Socket1SD,
+    M2Socket2,
+    M2Socket3,
+    MxmTypeI,
+    MxmTypeII,
+    MxmTypeIIIStandard,
+    MxmTypeIIIHe,
+    MxmTypeIV,
+    Mxm3TypeA,
+    Mxm3TypeB,
+    // PCI Express Gen 2 SFF-8639 (U.2)
+    PciExpressGen2Sff8629,
+    // PCI Express Gen 3 SFF-8639 (U.2)
+    PciExpressGen3Sff8629,
+    // PCI Express Mini 52-pin (CEM spec. 2.0) with bottom-side keep-outs
+    PciExpressMini52PinBottomSideKeepOuts,
+    // PCI Express Mini 52-pin (CEM spec. 2.0) without bottom-side keep-outs.
+    PciExpressMini52Pin,
+    PciExpressMini76Pin,
+    // PCI Express Gen 4 SFF-8639 (U.2)
+    PciExpressGen4Sff8639,
+    // PCI Express Gen 5 SFF-8639 (U.2)
+    PciExpressGen5Sff8639,
+    OcpNic3SFF,
+    OcpNic3LFF,
+    // OCP NIC Prior to 3.0
+    OcpNicPrior,
+    Pc98C20 = 0xA0,
+    Pc98C24,
+    Pc98E,
+    Pc98LocalBus,
+    Pc98Card,
+    PciExpress,
+    PciExpressx1,
+    PciExpressx2,
+    PciExpressx4,
+    PciExpressx8,
+    PciExpressx16,
+    PciExpressGen2,
+    PciExpressGen2x1,
+    PciExpressGen2x2,
+    PciExpressGen2x4,
+    PciExpressGen2x8,
+    PciExpressGen2x16,
+    PciExpressGen3,
+    PciExpressGen3x1,
+    PciExpressGen3x2,
+    PciExpressGen3x4,
+    PciExpressGen3x8,
+    PciExpressGen3x16,
+    PciExpressGen4 = 0xB8,
+    PciExpressGen4x1,
+    PciExpressGen4x2,
+    PciExpressGen4x4,
+    PciExpressGen4x8,
+    PciExpressGen4x16,
+    PciExpressGen5,
+    PciExpressGen5x1,
+    PciExpressGen5x2,
+    PciExpressGen5x4,
+    PciExpressGen5x8,
+    PciExpressGen5x16,
+    PciExpressGen6,
+    // Enterprise and Datacenter 1U E1 Form Factor Slot (EDSFF E1.S, E1.L)
+    EdsffE1SE1L,
+    // Enterprise and Datacenter 3" E3 Form Factor Slot (EDSFF E3.S, E3.L)
+    EdsffE3SE3L,
+}
+
+///
+/// System Slots - Slot Data Bus Width
+///
+#[derive(Copy, Clone, Debug)]
+pub enum SlotWidth {
+    Other = 0x01,
+    Unknown,
+    Bit8,
+    Bit16,
+    Bit32,
+    Bit64,
+    Bit128,
+    X1,
+    X2,
+    X4,
+    X8,
+    X12,
+    X16,
+    X32,
+}
+
+///
+/// System Slots - Current Usage
+///
+#[derive(Copy, Clone, Debug)]
+pub enum CurrentUsage {
+    Other = 0x01,
+    Unknown,
+    Available,
+    InUse,
+    Unavailable,
+}
+
+///
+/// System Slots - Slot Length
+///
+#[derive(Copy, Clone, Debug)]
+pub enum SlotLength {
+    Other = 0x01,
+    Unknown,
+    ShortLength,
+    LongLength,
+    // 2.5" drive form factor
+    DriveFF25,
+    // 3.5" drive form factor
+    DriveFF35,
+}
+
+bitfield! {
+    ///
+    /// System Slots - Slot Charcteristics 1
+    ///
+    pub struct SlotCharacteristics1(u8);
+    impl Debug;
+    pub characteristics_unknown, set_characteristics_unknown: 0;
+    pub provides_5_volts, set_provides_5_volts: 1;
+    pub provides_3_volts, set_provides_3_volts: 2;
+    pub shared_slot, set_shared_slot: 3;
+    pub pc_supports_pccard16, set_pc_supports_pccard16: 4;
+    pub pc_supports_cardbus, set_pc_supports_cardbus: 5;
+    pub pc_supports_zoomvideo, set_pc_supports_zoomvideo: 6;
+    pub pc_supports_modemringresume, set_pc_supports_modemringresume: 7;
+}
+
+impl SlotCharacteristics1 {
+    pub fn new(
+        characteristics_unknown: bool,
+        provides_5_volts: bool,
+        provides_3_volts: bool,
+        shared_slot: bool,
+        pc_supports_pccard16: bool,
+        pc_supports_cardbus: bool,
+        pc_supports_zoomvideo: bool,
+        pc_supports_modemringresume: bool,
+    ) -> Self{
+        let mut config = SlotCharacteristics1(0);
+        config.set_characteristics_unknown(characteristics_unknown);
+        config.set_provides_5_volts(provides_5_volts);
+        config.set_provides_3_volts(provides_3_volts);
+        config.set_shared_slot(shared_slot);
+        config.set_pc_supports_pccard16(pc_supports_pccard16);
+        config.set_pc_supports_cardbus(pc_supports_cardbus);
+        config.set_pc_supports_zoomvideo(pc_supports_zoomvideo);
+        config.set_pc_supports_modemringresume(pc_supports_modemringresume);
+        config
+    }
+}
+
+bitfield! {
+    ///
+    /// System Slots - Slot Charcteristics 2
+    ///
+    /// Various fields were added through SMBIOS Version 3. For not-applicable fields use '0'.
+    ///
+    pub struct  SlotCharacteristics2(u8);
+    impl Debug;
+    pub pci_supports_pme, set_pci_supports_pme: 0;
+    pub supports_hotplug, set_supports_hotplug: 1;
+    pub pci_supports_smbus, set_pci_supports_smbus: 2;
+    pub pcie_supports_bifurcation, set_pcie_supports_bifurcation: 3;
+    pub supports_async_removal, set_supports_async_removal: 4;
+    // Flexbus slot, CXL 1.0 capable
+    pub flexbus_slot1, set_flexbus_slot1: 5;
+    // Flexbus slot, CXL 2.0 capable
+    pub flexbus_slot2, set_flexbus_slot2: 6;
+    // Flexbus slot, CXL 3.0 capable
+    pub flexbus_slot3, set_flexbus_slot3: 7;
+}
+
+impl SlotCharacteristics2 {
+    pub fn new(
+        pci_supports_pme: bool,
+        supports_hotplug: bool,
+        pci_supports_smbus: bool,
+        pcie_supports_bifurcation: bool,
+        supports_async_removal: bool,
+        flexbus_slot1: bool,
+        flexbus_slot2: bool,
+        flexbus_slot3: bool,
+    ) -> Self{
+        let mut config = SlotCharacteristics2(0);
+        config.set_pci_supports_pme(pci_supports_pme);
+        config.set_supports_hotplug(supports_hotplug);
+        config.set_pci_supports_smbus(pci_supports_smbus);
+        config.set_pcie_supports_bifurcation(pcie_supports_bifurcation);
+        config.set_supports_async_removal(supports_async_removal);
+        config.set_flexbus_slot1(flexbus_slot1);
+        config.set_flexbus_slot2(flexbus_slot2);
+        config.set_flexbus_slot3(flexbus_slot3);
+        config
+    }
+}
+
+bitfield! {
+    ///
+    /// System Slots - Device/Function Number
+    ///
+    #[derive(Copy, Clone)] 
+    pub struct  DeviceFunctionNumber(u8);
+    impl Debug;
+    pub function_number, set_function_number : 2, 0;
+    pub device_number, set_device_number : 7, 3;
+}
+
+impl DeviceFunctionNumber {
+    pub fn new(
+        function_number: u8,
+        device_number: u8
+    ) -> Self{
+        let mut config = DeviceFunctionNumber(0);
+        config.set_function_number(function_number);
+        config.set_device_number(device_number);
+        config
+    }
+}
+
+///
+/// System Slots - Peer Segment/Bus/Device/Function/Width Groups
+///
+#[derive(Copy, Clone, Debug)]
+pub struct MiscSlotPeerGroup {
+    pub segment_group_num: u16,
+    pub bus_num: u8,
+    pub dev_func_num: DeviceFunctionNumber,
+    pub data_bus_width: u8,
+}
+
+///
+/// Memory Array - Location
+///
+#[derive(Copy, Clone, Debug)]
+pub enum MemoryArrayLocation {
+    Other = 0x01,
+    Unknown,
+    SystemBoard,
+    IsaAddOn,
+    EisaAddOn,
+    PciAddOn,
+    McaAddOn,
+    PcmciaAddOn,
+    ProprietaryAddOn,
+    NuBus,
+    Pc98C20AddOn = 0xA0,
+    Pc98C24AddOn,
+    Pc98EAddOn,
+    Pc98LocalAddOn,
+    CxlAddOn,
+}
+
+///
+/// Memory Array - Use
+///
+#[derive(Copy, Clone, Debug)]
+pub enum MemoryArrayUse {
+    Other = 0x01,
+    Unknown,
+    SystemMemory,
+    VideoMemory,
+    FlashMemory,
+    NonVolatileRam,
+    CacheMemory,
+}
+
+///
+/// Memory Array - Error Correction Types
+///
+#[derive(Copy, Clone, Debug)]
+pub enum ErrorCorrectionTypes {
+    Other = 0x01,
+    Unknown,
+    None,
+    Parity,
+    SingleBitEcc,
+    MultiBitEcc,
+    Crc,
+}
+
+///
+/// Memory Device - Form Factor
+///
+#[repr(u8)]
+#[derive(Copy, Clone, Debug)]
+pub enum MemoryFormFactor {
+    Other = 0x01,
+    Unknown,
+    Simm,
+    Sip,
+    Chip,
+    Dip,
+    Zip,
+    ProprietaryCard,
+    Dimm,
+    Tsop,
+    RowOfChips,
+    Rimm,
+    Sodimm,
+    Srimm,
+    FbDimm,
+    Die,
+    Camm,
+    Cudimm,
+    Csodimm,
+}
+
+///
+/// Memory Device - Type
+///
+#[derive(Copy, Clone, Debug)]
+pub enum MemoryDeviceType {
+    Other = 0x01,
+    Unknown,
+    Dram,
+    Edram,
+    Vram,
+    Sram,
+    Ram,
+    Rom,
+    Flash,
+    Eeprom,
+    Feprom,
+    Eprom,
+    Cdram,
+    ThreeDram,
+    Sdram,
+    Sgram,
+    Rdram,
+    Ddr,
+    Ddr2,
+    Ddr2FbDimm,
+    Ddr3 = 0x18,
+    Fbd2,
+    Ddr4,
+    Lpddr,
+    Lpddr2,
+    Lpddr3,
+    Lpddr4,
+    LogicalNonVolatileDevice,
+    Hbm,
+    Hbm2,
+    Ddr5,
+    Lpddr5,
+    Hbm3,
+    Mrdimm,
+}
+
+bitfield! {
+    ///
+    /// Memory Device - Type Detail
+    ///
+    pub struct MemoryDeviceTypeDetails(u16);
+    impl Debug;
+    pub reserved, set_reserved: 0;
+    pub other, set_other: 1;
+    pub unknown, set_unknown: 2;
+    pub fast_paged, set_fast_paged: 3;
+    pub static_column, set_static_column: 4;
+    pub pseudo_static, set_pseudo_static: 5;
+    pub rambus, set_rambus: 6;
+    pub synchronous, set_synchronous: 7;
+    pub cmos, set_cmos: 8;
+    pub edo, set_edo: 9;
+    pub window_dram, set_window_dram: 10;
+    pub cache_dram, set_cache_dram: 11;
+    pub nonvolatile, set_nonvolatile: 12;
+    pub registered, set_registered: 13;
+    pub unbuffered, set_unbuffered: 14;
+    pub lr_dimm, set_lr_dimm: 15;
+}
+
+impl MemoryDeviceTypeDetails {
+    pub fn new(
+        other: bool,
+        unknown: bool,
+        fast_paged: bool,
+        static_column: bool,
+        pseudo_static: bool,
+        rambus: bool,
+        synchronous: bool,
+        cmos: bool,
+        edo: bool,
+        window_dram: bool,
+        cache_dram: bool,
+        nonvolatile: bool,
+        registered: bool,
+        unbuffered: bool,
+        lr_dimm: bool
+    ) -> Self {
+        let mut config = MemoryDeviceTypeDetails(0);
+        config.set_reserved(false);
+        config.set_other(other);
+        config.set_unknown(unknown);
+        config.set_fast_paged(fast_paged);
+        config.set_static_column(static_column);
+        config.set_pseudo_static(pseudo_static);
+        config.set_rambus(rambus);
+        config.set_synchronous(synchronous);
+        config.set_cmos(cmos);
+        config.set_edo(edo);
+        config.set_window_dram(window_dram);
+        config.set_cache_dram(cache_dram);
+        config.set_nonvolatile(nonvolatile);
+        config.set_registered(registered);
+        config.set_unbuffered(unbuffered);
+        config.set_lr_dimm(lr_dimm);        
+        config
+    }
+}
+
+///
+/// Memory Device - Memory Technology
+///
+#[derive(Copy, Clone, Debug)]
+pub enum MemoryDeviceTechnology {
+    Other = 0x01,
+    Unknown,
+    Dram,
+    NvdimmN,
+    NvdimmF,
+    NvdimmP,
+    IntelOptanePersistentMemory,
+}
+
+bitfield! {
+    ///
+    /// Memory Device - Attributes
+    ///
+    pub struct MemoryDeviceAttributes(u8);
+    impl Debug;
+    pub rank, set_rank: 3, 0;
+    pub reserved, set_reserved: 7, 4;
+}
+
+impl MemoryDeviceAttributes {
+    pub fn new(
+        rank: u8
+    ) -> Self{
+        let mut config = MemoryDeviceAttributes(0);
+        config.set_rank(rank);
+        config.set_reserved(0);
+        config
+    }
+}
+
+bitfield! {
+    ///
+    /// Memory Device - Operating Mode Capability
+    ///
+    pub struct MemoryCapability(u16);
+    impl Debug;
+    // reserved is set to zero
+    pub reserved, set_reserved : 0;
+    pub other, set_other : 1;
+    pub unknown, set_unknown : 2;
+    pub volatile_memory, set_volatile_memory : 3;
+    // Byte-accessible persistent memory
+    pub byte_persistent_memory, set_byte_persistent_memory : 4;
+    // Block-accessible persistent memory
+    pub block_persistent_memory, set_block_persistent_memory : 5;
+    // reserved2 is set to zero
+    pub reserved2, set_reserved2 : 15, 6;
+}
+
+impl MemoryCapability {
+    pub fn new(
+        other: bool,
+        unknown: bool,
+        volatile_memory: bool,
+        byte_persistent_memory: bool,
+        block_persistent_memory: bool,
+    ) -> Self {
+        let mut config = MemoryCapability(0);
+        config.set_reserved(false);
+        config.set_other(other);
+        config.set_unknown(unknown);
+        config.set_volatile_memory(volatile_memory);
+        config.set_byte_persistent_memory(byte_persistent_memory);
+        config.set_block_persistent_memory(block_persistent_memory);
+        config.set_reserved2(0);
+        config
+    }
+}
+
+macro_rules! impl_to_le_bytes_u8 {
+    ($($t:ty),*) => {
+        $(
+            impl $t {
+                pub fn to_le_bytes(&self) -> alloc::vec::Vec<u8> {
+                    alloc::vec![*self as u8]
+                }
+            }
+        )*
+    };
+}
+
+macro_rules! impl_to_le_bytes_u16 {
+    ($($t:ty),*) => {
+        $(
+            impl $t {
+                pub fn to_le_bytes(&self) -> alloc::vec::Vec<u8> {
+                    (*self as u16).to_le_bytes().to_vec()
+                }
+            }
+        )*
+    };
+}
+
+macro_rules! impl_to_le_bytes_bitfield {
+    ($($t:ty),*) => {
+        $(
+            impl $t {
+                pub fn to_le_bytes(&self) -> alloc::vec::Vec<u8> {
+                    self.0.to_le_bytes().to_vec()
+                }
+            }
+        )*
+    };
+}
+
+// Use the macros
+impl_to_le_bytes_u8!(
+    ProcessorTypeData,
+    ProcessorUpgrade,
+    ErrorCorrectionType,
+    SystemCacheType,
+    AssociativityField,
+    SlotWidth,
+    CurrentUsage,
+    SlotLength,
+    MemoryArrayLocation,
+    MemoryArrayUse,
+    ErrorCorrectionTypes,
+    MemoryFormFactor,
+    MemoryDeviceType,
+    MemoryDeviceTechnology,
+    BoardType,
+    WakeUpType,
+    BootUpState,
+    PowerSupplyState,
+    ThermalState,
+    SecurityStatus
+);
+
+impl_to_le_bytes_u16!(
+    ProcessorFamilyData,
+    SlotType
+);
+
+impl_to_le_bytes_bitfield!(
+    ProcessorCharacteristics,
+    CacheConfiguration,
+    CacheSize,
+    CacheSramTypeData,
+    MemoryDeviceTypeDetails,
+    MemoryCapability,
+    ExtendedBiosRomSize,
+    CacheSize2,
+    BiosCharacteristics,
+    ProcessorVoltage,
+    ProcessorInformationStatus,
+    SlotCharacteristics1,
+    SlotCharacteristics2,
+    DeviceFunctionNumber,
+    MemoryDeviceAttributes,
+    BiosCharacteristicsExt1,
+    BiosCharacteristicsExt2,
+    ContainedElementType,
+    FeatureFlags
+);
+
+// special to_le_bytes for structs that use bitfields
+impl MiscSlotPeerGroup {
+    pub fn to_le_bytes(&self) -> alloc::vec::Vec<u8> {
+        let mut bytes = alloc::vec::Vec::new();
+        bytes.extend_from_slice(&self.segment_group_num.to_le_bytes());
+        bytes.push(self.bus_num);
+        bytes.push(self.dev_func_num.0);
+        bytes.push(self.data_bus_width);
+        bytes
+    }
+}
+
+impl ContainedElements {
+    pub fn to_le_bytes(&self) -> alloc::vec::Vec<u8> {
+        let mut bytes = alloc::vec::Vec::new();
+        bytes.push(self.contained_element_type.0);
+        bytes.push(self.contained_element_minimum);
+        bytes.push(self.contained_element_maximum);
+        bytes
+    }
+}

--- a/components/patina_smbios/src/smbios_types.rs
+++ b/components/patina_smbios/src/smbios_types.rs
@@ -1,6 +1,12 @@
 //! SMBIOS Types
 //!
-//! Defines the types used in SMBIOS Records 
+//! Defines the types used in SMBIOS Records.
+//!
+//! Bitfield types are defined with [`bitfield_struct::bitfield`] and derive
+//! [`zerocopy::IntoBytes`] so they can be serialized directly by the
+//! `SmbiosRecord` derive macro. Enum types are tagged with `#[repr(u8)]` or
+//! `#[repr(u16)]` per the SMBIOS specification field width and likewise
+//! derive `IntoBytes`.
 //!
 //! ## License
 //!
@@ -8,398 +14,204 @@
 //!
 //! SPDX-License-Identifier: Apache-2.0
 
-use bitfield::bitfield;
+#![allow(missing_docs)]
+
 extern crate alloc;
 
+use bitfield_struct::bitfield;
+use zerocopy::{Immutable, IntoBytes, KnownLayout};
 
-bitfield! {
-    ///
-    /// BIOS Characteristics
-    /// 
-    pub struct BiosCharacteristics (u64);
-    impl Debug;
-    pub reserved, set_reserved: 1, 0;
-    pub unknown, set_unknown: 2;
-    pub bios_characteristics_unsupported, set_bios_characteristics_unsupported: 3;
-    pub isa_supported, set_isa_supported: 4;
-    pub mca_supported, set_mca_supported: 5;
-    pub eisa_supported, set_eisa_supported: 6;
-    pub pci_supported, set_pci_supported: 7;
-    pub pcmcia_supported, set_pcmcia_supported: 8;
-    pub plug_play_supported, set_plug_play_supported: 9;
-    pub apm_supported, set_apm_supported: 10;
-    pub bios_is_upgradable, set_bios_is_upgradable: 11;
-    pub bios_shadowing_allowed, set_bios_shadowing_allowed: 12;
-    pub vlvesa_supported, set_vlvesa_supported: 13;
-    pub escd_supported, set_escd_supported: 14;
-    pub cd_boot_supported, set_cd_boot_supported: 15;
-    pub selectable_boot_supported, set_selectable_boot_supported: 16;
-    pub bios_rom_socketed, set_bios_rom_socketed: 17;
-    pub pc_card_boot_supported, set_pc_card_boot_supported: 18;
-    pub edd_spec_supported, set_edd_spec_supported: 19;
-    pub japanese_nec_9800_supported, set_japanese_nec_9800_supported: 20;
-    pub japanese_toshiba_supported, set_japanese_toshiba_supported: 21;
-    pub kb_525_360_supported, set_kb_525_360_supported: 22;
-    pub mb_535_12_supported, set_mb_535_12_supported: 23;
-    pub mb_35_720_supported, set_mb_35_720_supported: 24;
-    pub mb_35_288_supported, set_mb_35_288_supported: 25;
-    pub print_screen_supported, set_print_screen_supported: 26;
-    pub keyboard_8042_supported, set_keyboard_8042_supported: 27;
-    pub serial_services_supported, set_serial_services_supported: 28;
-    pub printer_services_supported, set_printer_services_supported: 29;
-    pub cga_mono_video_supported, set_cga_mono_video_supported: 30;
-    pub nec_pc_98, set_nec_pc_98: 31;
-    pub reserved_bios_vendor, set_reserved_bios_vendor: 47, 32;
-    pub reserved_system_vendor, set_reserved_system_vendor: 63, 48;
+/// BIOS Characteristics (Type 0, offset 0x0A) - 8 bytes
+#[bitfield(u64)]
+#[derive(IntoBytes, Immutable, KnownLayout)]
+pub struct BiosCharacteristics {
+    #[bits(2)]
+    pub reserved: u8,
+    pub unknown: bool,
+    pub bios_characteristics_unsupported: bool,
+    pub isa_supported: bool,
+    pub mca_supported: bool,
+    pub eisa_supported: bool,
+    pub pci_supported: bool,
+    pub pcmcia_supported: bool,
+    pub plug_play_supported: bool,
+    pub apm_supported: bool,
+    pub bios_is_upgradable: bool,
+    pub bios_shadowing_allowed: bool,
+    pub vlvesa_supported: bool,
+    pub escd_supported: bool,
+    pub cd_boot_supported: bool,
+    pub selectable_boot_supported: bool,
+    pub bios_rom_socketed: bool,
+    pub pc_card_boot_supported: bool,
+    pub edd_spec_supported: bool,
+    pub japanese_nec_9800_supported: bool,
+    pub japanese_toshiba_supported: bool,
+    pub kb_525_360_supported: bool,
+    pub mb_535_12_supported: bool,
+    pub mb_35_720_supported: bool,
+    pub mb_35_288_supported: bool,
+    pub print_screen_supported: bool,
+    pub keyboard_8042_supported: bool,
+    pub serial_services_supported: bool,
+    pub printer_services_supported: bool,
+    pub cga_mono_video_supported: bool,
+    pub nec_pc_98: bool,
+    #[bits(16)]
+    pub reserved_bios_vendor: u16,
+    #[bits(16)]
+    pub reserved_system_vendor: u16,
 }
 
-impl BiosCharacteristics {
-    pub fn new(
-        unknown: bool,
-        bios_characteristics_unsupported: bool,
-        isa_supported: bool,
-        mca_supported: bool,
-        eisa_supported: bool,
-        pci_supported: bool,
-        pcmcia_supported: bool,
-        plug_play_supported: bool,
-        apm_supported: bool,
-        bios_is_upgradable: bool,
-        bios_shadowing_allowed: bool,
-        vlvesa_supported: bool,
-        escd_supported: bool,
-        cd_boot_supported: bool,
-        selectable_boot_supported: bool,
-        bios_rom_socketed: bool,
-        pc_card_boot_supported: bool,
-        edd_spec_supported: bool,
-        japanese_nec_9800_supported: bool,
-        japanese_toshiba_supported: bool,
-        kb_525_360_supported: bool,
-        mb_535_12_supported: bool,
-        mb_35_720_supported: bool,
-        mb_35_288_supported: bool,
-        print_screen_supported: bool,
-        keyboard_8042_supported: bool,
-        serial_services_supported: bool,
-        printer_services_supported: bool,
-        cga_mono_video_supported: bool,
-        nec_pc_98: bool,
-        reserved_bios_vendor: u64,
-        reserved_system_vendor:u64,
-    ) -> Self{
-        let mut config = BiosCharacteristics(0);
-        config.set_reserved(0);
-        config.set_unknown(unknown);
-        config.set_bios_characteristics_unsupported(bios_characteristics_unsupported);
-        config.set_isa_supported(isa_supported);
-        config.set_mca_supported(mca_supported);
-        config.set_eisa_supported(eisa_supported);
-        config.set_pci_supported(pci_supported);
-        config.set_pcmcia_supported(pcmcia_supported);
-        config.set_plug_play_supported(plug_play_supported);
-        config.set_apm_supported(apm_supported);
-        config.set_bios_is_upgradable(bios_is_upgradable);
-        config.set_bios_shadowing_allowed(bios_shadowing_allowed);
-        config.set_vlvesa_supported(vlvesa_supported);
-        config.set_escd_supported(escd_supported);
-        config.set_cd_boot_supported(cd_boot_supported);
-        config.set_selectable_boot_supported(selectable_boot_supported);
-        config.set_bios_rom_socketed(bios_rom_socketed);
-        config.set_pc_card_boot_supported(pc_card_boot_supported);
-        config.set_edd_spec_supported(edd_spec_supported);
-        config.set_japanese_nec_9800_supported(japanese_nec_9800_supported);
-        config.set_japanese_toshiba_supported(japanese_toshiba_supported);
-        config.set_kb_525_360_supported(kb_525_360_supported);
-        config.set_mb_535_12_supported(mb_535_12_supported);
-        config.set_mb_35_720_supported(mb_35_720_supported);
-        config.set_mb_35_288_supported(mb_35_288_supported);
-        config.set_print_screen_supported(print_screen_supported);
-        config.set_keyboard_8042_supported(keyboard_8042_supported);
-        config.set_serial_services_supported(serial_services_supported);
-        config.set_printer_services_supported(printer_services_supported);
-        config.set_cga_mono_video_supported(cga_mono_video_supported);
-        config.set_nec_pc_98(nec_pc_98);
-        config.set_reserved_bios_vendor(reserved_bios_vendor);
-        config.set_reserved_system_vendor(reserved_system_vendor);
-        config
-    }
+/// BIOS Characteristics Extension Byte 1 (Type 0, offset 0x12)
+#[bitfield(u8)]
+#[derive(IntoBytes, Immutable, KnownLayout)]
+pub struct BiosCharacteristicsExt1 {
+    pub acpi_supported: bool,
+    pub usb_legacy_supported: bool,
+    pub agp_supported: bool,
+    pub i20_supported: bool,
+    pub superdisk_boot_supported: bool,
+    pub zip_drive_boot_supported: bool,
+    pub boot_1394_supported: bool,
+    pub smart_battery_supported: bool,
 }
 
-bitfield! {
-    ///
-    /// BIOS Characteristics Extension Byte 1
-    /// 
-    pub struct BiosCharacteristicsExt1 (u8);
-    impl Debug;
-    pub acpi_supported, set_acpi_supported: 0;
-    pub usb_legacy_supported, set_usb_legacy_supported: 1;
-    pub agp_supported, set_agp_supported: 2;
-    pub i20_supported, set_i20_supported: 3;
-    pub superdisk_boot_supported, set_superdisk_boot_supported: 4;
-    pub zip_drive_boot_supported, set_zip_drive_boot_supported: 5;
-    pub boot_1394_supported, set_boot_1394_supported: 6;
-    pub smart_battery_supported, set_smart_battery_supported: 7;
+/// BIOS Characteristics Extension Byte 2 (Type 0, offset 0x13)
+#[bitfield(u8)]
+#[derive(IntoBytes, Immutable, KnownLayout)]
+pub struct BiosCharacteristicsExt2 {
+    pub bios_boot_specification_supported: bool,
+    pub fn_network_service_boot_supported: bool,
+    pub enable_targeted_content_distribution: bool,
+    pub uefi_spec_supported: bool,
+    pub smbios_describes_vm: bool,
+    #[bits(3)]
+    pub reserved: u8,
 }
 
-impl BiosCharacteristicsExt1 {
-    pub fn new(
-        acpi_supported: bool,
-        usb_legacy_supported: bool,
-        agp_supported: bool,
-        i20_supported: bool,
-        superdisk_boot_supported: bool,
-        zip_drive_boot_supported: bool,
-        boot_1394_supported: bool,
-        smart_battery_supported: bool,
-    ) -> Self{
-        let mut config = BiosCharacteristicsExt1(0);
-        config.set_acpi_supported(acpi_supported);
-        config.set_usb_legacy_supported(usb_legacy_supported);
-        config.set_agp_supported(agp_supported);
-        config.set_i20_supported(i20_supported);
-        config.set_superdisk_boot_supported(superdisk_boot_supported);
-        config.set_zip_drive_boot_supported(zip_drive_boot_supported);
-        config.set_boot_1394_supported(boot_1394_supported);
-        config.set_smart_battery_supported(smart_battery_supported);
-        config
-    }
+/// Extended BIOS ROM Size (Type 0, offset 0x18) - 2 bytes
+#[bitfield(u16)]
+#[derive(IntoBytes, Immutable, KnownLayout)]
+pub struct ExtendedBiosRomSize {
+    #[bits(14)]
+    pub size: u16,
+    #[bits(2)]
+    pub unit: u8,
 }
 
-bitfield! {
-    ///
-    /// BIOS Characteristics Extension Byte 2
-    /// 
-    pub struct BiosCharacteristicsExt2 (u8);
-    impl Debug;
-    pub bios_boot_specification_supported, set_bios_boot_specification_supported: 0;
-    pub fn_network_service_boot_supported, set_fn_network_service_boot_supported: 1;
-    pub enable_targeted_content_distribution, set_enable_targeted_content_distribution: 2;
-    pub uefi_spec_supported, set_uefi_spec_supported: 3;
-    pub smbios_describes_vm, set_smbios_describes_vm: 4;
-    pub reserved, set_reserved: 7, 5;
-}
-
-impl BiosCharacteristicsExt2 {
-    pub fn new(
-        bios_boot_specification_supported: bool,
-        fn_network_service_boot_supported: bool,
-        enable_targeted_content_distribution: bool,
-        uefi_spec_supported: bool,
-        smbios_describes_vm: bool,
-    ) -> Self{
-        let mut config = BiosCharacteristicsExt2(0);
-        config.set_bios_boot_specification_supported(bios_boot_specification_supported);
-        config.set_fn_network_service_boot_supported(fn_network_service_boot_supported);
-        config.set_enable_targeted_content_distribution(enable_targeted_content_distribution);
-        config.set_uefi_spec_supported(uefi_spec_supported);
-        config.set_smbios_describes_vm(smbios_describes_vm);
-        config.set_reserved(0);
-        config
-    }
-}
-
-bitfield! {
-    ///
-    /// Extended BIOS Rom Size
-    /// 
-    pub struct ExtendedBiosRomSize (u16);
-    impl Debug;
-    pub size, set_size: 13, 0;
-    pub unit, set_unit: 15, 14;
-}
-
-impl ExtendedBiosRomSize {
-    pub fn new(
-        size: u16,
-        unit: u16,
-    ) -> Self{
-        let mut config = ExtendedBiosRomSize(0);
-        config.set_size(size);
-        config.set_unit(unit);
-        config
-    }
-}
-
-
-
-///
-/// Wake Up Type
-/// 
-#[derive(Copy, Clone, Debug)]
+/// Wake-Up Type (Type 1, offset 0x18)
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, IntoBytes, Immutable, KnownLayout)]
 pub enum WakeUpType {
-    Reserved = 0x0,
-    Other,
-    Unknown,
-    ApmTimer,
-    ModemRing,
-    LanRemote,
-    PowerSwitch,
-    PciPme,
-    AcPowerRestored
+    Reserved = 0x00,
+    Other = 0x01,
+    Unknown = 0x02,
+    ApmTimer = 0x03,
+    ModemRing = 0x04,
+    LanRemote = 0x05,
+    PowerSwitch = 0x06,
+    PciPme = 0x07,
+    AcPowerRestored = 0x08,
 }
 
-bitfield! {
-    ///
-    /// Feature Flags
-    /// 
-    pub struct FeatureFlags (u8);
-    impl Debug;
-    pub hosting_board, set_hosting_board: 0;
-    pub require_aux_board, set_require_aux_board: 1;
-    pub removable_board, set_removable_board: 2;
-    pub replaceable_board, set_replaceable_board: 3;
-    pub hot_swappable_board, set_hot_swappable_board: 4;
-    pub reserved, set_reserved: 7, 5;
+/// Baseboard Feature Flags (Type 2, offset 0x09)
+#[bitfield(u8)]
+#[derive(IntoBytes, Immutable, KnownLayout)]
+pub struct FeatureFlags {
+    pub hosting_board: bool,
+    pub require_aux_board: bool,
+    pub removable_board: bool,
+    pub replaceable_board: bool,
+    pub hot_swappable_board: bool,
+    #[bits(3)]
+    pub reserved: u8,
 }
 
-impl FeatureFlags {
-    pub fn new(
-        hosting_board: bool,
-        require_aux_board: bool,
-        removable_board: bool,
-        replaceable_board: bool,
-        hot_swappable_board: bool,
-    ) -> Self{
-        let mut config = FeatureFlags(0);
-        config.set_hosting_board(hosting_board);
-        config.set_require_aux_board(require_aux_board);
-        config.set_removable_board(removable_board);
-        config.set_replaceable_board(replaceable_board);
-        config.set_hot_swappable_board(hot_swappable_board);
-        config.set_reserved(0);
-        config
-    }
-}
-
-///
-/// Board Type
-/// 
-#[derive(Copy, Clone, Debug)]
+/// Baseboard Type (Type 2, offset 0x0D)
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, IntoBytes, Immutable, KnownLayout)]
 pub enum BoardType {
     Unknown = 0x01,
-    Other,
-    ServerBlade,
-    ConnectivitySwitch,
-    SystemManagementModule,
-    ProcessorModule,
-    IoModule,
-    MemoryModule,
-    DaughterBoard,
-    Motherboard,
-    ProcessorMemoryModule,
-    ProcessorIoModule,
-    InterconnectBoard
+    Other = 0x02,
+    ServerBlade = 0x03,
+    ConnectivitySwitch = 0x04,
+    SystemManagementModule = 0x05,
+    ProcessorModule = 0x06,
+    IoModule = 0x07,
+    MemoryModule = 0x08,
+    DaughterBoard = 0x09,
+    Motherboard = 0x0A,
+    ProcessorMemoryModule = 0x0B,
+    ProcessorIoModule = 0x0C,
+    InterconnectBoard = 0x0D,
 }
 
+/// System Enclosure Boot-Up State (Type 3, offset 0x09).
 ///
-/// Boot Up State
-///
-#[derive(Copy, Clone, Debug)]
+/// Per SMBIOS spec Table 17 (System — Boot Up State).
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, IntoBytes, Immutable, KnownLayout)]
 pub enum BootUpState {
     Other = 0x01,
-    Unknown,
-    Desktop,
-    LowProfileDesktop,
-    Pizzabox,
-    MiniTower,
-    Tower,
-    Portable,
-    Laptop,
-    Notebook,
-    HandHeld,
-    DockingStation,
-    AllInOne,
-    SubNotebook,
-    SpaceSaving,
-    LunchBox,
-    MainServerChassis,
-    ExpansionChassis,
-    SubChassis,
-    BusExpansionChassis,
-    PeripheralChassis,
-    RaidChassis,
-    RackMountChassis,
-    SealedCasePc,
-    MultiSystemChassis,
-    CompactPci,
-    AdvancedTca,
-    Blade,
-    BladeEnclosure,
-    Tablet,
-    Convertible,
-    Detachable,
-    IotGateway,
-    EmbeddedPc,
-    MiniPc,
-    StickPc
+    Unknown = 0x02,
+    Safe = 0x03,
+    Warning = 0x04,
+    Critical = 0x05,
+    NonRecoverable = 0x06,
 }
 
+/// System Enclosure Power Supply State (Type 3, offset 0x0A).
 ///
-/// Power Supply State
-///
-#[derive(Copy, Clone, Debug)]
+/// Per SMBIOS spec Table 17 (Power Supply State).
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, IntoBytes, Immutable, KnownLayout)]
 pub enum PowerSupplyState {
-    ProcessorOther = 0x01,
-    ProcessorUnknown,
-    CentralProcessor,
-    MathProcessor,
-    DspProcessor,
-    VideoProcessor,
+    Other = 0x01,
+    Unknown = 0x02,
+    Safe = 0x03,
+    Warning = 0x04,
+    Critical = 0x05,
+    NonRecoverable = 0x06,
 }
 
-///
-/// Thermal State
-///
-#[derive(Copy, Clone, Debug)]
+/// System Enclosure Thermal State (Type 3, offset 0x0B)
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, IntoBytes, Immutable, KnownLayout)]
 pub enum ThermalState {
     Other = 0x01,
-    Unknown,
-    Safe,
-    Warning,
-    Critical,
-    NonRecoverable
+    Unknown = 0x02,
+    Safe = 0x03,
+    Warning = 0x04,
+    Critical = 0x05,
+    NonRecoverable = 0x06,
 }
 
+/// System Enclosure Security Status (Type 3, offset 0x0C).
 ///
-/// Security Status
-///
-#[derive(Copy, Clone, Debug)]
+/// `NoneStatus` is named to avoid the reserved `None` keyword.
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, IntoBytes, Immutable, KnownLayout)]
 pub enum SecurityStatus {
     Other = 0x01,
-    Unknown,
-    _None,
-    ExternalInterfaceLockedOut,
-    ExternalInterfaceEnabled
+    Unknown = 0x02,
+    NoneStatus = 0x03,
+    ExternalInterfaceLockedOut = 0x04,
+    ExternalInterfaceEnabled = 0x05,
 }
 
-bitfield! {
-    ///
-    /// Contained Elements - Contained Element Type
-    ///
-    #[derive(Copy, Clone)] 
-    pub struct  ContainedElementType(u8);
-    impl Debug;
-    pub _type, set_type : 6, 0;
-    pub type_select, set_type_select : 7;
+/// Contained Element Type (Type 3 element record, byte 0)
+#[bitfield(u8)]
+#[derive(IntoBytes, Immutable, KnownLayout)]
+pub struct ContainedElementType {
+    #[bits(7)]
+    pub r#type: u8,
+    pub type_select: bool,
 }
 
-impl ContainedElementType {
-    pub fn new(
-        _type: u8,
-        type_select: bool,
-    ) -> Self{
-        let mut config = ContainedElementType(0);
-        config.set_type(_type);
-        config.set_type_select(type_select);
-        config
-    }
-}
-
-///
-/// Contained Elements
-///
-#[derive(Copy, Clone, Debug)]
+/// Contained Element (Type 3 element record - 3 bytes)
+#[repr(C, packed)]
+#[derive(Copy, Clone, Debug, IntoBytes, Immutable, KnownLayout)]
 pub struct ContainedElements {
     pub contained_element_type: ContainedElementType,
     pub contained_element_minimum: u8,
@@ -409,906 +221,681 @@ pub struct ContainedElements {
 impl Default for ContainedElements {
     fn default() -> Self {
         Self {
-            contained_element_type: ContainedElementType::new(0, false),
+            contained_element_type: ContainedElementType::new(),
             contained_element_minimum: 0,
-            contained_element_maximum: 0
+            contained_element_maximum: 0,
         }
     }
 }
 
-///
-/// Processor Information
-///
-#[derive(Copy, Clone, Debug)]
+/// Processor Type (Type 4, offset 0x05)
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, IntoBytes, Immutable, KnownLayout)]
 pub enum ProcessorTypeData {
     ProcessorOther = 0x01,
-    ProcessorUnknown,
-    CentralProcessor,
-    MathProcessor,
-    DspProcessor,
-    VideoProcessor,
+    ProcessorUnknown = 0x02,
+    CentralProcessor = 0x03,
+    MathProcessor = 0x04,
+    DspProcessor = 0x05,
+    VideoProcessor = 0x06,
 }
 
+/// Processor Family / Family 2 (Type 4, offset 0x06 BYTE / 0x28 WORD).
 ///
-/// Processor Information - Processor Family
-///
-#[derive(Copy, Clone, Debug)]
+/// Tagged `#[repr(u16)]` to cover the full SMBIOS extended family list.
+/// The 1-byte `processor_family` field on `Type4ProcessorInformation` is a
+/// raw `u8`; set it to `0xFE` (IndicatorFamily2) when using the extended
+/// `processor_family2` field for values >= 0x100.
+#[repr(u16)]
+#[derive(Copy, Clone, Debug, IntoBytes, Immutable, KnownLayout)]
 pub enum ProcessorFamilyData {
     Other = 0x01,
-    Unknown,
-    Processor8086,
-    Processor80286,
-    Intel386,
-    Intel486,
-    Processor8087,
-    Processor80287,
-    Processor80387,
-    Processor80487,
-    Pentium,
-    PentiumPro,
-    PentiumII,
-    PentiumMMX,
-    Celeron,
-    PentiumIIXeon,
-    PentiumIII,
-    M1Family,
-    M2Family,
-    IntelCeleronM,
-    IntelPentium4Ht,
-    IntelProcessor,
+    Unknown = 0x02,
+    Processor8086 = 0x03,
+    Processor80286 = 0x04,
+    Intel386 = 0x05,
+    Intel486 = 0x06,
+    Processor8087 = 0x07,
+    Processor80287 = 0x08,
+    Processor80387 = 0x09,
+    Processor80487 = 0x0A,
+    Pentium = 0x0B,
+    PentiumPro = 0x0C,
+    PentiumII = 0x0D,
+    PentiumMMX = 0x0E,
+    Celeron = 0x0F,
+    PentiumIIXeon = 0x10,
+    PentiumIII = 0x11,
+    M1Family = 0x12,
+    M2Family = 0x13,
+    IntelCeleronM = 0x14,
+    IntelPentium4Ht = 0x15,
+    IntelProcessor = 0x16,
     AmdDuron = 0x18,
-    K5Family,
-    K6Family,
-    K6_2,
-    K6_3,
-    AmdAthlon,
-    Amd29000,
-    K6_2Plus,
-    PowerPC,
-    PowerPC601,
-    PowerPC603,
-    PowerPC603Plus,
-    PowerPC604,
-    PowerPC620,
-    PowerPCx704,
-    PowerPC750,
-    IntelCoreDuo,
-    IntelCoreDuoMobile,
-    IntelCoreSoloMobile,
-    IntelAtom,
-    IntelCoreM,
-    IntelCorem3,
-    IntelCorem5,
-    IntelCorem7,
-    Alpha,
-    Alpha21064,
-    Alpha21066,
-    Alpha21164,
-    Alpha21164PC,
-    Alpha21164a,
-    Alpha21264,
-    Alpha21364,
-    AmdTurionIIUltraDualCoreMobileM,
-    AmdTurionIIDualCoreMobileM,
-    AmdAthlonIIDualCoreM,
-    AmdOpteron6100Series,
-    AmdOpteron4100Series,
-    AmdOpteron6200Series,
-    AmdOpteron4200Series,
-    AmdFxSeries,
-    MipsFamily,
-    MipsR4000,
-    MipsR4200,
-    MipsR4400,
-    MipsR4600,
-    MipsR10000,
-    AmdCSeries,
-    AmdESeries,
-    AmdASeries,
-    AmdGSeries,
-    AmdZSeries,
-    AmdRSeries,
-    AmdOpteron4300,
-    AmdOpteron6300,
-    AmdOpteron3300,
-    AmdFireProSeries,
-    Sparc,
-    SuperSparc,
-    MicroSparcII,
-    MicroSparcIIep,
-    UltraSparc,
-    UltraSparcII,
-    UltraSparcIii,
-    UltraSparcIII,
-    UltraSparcIIIi,
+    K5Family = 0x19,
+    K6Family = 0x1A,
+    K6_2 = 0x1B,
+    K6_3 = 0x1C,
+    AmdAthlon = 0x1D,
+    Amd29000 = 0x1E,
+    K6_2Plus = 0x1F,
+    PowerPC = 0x20,
+    PowerPC601 = 0x21,
+    PowerPC603 = 0x22,
+    PowerPC603Plus = 0x23,
+    PowerPC604 = 0x24,
+    PowerPC620 = 0x25,
+    PowerPCx704 = 0x26,
+    PowerPC750 = 0x27,
+    IntelCoreDuo = 0x28,
+    IntelCoreDuoMobile = 0x29,
+    IntelCoreSoloMobile = 0x2A,
+    IntelAtom = 0x2B,
+    IntelCoreM = 0x2C,
+    IntelCorem3 = 0x2D,
+    IntelCorem5 = 0x2E,
+    IntelCorem7 = 0x2F,
+    Alpha = 0x30,
+    Alpha21064 = 0x31,
+    Alpha21066 = 0x32,
+    Alpha21164 = 0x33,
+    Alpha21164PC = 0x34,
+    Alpha21164a = 0x35,
+    Alpha21264 = 0x36,
+    Alpha21364 = 0x37,
+    AmdTurionIIUltraDualCoreMobileM = 0x38,
+    AmdTurionIIDualCoreMobileM = 0x39,
+    AmdAthlonIIDualCoreM = 0x3A,
+    AmdOpteron6100Series = 0x3B,
+    AmdOpteron4100Series = 0x3C,
+    AmdOpteron6200Series = 0x3D,
+    AmdOpteron4200Series = 0x3E,
+    AmdFxSeries = 0x3F,
+    MipsFamily = 0x40,
+    MipsR4000 = 0x41,
+    MipsR4200 = 0x42,
+    MipsR4400 = 0x43,
+    MipsR4600 = 0x44,
+    MipsR10000 = 0x45,
+    AmdCSeries = 0x46,
+    AmdESeries = 0x47,
+    AmdASeries = 0x48,
+    AmdGSeries = 0x49,
+    AmdZSeries = 0x4A,
+    AmdRSeries = 0x4B,
+    AmdOpteron4300 = 0x4C,
+    AmdOpteron6300 = 0x4D,
+    AmdOpteron3300 = 0x4E,
+    AmdFireProSeries = 0x4F,
+    Sparc = 0x50,
+    SuperSparc = 0x51,
+    MicroSparcII = 0x52,
+    MicroSparcIIep = 0x53,
+    UltraSparc = 0x54,
+    UltraSparcII = 0x55,
+    UltraSparcIii = 0x56,
+    UltraSparcIII = 0x57,
+    UltraSparcIIIi = 0x58,
     Processor68040 = 0x60,
-    Processor68xxx,
-    Processor68000,
-    Processor68010,
-    Processor68020,
-    Processor68030,
-    AmdAthlonX4QuadCore,
-    AmdOpteronX1000Series,
-    AmdOpteronX2000Series,
-    AmdOpteronASeries,
-    AmdOpteronX3000Series,
-    AmdZen,
+    Processor68xxx = 0x61,
+    Processor68000 = 0x62,
+    Processor68010 = 0x63,
+    Processor68020 = 0x64,
+    Processor68030 = 0x65,
+    AmdAthlonX4QuadCore = 0x66,
+    AmdOpteronX1000Series = 0x67,
+    AmdOpteronX2000Series = 0x68,
+    AmdOpteronASeries = 0x69,
+    AmdOpteronX3000Series = 0x6A,
+    AmdZen = 0x6B,
     HobbitFamily = 0x70,
     CrusoeTM5000 = 0x78,
-    CrusoeTM3000,
-    EfficeonTM8000,
+    CrusoeTM3000 = 0x79,
+    EfficeonTM8000 = 0x7A,
     Weitek = 0x80,
     Itanium = 0x82,
-    AmdAthlon64,
-    AmdOpteron,
-    AmdSempron,
-    AmdTurion64Mobile,
-    DualCoreAmdOpteron,
-    AmdAthlon64X2DualCore,
-    AmdTurion64X2Mobile,
-    QuadCoreAmdOpteron,
-    ThirdGenerationAmdOpteron,
-    AmdPhenomFxQuadCore,
-    AmdPhenomX4QuadCore,
-    AmdPhenomX2DualCore,
-    AmdAthlonX2DualCore,
-    Parisc,
-    PaRisc8500,
-    PaRisc8000,
-    PaRisc7300LC,
-    PaRisc7200,
-    PaRisc7100LC,
-    PaRisc7100,
+    AmdAthlon64 = 0x83,
+    AmdOpteron = 0x84,
+    AmdSempron = 0x85,
+    AmdTurion64Mobile = 0x86,
+    DualCoreAmdOpteron = 0x87,
+    AmdAthlon64X2DualCore = 0x88,
+    AmdTurion64X2Mobile = 0x89,
+    QuadCoreAmdOpteron = 0x8A,
+    ThirdGenerationAmdOpteron = 0x8B,
+    AmdPhenomFxQuadCore = 0x8C,
+    AmdPhenomX4QuadCore = 0x8D,
+    AmdPhenomX2DualCore = 0x8E,
+    AmdAthlonX2DualCore = 0x8F,
+    Parisc = 0x90,
+    PaRisc8500 = 0x91,
+    PaRisc8000 = 0x92,
+    PaRisc7300LC = 0x93,
+    PaRisc7200 = 0x94,
+    PaRisc7100LC = 0x95,
+    PaRisc7100 = 0x96,
     V30Family = 0xA0,
-    QuadCoreIntelXeon3200Series,
-    DualCoreIntelXeon3000Series,
-    QuadCoreIntelXeon5300Series,
-    DualCoreIntelXeon5100Series,
-    DualCoreIntelXeon5000Series,
-    DualCoreIntelXeonLV,
-    DualCoreIntelXeonULV,
-    DualCoreIntelXeon7100Series,
-    QuadCoreIntelXeon5400Series,
-    QuadCoreIntelXeon,
-    DualCoreIntelXeon5200Series,
-    DualCoreIntelXeon7200Series,
-    QuadCoreIntelXeon7300Series,
-    QuadCoreIntelXeon7400Series,
-    MultiCoreIntelXeon7400Series,
-    PentiumIIIXeon,
-    PentiumIIISpeedStep,
-    Pentium4,
-    IntelXeon,
-    As400,
-    IntelXeonMP,
-    AMDAthlonXP,
-    AMDAthlonMP,
-    IntelItanium2,
-    IntelPentiumM,
-    IntelCeleronD,
-    IntelPentiumD,
-    IntelPentiumEx,
-    IntelCoreSolo,
-    Reserved,
-    IntelCore2,
-    IntelCore2Solo,
-    IntelCore2Extreme,
-    IntelCore2Quad,
-    IntelCore2ExtremeMobile,
-    IntelCore2DuoMobile,
-    IntelCore2SoloMobile,
-    IntelCoreI7,
-    DualCoreIntelCeleron,
-    Ibm390,
-    G4,
-    G5,
-    EsaG6,
-    ZArchitecture,
-    IntelCoreI5,
-    IntelCoreI3,
-    IntelCoreI9,
-    IntelXeonD,
+    QuadCoreIntelXeon3200Series = 0xA1,
+    DualCoreIntelXeon3000Series = 0xA2,
+    QuadCoreIntelXeon5300Series = 0xA3,
+    DualCoreIntelXeon5100Series = 0xA4,
+    DualCoreIntelXeon5000Series = 0xA5,
+    DualCoreIntelXeonLV = 0xA6,
+    DualCoreIntelXeonULV = 0xA7,
+    DualCoreIntelXeon7100Series = 0xA8,
+    QuadCoreIntelXeon5400Series = 0xA9,
+    QuadCoreIntelXeon = 0xAA,
+    DualCoreIntelXeon5200Series = 0xAB,
+    DualCoreIntelXeon7200Series = 0xAC,
+    QuadCoreIntelXeon7300Series = 0xAD,
+    QuadCoreIntelXeon7400Series = 0xAE,
+    MultiCoreIntelXeon7400Series = 0xAF,
+    PentiumIIIXeon = 0xB0,
+    PentiumIIISpeedStep = 0xB1,
+    Pentium4 = 0xB2,
+    IntelXeon = 0xB3,
+    As400 = 0xB4,
+    IntelXeonMP = 0xB5,
+    AMDAthlonXP = 0xB6,
+    AMDAthlonMP = 0xB7,
+    IntelItanium2 = 0xB8,
+    IntelPentiumM = 0xB9,
+    IntelCeleronD = 0xBA,
+    IntelPentiumD = 0xBB,
+    IntelPentiumEx = 0xBC,
+    IntelCoreSolo = 0xBD,
+    Reserved = 0xBE,
+    IntelCore2 = 0xBF,
+    IntelCore2Solo = 0xC0,
+    IntelCore2Extreme = 0xC1,
+    IntelCore2Quad = 0xC2,
+    IntelCore2ExtremeMobile = 0xC3,
+    IntelCore2DuoMobile = 0xC4,
+    IntelCore2SoloMobile = 0xC5,
+    IntelCoreI7 = 0xC6,
+    DualCoreIntelCeleron = 0xC7,
+    Ibm390 = 0xC8,
+    G4 = 0xC9,
+    G5 = 0xCA,
+    EsaG6 = 0xCB,
+    ZArchitecture = 0xCC,
+    IntelCoreI5 = 0xCD,
+    IntelCoreI3 = 0xCE,
+    IntelCoreI9 = 0xCF,
+    IntelXeonD = 0xD0,
     ViaC7M = 0xD2,
-    ViaC7D,
-    ViaC7,
-    ViaEden,
-    MultiCoreIntelXeon,
-    DualCoreIntelXeon3Series,
-    QuadCoreIntelXeon3Series,
-    ViaNano,
-    DualCoreIntelXeon5Series,
-    QuadCoreIntelXeon5Series,
+    ViaC7D = 0xD3,
+    ViaC7 = 0xD4,
+    ViaEden = 0xD5,
+    MultiCoreIntelXeon = 0xD6,
+    DualCoreIntelXeon3Series = 0xD7,
+    QuadCoreIntelXeon3Series = 0xD8,
+    ViaNano = 0xD9,
+    DualCoreIntelXeon5Series = 0xDA,
+    QuadCoreIntelXeon5Series = 0xDB,
     DualCoreIntelXeon7Series = 0xDD,
-    QuadCoreIntelXeon7Series,
-    MultiCoreIntelXeon7Series,
-    MultiCoreIntelXeon3400Series,
+    QuadCoreIntelXeon7Series = 0xDE,
+    MultiCoreIntelXeon7Series = 0xDF,
+    MultiCoreIntelXeon3400Series = 0xE0,
     AmdOpteron3000Series = 0xE4,
-    AmdSempronII,
-    EmbeddedAmdOpteronQuadCore,
-    AmdPhenomTripleCore,
-    AmdTurionUltraDualCoreMobile,
-    AmdTurionDualCoreMobile,
-    AmdAthlonDualCore,
-    AmdSempronSI,
-    AmdPhenomII,
-    AmdAthlonII,
-    SixCoreAmdOpteron,
-    AmdSempronM,
+    AmdSempronII = 0xE5,
+    EmbeddedAmdOpteronQuadCore = 0xE6,
+    AmdPhenomTripleCore = 0xE7,
+    AmdTurionUltraDualCoreMobile = 0xE8,
+    AmdTurionDualCoreMobile = 0xE9,
+    AmdAthlonDualCore = 0xEA,
+    AmdSempronSI = 0xEB,
+    AmdPhenomII = 0xEC,
+    AmdAthlonII = 0xED,
+    SixCoreAmdOpteron = 0xEE,
+    AmdSempronM = 0xEF,
     I860 = 0xFA,
-    I960,
+    I960 = 0xFB,
+    /// Use this u8 marker (0xFE) in `processor_family` to indicate that the
+    /// real value is in `processor_family2`.
     IndicatorFamily2 = 0xFE,
-    Reserved1,
+    Reserved1 = 0xFF,
     ARMv7 = 0x0100,
-    ARMv8,
-    ARMv9,
-    Sh3,
-    Sh4,
+    ARMv8 = 0x0101,
+    ARMv9 = 0x0102,
+    Sh3 = 0x0103,
+    Sh4 = 0x0104,
     Arm = 0x0118,
-    StrongARM,
+    StrongARM = 0x0119,
     Processor6x86 = 0x012C,
-    MediaGX,
-    Mii,
+    MediaGX = 0x012D,
+    Mii = 0x012E,
     WinChip = 0x0140,
     Dsp = 0x015E,
     VideoProcessor = 0x01F4,
     RiscvRV32 = 0x0200,
-    RiscVRV64,
-    RiscVRV128,
+    RiscVRV64 = 0x0201,
+    RiscVRV128 = 0x0202,
     LoongArch = 0x0258,
-    Loongson1,
-    Loongson2,
-    Loongson3,
-    Loongson2K,
-    Loongson3A,
-    Loongson3B,
-    Loongson3C,
-    Loongson3D,
-    Loongson3E,
-    DualCoreLoongson2K,
+    Loongson1 = 0x0259,
+    Loongson2 = 0x025A,
+    Loongson3 = 0x025B,
+    Loongson2K = 0x025C,
+    Loongson3A = 0x025D,
+    Loongson3B = 0x025E,
+    Loongson3C = 0x025F,
+    Loongson3D = 0x0260,
+    Loongson3E = 0x0261,
+    DualCoreLoongson2K = 0x0262,
     QuadCoreLoongson3A = 0x026C,
-    MultiCoreLoongson3A,
-    QuadCoreLoongson3B,
-    MultiCoreLoongson3B,
-    MultiCoreLoongson3C,
-    MultiCoreLoongson3D,
+    MultiCoreLoongson3A = 0x026D,
+    QuadCoreLoongson3B = 0x026E,
+    MultiCoreLoongson3B = 0x026F,
+    MultiCoreLoongson3C = 0x0270,
+    MultiCoreLoongson3D = 0x0271,
     IntelCore3 = 0x0300,
-    IntelCore5,
-    IntelCore7,
-    IntelCore9,
-    IntelCoreUltra3,
-    IntelCoreUltra5,
-    IntelCoreUltra7,
-    IntelCoreUltra9,
+    IntelCore5 = 0x0301,
+    IntelCore7 = 0x0302,
+    IntelCore9 = 0x0303,
+    IntelCoreUltra3 = 0x0304,
+    IntelCoreUltra5 = 0x0305,
+    IntelCoreUltra7 = 0x0306,
+    IntelCoreUltra9 = 0x0307,
 }
 
-///
-/// Processor Information - Processor Upgrade
-///
-#[derive(Copy, Clone, Debug)]
+/// Processor Upgrade (Type 4, offset 0x19)
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, IntoBytes, Immutable, KnownLayout)]
 pub enum ProcessorUpgrade {
     Other = 0x01,
-    Unknown,
-    DaughterBoard,
-    ZIFSocket,
-    ReplaceablePiggyBack,
-    None,
-    LIFSocket,
-    Slot1,
-    Slot2,
-    Pin370Socket,
-    SlotA,
-    SlotM,
-    Socket423,
-    SocketA, //  Socket 462
-    Socket478,
-    Socket754,
-    Socket940,
-    Socket939,
-    SocketmPGA604,
-    SocketLGA771,
-    SocketLGA775,
-    SocketS1,
-    SocketAM2,
-    SocketF1207,
-    SocketLGA1366,
-    SocketG34,
-    SocketAM3,
-    SocketC32,
-    SocketLGA1156,
-    SocketLGA1567,
-    SocketPGA988A,
-    SocketBGA1288,
-    SocketrPGA988B,
-    SocketBGA1023,
-    SocketBGA1224,
-    SocketLGA1155,
-    SocketLGA1356,
-    SocketLGA2011,
-    SocketFS1,
-    SocketFS2,
-    SocketFM1,
-    SocketFM2,
-    SocketLGA2011_3,
-    SocketLGA1356_3,
-    SocketLGA1150,
-    SocketBGA1168,
-    SocketBGA1234,
-    SocketBGA1364,
-    SocketAM4,
-    SocketLGA1151,
-    SocketBGA1356,
-    SocketBGA1440,
-    SocketBGA1515,
-    SocketLGA3647_1,
-    SocketSP3,
-    SocketSP3r2,
-    SocketLGA2066,
-    SocketBGA1392,
-    SocketBGA1510,
-    SocketBGA1528,
-    SocketLGA4189,
-    SocketLGA1200,
-    SocketLGA4677,
-    SocketLGA1700,
-    SocketBGA1744,
-    SocketBGA1781,
-    SocketBGA1211,
-    SocketBGA2422,
-    SocketLGA1211,
-    SocketLGA2422,
-    SocketLGA5773,
-    SocketBGA5773,
-    SocketAM5,
-    SocketSP5,
-    SocketSP6,
-    SocketBGA883,
-    SocketBGA1190,
-    SocketBGA4129,
-    SocketLGA4710,
-    SocketLGA7529,
-    SocketBGA1964, //ANS: check for the rest of list, not on 3.7
-    SocketBGA1792,
-    SocketBGA2049,
-    SocketBGA2551,
-    SocketLGA1851,
-    SocketBGA2114,
-    SocketBGA2833,
-    // Use this when no other valid enumeration is available.
-    // When this enumeration is used, Socket Type at offset 32h must be non-null.
+    Unknown = 0x02,
+    DaughterBoard = 0x03,
+    ZIFSocket = 0x04,
+    ReplaceablePiggyBack = 0x05,
+    NoUpgrade = 0x06,
+    LIFSocket = 0x07,
+    Slot1 = 0x08,
+    Slot2 = 0x09,
+    Pin370Socket = 0x0A,
+    SlotA = 0x0B,
+    SlotM = 0x0C,
+    Socket423 = 0x0D,
+    SocketA = 0x0E,
+    Socket478 = 0x0F,
+    Socket754 = 0x10,
+    Socket940 = 0x11,
+    Socket939 = 0x12,
+    SocketmPGA604 = 0x13,
+    SocketLGA771 = 0x14,
+    SocketLGA775 = 0x15,
+    SocketS1 = 0x16,
+    SocketAM2 = 0x17,
+    SocketF1207 = 0x18,
+    SocketLGA1366 = 0x19,
+    SocketG34 = 0x1A,
+    SocketAM3 = 0x1B,
+    SocketC32 = 0x1C,
+    SocketLGA1156 = 0x1D,
+    SocketLGA1567 = 0x1E,
+    SocketPGA988A = 0x1F,
+    SocketBGA1288 = 0x20,
+    SocketrPGA988B = 0x21,
+    SocketBGA1023 = 0x22,
+    SocketBGA1224 = 0x23,
+    SocketLGA1155 = 0x24,
+    SocketLGA1356 = 0x25,
+    SocketLGA2011 = 0x26,
+    SocketFS1 = 0x27,
+    SocketFS2 = 0x28,
+    SocketFM1 = 0x29,
+    SocketFM2 = 0x2A,
+    SocketLGA2011_3 = 0x2B,
+    SocketLGA1356_3 = 0x2C,
+    SocketLGA1150 = 0x2D,
+    SocketBGA1168 = 0x2E,
+    SocketBGA1234 = 0x2F,
+    SocketBGA1364 = 0x30,
+    SocketAM4 = 0x31,
+    SocketLGA1151 = 0x32,
+    SocketBGA1356 = 0x33,
+    SocketBGA1440 = 0x34,
+    SocketBGA1515 = 0x35,
+    SocketLGA3647_1 = 0x36,
+    SocketSP3 = 0x37,
+    SocketSP3r2 = 0x38,
+    SocketLGA2066 = 0x39,
+    SocketBGA1392 = 0x3A,
+    SocketBGA1510 = 0x3B,
+    SocketBGA1528 = 0x3C,
+    SocketLGA4189 = 0x3D,
+    SocketLGA1200 = 0x3E,
+    SocketLGA4677 = 0x3F,
+    SocketLGA1700 = 0x40,
+    SocketBGA1744 = 0x41,
+    SocketBGA1781 = 0x42,
+    SocketBGA1211 = 0x43,
+    SocketBGA2422 = 0x44,
+    SocketLGA1211 = 0x45,
+    SocketLGA2422 = 0x46,
+    SocketLGA5773 = 0x47,
+    SocketBGA5773 = 0x48,
+    SocketAM5 = 0x49,
+    SocketSP5 = 0x4A,
+    SocketSP6 = 0x4B,
+    SocketBGA883 = 0x4C,
+    SocketBGA1190 = 0x4D,
+    SocketBGA4129 = 0x4E,
+    SocketLGA4710 = 0x4F,
+    SocketLGA7529 = 0x50,
+    SocketBGA1964 = 0x51,
+    SocketBGA1792 = 0x52,
+    SocketBGA2049 = 0x53,
+    SocketBGA2551 = 0x54,
+    SocketLGA1851 = 0x55,
+    SocketBGA2114 = 0x56,
+    SocketBGA2833 = 0x57,
     NotAvailable = 0xFF,
 }
 
-bitfield! {
-    ///
-    /// Processor Information - Voltage
-    ///
-    pub struct ProcessorVoltage (u8);
-    impl Debug;
-    pub processor_voltage_capability_5v, set_processor_voltage_capability_5v: 0;
-    pub processor_voltage_capability_3_3v, set_processor_voltage_capability_3_3v: 1;
-    pub processor_voltage_capability_2_9v, set_processor_voltage_capability_2_9v: 2;
-    pub processor_voltage_capability_reserved, set_processor_voltage_capability_reserved: 3;
-    pub processor_voltage_reserved, set_processor_voltage_reserved: 6, 4;
-    pub processor_voltage_indicate_legacy, set_processor_voltage_indicate_legacy: 7;
+/// Processor Voltage (Type 4, offset 0x11)
+#[bitfield(u8)]
+#[derive(IntoBytes, Immutable, KnownLayout)]
+pub struct ProcessorVoltage {
+    pub processor_voltage_capability_5v: bool,
+    pub processor_voltage_capability_3_3v: bool,
+    pub processor_voltage_capability_2_9v: bool,
+    pub processor_voltage_capability_reserved: bool,
+    #[bits(3)]
+    pub processor_voltage_reserved: u8,
+    pub processor_voltage_indicate_legacy: bool,
 }
 
-impl ProcessorVoltage {
-    pub fn new(
-        processor_voltage_capability_5v: bool,
-        processor_voltage_capability_3_3v: bool,
-        processor_voltage_capability_2_9v: bool,
-        processor_voltage_capability_reserved: bool,
-        processor_voltage_reserved: u8,
-        processor_voltage_indicate_legacy: bool,
-    ) -> Self{
-        let mut config = ProcessorVoltage(0);
-        config.set_processor_voltage_capability_5v(processor_voltage_capability_5v);
-        config.set_processor_voltage_capability_3_3v(processor_voltage_capability_3_3v);
-        config.set_processor_voltage_capability_2_9v(processor_voltage_capability_2_9v);
-        config.set_processor_voltage_capability_reserved(processor_voltage_capability_reserved);
-        config.set_processor_voltage_reserved(processor_voltage_reserved);
-        config.set_processor_voltage_indicate_legacy(processor_voltage_indicate_legacy);
-        config
-    }
+/// Processor Information Status (Type 4, offset 0x18)
+#[bitfield(u8)]
+#[derive(IntoBytes, Immutable, KnownLayout)]
+pub struct ProcessorInformationStatus {
+    #[bits(3)]
+    pub cpu_status: u8,
+    #[bits(3)]
+    pub reserved: u8,
+    pub cpu_socket_populated: bool,
+    pub reserved2: bool,
 }
 
-bitfield! {
-    ///
-    /// Processor Information - Status
-    ///
-    pub struct ProcessorInformationStatus (u8);
-    impl Debug;
-    pub cpu_status, set_cpu_status: 2, 0;
-    // reserved must be zero
-    pub reserved, set_reserved: 5, 3;
-    pub cpu_socket_populated, set_cpu_socket_populated: 6;
-    // reserved2 must be zero
-    pub reserved2, set_reserved2: 7;
+/// Processor Characteristics (Type 4, offset 0x26)
+#[bitfield(u16)]
+#[derive(IntoBytes, Immutable, KnownLayout)]
+pub struct ProcessorCharacteristics {
+    pub reserved: bool,
+    pub unknown: bool,
+    pub capable_64bit: bool,
+    pub multi_core: bool,
+    pub hardware_thread: bool,
+    pub execute_protection: bool,
+    pub enhanced_virtualization: bool,
+    pub performance_control: bool,
+    pub capable_128bit: bool,
+    pub arm64_soc_id: bool,
+    #[bits(6)]
+    pub reserved2: u8,
 }
 
-impl ProcessorInformationStatus {
-    pub fn new(
-        cpu_status: u8,
-        cpu_socket_populated: bool,
-    ) -> Self{
-        let mut config = ProcessorInformationStatus(0);
-        config.set_cpu_status(cpu_status);
-        config.set_reserved(0);
-        config.set_cpu_socket_populated(cpu_socket_populated);
-        config.set_reserved2(false);
-        config
-    }
+/// Cache Configuration (Type 7, offset 0x05)
+#[bitfield(u16)]
+#[derive(IntoBytes, Immutable, KnownLayout)]
+pub struct CacheConfiguration {
+    #[bits(3)]
+    pub cache_level: u8,
+    pub cache_socketed: bool,
+    pub reserved: bool,
+    #[bits(2)]
+    pub location: u8,
+    pub enabled_disabled: bool,
+    #[bits(2)]
+    pub operational_mode: u8,
+    #[bits(6)]
+    pub reserved2: u8,
 }
 
-bitfield! {
-    ///
-    /// Processor Information - Status
-    ///
-    pub struct ProcessorCharacteristics (u16);
-    impl Debug;
-    pub reserved, set_reserved : 0;
-    pub unknown, set_unknown : 1;
-    pub _64bit_capable, set_64bit_capable : 2;
-    pub multi_core, set_multi_core : 3;
-    pub hardware_thread, set_hardware_thread : 4;
-    pub execute_protection, set_execute_protection : 5;
-    pub enhanced_virtualization, set_enhanced_virtualization : 6;
-    pub performance_control, set_performance_control : 7;
-    pub _128bit_capable, set_128bit_capable : 8;
-    pub arm64_soc_id, set_arm64_soc_id : 9;
-    pub reserved2, set_reserved2 : 15, 10;
+/// Cache Size (Type 7, offset 0x07 / 0x09)
+#[bitfield(u16)]
+#[derive(IntoBytes, Immutable, KnownLayout)]
+pub struct CacheSize {
+    #[bits(15)]
+    pub max_size: u16,
+    pub granularity: bool,
 }
 
-impl ProcessorCharacteristics {
-    pub fn new(
-        unknown: bool,
-        _64bit_capable: bool,
-        multi_core: bool,
-        hardware_thread: bool,
-        execute_protection: bool,
-        enhanced_virtualization: bool,
-        performance_control: bool,
-        _128bit_capable: bool,
-        arm64_soc_id: bool,
-    ) -> Self{
-        let mut config = ProcessorCharacteristics(0);
-        config.set_reserved(false);
-        config.set_unknown(unknown);
-        config.set_64bit_capable(_64bit_capable);
-        config.set_multi_core(multi_core);
-        config.set_hardware_thread(hardware_thread);
-        config.set_execute_protection(execute_protection);
-        config.set_enhanced_virtualization(enhanced_virtualization);
-        config.set_performance_control(performance_control);
-        config.set_128bit_capable(_128bit_capable);
-        config.set_arm64_soc_id(arm64_soc_id);
-        config.set_reserved2(0);
-        config
-    }
+/// Cache Size 2 (Type 7, offset 0x13 / 0x17)
+#[bitfield(u32)]
+#[derive(IntoBytes, Immutable, KnownLayout)]
+pub struct CacheSize2 {
+    #[bits(31)]
+    pub max_size: u32,
+    pub granularity: bool,
 }
 
-bitfield! {
-    ///
-    /// Cache Information - Cache Configuration
-    ///
-    pub struct CacheConfiguration (u16);
-    impl Debug;
-    pub cache_level, set_cache_level: 2, 0;
-    pub cache_socketed, set_cache_socketed: 3;
-    // reserved must be zero
-    pub reserved, set_reserved: 4;
-    pub location, set_location: 6, 5;
-    pub enabled_disabled, set_enabled_disabled: 7;
-    pub operational_mode, set_operational_mode: 9, 8;
-    // reserved2 must be zero
-    pub reserved2, set_reserved2: 15, 10;
+/// Cache SRAM Type (Type 7, offset 0x0B / 0x0D)
+#[bitfield(u16)]
+#[derive(IntoBytes, Immutable, KnownLayout)]
+pub struct CacheSramTypeData {
+    pub other: bool,
+    pub unknown: bool,
+    pub non_burst: bool,
+    pub burst: bool,
+    pub pipeline_burst: bool,
+    pub synchronous: bool,
+    pub asynchronous: bool,
+    #[bits(9)]
+    pub reserved: u16,
 }
 
-impl CacheConfiguration {
-    pub fn new(
-        cache_level: u16,
-        cache_socketed: bool,
-        location: u16,
-        enabled_disabled: bool,
-        operational_mode: u16,
-    ) -> Self {
-        let mut config = CacheConfiguration(0);
-        config.set_cache_level(cache_level);
-        config.set_cache_socketed(cache_socketed);
-        config.set_reserved(false); // reserved must be zero
-        config.set_location(location);
-        config.set_enabled_disabled(enabled_disabled);
-        config.set_operational_mode(operational_mode);
-        config.set_reserved2(0); // reserved2 must be zero
-        config
-    }
-}
-
-bitfield! {
-    ///
-    /// Cache Information - Cache Size
-    ///
-    pub struct CacheSize (u16);
-    impl Debug;
-    pub max_size, set_max_size : 14, 0;
-    pub granularity, set_granularity : 15;
-}
-
-impl CacheSize {
-    pub fn new(
-        max_size: u16,
-        granularity: bool,
-    ) -> Self {
-        let mut config = CacheSize(0);
-        config.set_max_size(max_size);
-        config.set_granularity(granularity);
-        config
-    }
-}
-
-bitfield! {
-    ///
-    /// Cache Information - Cache Size 2
-    ///
-    pub struct CacheSize2 (u32);
-    impl Debug;
-    pub max_size, set_max_size : 30, 0;
-    pub granularity, set_granularity : 31;
-}
-
-impl CacheSize2 {
-    pub fn new(
-        max_size: u32,
-        granularity: bool,
-    ) -> Self {
-        let mut config = CacheSize2(0);
-        config.set_max_size(max_size);
-        config.set_granularity(granularity);
-        config
-    }
-}
-
-bitfield! {
-    ///
-    /// Cache Information - SRAM Type
-    ///
-    pub struct CacheSramTypeData(u16);
-    impl Debug;
-    pub other, set_other: 0;
-    pub unknown, set_unknown: 1;
-    pub non_burst, set_non_burst: 2;
-    pub burst, set_burst: 3;
-    pub pipeline_burst, set_pipeline_burst: 4;
-    pub synchronous, set_synchronous: 5;
-    pub asynchronous, set_asynchronous: 6;
-    // reserved must be zero
-    pub reserved, set_reserved: 15, 7;
-}
-
-impl CacheSramTypeData {
-    pub fn new(
-        other: bool,
-        unknown: bool,
-        non_burst: bool,
-        burst: bool,
-        pipeline_burst: bool,
-        synchronous: bool,
-        asynchronous: bool,
-    ) -> Self {
-        let mut config = CacheSramTypeData(0);
-        config.set_other(other);
-        config.set_unknown(unknown);
-        config.set_non_burst(non_burst);
-        config.set_burst(burst);
-        config.set_pipeline_burst(pipeline_burst);
-        config.set_synchronous(synchronous);
-        config.set_asynchronous(asynchronous);
-        config.set_reserved(0);
-        config
-    }
-}
-
-///
-/// Cache Information - Error Correction Type
-///
-#[derive(Copy, Clone, Debug)]
+/// Cache Error Correction Type (Type 7, offset 0x10)
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, IntoBytes, Immutable, KnownLayout)]
 pub enum ErrorCorrectionType {
     Other = 0x01,
-    Unknown,
-    None,
-    Parity,
-    SingleBitEcc,
-    MutliBitEcc,
+    Unknown = 0x02,
+    NoEcc = 0x03,
+    Parity = 0x04,
+    SingleBitEcc = 0x05,
+    MutliBitEcc = 0x06,
 }
 
-///
-/// Cache Information - System Cache Type
-///
-#[derive(Copy, Clone, Debug)]
+/// System Cache Type (Type 7, offset 0x11)
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, IntoBytes, Immutable, KnownLayout)]
 pub enum SystemCacheType {
     Other = 0x01,
-    Unknown,
-    Instruction,
-    Data,
-    Unified,
+    Unknown = 0x02,
+    Instruction = 0x03,
+    Data = 0x04,
+    Unified = 0x05,
 }
 
-///
-/// Cache Information - Error Correction Type
-///
-#[derive(Copy, Clone, Debug)]
+/// Cache Associativity Field (Type 7, offset 0x12)
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, IntoBytes, Immutable, KnownLayout)]
 pub enum AssociativityField {
     Other = 0x01,
-    Unknown,
-    DirectMapped,
-    SetAssociative2Way,
-    SetAssociative4Way,
-    FullyAssociative,
-    SetAssociative8Way,
-    SetAssociative16Way,
-    SetAssociative12Way,
-    SetAssociative24Way,
-    SetAssociative32Way,
-    SetAssociative48Way,
-    SetAssociative64Way,
-    SetAssociative20Way,
+    Unknown = 0x02,
+    DirectMapped = 0x03,
+    SetAssociative2Way = 0x04,
+    SetAssociative4Way = 0x05,
+    FullyAssociative = 0x06,
+    SetAssociative8Way = 0x07,
+    SetAssociative16Way = 0x08,
+    SetAssociative12Way = 0x09,
+    SetAssociative24Way = 0x0A,
+    SetAssociative32Way = 0x0B,
+    SetAssociative48Way = 0x0C,
+    SetAssociative64Way = 0x0D,
+    SetAssociative20Way = 0x0E,
 }
 
-///
-/// System Slots - Slot Type
-///
-#[derive(Copy, Clone, Debug)]
+/// System Slot Type (Type 9, offset 0x05) - BYTE per spec
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, IntoBytes, Immutable, KnownLayout)]
 pub enum SlotType {
     Other = 0x01,
-    Unknown,
-    Isa,
-    Mca,
-    Eisa,
-    Pci,
-    PcCard,
-    VlVesa,
-    Proprietary,
-    ProcessorCardSlot,
-    ProprietaryMemroyCardSlot,
-    IoRiserCardSlot,
-    NuBus,
-    // 66MHz Capable PCI
-    Pci66mhz,
-    Agp,
-    Agp2x,
-    Agp4x,
-    PciX,
-    Agp8x,
-    M2Socket1DP,
-    M2Socket1SD,
-    M2Socket2,
-    M2Socket3,
-    MxmTypeI,
-    MxmTypeII,
-    MxmTypeIIIStandard,
-    MxmTypeIIIHe,
-    MxmTypeIV,
-    Mxm3TypeA,
-    Mxm3TypeB,
-    // PCI Express Gen 2 SFF-8639 (U.2)
-    PciExpressGen2Sff8629,
-    // PCI Express Gen 3 SFF-8639 (U.2)
-    PciExpressGen3Sff8629,
-    // PCI Express Mini 52-pin (CEM spec. 2.0) with bottom-side keep-outs
-    PciExpressMini52PinBottomSideKeepOuts,
-    // PCI Express Mini 52-pin (CEM spec. 2.0) without bottom-side keep-outs.
-    PciExpressMini52Pin,
-    PciExpressMini76Pin,
-    // PCI Express Gen 4 SFF-8639 (U.2)
-    PciExpressGen4Sff8639,
-    // PCI Express Gen 5 SFF-8639 (U.2)
-    PciExpressGen5Sff8639,
-    OcpNic3SFF,
-    OcpNic3LFF,
-    // OCP NIC Prior to 3.0
-    OcpNicPrior,
+    Unknown = 0x02,
+    Isa = 0x03,
+    Mca = 0x04,
+    Eisa = 0x05,
+    Pci = 0x06,
+    PcCard = 0x07,
+    VlVesa = 0x08,
+    Proprietary = 0x09,
+    ProcessorCardSlot = 0x0A,
+    ProprietaryMemroyCardSlot = 0x0B,
+    IoRiserCardSlot = 0x0C,
+    NuBus = 0x0D,
+    Pci66mhz = 0x0E,
+    Agp = 0x0F,
+    Agp2x = 0x10,
+    Agp4x = 0x11,
+    PciX = 0x12,
+    Agp8x = 0x13,
+    M2Socket1DP = 0x14,
+    M2Socket1SD = 0x15,
+    M2Socket2 = 0x16,
+    M2Socket3 = 0x17,
+    MxmTypeI = 0x18,
+    MxmTypeII = 0x19,
+    MxmTypeIIIStandard = 0x1A,
+    MxmTypeIIIHe = 0x1B,
+    MxmTypeIV = 0x1C,
+    Mxm3TypeA = 0x1D,
+    Mxm3TypeB = 0x1E,
+    PciExpressGen2Sff8629 = 0x1F,
+    PciExpressGen3Sff8629 = 0x20,
+    PciExpressMini52PinBottomSideKeepOuts = 0x21,
+    PciExpressMini52Pin = 0x22,
+    PciExpressMini76Pin = 0x23,
+    PciExpressGen4Sff8639 = 0x24,
+    PciExpressGen5Sff8639 = 0x25,
+    OcpNic3SFF = 0x26,
+    OcpNic3LFF = 0x27,
+    OcpNicPrior = 0x28,
     Pc98C20 = 0xA0,
-    Pc98C24,
-    Pc98E,
-    Pc98LocalBus,
-    Pc98Card,
-    PciExpress,
-    PciExpressx1,
-    PciExpressx2,
-    PciExpressx4,
-    PciExpressx8,
-    PciExpressx16,
-    PciExpressGen2,
-    PciExpressGen2x1,
-    PciExpressGen2x2,
-    PciExpressGen2x4,
-    PciExpressGen2x8,
-    PciExpressGen2x16,
-    PciExpressGen3,
-    PciExpressGen3x1,
-    PciExpressGen3x2,
-    PciExpressGen3x4,
-    PciExpressGen3x8,
-    PciExpressGen3x16,
+    Pc98C24 = 0xA1,
+    Pc98E = 0xA2,
+    Pc98LocalBus = 0xA3,
+    Pc98Card = 0xA4,
+    PciExpress = 0xA5,
+    PciExpressx1 = 0xA6,
+    PciExpressx2 = 0xA7,
+    PciExpressx4 = 0xA8,
+    PciExpressx8 = 0xA9,
+    PciExpressx16 = 0xAA,
+    PciExpressGen2 = 0xAB,
+    PciExpressGen2x1 = 0xAC,
+    PciExpressGen2x2 = 0xAD,
+    PciExpressGen2x4 = 0xAE,
+    PciExpressGen2x8 = 0xAF,
+    PciExpressGen2x16 = 0xB0,
+    PciExpressGen3 = 0xB1,
+    PciExpressGen3x1 = 0xB2,
+    PciExpressGen3x2 = 0xB3,
+    PciExpressGen3x4 = 0xB4,
+    PciExpressGen3x8 = 0xB5,
+    PciExpressGen3x16 = 0xB6,
     PciExpressGen4 = 0xB8,
-    PciExpressGen4x1,
-    PciExpressGen4x2,
-    PciExpressGen4x4,
-    PciExpressGen4x8,
-    PciExpressGen4x16,
-    PciExpressGen5,
-    PciExpressGen5x1,
-    PciExpressGen5x2,
-    PciExpressGen5x4,
-    PciExpressGen5x8,
-    PciExpressGen5x16,
-    PciExpressGen6,
-    // Enterprise and Datacenter 1U E1 Form Factor Slot (EDSFF E1.S, E1.L)
-    EdsffE1SE1L,
-    // Enterprise and Datacenter 3" E3 Form Factor Slot (EDSFF E3.S, E3.L)
-    EdsffE3SE3L,
+    PciExpressGen4x1 = 0xB9,
+    PciExpressGen4x2 = 0xBA,
+    PciExpressGen4x4 = 0xBB,
+    PciExpressGen4x8 = 0xBC,
+    PciExpressGen4x16 = 0xBD,
+    PciExpressGen5 = 0xBE,
+    PciExpressGen5x1 = 0xBF,
+    PciExpressGen5x2 = 0xC0,
+    PciExpressGen5x4 = 0xC1,
+    PciExpressGen5x8 = 0xC2,
+    PciExpressGen5x16 = 0xC3,
+    PciExpressGen6 = 0xC4,
+    EdsffE1SE1L = 0xC5,
+    EdsffE3SE3L = 0xC6,
 }
 
-///
-/// System Slots - Slot Data Bus Width
-///
-#[derive(Copy, Clone, Debug)]
+/// System Slot Data Bus Width (Type 9, offset 0x06)
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, IntoBytes, Immutable, KnownLayout)]
 pub enum SlotWidth {
     Other = 0x01,
-    Unknown,
-    Bit8,
-    Bit16,
-    Bit32,
-    Bit64,
-    Bit128,
-    X1,
-    X2,
-    X4,
-    X8,
-    X12,
-    X16,
-    X32,
+    Unknown = 0x02,
+    Bit8 = 0x03,
+    Bit16 = 0x04,
+    Bit32 = 0x05,
+    Bit64 = 0x06,
+    Bit128 = 0x07,
+    X1 = 0x08,
+    X2 = 0x09,
+    X4 = 0x0A,
+    X8 = 0x0B,
+    X12 = 0x0C,
+    X16 = 0x0D,
+    X32 = 0x0E,
 }
 
-///
-/// System Slots - Current Usage
-///
-#[derive(Copy, Clone, Debug)]
+/// System Slot Current Usage (Type 9, offset 0x07)
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, IntoBytes, Immutable, KnownLayout)]
 pub enum CurrentUsage {
     Other = 0x01,
-    Unknown,
-    Available,
-    InUse,
-    Unavailable,
+    Unknown = 0x02,
+    Available = 0x03,
+    InUse = 0x04,
+    Unavailable = 0x05,
 }
 
-///
-/// System Slots - Slot Length
-///
-#[derive(Copy, Clone, Debug)]
+/// System Slot Length (Type 9, offset 0x08)
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, IntoBytes, Immutable, KnownLayout)]
 pub enum SlotLength {
     Other = 0x01,
-    Unknown,
-    ShortLength,
-    LongLength,
-    // 2.5" drive form factor
-    DriveFF25,
-    // 3.5" drive form factor
-    DriveFF35,
+    Unknown = 0x02,
+    ShortLength = 0x03,
+    LongLength = 0x04,
+    DriveFF25 = 0x05,
+    DriveFF35 = 0x06,
 }
 
-bitfield! {
-    ///
-    /// System Slots - Slot Charcteristics 1
-    ///
-    pub struct SlotCharacteristics1(u8);
-    impl Debug;
-    pub characteristics_unknown, set_characteristics_unknown: 0;
-    pub provides_5_volts, set_provides_5_volts: 1;
-    pub provides_3_volts, set_provides_3_volts: 2;
-    pub shared_slot, set_shared_slot: 3;
-    pub pc_supports_pccard16, set_pc_supports_pccard16: 4;
-    pub pc_supports_cardbus, set_pc_supports_cardbus: 5;
-    pub pc_supports_zoomvideo, set_pc_supports_zoomvideo: 6;
-    pub pc_supports_modemringresume, set_pc_supports_modemringresume: 7;
+/// System Slot Characteristics 1 (Type 9, offset 0x0B)
+#[bitfield(u8)]
+#[derive(IntoBytes, Immutable, KnownLayout)]
+pub struct SlotCharacteristics1 {
+    pub characteristics_unknown: bool,
+    pub provides_5_volts: bool,
+    pub provides_3_volts: bool,
+    pub shared_slot: bool,
+    pub pc_supports_pccard16: bool,
+    pub pc_supports_cardbus: bool,
+    pub pc_supports_zoomvideo: bool,
+    pub pc_supports_modemringresume: bool,
 }
 
-impl SlotCharacteristics1 {
-    pub fn new(
-        characteristics_unknown: bool,
-        provides_5_volts: bool,
-        provides_3_volts: bool,
-        shared_slot: bool,
-        pc_supports_pccard16: bool,
-        pc_supports_cardbus: bool,
-        pc_supports_zoomvideo: bool,
-        pc_supports_modemringresume: bool,
-    ) -> Self{
-        let mut config = SlotCharacteristics1(0);
-        config.set_characteristics_unknown(characteristics_unknown);
-        config.set_provides_5_volts(provides_5_volts);
-        config.set_provides_3_volts(provides_3_volts);
-        config.set_shared_slot(shared_slot);
-        config.set_pc_supports_pccard16(pc_supports_pccard16);
-        config.set_pc_supports_cardbus(pc_supports_cardbus);
-        config.set_pc_supports_zoomvideo(pc_supports_zoomvideo);
-        config.set_pc_supports_modemringresume(pc_supports_modemringresume);
-        config
-    }
+/// System Slot Characteristics 2 (Type 9, offset 0x0C)
+#[bitfield(u8)]
+#[derive(IntoBytes, Immutable, KnownLayout)]
+pub struct SlotCharacteristics2 {
+    pub pci_supports_pme: bool,
+    pub supports_hotplug: bool,
+    pub pci_supports_smbus: bool,
+    pub pcie_supports_bifurcation: bool,
+    pub supports_async_removal: bool,
+    pub flexbus_slot1: bool,
+    pub flexbus_slot2: bool,
+    pub flexbus_slot3: bool,
 }
 
-bitfield! {
-    ///
-    /// System Slots - Slot Charcteristics 2
-    ///
-    /// Various fields were added through SMBIOS Version 3. For not-applicable fields use '0'.
-    ///
-    pub struct  SlotCharacteristics2(u8);
-    impl Debug;
-    pub pci_supports_pme, set_pci_supports_pme: 0;
-    pub supports_hotplug, set_supports_hotplug: 1;
-    pub pci_supports_smbus, set_pci_supports_smbus: 2;
-    pub pcie_supports_bifurcation, set_pcie_supports_bifurcation: 3;
-    pub supports_async_removal, set_supports_async_removal: 4;
-    // Flexbus slot, CXL 1.0 capable
-    pub flexbus_slot1, set_flexbus_slot1: 5;
-    // Flexbus slot, CXL 2.0 capable
-    pub flexbus_slot2, set_flexbus_slot2: 6;
-    // Flexbus slot, CXL 3.0 capable
-    pub flexbus_slot3, set_flexbus_slot3: 7;
+/// System Slot Device/Function Number (Type 9, offset 0x10)
+#[bitfield(u8)]
+#[derive(IntoBytes, Immutable, KnownLayout)]
+pub struct DeviceFunctionNumber {
+    #[bits(3)]
+    pub function_number: u8,
+    #[bits(5)]
+    pub device_number: u8,
 }
 
-impl SlotCharacteristics2 {
-    pub fn new(
-        pci_supports_pme: bool,
-        supports_hotplug: bool,
-        pci_supports_smbus: bool,
-        pcie_supports_bifurcation: bool,
-        supports_async_removal: bool,
-        flexbus_slot1: bool,
-        flexbus_slot2: bool,
-        flexbus_slot3: bool,
-    ) -> Self{
-        let mut config = SlotCharacteristics2(0);
-        config.set_pci_supports_pme(pci_supports_pme);
-        config.set_supports_hotplug(supports_hotplug);
-        config.set_pci_supports_smbus(pci_supports_smbus);
-        config.set_pcie_supports_bifurcation(pcie_supports_bifurcation);
-        config.set_supports_async_removal(supports_async_removal);
-        config.set_flexbus_slot1(flexbus_slot1);
-        config.set_flexbus_slot2(flexbus_slot2);
-        config.set_flexbus_slot3(flexbus_slot3);
-        config
-    }
-}
-
-bitfield! {
-    ///
-    /// System Slots - Device/Function Number
-    ///
-    #[derive(Copy, Clone)] 
-    pub struct  DeviceFunctionNumber(u8);
-    impl Debug;
-    pub function_number, set_function_number : 2, 0;
-    pub device_number, set_device_number : 7, 3;
-}
-
-impl DeviceFunctionNumber {
-    pub fn new(
-        function_number: u8,
-        device_number: u8
-    ) -> Self{
-        let mut config = DeviceFunctionNumber(0);
-        config.set_function_number(function_number);
-        config.set_device_number(device_number);
-        config
-    }
-}
-
-///
-/// System Slots - Peer Segment/Bus/Device/Function/Width Groups
-///
-#[derive(Copy, Clone, Debug)]
+/// System Slot Peer Group entry (5 bytes)
+#[repr(C, packed)]
+#[derive(Copy, Clone, Debug, IntoBytes, Immutable, KnownLayout)]
 pub struct MiscSlotPeerGroup {
     pub segment_group_num: u16,
     pub bus_num: u8,
@@ -1316,366 +903,173 @@ pub struct MiscSlotPeerGroup {
     pub data_bus_width: u8,
 }
 
-///
-/// Memory Array - Location
-///
-#[derive(Copy, Clone, Debug)]
+/// Memory Array Location (Type 16, offset 0x04)
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, IntoBytes, Immutable, KnownLayout)]
 pub enum MemoryArrayLocation {
     Other = 0x01,
-    Unknown,
-    SystemBoard,
-    IsaAddOn,
-    EisaAddOn,
-    PciAddOn,
-    McaAddOn,
-    PcmciaAddOn,
-    ProprietaryAddOn,
-    NuBus,
+    Unknown = 0x02,
+    SystemBoard = 0x03,
+    IsaAddOn = 0x04,
+    EisaAddOn = 0x05,
+    PciAddOn = 0x06,
+    McaAddOn = 0x07,
+    PcmciaAddOn = 0x08,
+    ProprietaryAddOn = 0x09,
+    NuBus = 0x0A,
     Pc98C20AddOn = 0xA0,
-    Pc98C24AddOn,
-    Pc98EAddOn,
-    Pc98LocalAddOn,
-    CxlAddOn,
+    Pc98C24AddOn = 0xA1,
+    Pc98EAddOn = 0xA2,
+    Pc98LocalAddOn = 0xA3,
+    CxlAddOn = 0xA4,
 }
 
-///
-/// Memory Array - Use
-///
-#[derive(Copy, Clone, Debug)]
+/// Memory Array Use (Type 16, offset 0x05)
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, IntoBytes, Immutable, KnownLayout)]
 pub enum MemoryArrayUse {
     Other = 0x01,
-    Unknown,
-    SystemMemory,
-    VideoMemory,
-    FlashMemory,
-    NonVolatileRam,
-    CacheMemory,
+    Unknown = 0x02,
+    SystemMemory = 0x03,
+    VideoMemory = 0x04,
+    FlashMemory = 0x05,
+    NonVolatileRam = 0x06,
+    CacheMemory = 0x07,
 }
 
-///
-/// Memory Array - Error Correction Types
-///
-#[derive(Copy, Clone, Debug)]
+/// Memory Array Error Correction Types (Type 16, offset 0x06)
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, IntoBytes, Immutable, KnownLayout)]
 pub enum ErrorCorrectionTypes {
     Other = 0x01,
-    Unknown,
-    None,
-    Parity,
-    SingleBitEcc,
-    MultiBitEcc,
-    Crc,
+    Unknown = 0x02,
+    NoEcc = 0x03,
+    Parity = 0x04,
+    SingleBitEcc = 0x05,
+    MultiBitEcc = 0x06,
+    Crc = 0x07,
 }
 
-///
-/// Memory Device - Form Factor
-///
+/// Memory Device Form Factor (Type 17, offset 0x0E)
 #[repr(u8)]
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone, Debug, IntoBytes, Immutable, KnownLayout)]
 pub enum MemoryFormFactor {
     Other = 0x01,
-    Unknown,
-    Simm,
-    Sip,
-    Chip,
-    Dip,
-    Zip,
-    ProprietaryCard,
-    Dimm,
-    Tsop,
-    RowOfChips,
-    Rimm,
-    Sodimm,
-    Srimm,
-    FbDimm,
-    Die,
-    Camm,
-    Cudimm,
-    Csodimm,
+    Unknown = 0x02,
+    Simm = 0x03,
+    Sip = 0x04,
+    Chip = 0x05,
+    Dip = 0x06,
+    Zip = 0x07,
+    ProprietaryCard = 0x08,
+    Dimm = 0x09,
+    Tsop = 0x0A,
+    RowOfChips = 0x0B,
+    Rimm = 0x0C,
+    Sodimm = 0x0D,
+    Srimm = 0x0E,
+    FbDimm = 0x0F,
+    Die = 0x10,
+    Camm = 0x11,
+    Cudimm = 0x12,
+    Csodimm = 0x13,
 }
 
-///
-/// Memory Device - Type
-///
-#[derive(Copy, Clone, Debug)]
+/// Memory Device Memory Type (Type 17, offset 0x12)
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, IntoBytes, Immutable, KnownLayout)]
 pub enum MemoryDeviceType {
     Other = 0x01,
-    Unknown,
-    Dram,
-    Edram,
-    Vram,
-    Sram,
-    Ram,
-    Rom,
-    Flash,
-    Eeprom,
-    Feprom,
-    Eprom,
-    Cdram,
-    ThreeDram,
-    Sdram,
-    Sgram,
-    Rdram,
-    Ddr,
-    Ddr2,
-    Ddr2FbDimm,
+    Unknown = 0x02,
+    Dram = 0x03,
+    Edram = 0x04,
+    Vram = 0x05,
+    Sram = 0x06,
+    Ram = 0x07,
+    Rom = 0x08,
+    Flash = 0x09,
+    Eeprom = 0x0A,
+    Feprom = 0x0B,
+    Eprom = 0x0C,
+    Cdram = 0x0D,
+    ThreeDram = 0x0E,
+    Sdram = 0x0F,
+    Sgram = 0x10,
+    Rdram = 0x11,
+    Ddr = 0x12,
+    Ddr2 = 0x13,
+    Ddr2FbDimm = 0x14,
     Ddr3 = 0x18,
-    Fbd2,
-    Ddr4,
-    Lpddr,
-    Lpddr2,
-    Lpddr3,
-    Lpddr4,
-    LogicalNonVolatileDevice,
-    Hbm,
-    Hbm2,
-    Ddr5,
-    Lpddr5,
-    Hbm3,
-    Mrdimm,
+    Fbd2 = 0x19,
+    Ddr4 = 0x1A,
+    Lpddr = 0x1B,
+    Lpddr2 = 0x1C,
+    Lpddr3 = 0x1D,
+    Lpddr4 = 0x1E,
+    LogicalNonVolatileDevice = 0x1F,
+    Hbm = 0x20,
+    Hbm2 = 0x21,
+    Ddr5 = 0x22,
+    Lpddr5 = 0x23,
+    Hbm3 = 0x24,
+    Mrdimm = 0x25,
 }
 
-bitfield! {
-    ///
-    /// Memory Device - Type Detail
-    ///
-    pub struct MemoryDeviceTypeDetails(u16);
-    impl Debug;
-    pub reserved, set_reserved: 0;
-    pub other, set_other: 1;
-    pub unknown, set_unknown: 2;
-    pub fast_paged, set_fast_paged: 3;
-    pub static_column, set_static_column: 4;
-    pub pseudo_static, set_pseudo_static: 5;
-    pub rambus, set_rambus: 6;
-    pub synchronous, set_synchronous: 7;
-    pub cmos, set_cmos: 8;
-    pub edo, set_edo: 9;
-    pub window_dram, set_window_dram: 10;
-    pub cache_dram, set_cache_dram: 11;
-    pub nonvolatile, set_nonvolatile: 12;
-    pub registered, set_registered: 13;
-    pub unbuffered, set_unbuffered: 14;
-    pub lr_dimm, set_lr_dimm: 15;
+/// Memory Device Type Detail (Type 17, offset 0x13)
+#[bitfield(u16)]
+#[derive(IntoBytes, Immutable, KnownLayout)]
+pub struct MemoryDeviceTypeDetails {
+    pub reserved: bool,
+    pub other: bool,
+    pub unknown: bool,
+    pub fast_paged: bool,
+    pub static_column: bool,
+    pub pseudo_static: bool,
+    pub rambus: bool,
+    pub synchronous: bool,
+    pub cmos: bool,
+    pub edo: bool,
+    pub window_dram: bool,
+    pub cache_dram: bool,
+    pub nonvolatile: bool,
+    pub registered: bool,
+    pub unbuffered: bool,
+    pub lr_dimm: bool,
 }
 
-impl MemoryDeviceTypeDetails {
-    pub fn new(
-        other: bool,
-        unknown: bool,
-        fast_paged: bool,
-        static_column: bool,
-        pseudo_static: bool,
-        rambus: bool,
-        synchronous: bool,
-        cmos: bool,
-        edo: bool,
-        window_dram: bool,
-        cache_dram: bool,
-        nonvolatile: bool,
-        registered: bool,
-        unbuffered: bool,
-        lr_dimm: bool
-    ) -> Self {
-        let mut config = MemoryDeviceTypeDetails(0);
-        config.set_reserved(false);
-        config.set_other(other);
-        config.set_unknown(unknown);
-        config.set_fast_paged(fast_paged);
-        config.set_static_column(static_column);
-        config.set_pseudo_static(pseudo_static);
-        config.set_rambus(rambus);
-        config.set_synchronous(synchronous);
-        config.set_cmos(cmos);
-        config.set_edo(edo);
-        config.set_window_dram(window_dram);
-        config.set_cache_dram(cache_dram);
-        config.set_nonvolatile(nonvolatile);
-        config.set_registered(registered);
-        config.set_unbuffered(unbuffered);
-        config.set_lr_dimm(lr_dimm);        
-        config
-    }
-}
-
-///
-/// Memory Device - Memory Technology
-///
-#[derive(Copy, Clone, Debug)]
+/// Memory Device Memory Technology (Type 17, offset 0x28)
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, IntoBytes, Immutable, KnownLayout)]
 pub enum MemoryDeviceTechnology {
     Other = 0x01,
-    Unknown,
-    Dram,
-    NvdimmN,
-    NvdimmF,
-    NvdimmP,
-    IntelOptanePersistentMemory,
+    Unknown = 0x02,
+    Dram = 0x03,
+    NvdimmN = 0x04,
+    NvdimmF = 0x05,
+    NvdimmP = 0x06,
+    IntelOptanePersistentMemory = 0x07,
 }
 
-bitfield! {
-    ///
-    /// Memory Device - Attributes
-    ///
-    pub struct MemoryDeviceAttributes(u8);
-    impl Debug;
-    pub rank, set_rank: 3, 0;
-    pub reserved, set_reserved: 7, 4;
+/// Memory Device Attributes (Type 17, offset 0x21)
+#[bitfield(u8)]
+#[derive(IntoBytes, Immutable, KnownLayout)]
+pub struct MemoryDeviceAttributes {
+    #[bits(4)]
+    pub rank: u8,
+    #[bits(4)]
+    pub reserved: u8,
 }
 
-impl MemoryDeviceAttributes {
-    pub fn new(
-        rank: u8
-    ) -> Self{
-        let mut config = MemoryDeviceAttributes(0);
-        config.set_rank(rank);
-        config.set_reserved(0);
-        config
-    }
-}
-
-bitfield! {
-    ///
-    /// Memory Device - Operating Mode Capability
-    ///
-    pub struct MemoryCapability(u16);
-    impl Debug;
-    // reserved is set to zero
-    pub reserved, set_reserved : 0;
-    pub other, set_other : 1;
-    pub unknown, set_unknown : 2;
-    pub volatile_memory, set_volatile_memory : 3;
-    // Byte-accessible persistent memory
-    pub byte_persistent_memory, set_byte_persistent_memory : 4;
-    // Block-accessible persistent memory
-    pub block_persistent_memory, set_block_persistent_memory : 5;
-    // reserved2 is set to zero
-    pub reserved2, set_reserved2 : 15, 6;
-}
-
-impl MemoryCapability {
-    pub fn new(
-        other: bool,
-        unknown: bool,
-        volatile_memory: bool,
-        byte_persistent_memory: bool,
-        block_persistent_memory: bool,
-    ) -> Self {
-        let mut config = MemoryCapability(0);
-        config.set_reserved(false);
-        config.set_other(other);
-        config.set_unknown(unknown);
-        config.set_volatile_memory(volatile_memory);
-        config.set_byte_persistent_memory(byte_persistent_memory);
-        config.set_block_persistent_memory(block_persistent_memory);
-        config.set_reserved2(0);
-        config
-    }
-}
-
-macro_rules! impl_to_le_bytes_u8 {
-    ($($t:ty),*) => {
-        $(
-            impl $t {
-                pub fn to_le_bytes(&self) -> alloc::vec::Vec<u8> {
-                    alloc::vec![*self as u8]
-                }
-            }
-        )*
-    };
-}
-
-macro_rules! impl_to_le_bytes_u16 {
-    ($($t:ty),*) => {
-        $(
-            impl $t {
-                pub fn to_le_bytes(&self) -> alloc::vec::Vec<u8> {
-                    (*self as u16).to_le_bytes().to_vec()
-                }
-            }
-        )*
-    };
-}
-
-macro_rules! impl_to_le_bytes_bitfield {
-    ($($t:ty),*) => {
-        $(
-            impl $t {
-                pub fn to_le_bytes(&self) -> alloc::vec::Vec<u8> {
-                    self.0.to_le_bytes().to_vec()
-                }
-            }
-        )*
-    };
-}
-
-// Use the macros
-impl_to_le_bytes_u8!(
-    ProcessorTypeData,
-    ProcessorUpgrade,
-    ErrorCorrectionType,
-    SystemCacheType,
-    AssociativityField,
-    SlotWidth,
-    CurrentUsage,
-    SlotLength,
-    MemoryArrayLocation,
-    MemoryArrayUse,
-    ErrorCorrectionTypes,
-    MemoryFormFactor,
-    MemoryDeviceType,
-    MemoryDeviceTechnology,
-    BoardType,
-    WakeUpType,
-    BootUpState,
-    PowerSupplyState,
-    ThermalState,
-    SecurityStatus
-);
-
-impl_to_le_bytes_u16!(
-    ProcessorFamilyData,
-    SlotType
-);
-
-impl_to_le_bytes_bitfield!(
-    ProcessorCharacteristics,
-    CacheConfiguration,
-    CacheSize,
-    CacheSramTypeData,
-    MemoryDeviceTypeDetails,
-    MemoryCapability,
-    ExtendedBiosRomSize,
-    CacheSize2,
-    BiosCharacteristics,
-    ProcessorVoltage,
-    ProcessorInformationStatus,
-    SlotCharacteristics1,
-    SlotCharacteristics2,
-    DeviceFunctionNumber,
-    MemoryDeviceAttributes,
-    BiosCharacteristicsExt1,
-    BiosCharacteristicsExt2,
-    ContainedElementType,
-    FeatureFlags
-);
-
-// special to_le_bytes for structs that use bitfields
-impl MiscSlotPeerGroup {
-    pub fn to_le_bytes(&self) -> alloc::vec::Vec<u8> {
-        let mut bytes = alloc::vec::Vec::new();
-        bytes.extend_from_slice(&self.segment_group_num.to_le_bytes());
-        bytes.push(self.bus_num);
-        bytes.push(self.dev_func_num.0);
-        bytes.push(self.data_bus_width);
-        bytes
-    }
-}
-
-impl ContainedElements {
-    pub fn to_le_bytes(&self) -> alloc::vec::Vec<u8> {
-        let mut bytes = alloc::vec::Vec::new();
-        bytes.push(self.contained_element_type.0);
-        bytes.push(self.contained_element_minimum);
-        bytes.push(self.contained_element_maximum);
-        bytes
-    }
+/// Memory Device Operating Mode Capability (Type 17, offset 0x29)
+#[bitfield(u16)]
+#[derive(IntoBytes, Immutable, KnownLayout)]
+pub struct MemoryCapability {
+    pub reserved: bool,
+    pub other: bool,
+    pub unknown: bool,
+    pub volatile_memory: bool,
+    pub byte_persistent_memory: bool,
+    pub block_persistent_memory: bool,
+    #[bits(10)]
+    pub reserved2: u16,
 }

--- a/cspell.yml
+++ b/cspell.yml
@@ -33,42 +33,13 @@ allowCompoundWords: true
 words:
   - aarch
   - acpibase
-  - athlon
-  - cdram
-  - celeron
-  - corem
-  - csodimm
-  - cudimm
-  - duron
-  - edram
-  - edsff
-  - eeprom
-  - efficeon
-  - eprom
-  - expressx
-  - feprom
-  - loong
-  - loongson
-  - lpddr
-  - mrdimm
-  - mutli
-  - opteron
-  - rdram
-  - riscv
-  - sgram
-  - socketm
-  - socketr
-  - sodimm
-  - srimm
-  - turion
-  - vlvesa
-  - weitek
   - addrs
   - amanieu
   - anstream
   - anstyle
   - antras
   - armasm
+  - athlon
   - autocfg
   - bitvec
   - bootx
@@ -76,14 +47,19 @@ words:
   - bumpalo
   - cbindgen
   - cdecl
+  - cdram
   - cdrom
+  - celeron
   - clangpdb
   - cntfrq
   - cntpct
+  - corem
   - corosensei
   - coverity
   - cpuid
+  - csodimm
   - ctypes
+  - cudimm
   - cuviper
   - deassertion
   - depex
@@ -94,16 +70,24 @@ words:
   - dnested
   - docsrs
   - dtolnay
+  - duron
   - dword
   - dxefv
   - dxeipl
   - edkii
+  - edram
+  - edsff
+  - eeprom
+  - efficeon
   - efiapi
   - eficall
   - efierror
   - eflags
   - epage
+  - eprom
+  - expressx
   - fastrlp
+  - feprom
   - fnent
   - funty
   - fvmain
@@ -113,8 +97,8 @@ words:
   - genfw
   - getrsp
   - getsp
-  - gigantor
   - gicr
+  - gigantor
   - gnullvm
   - gohman
   - granularities
@@ -140,6 +124,10 @@ words:
   - libyaml
   - linkme
   - longjmp
+  - loong
+  - loongson
+  - lpddr
+  - lrdimm
   - lrpair
   - lzmatest
   - mdbook
@@ -147,6 +135,7 @@ words:
   - mmiport
   - mmram
   - mpidr
+  - mrdimm
   - msdia
   - mtrrs
   - nestedfv
@@ -164,6 +153,7 @@ words:
   - openvmm
   - opinfo
   - oprom
+  - opteron
   - ordinalize
   - oslar
   - oslsr
@@ -183,18 +173,25 @@ words:
   - pywin
   - qword
   - rdmsr
+  - rdram
   - rdtsc
   - reentrancy
   - regsvr
   - relia
   - reloc
+  - riscv
   - rposition
   - ruint
   - rwlock
+  - sgram
   - smbus
   - smcport
   - smiport
   - smram
+  - socketm
+  - socketr
+  - sodimm
+  - srimm
   - swmmis
   - syscall
   - syscalls
@@ -203,6 +200,7 @@ words:
   - tiano
   - tianocore
   - tolnay
+  - turion
   - typenum
   - typer
   - uefiext
@@ -214,16 +212,18 @@ words:
   - uncrustify
   - unmaps
   - unrecovered
-  - unregisters
   - unreg
+  - unregisters
   - unspec
   - unsynchronized
   - vcvarsamd
   - vcvarsarm
+  - vlvesa
   - vtable
   - wakeup
   - wasip
   - wbinvd
+  - weitek
   - windbg
   - withf
   - wrmsr

--- a/cspell.yml
+++ b/cspell.yml
@@ -33,6 +33,36 @@ allowCompoundWords: true
 words:
   - aarch
   - acpibase
+  - athlon
+  - cdram
+  - celeron
+  - corem
+  - csodimm
+  - cudimm
+  - duron
+  - edram
+  - edsff
+  - eeprom
+  - efficeon
+  - eprom
+  - expressx
+  - feprom
+  - loong
+  - loongson
+  - lpddr
+  - mrdimm
+  - mutli
+  - opteron
+  - rdram
+  - riscv
+  - sgram
+  - socketm
+  - socketr
+  - sodimm
+  - srimm
+  - turion
+  - vlvesa
+  - weitek
   - addrs
   - amanieu
   - anstream


### PR DESCRIPTION
## Description

Define types for SMBIOS records according the SMBIOS specs 3.0+ and update records to use types. These structs/enums/bitfields force typing when creating SMBIOS records.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [x] Breaking change?
- [x] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

`cargo make all`, plus patina-dxe-core-qemu integration: ported the Q35 and
SBSA SMBIOS platform components onto the new typed records, booted Q35 in
QEMU, and confirmed `q35_smbios_ffi_test` passes against the published SMBIOS
table.

## Integration Instructions

Downstream consumers of `patina_smbios` Type 0 / 1 / 2 / 3 / 4 / 7 / 16 / 17 /
19 records must construct fields with the new types instead of raw integers
(e.g. `BiosCharacteristics::from_bits(0x08)`, `WakeUpType::PowerSwitch`,
`BootUpState::Safe`). For Type 4, set `processor_family: u8 = 0xFE` and put
the typed value in `processor_family2`.

Co-Authored-By: Ansley Thompson <ansley.thompson@dell.com>