### PR TITLE
[REBASE & FF] patina_debugger: Don't Touch Uncached Memory By Default

### DIFF
--- a/core/patina_debugger/src/arch.rs
+++ b/core/patina_debugger/src/arch.rs
@@ -14,8 +14,7 @@
 //!
 
 use gdbstub::target::ext::breakpoints;
-use patina_internal_cpu::interrupts::ExceptionContext;
-use patina_paging::PageTable;
+use patina_internal_cpu::{interrupts::ExceptionContext, paging::PatinaPageTable};
 
 use crate::ExceptionInfo;
 
@@ -42,8 +41,6 @@ pub trait DebuggerArch {
     const BREAKPOINT_INSTRUCTION: &'static [u8];
     const GDB_TARGET_XML: &'static str;
     const GDB_REGISTERS_XML: &'static str;
-
-    type PageTable: PageTable;
 
     /// Executes a breakpoint instruction if the debugger is enabled and initialized.
     fn breakpoint();
@@ -72,7 +69,7 @@ pub trait DebuggerArch {
     fn reboot();
 
     /// Gets the current page table.
-    fn get_page_table() -> Result<Self::PageTable, ()>;
+    fn get_page_table() -> Result<impl PatinaPageTable, ()>;
 
     /// Process architecture specific monitor commands.
     fn monitor_cmd(_tokens: &mut core::str::SplitWhitespace, _out: &mut dyn core::fmt::Write) {}

--- a/core/patina_debugger/src/arch/aarch64.rs
+++ b/core/patina_debugger/src/arch/aarch64.rs
@@ -7,7 +7,7 @@ use core::{
 
 use gdbstub::arch::{RegId, Registers};
 use patina::{read_sysreg, write_sysreg};
-use patina_internal_cpu::interrupts::ExceptionContext;
+use patina_internal_cpu::{interrupts::ExceptionContext, paging::PatinaPageTable};
 
 use crate::{ExceptionInfo, ExceptionType};
 
@@ -55,8 +55,6 @@ impl DebuggerArch for Aarch64Arch {
     const BREAKPOINT_INSTRUCTION: &'static [u8] = &[0x00, 0x00, 0x20, 0xD4]; // BRK #0
     const GDB_TARGET_XML: &'static str = r#"<?xml version="1.0"?><!DOCTYPE target SYSTEM "gdb-target.dtd"><target><architecture>aarch64</architecture><xi:include href="registers.xml"/></target>"#;
     const GDB_REGISTERS_XML: &'static str = include_str!("xml/aarch64_registers.xml");
-
-    type PageTable = patina_paging::aarch64::AArch64PageTable<patina_paging::page_allocator::PageAllocatorStub>;
 
     #[inline(always)]
     fn breakpoint() {
@@ -215,11 +213,11 @@ impl DebuggerArch for Aarch64Arch {
         }
     }
 
-    fn get_page_table() -> Result<Self::PageTable, ()> {
+    fn get_page_table() -> Result<impl PatinaPageTable, ()> {
         // SAFETY: We are operating in an exception context with interrupts disabled. No other entity is altering
         // the page tables.
         unsafe {
-            patina_paging::aarch64::AArch64PageTable::open_active(patina_paging::page_allocator::PageAllocatorStub)
+            patina_internal_cpu::paging::open_active_cpu_paging(patina_paging::page_allocator::PageAllocatorStub)
                 .map_err(|_| ())
         }
     }

--- a/core/patina_debugger/src/arch/x64.rs
+++ b/core/patina_debugger/src/arch/x64.rs
@@ -8,7 +8,7 @@ use gdbstub::{
     arch::{RegId, Registers},
     target::ext::breakpoints::WatchKind,
 };
-use patina_internal_cpu::interrupts::ExceptionContext;
+use patina_internal_cpu::{interrupts::ExceptionContext, paging::PatinaPageTable};
 use patina_mtrr::Mtrr;
 
 use super::{DebuggerArch, UefiArchRegs};
@@ -34,8 +34,6 @@ impl DebuggerArch for X64Arch {
     const BREAKPOINT_INSTRUCTION: &'static [u8] = &[INT_3];
     const GDB_TARGET_XML: &'static str = r#"<?xml version="1.0"?><!DOCTYPE target SYSTEM "gdb-target.dtd"><target><architecture>i386:x86-64</architecture><xi:include href="registers.xml"/></target>"#;
     const GDB_REGISTERS_XML: &'static str = include_str!("xml/x64_registers.xml");
-
-    type PageTable = patina_paging::x64::X64PageTable<patina_paging::page_allocator::PageAllocatorStub>;
 
     #[inline(always)]
     fn breakpoint() {
@@ -146,11 +144,11 @@ impl DebuggerArch for X64Arch {
         }
     }
 
-    fn get_page_table() -> Result<Self::PageTable, ()> {
+    fn get_page_table() -> Result<impl PatinaPageTable, ()> {
         // SAFETY: We are operating in an exception context with interrupts disabled. No other entity is altering
         // the page tables.
         unsafe {
-            patina_paging::x64::X64PageTable::open_active(patina_paging::page_allocator::PageAllocatorStub)
+            patina_internal_cpu::paging::open_active_cpu_paging(patina_paging::page_allocator::PageAllocatorStub)
                 .map_err(|_| ())
         }
     }

--- a/core/patina_debugger/src/dbg_target/monitor.rs
+++ b/core/patina_debugger/src/dbg_target/monitor.rs
@@ -15,6 +15,7 @@ use gdbstub::target::ext::{self, monitor_cmd::ConsoleOutput};
 
 use crate::{
     arch::{DebuggerArch, SystemArch},
+    memory,
     system::SystemStateTrait,
 };
 
@@ -22,19 +23,21 @@ use super::PatinaTarget;
 
 const MONITOR_HELP: &str = "
 Patina Rust Debugger monitor commands:
-    help - Display this help.
     ? - Display information about the state of the machine.
-    reboot - Prepares to reboot the machine on the next continue.
-    mod ... - Commands for breaking on or quering modules.
     arch ... - Architecture specific commands.
+    mod ... - Commands for breaking on or quering modules.
+    help - Display this help.
+    reboot - Prepares to reboot the machine on the next continue.
+    toggle_uncached_access - Toggle accessing uncached memory regions.
+                             By default uncached memory access is disabled.
 ";
 
 const MOD_HELP: &str = "
 Mod commands:
-    list [count] [index] - List loaded modules.
     break [module] - Set load breakpoint for a module.
     breakall - Break on all module loads.
     clear - clear all module breakpoints.
+    list [count] [index] - List loaded modules.
 ";
 
 impl ext::monitor_cmd::MonitorCmd for PatinaTarget {
@@ -91,6 +94,14 @@ impl ext::monitor_cmd::MonitorCmd for PatinaTarget {
             }
             Some("arch") => {
                 SystemArch::monitor_cmd(&mut tokens, &mut buf);
+            }
+            Some("toggle_uncached_access") => {
+                let enabled = memory::toggle_uncached_access();
+                if enabled {
+                    let _ = buf.write_str("Uncached memory access enabled.");
+                } else {
+                    let _ = buf.write_str("Uncached memory access disabled.");
+                }
             }
             Some(cmd) => match self.system_state.try_lock() {
                 Some(state) => {

--- a/core/patina_debugger/src/memory.rs
+++ b/core/patina_debugger/src/memory.rs
@@ -7,7 +7,10 @@
 //! SPDX-License-Identifier: Apache-2.0
 //!
 
-use core::ptr;
+use core::{
+    ptr,
+    sync::atomic::{AtomicBool, Ordering},
+};
 
 use patina_internal_cpu::paging::PatinaPageTable;
 use patina_paging::MemoryAttributes;
@@ -16,6 +19,16 @@ use crate::arch::DebuggerArch;
 
 const PAGE_SIZE: u64 = 0x1000;
 const PAGE_MASK: u64 = !(PAGE_SIZE - 1);
+
+/// Controls whether the debugger will read/write uncached memory regions.
+/// By default (`false`), uncached regions are skipped to avoid side-effects
+/// on memory-mapped I/O. A monitor command can toggle this to `true`.
+static ALLOW_UNCACHED_ACCESS: AtomicBool = AtomicBool::new(false);
+
+/// Toggles uncached memory access and returns the new state.
+pub fn toggle_uncached_access() -> bool {
+    !ALLOW_UNCACHED_ACCESS.fetch_xor(true, Ordering::Relaxed)
+}
 
 /// Reads memory from the specified address into the buffer.
 ///
@@ -122,6 +135,8 @@ fn check_range_access<Arch: DebuggerArch>(
 /// to read from. If the region is uncached and uncached access is not allowed, it will
 /// be treated as invalid.
 fn check_paging_range<P: PatinaPageTable>(page_table: &P, start_address: u64, length: usize) -> Result<usize, ()> {
+    let allow_uncached = ALLOW_UNCACHED_ACCESS.load(Ordering::Relaxed);
+
     // This is done page-by-page because it is unknown if the memory region has
     // consistent attributes across the entire range.
     // The length takes us to the start of the next memory range, so we go until the end of the range, e.g
@@ -130,7 +145,10 @@ fn check_paging_range<P: PatinaPageTable>(page_table: &P, start_address: u64, le
     while page <= start_address + (length - 1) as u64 {
         let res = page_table.query_memory_region(page, PAGE_SIZE);
         let valid = match res {
-            Ok(attributes) => !attributes.contains(MemoryAttributes::ReadProtect),
+            Ok(attributes) => {
+                !attributes.contains(MemoryAttributes::ReadProtect)
+                    && (allow_uncached || !attributes.contains(MemoryAttributes::Uncached))
+            }
             Err(_) => false,
         };
 
@@ -358,5 +376,49 @@ mod tests {
 
         // SAFETY: dest was allocated with this layout.
         unsafe { std::alloc::dealloc(dest, layout) };
+    }
+
+    #[test]
+    fn test_access_check_uncached_page_skipped_by_default() {
+        let _lock = PAGE_LOCK.lock().unwrap();
+        // Reset the toggle to the default (disabled).
+        ALLOW_UNCACHED_ACCESS.store(false, Ordering::Relaxed);
+
+        let mut mock_page_table = MockMemPageTable::new();
+        mock_page_table.expect_query_memory_region().once().returning(|_, _| Ok(MemoryAttributes::Uncached));
+
+        let result = check_paging_range(&mock_page_table, 0, 0x1000);
+        result.expect_err("Uncached page should be treated as invalid by default.");
+    }
+
+    #[test]
+    fn test_access_check_uncached_page_allowed_when_toggled() {
+        let _lock = PAGE_LOCK.lock().unwrap();
+        // Enable uncached access.
+        ALLOW_UNCACHED_ACCESS.store(true, Ordering::Relaxed);
+
+        let mut mock_page_table = MockMemPageTable::new();
+        mock_page_table.expect_query_memory_region().once().returning(|_, _| Ok(MemoryAttributes::Uncached));
+
+        let result = check_paging_range(&mock_page_table, 0, 0x1000);
+        assert_eq!(result.expect("Uncached page should be allowed when toggled."), 0x1000);
+
+        // Reset the toggle back to default.
+        ALLOW_UNCACHED_ACCESS.store(false, Ordering::Relaxed);
+    }
+
+    #[test]
+    fn test_toggle_uncached_access() {
+        let _lock = PAGE_LOCK.lock().unwrap();
+        ALLOW_UNCACHED_ACCESS.store(false, Ordering::Relaxed);
+        assert!(!ALLOW_UNCACHED_ACCESS.load(Ordering::Relaxed));
+
+        let enabled = toggle_uncached_access();
+        assert!(enabled);
+        assert!(ALLOW_UNCACHED_ACCESS.load(Ordering::Relaxed));
+
+        let disabled = toggle_uncached_access();
+        assert!(!disabled);
+        assert!(!ALLOW_UNCACHED_ACCESS.load(Ordering::Relaxed));
     }
 }

--- a/core/patina_debugger/src/memory.rs
+++ b/core/patina_debugger/src/memory.rs
@@ -9,7 +9,8 @@
 
 use core::ptr;
 
-use patina_paging::{MemoryAttributes, PageTable};
+use patina_internal_cpu::paging::PatinaPageTable;
+use patina_paging::MemoryAttributes;
 
 use crate::arch::DebuggerArch;
 
@@ -71,6 +72,7 @@ pub fn write_memory<Arch: DebuggerArch>(address: u64, buffer: &[u8]) -> Result<(
         // modify the page table to allow writing.
         let attributes = page_table
             .query_memory_region(page, PAGE_SIZE)
+            .map_err(|_| ())
             .expect("Unexpected failure on address that was already checked.");
 
         if attributes.contains(MemoryAttributes::ReadOnly) {
@@ -88,7 +90,6 @@ pub fn write_memory<Arch: DebuggerArch>(address: u64, buffer: &[u8]) -> Result<(
             // debugger should not allow the system to continue if it's state cannot be restored.
             page_table
                 .map_memory_region(page, PAGE_SIZE, attributes)
-                .map_err(|_| ())
                 .expect("Failed to restore page table attributes!");
         }
 
@@ -101,7 +102,7 @@ pub fn write_memory<Arch: DebuggerArch>(address: u64, buffer: &[u8]) -> Result<(
 /// Checks if the range is valid for access. This will check the page tables and
 /// attempt to read the memory at the address to ensure that it is accessible.
 fn check_range_access<Arch: DebuggerArch>(
-    page_table: &Arch::PageTable,
+    page_table: &impl PatinaPageTable,
     address: u64,
     length: usize,
 ) -> Result<usize, ()> {
@@ -118,15 +119,16 @@ fn check_range_access<Arch: DebuggerArch>(
 
 /// Checks that the range of memory is valid in the page tables. This ensures that
 /// reads to this region will not fault. On success returns the number of bytes valid
-/// to read from.
-fn check_paging_range<P: PageTable>(page_table: &P, start_address: u64, length: usize) -> Result<usize, ()> {
+/// to read from. If the region is uncached and uncached access is not allowed, it will
+/// be treated as invalid.
+fn check_paging_range<P: PatinaPageTable>(page_table: &P, start_address: u64, length: usize) -> Result<usize, ()> {
     // This is done page-by-page because it is unknown if the memory region has
     // consistent attributes across the entire range.
     // The length takes us to the start of the next memory range, so we go until the end of the range, e.g
     // start_address + length - 1. This avoids overflow in the self map case
     let mut page = start_address & PAGE_MASK;
     while page <= start_address + (length - 1) as u64 {
-        let res = page_table.query_memory_region(page, PAGE_SIZE).map_err(|_| ());
+        let res = page_table.query_memory_region(page, PAGE_SIZE);
         let valid = match res {
             Ok(attributes) => !attributes.contains(MemoryAttributes::ReadProtect),
             Err(_) => false,
@@ -161,16 +163,17 @@ mod tests {
     use crate::*;
     use gdbstub::target::ext::breakpoints;
     use mockall::{predicate::*, *};
+    use patina_internal_cpu::paging::CacheAttributeValue;
     use patina_paging::{MemoryAttributes, PtError};
 
     mock! {
         pub MemPageTable {}
 
-        impl PageTable for MemPageTable {
+        impl PatinaPageTable for MemPageTable {
             fn map_memory_region(&mut self, address: u64, size: u64, attributes: MemoryAttributes) -> Result<(), PtError>;
             fn unmap_memory_region(&mut self, address: u64, size: u64) -> Result<(), PtError>;
             fn install_page_table(&mut self) -> Result<(), PtError>;
-            fn query_memory_region(&self, address: u64, size: u64) -> Result<MemoryAttributes, PtError>;
+            fn query_memory_region(&self, address: u64, size: u64) -> Result<MemoryAttributes, (PtError, CacheAttributeValue)>;
             fn dump_page_tables(&self, address: u64, size: u64) -> Result<(), PtError>;
         }
     }
@@ -178,12 +181,13 @@ mod tests {
     mock! {
         pub MemDebuggerArch {}
 
+        // mockall doesn't support mocking associated types, so we have to use a concrete type for the page table.
+        #[allow(refining_impl_trait_internal)]
         impl DebuggerArch for MemDebuggerArch {
             const DEFAULT_EXCEPTION_TYPES: &'static [usize] = &[];
             const BREAKPOINT_INSTRUCTION: &'static [u8] = &[];
             const GDB_TARGET_XML: &'static str = "";
             const GDB_REGISTERS_XML: &'static str = "";
-            type PageTable = MockMemPageTable;
 
             fn breakpoint();
             fn process_entry(exception_type: u64, context: &mut ExceptionContext) -> ExceptionInfo;
@@ -214,7 +218,7 @@ mod tests {
         mock_page_table
             .expect_query_memory_region()
             .times(2)
-            .returning(|_, _| Err(patina_paging::PtError::InvalidMemoryRange));
+            .returning(|_, _| Err((PtError::InvalidMemoryRange, CacheAttributeValue::NotSupported)));
 
         let result = check_paging_range(&mock_page_table, 0, 0x1000);
         result.expect_err("Should have return a failure.");
@@ -235,10 +239,12 @@ mod tests {
     fn test_access_check_partially_valid_range() {
         let mut mock_page_table = MockMemPageTable::new();
         mock_page_table.expect_query_memory_region().times(2).returning(|_, _| Ok(MemoryAttributes::empty()));
-        mock_page_table
-            .expect_query_memory_region()
-            .times(1)
-            .returning(|_, _| Err(patina_paging::PtError::InvalidMemoryRange));
+        mock_page_table.expect_query_memory_region().times(1).returning(|_, _| {
+            Err((
+                patina_paging::PtError::InvalidMemoryRange,
+                patina_internal_cpu::paging::CacheAttributeValue::NotSupported,
+            ))
+        });
 
         let result = check_paging_range(&mock_page_table, 0x800, 0x3000);
         assert!(result.expect("Failed to check range access.") == 0x1800);
@@ -277,9 +283,12 @@ mod tests {
         let ctx = MockMemDebuggerArch::get_page_table_context();
         ctx.expect().returning(|| {
             let mut mock_page_table = MockMemPageTable::new();
-            mock_page_table
-                .expect_query_memory_region()
-                .returning(|_, _| Err(patina_paging::PtError::InvalidMemoryRange));
+            mock_page_table.expect_query_memory_region().returning(|_, _| {
+                Err((
+                    patina_paging::PtError::InvalidMemoryRange,
+                    patina_internal_cpu::paging::CacheAttributeValue::NotSupported,
+                ))
+            });
             Ok(mock_page_table)
         });
 

--- a/core/patina_internal_cpu/src/paging.rs
+++ b/core/patina_internal_cpu/src/paging.rs
@@ -15,12 +15,15 @@ cfg_if::cfg_if! {
     if #[cfg(all(target_arch = "x86_64"))] {
         mod x64;
         pub use x64::create_cpu_x64_paging as create_cpu_paging;
+        pub use x64::open_active_cpu_x64_paging as open_active_cpu_paging;
     } else if #[cfg(all(target_arch = "aarch64"))] {
         mod aarch64;
         pub use aarch64::create_cpu_aarch64_paging as create_cpu_paging;
+        pub use aarch64::open_active_cpu_aarch64_paging as open_active_cpu_paging;
     } else {
         mod null;
         pub use null::create_cpu_null_paging as create_cpu_paging;
+        pub use null::open_active_cpu_null_paging as open_active_cpu_paging;
     }
 }
 

--- a/core/patina_internal_cpu/src/paging/aarch64.rs
+++ b/core/patina_internal_cpu/src/paging/aarch64.rs
@@ -53,10 +53,24 @@ where
 }
 
 /// Create an AArch64 paging instance under the general PatinaPageTable trait.
+#[coverage(off)]
 pub fn create_cpu_aarch64_paging<A: PageAllocator + 'static>(
     page_allocator: A,
 ) -> Result<impl PatinaPageTable, efi::Status> {
     Ok(EfiCpuPagingAArch64 { paging: AArch64PageTable::new(page_allocator, PagingType::Paging4Level).unwrap() })
+}
+
+/// Open the active AArch64 page table wrapped in the PatinaPageTable trait.
+///
+/// ## Safety
+/// The caller must ensure no other entity is concurrently modifying the page tables.
+#[coverage(off)]
+pub unsafe fn open_active_cpu_aarch64_paging<A: PageAllocator + 'static>(
+    page_allocator: A,
+) -> Result<impl PatinaPageTable, PtError> {
+    // SAFETY: Caller ensures no concurrent page table modifications.
+    let page_table = unsafe { AArch64PageTable::open_active(page_allocator)? };
+    Ok(EfiCpuPagingAArch64 { paging: page_table })
 }
 
 #[cfg(test)]

--- a/core/patina_internal_cpu/src/paging/null.rs
+++ b/core/patina_internal_cpu/src/paging/null.rs
@@ -59,3 +59,13 @@ pub fn create_cpu_null_paging<A: PageAllocator + 'static>(
 ) -> Result<impl PatinaPageTable, efi::Status> {
     Err(efi::Status::UNSUPPORTED)
 }
+
+/// Open the active page table. Not supported on this architecture.
+///
+/// ## Safety
+/// N/A — always returns an error.
+pub unsafe fn open_active_cpu_null_paging<A: PageAllocator + 'static>(
+    _page_allocator: A,
+) -> Result<impl PatinaPageTable, PtError> {
+    Err::<EfiCpuPagingNull<A>, _>(PtError::UnsupportedPagingType)
+}

--- a/core/patina_internal_cpu/src/paging/x64.rs
+++ b/core/patina_internal_cpu/src/paging/x64.rs
@@ -133,6 +133,7 @@ fn apply_caching_attributes<M: Mtrr>(
 }
 
 /// Create an x86_64 paging instance under the general PatinaPageTable trait.
+#[coverage(off)]
 pub fn create_cpu_x64_paging<A: PageAllocator + 'static>(
     page_allocator: A,
 ) -> Result<impl PatinaPageTable, efi::Status> {
@@ -141,6 +142,19 @@ pub fn create_cpu_x64_paging<A: PageAllocator + 'static>(
             .map_err(|_| efi::Status::INVALID_PARAMETER)?,
         mtrr: create_mtrr_lib(0),
     })
+}
+
+/// Open the active x86_64 page table wrapped in the PatinaPageTable trait.
+///
+/// ## Safety
+/// The caller must ensure no other entity is concurrently modifying the page tables.
+#[coverage(off)]
+pub unsafe fn open_active_cpu_x64_paging<A: PageAllocator + 'static>(
+    page_allocator: A,
+) -> Result<impl PatinaPageTable, PtError> {
+    // SAFETY: Caller ensures no concurrent page table modifications.
+    let page_table = unsafe { X64PageTable::open_active(page_allocator)? };
+    Ok(EfiCpuPagingX64 { paging: page_table, mtrr: create_mtrr_lib(0) })
 }
 
 fn mtrr_err_to_efi_status(err: MtrrError) -> EfiError {


### PR DESCRIPTION
## Description

This PR contains two commits:

Debugger: Move to PatinaPageTable Trait
--
Currently, the debugger uses the PageTable trait from patina_paging directly. On X64, this does not allow getting caching attributes since they are managed by MTRRs.

In preparation for using caching attributes in the debugger, move to the PatinaPageTable trait from patina_internal_cpu to get caching attributes uniformly.

This requires a new API in patina_internal_cpu to get the existing page table instead of creating a new one.

patina_debugger: Don't Access Uncached Memory By Default
--
It has been observed on physical platforms that WinDbg can request addresses in uncached memory. This results in the debugger attempting to read them. It uses the poke test to tell if this is safe. Sometimes the poke test works, but in one case, a machine check is generated to all cpus and the poke test cannot recover from this.

This changes this to check if memory is uncached. If so, the debugger will fail to read it. A new monitor cmd will toggle the ability of the debugger to read uncached memory or not.

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

On a physical Intel platform that was getting a #MC when an uncached range was requested to be read by WinDbg and so the debugger read it because it was mapped. After this, the #MC doesn't occur.

## Integration Instructions

If uncached memory must be touched from the debugger, call `!uefiext.monitor toggle_uncached_access` (or otherwise call the monitor command) to toggle the ability.
