### PR TITLE
Add Code First Files [Rebase & FF]

### DIFF
--- a/.github/ISSUE_TEMPLATE/code_first.yml
+++ b/.github/ISSUE_TEMPLATE/code_first.yml
@@ -1,0 +1,57 @@
+# Patina Code First Template
+#
+##
+# Copyright (c) Microsoft Corporation.
+# SPDX-License-Identifier: Apache-2.0
+##
+name: </> Code First
+description: Code first tracking issue
+title: "[Code First]: <title>"
+labels: ["type:code-first"]
+
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Introductory text for the GitHub issue
+
+  - type: textarea
+    id: overview
+    attributes:
+      label: Code First Item Overview
+      description: Provide a brief overview of the code first change.
+    validations:
+      required: true
+
+  - type: dropdown
+    id: specs_impacted
+    attributes:
+      label: What specification(s) are directly related?
+      description: |
+        *Select all that apply*
+      multiple: true
+      options:
+        - ACPI
+        - Platform Initialization (PI)
+        - UEFI
+        - UEFI PI Distribution Packaging
+        - UEFI Shell
+    validations:
+      required: true
+
+  - type: textarea
+    id: anything_else
+    attributes:
+      label: Anything else?
+      description: |
+        Links? References? Anything that will give us more context about the code first change.
+
+        - Update this section to include links to any pull requests associated with the code first change as they are
+          created.
+
+        - Update this section to include links to the "code first" markdown file for this change after it is merged
+          into the default branch (`main`) of the `OpenDevicePartnership/patina` repository.
+
+        Tip: You can attach images or log files by clicking this area to highlight it and then dragging files in.
+    validations:
+      required: false

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -23,6 +23,7 @@
 
 # Developer Guides
 
+- [Code First Process](code_first/code_first_process.md)
 - [Code First Template](code_first/template.md)
 - [Creating a New Unstable Feature](dev/unstable_feature.md)
 - [Debugging](dev/debugging.md)

--- a/docs/src/code_first/code_first_process.md
+++ b/docs/src/code_first/code_first_process.md
@@ -1,0 +1,48 @@
+# Code First Process
+
+The code first process allows Patina source code to be developed alongside draft specification changes
+(e.g. UEFI Forum ECRs). Implementation and testing happen in parallel with specification drafting so that design
+decisions are validated through working code before being finalized in a published specification.
+
+This page is intended to provide a high-level overview of the code first process to supplement the formal definition in
+[RFC 0027 - Code First](https://github.com/OpenDevicePartnership/patina/blob/main/docs/src/rfc/text/0027-code-first.md).
+Once you have a good understanding of the process from this page, refer to the RFC for more details.
+
+## When to Use Code First
+
+Use this process when a Patina change depends on a specification modification that has **not yet** been brought to the
+attention of the relevant specification working group. Common scenarios include:
+
+- Implementing a new UEFI/PI protocol or interface.
+- Modifying behavior governed by an existing specification clause that is being revised.
+- Proposing a new specification feature where Patina serves as the reference implementation.
+
+If the specification change is already published, the standard contribution workflow applies and code first is not
+required.
+
+## Key Principles
+
+1. **Open source first** - The tracking issue and pull request in Patina must exist *before* any ECR submission to
+   working-group engagement. This ordering keeps the work public and avoids NDA constraints.
+2. **Specification draft included in-tree** - Every code first PR carries a markdown file in `docs/src/code_first/`
+   (using the [Code First Template](template.md)) that captures the proposed specification text. One file per impacted
+   specification. This ensures Patina developers can see key specification details even if they don't have access to the
+   ECR or working group discussions.
+3. **Working-group review on the PR** - Specification reviewers participate directly on the GitHub pull request. The PR
+   cannot merge until working-group approval is obtained.
+4. **Tracking issue stays open** - The code first tracking issue is closed only after the specification change is
+   published *and* all related code is merged to `main`.
+
+## Key Steps
+
+| Step                | Location                                              | Purpose                                                       |
+|---------------------|-------------------------------------------------------|---------------------------------------------------------------|
+| Tracking issue      | GitHub Issues (`type:code-first` label)               | Tracks the lifecycle from draft through publication           |
+| Specification draft | `docs/src/code_first/<issue_number>-<description>.md` | Proposed specification text using the [template](template.md) |
+| Code first PR       | GitHub Pull Requests (`type:code-first` label)        | Contains the implementation and specification draft           |
+
+## Other Resources
+
+- [RFC 0027 - Code First](https://github.com/OpenDevicePartnership/patina/blob/main/docs/src/rfc/text/0027-code-first.md)
+  \- Full process definition and rationale.
+- [Code First Template](template.md) - Template for specification draft files.

--- a/docs/src/code_first/template.md
+++ b/docs/src/code_first/template.md
@@ -2,7 +2,7 @@
 
 > Template instruction lines begin with `>`. Delete these lines when filling out the template.
 
-## Status: [Status]
+## Status: \[Status\]
 
 > \[Status\] must be one of the following:
 >


### PR DESCRIPTION
## Description

These are changes to the repo as a follow up to the Code First RFC being merged.

---

**.github: Add Code First issue template**

Adds a GitHub issue template that is used to submit code first
tracking issues.

The template and how it is used is described in the Patina Code First
RFC:

https://github.com/OpenDevicePartnership/patina/blob/HEAD/docs/src/rfc/text/0027-code-first.md

---

**mdbook: Add Code First Process page**

Adds a page to give a high-level intro to the Patina Code First
process and link to the RFC.

This page is meant to serve as a place in the book to get a quick
understanding of when the process applies and how it used with the
formal definition being maintained in the RFC.

Also updates text in code_first/template.md to escape square brackets
so they might not be interpreted as a markdown link.

---

Example of the Code First GitHub issue form:

<img width="811" height="810" alt="image" src="https://github.com/user-attachments/assets/6858a04d-d3cc-4038-a8f7-b9f4a2bd8fd7" />

---

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [x] Includes documentation?

## How This Was Tested

- `cargo make cspell`
- `mdbook build ./docs`

## Integration Instructions

N/A