### PR TITLE
gcd: Move mapping memory range message prior to adding memory space

### DIFF
--- a/patina_dxe_core/src/gcd.rs
+++ b/patina_dxe_core/src/gcd.rs
@@ -635,6 +635,10 @@ pub fn add_hob_resource_descriptors_to_gcd(hob_list: &HobList) {
                     .take_while(|r| r.is_some())
                     .flatten()
             {
+                log::info!(
+                    "Mapping memory range {split_range:#x?} as {gcd_mem_type:?} with attributes {memory_attributes:#x?}",
+                );
+
                 // SAFETY: GCD is initialized and split_range is derived from valid HOB ranges.
                 unsafe {
                     GCD.add_memory_space(
@@ -645,10 +649,6 @@ pub fn add_hob_resource_descriptors_to_gcd(hob_list: &HobList) {
                     )
                     .expect("Failed to add memory space to GCD");
                 }
-
-                log::info!(
-                    "Mapping memory range {split_range:#x?} as {gcd_mem_type:?} with attributes {memory_attributes:#x?}",
-                );
 
                 match GCD.set_memory_space_attributes(
                     split_range.start as usize,


### PR DESCRIPTION
## Description

Allows the memory range details to be visible if the call to `GCD.add_memory_space()` fails.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

- `cargo make all`
- Boot and examine when the message is printed.

## Integration Instructions

- N/A