### PR TITLE
Small Set of FFI Safety Improvements [Rebase & FF]

### DIFF
--- a/components/patina_acpi/src/acpi_protocol.rs
+++ b/components/patina_acpi/src/acpi_protocol.rs
@@ -80,7 +80,7 @@ impl AcpiTableProtocol {
 
         // The size of the allocated table buffer must be large enough to store the whole table.
         // SAFETY: `acpi_table_buffer` is checked non-null and large enough to read an AcpiTableHeader.
-        let table_header = unsafe { (*(acpi_table_buffer as *const AcpiTableHeader)).clone() };
+        let table_header = unsafe { core::ptr::read_unaligned(acpi_table_buffer as *const AcpiTableHeader) };
         let tbl_length = table_header.length as usize;
         if tbl_length != acpi_table_buffer_size {
             return efi::Status::INVALID_PARAMETER;
@@ -105,7 +105,7 @@ impl AcpiTableProtocol {
                 match install_result {
                     Ok(key) => {
                         // SAFETY: The caller must ensure the buffer passed in for the key is appropriately sized and non-null.
-                        unsafe { *table_key = key.0 };
+                        unsafe { table_key.write_unaligned(key.0) };
                         log::trace!(
                             "ACPI protocol: Successfully installed table with signature: 0x{:08X}, key: {}",
                             signature,
@@ -206,12 +206,12 @@ impl AcpiGetProtocol {
                 // SAFETY: table_info is valid and output pointers have been checked for null
                 // We only support ACPI versions >= 2.0
                 // SAFETY: We check that `version` is non-null above.
-                unsafe { *version = ACPI_VERSIONS_GTE_2 };
+                unsafe { version.write_unaligned(ACPI_VERSIONS_GTE_2) };
                 // SAFETY: We check that `table_key` is non-null above.
-                unsafe { *table_key = key_at_idx.0 };
+                unsafe { table_key.write_unaligned(key_at_idx.0) };
 
                 // SAFETY: We check that `table` is non-null above.
-                unsafe { *table = table_at_idx.as_mut_ptr() };
+                unsafe { table.write_unaligned(table_at_idx.as_mut_ptr()) };
                 log::trace!(
                     "ACPI protocol: Successfully retrieved table at index {} with key: {} and signature: 0x{:08X}",
                     index,

--- a/components/patina_adv_logger/Cargo.toml
+++ b/components/patina_adv_logger/Cargo.toml
@@ -30,6 +30,7 @@ clap = { workspace = true, features = ['derive'], optional = true }
 
 [dev-dependencies]
 patina_dxe_core = { path = "../../patina_dxe_core" }
+serial_test = { workspace = true }
 
 [features]
 alloc = []

--- a/components/patina_adv_logger/src/component.rs
+++ b/components/patina_adv_logger/src/component.rs
@@ -61,12 +61,17 @@ where
         buffer: *const u8,
         num_bytes: usize,
     ) -> efi::Status {
-        // SAFETY: We have no choice but to trust the caller on the buffer size. convert
-        //         to a reference for internal safety.
+        if this.is_null() || buffer.is_null() {
+            return efi::Status::INVALID_PARAMETER;
+        }
+
+        // SAFETY: `buffer` is null-checked above. We have no choice but to trust the caller
+        //         on the buffer size. Convert to a slice for internal use.
         let data = unsafe { core::slice::from_raw_parts(buffer, num_bytes) };
         let error_level = error_level as u32;
 
-        // SAFETY: We must trust the C code was a responsible steward of this buffer.
+        // SAFETY: `this` is null-checked above. The protocol struct is installed by Patina with
+        //         `Box::leak`, so its alignment and validity are guaranteed.
         let internal = unsafe { &*(this as *const AdvancedLoggerProtocolInternal<S>) };
 
         internal.adv_logger.log_write(error_level, None, data);

--- a/components/patina_adv_logger/src/component.rs
+++ b/components/patina_adv_logger/src/component.rs
@@ -108,3 +108,97 @@ where
         }
     }
 }
+
+#[cfg(test)]
+#[coverage(off)]
+mod tests {
+    use super::*;
+    use crate::{
+        logger::{AdvancedLogger, TargetFilter},
+        writer::AdvancedLogWriter,
+    };
+    use patina::{
+        component::service::{IntoService, Service, perf_timer::ArchTimerFunctionality},
+        log::Format,
+        serial::uart::UartNull,
+    };
+    use serial_test::serial;
+
+    #[derive(IntoService)]
+    #[service(dyn ArchTimerFunctionality)]
+    struct MockTimer {}
+
+    impl ArchTimerFunctionality for MockTimer {
+        fn perf_frequency(&self) -> u64 {
+            100
+        }
+        fn cpu_count(&self) -> u64 {
+            200
+        }
+    }
+
+    static TEST_LOGGER: AdvancedLogger<UartNull> = AdvancedLogger::new(
+        Format::Standard,
+        &[TargetFilter { target: "", log_level: log::LevelFilter::Trace, hw_filter_override: None }],
+        log::LevelFilter::Trace,
+        UartNull {},
+    );
+
+    /// Initializes `TEST_LOGGER` with a newly allocated memory log and a mock timer.
+    fn init_test_logger() {
+        const LOG_LEN: usize = 0x2000;
+        let log_buff = Box::into_raw(Box::new([0_u8; LOG_LEN]));
+        let log_address = log_buff as *const u8 as efi::PhysicalAddress;
+        // SAFETY: This memory was just allocated, so it is valid for LOG_LEN bytes.
+        unsafe { AdvancedLogWriter::initialize_memory_log(log_address, LOG_LEN as u32) };
+        TEST_LOGGER.set_log_info_address(log_address);
+        TEST_LOGGER.init_timer(Service::mock(Box::new(MockTimer {})));
+    }
+
+    /// Builds a leaked `AdvancedLoggerProtocolInternal` structure and returns a `*const AdvancedLoggerProtocol`
+    /// that can be passed as `this` to `adv_log_write`.
+    fn leak_protocol_this() -> *const AdvancedLoggerProtocol {
+        let internal = Box::leak(Box::new(AdvancedLoggerProtocolInternal::<UartNull> {
+            protocol: AdvancedLoggerProtocol::new(
+                AdvancedLoggerComponent::<UartNull>::adv_log_write,
+                TEST_LOGGER.get_log_address().unwrap_or(0),
+            ),
+            adv_logger: &TEST_LOGGER,
+        }));
+        &raw const internal.protocol
+    }
+
+    #[test]
+    fn adv_log_write_null_this_returns_invalid_parameter() {
+        let data = b"hello";
+        let status =
+            AdvancedLoggerComponent::<UartNull>::adv_log_write(core::ptr::null(), 0, data.as_ptr(), data.len());
+        assert_eq!(status, efi::Status::INVALID_PARAMETER);
+    }
+
+    #[test]
+    fn adv_log_write_null_buffer_returns_invalid_parameter() {
+        // `this` is dangling but non-null. The function returns before dereferencing it
+        // because the buffer null check is tripped first.
+        let this = core::ptr::dangling::<AdvancedLoggerProtocol>();
+        // Non-zero length.
+        let status = AdvancedLoggerComponent::<UartNull>::adv_log_write(this, 0, core::ptr::null(), 4);
+        assert_eq!(status, efi::Status::INVALID_PARAMETER);
+        // Zero length still invalid because `slice::from_raw_parts` requires a non-null pointer
+        // even for zero-length slices.
+        let status = AdvancedLoggerComponent::<UartNull>::adv_log_write(this, 0, core::ptr::null(), 0);
+        assert_eq!(status, efi::Status::INVALID_PARAMETER);
+    }
+
+    // This is serialized since it mutates the `test` module-level `TEST_LOGGER` static.
+    #[test]
+    #[serial(adv_logger_test)]
+    fn adv_log_write_normal_path_succeeds() {
+        init_test_logger();
+        let this = leak_protocol_this();
+
+        let data = b"hello, advanced logger";
+        let status = AdvancedLoggerComponent::<UartNull>::adv_log_write(this, 0, data.as_ptr(), data.len());
+        assert_eq!(status, efi::Status::SUCCESS);
+    }
+}

--- a/components/patina_adv_logger/src/lib.rs
+++ b/components/patina_adv_logger/src/lib.rs
@@ -4,7 +4,7 @@
     " Copyright (c) Microsoft Corporation.\n\n",
     " SPDX-License-Identifier: Apache-2.0\n",
 )]
-#![cfg_attr(all(not(feature = "std"), not(doc)), no_std)]
+#![cfg_attr(all(not(feature = "std"), not(test), not(doc)), no_std)]
 #![deny(missing_docs)]
 #![feature(coverage_attribute)]
 

--- a/components/patina_adv_logger/src/logger.rs
+++ b/components/patina_adv_logger/src/logger.rs
@@ -363,6 +363,7 @@ mod tests {
         memory_log,
         writer::AdvancedLogWriter,
     };
+    use serial_test::serial;
 
     #[derive(IntoService)]
     #[service(dyn ArchTimerFunctionality)]
@@ -437,7 +438,10 @@ mod tests {
         (log_address, hob_buff as *const c_void)
     }
 
+    // This is serialized since it mutates the `test` module-level `TEST_LOGGER` static
+    // (and the `DBG_ADV_LOG_BUFFER` global).
     #[test]
+    #[serial(adv_logger_test)]
     fn component_test() {
         let (log_address, hob_list) = create_adv_logger_hob_list();
 

--- a/docs/src/dev/principles/ffi.md
+++ b/docs/src/dev/principles/ffi.md
@@ -51,21 +51,142 @@ unaligned access intrinsics [`read_unaligned()`] and [`write_unaligned()`] or a 
 
 #### Rules
 
-1. **Read FFI pointers with [`read_unaligned()`].** Do not use methods that assume alignment, such as `*ptr`, `ptr::read`,
-   `&*ptr`, `(*ptr).field`, or `(*(ptr as *const T)).clone()` on a caller-supplied pointer.
-2. **Write FFI pointers with [`write_unaligned()`].** Do not use `*ptr = value` or `ptr::write`.
-3. **Be consistent within a function.** Mixing aligned and unaligned access on the same pointer is a code smell and
-   risks UB if the pointer is in fact misaligned.
-4. **Null-check before every unaligned access.** `read_unaligned()` and `write_unaligned()` only relax the *alignment*
-   requirement. The pointer must still be non-null and valid for the access. A null check should be the first operation
-   performed on an untrusted caller-supplied pointer before any other dereference or access, including unaligned ones.
-5. **Prefer [`zerocopy`] for structured reads.** When pulling a typed value out of a caller-supplied byte buffer,
+1. **Prefer [`zerocopy`] for structured reads.** When pulling a typed value out of a caller-supplied byte buffer,
    `zerocopy::FromBytes` provides a safe, alignment-agnostic alternative to manual `read_unaligned()` of a casted
    pointer.
+2. **Read FFI pointers with [`read_unaligned()`].** Do not use methods that assume alignment, such as `*ptr`, `ptr::read`,
+   `&*ptr`, `(*ptr).field`, or `(*(ptr as *const T)).clone()` on a caller-supplied pointer.
+3. **Write FFI pointers with [`write_unaligned()`].** Do not use `*ptr = value` or `ptr::write`.
+4. **Be consistent within a function.** Mixing aligned and unaligned access on the same pointer is a code smell and
+   risks UB if the pointer is in fact misaligned.
+5. **Null-check before every unaligned access.** `read_unaligned()` and `write_unaligned()` only relax the *alignment*
+   requirement. The pointer must still be non-null and valid for the access. A null check should be the first operation
+   performed on an untrusted caller-supplied pointer before any other dereference or access, including unaligned ones.
 
 [`read_unaligned()`]: https://doc.rust-lang.org/std/primitive.pointer.html#method.read_unaligned()
 [`write_unaligned()`]: https://doc.rust-lang.org/std/primitive.pointer.html#method.write_unaligned()
 [`zerocopy`]: https://crates.io/crates/zerocopy
+
+#### Zerocopy example
+
+The following example shows an `extern "efiapi"` function that receives an untrusted, potentially unaligned byte
+buffer from a C caller and parses a fixed-layout header out of it using [`zerocopy`].
+
+Note that there are no raw-pointer casts, no `read_unaligned()` calls, and no `unsafe` blocks needed for the parse
+itself: `FromBytes::ref_from_prefix` validates the length and returns a `&PacketHeader` borrowed directly from the
+caller's buffer, regardless of its alignment.
+
+```rust,editable
+# extern crate zerocopy;
+# extern crate zerocopy_derive;
+use std::slice;
+use zerocopy_derive::{FromBytes, Immutable, KnownLayout, Unaligned};
+
+// This is a stand-in for `r_efi::efi::Status` so the example is self-contained
+// and runnable on the Rust Playground (which does not have `r_efi`).
+#[repr(transparent)]
+#[derive(Copy, Clone, PartialEq, Eq, Debug)]
+struct Status(usize);
+
+impl Status {
+    const SUCCESS: Self = Self(0);
+    const INVALID_PARAMETER: Self = Self(0x8000_0000_0000_0002);
+}
+
+// `#[repr(C, packed)]` plus `Unaligned` means this type has no alignment requirement,
+// so `zerocopy` will reinterpret an arbitrary byte slice as `&PacketHeader`.
+#[repr(C, packed)]
+#[derive(Copy, Clone, Debug, FromBytes, Immutable, KnownLayout, Unaligned)]
+struct PacketHeader {
+    version: u16,
+    flags: u16,
+    payload_len: u32,
+}
+
+/// Parses the header of a caller-supplied buffer and writes the payload length back through
+/// `out_payload_len`. Returns `INVALID_PARAMETER` if any pointer is null or the buffer is
+/// too small to contain a `PacketHeader`.
+///
+/// # Safety
+///
+/// Although this function is not marked `unsafe` (it is invoked across the EFIAPI C boundary
+/// with the UEFI ABI), the caller must still uphold the following invariants:
+///
+/// - If `buffer` is non-null, it points to at least `buffer_len` consecutive, initialized,
+///   readable bytes.
+/// - If `out_payload_len` is non-null, it points to a writable `u32`.
+/// - Both regions remain valid and are not mutated by another thread for the duration of
+///   the call.
+///
+/// Violating any of these is undefined behavior. Null pointers and a `buffer_len` smaller
+/// than `size_of::<PacketHeader>()` are handled safely and return `INVALID_PARAMETER`.
+pub extern "efiapi" fn parse_packet_header(
+    buffer: *const u8,
+    buffer_len: usize,
+    out_payload_len: *mut u32,
+) -> Status {
+    if buffer.is_null() || out_payload_len.is_null() {
+        return Status::INVALID_PARAMETER;
+    }
+
+    // SAFETY: Per the function's safety contract, when `buffer` is non-null it points to
+    // `buffer_len` readable, initialized bytes in a single allocation. `from_raw_parts::<u8>()`
+    // only requires `align_of::<u8>() == 1`, so any non-null `buffer` is sufficiently aligned.
+    // The resulting `[u8]` is only handed to `zerocopy::FromBytes::ref_from_prefix()`, which
+    // (thanks to `PacketHeader: Unaligned`) imposes no further alignment requirement.
+    let bytes = unsafe { slice::from_raw_parts(buffer, buffer_len) };
+
+    let Ok((header, _rest)) = <PacketHeader as zerocopy::FromBytes>::ref_from_prefix(bytes) else {
+        return Status::INVALID_PARAMETER;
+    };
+
+    // Copy the packed field into a local to avoid taking a reference to an unaligned field.
+    let payload_len = header.payload_len;
+
+    // SAFETY: Per the function's safety contract, when `out_payload_len` is non-null it
+    // points to a writable `u32`. `write_unaligned` removes the alignment requirement, so
+    // any alignment the caller supplied is sound.
+    unsafe { out_payload_len.write_unaligned(payload_len) };
+    Status::SUCCESS
+}
+
+// You would not normally include a `main()` function in an FFI module, this is just done
+// for demonstration purposes so the code can run on the Rust Playground.
+fn main() {
+    // Simulate a buffer handed to us by a C caller: a `PacketHeader` followed by
+    // four extra trailing bytes. The buffer is intentionally larger than the header
+    // to show that `ref_from_prefix` only consumes what it needs.
+    let buffer: [u8; 12] = [
+        0x01, 0x00,             // version       = 1
+        0x02, 0x00,             // flags         = 2
+        0x34, 0x12, 0x00, 0x00, // payload_len   = 0x1234
+        0xAA, 0xBB, 0xCC, 0xDD, // trailing data (ignored by the header parse)
+    ];
+
+    let mut payload_len: u32 = 0;
+    let status = parse_packet_header(buffer.as_ptr(), buffer.len(), &mut payload_len);
+
+    assert_eq!(status, Status::SUCCESS);
+    println!("payload_len = 0x{:x}", payload_len);
+}
+```
+
+Running the example will print:
+
+```text
+payload_len = 0x1234
+```
+
+Key points:
+
+- Null checks come first, before any dereference or slice construction.
+- The parse itself is safe Rust. The only `unsafe` blocks are the unavoidable FFI primitives:
+  - Constructing the slice from the caller's `(ptr, len)` pair
+  - Writing through the out-pointer.
+- `Unaligned` on `PacketHeader` lets `zerocopy` borrow directly from any byte alignment. Without it,
+  `ref_from_prefix()` would only succeed on a properly aligned buffer.
+- `ref_from_prefix()` performs the length check, so a manual `buffer_len >= size_of::<PacketHeader>()`
+  comparison is not required.
 
 #### When direct dereference is acceptable
 
@@ -95,7 +216,7 @@ let header = unsafe { (*(buffer as *const Header)).clone() };
 // WRONG: inconsistent as the same pointer is read aligned and is written unaligned.
 let n = unsafe { *num_bytes };
 // ...
-unsafe { num_bytes.write_unaligned()(actual) };
+unsafe { num_bytes.write_unaligned(actual) };
 ```
 
 Replace each with the corresponding `read_unaligned()` / `write_unaligned()` form (and, for the struct case, a

--- a/docs/src/dev/principles/ffi.md
+++ b/docs/src/dev/principles/ffi.md
@@ -36,3 +36,67 @@ the va_list type in FFIs. In practice, this has been seen very little.
 
 >**Note:** This does not affect using variadic functions that take `...` as a parameter. Those are supported across
 C FFIs. It is only the va_list type itself that cannot be passed by value or by reference.
+
+### Pointer Alignment
+
+Raw pointers received across an `extern "efiapi"` (or `extern "C"`) boundary must be treated as **potentially
+unaligned**. C callers are not required to honor Rust's alignment invariants for `*mut T` / `*const T`, and the UEFI
+specification often passes out-pointers whose alignment cannot be statically guaranteed (e.g. fields embedded in packed
+C structures and addresses computed from byte offsets).
+
+A misaligned read or write through a normal Rust dereference is undefined behavior even on architectures that
+tolerate it in hardware. The compiler is also free to assume the pointer is aligned and reorder or coalesce accesses
+based on that assumption. So, when working with caller-supplied pointers across an FFI boundary, you must use the
+unaligned access intrinsics [`read_unaligned()`] and [`write_unaligned()`] or a safe abstraction like [`zerocopy`].
+
+#### Rules
+
+1. **Read FFI pointers with [`read_unaligned()`].** Do not use methods that assume alignment, such as `*ptr`, `ptr::read`,
+   `&*ptr`, `(*ptr).field`, or `(*(ptr as *const T)).clone()` on a caller-supplied pointer.
+2. **Write FFI pointers with [`write_unaligned()`].** Do not use `*ptr = value` or `ptr::write`.
+3. **Be consistent within a function.** Mixing aligned and unaligned access on the same pointer is a code smell and
+   risks UB if the pointer is in fact misaligned.
+4. **Null-check before every unaligned access.** `read_unaligned()` and `write_unaligned()` only relax the *alignment*
+   requirement. The pointer must still be non-null and valid for the access. A null check should be the first operation
+   performed on an untrusted caller-supplied pointer before any other dereference or access, including unaligned ones.
+5. **Prefer [`zerocopy`] for structured reads.** When pulling a typed value out of a caller-supplied byte buffer,
+   `zerocopy::FromBytes` provides a safe, alignment-agnostic alternative to manual `read_unaligned()` of a casted
+   pointer.
+
+[`read_unaligned()`]: https://doc.rust-lang.org/std/primitive.pointer.html#method.read_unaligned()
+[`write_unaligned()`]: https://doc.rust-lang.org/std/primitive.pointer.html#method.write_unaligned()
+[`zerocopy`]: https://crates.io/crates/zerocopy
+
+#### When direct dereference is acceptable
+
+Direct dereference (`*ptr`, `&*ptr`, `&mut *ptr`) is sound when the pointer's provenance guarantees alignment. In
+Patina, this is typically the case for:
+
+- Pointers obtained from `Box::leak`, `Vec`, or other Rust allocators (where alignment is guaranteed by construction).
+- The `this` pointer of an internally-produced protocol struct that Patina itself installed via `Box::leak`. The
+  layout of `#[repr(C)]` protocol structs is well-defined and Patina-allocated instances are aligned.
+- Pointers derived from `&T` / `&mut T` references obtained earlier in the same function.
+
+When in doubt, prefer the unaligned variants as they have very little to no measurable cost on properly aligned
+pointers on the targets Patina supports.
+
+#### Anti-pattern examples
+
+```rust,ignore
+// WRONG: direct write through a caller-supplied out-pointer.
+unsafe { *handle = installed_handle };
+
+// WRONG: aligned read of a caller-supplied integer.
+let n = unsafe { *num_bytes };
+
+// WRONG: aligned struct read out of an arbitrary byte buffer.
+let header = unsafe { (*(buffer as *const Header)).clone() };
+
+// WRONG: inconsistent as the same pointer is read aligned and is written unaligned.
+let n = unsafe { *num_bytes };
+// ...
+unsafe { num_bytes.write_unaligned()(actual) };
+```
+
+Replace each with the corresponding `read_unaligned()` / `write_unaligned()` form (and, for the struct case, a
+`core::ptr::read_unaligned()::<Header>(buffer.cast())` or a `zerocopy::FromBytes` parse).

--- a/patina_dxe_core/src/allocator.rs
+++ b/patina_dxe_core/src/allocator.rs
@@ -791,12 +791,29 @@ pub fn core_free_pages(memory: efi::PhysicalAddress, pages: usize) -> Result<(),
 }
 
 extern "efiapi" fn copy_mem(destination: *mut c_void, source: *mut c_void, length: usize) {
+    if length == 0 {
+        return;
+    }
+    debug_assert!(!destination.is_null(), "copy_mem called with null destination and non-zero length");
+    debug_assert!(!source.is_null(), "copy_mem called with null source and non-zero length");
+    if destination.is_null() || source.is_null() {
+        return;
+    }
     // SAFETY: caller must ensure that the source and destination are valid for length bytes.
+    //         destination and source have been null-checked above.
     unsafe { core::ptr::copy(source as *mut u8, destination as *mut u8, length) }
 }
 
 extern "efiapi" fn set_mem(buffer: *mut c_void, size: usize, value: u8) {
+    if size == 0 {
+        return;
+    }
+    debug_assert!(!buffer.is_null(), "set_mem called with null buffer and non-zero size");
+    if buffer.is_null() {
+        return;
+    }
     // SAFETY: caller must ensure that the buffer is valid for size bytes.
+    //         buffer has been null-checked above.
     unsafe {
         let dst_buffer = from_raw_parts_mut(buffer as *mut u8, size);
         dst_buffer.fill(value);
@@ -1835,10 +1852,55 @@ mod tests {
     }
 
     #[test]
+    fn copy_mem_zero_length_is_noop_even_with_null() {
+        // A zero-length copy is a valid no-op
+        copy_mem(core::ptr::null_mut(), core::ptr::null_mut(), 0);
+    }
+
+    #[test]
     fn set_mem_should_set_mem() {
         let mut dest = vec![0xa5u8; 0x10];
         set_mem(dest.as_mut_ptr() as *mut c_void, 0x10, 0x00);
         assert_eq!(dest, vec![0x00u8; 0x10]);
+    }
+
+    #[test]
+    fn set_mem_fills_bytes() {
+        let mut buf: [u8; 8] = [0; 8];
+        set_mem(buf.as_mut_ptr() as *mut c_void, buf.len(), 0xAB);
+        assert_eq!(buf, [0xAB; 8]);
+    }
+
+    #[test]
+    fn set_mem_zero_size_is_noop_even_with_null() {
+        // A zero-size fill is a valid no-op
+        set_mem(core::ptr::null_mut(), 0, 0xFF);
+    }
+
+    #[test]
+    #[cfg(not(debug_assertions))]
+    fn copy_mem_null_destination_returns_without_writing() {
+        let src: [u8; 4] = [1, 2, 3, 4];
+        // When given a null destination with a non-zero length, the function either
+        // asserts (if debug_assertions are enabled) or returns without dereferencing either pointer.
+        copy_mem(core::ptr::null_mut(), src.as_ptr() as *mut c_void, src.len());
+    }
+
+    #[test]
+    #[cfg(not(debug_assertions))]
+    fn copy_mem_null_source_returns_without_writing() {
+        let mut dst: [u8; 4] = [0xAA; 4];
+        // When given a null source with a non-zero length, the function either
+        // asserts (if debug_assertions are enabled) or returns without dereferencing either pointer.
+        copy_mem(dst.as_mut_ptr() as *mut c_void, core::ptr::null_mut(), dst.len());
+        assert_eq!(dst, [0xAA; 4]);
+    }
+
+    #[test]
+    #[cfg(not(debug_assertions))]
+    fn set_mem_null_buffer_returns_without_writing() {
+        // A null buffer with a non-zero size returns without dereferencing.
+        set_mem(core::ptr::null_mut(), 4, 0xFF);
     }
 
     #[test]

--- a/patina_dxe_core/src/cpu/cpu_arch_protocol.rs
+++ b/patina_dxe_core/src/cpu/cpu_arch_protocol.rs
@@ -78,23 +78,28 @@ unsafe impl ProtocolInterface for EfiCpuArchProtocolImpl {
     const PROTOCOL_GUID: patina::BinaryGuid = PROTOCOL_GUID;
 }
 
-// Helper function to convert a raw mutable pointer to a mutable reference.
-fn get_impl_ref<'a>(this: *const Protocol) -> &'a EfiCpuArchProtocolImpl {
+// Helper to convert a raw protocol pointer to a reference. Returns `None` when the caller passes a
+// null pointer so the caller can determine the appropriate action to take.
+fn get_impl_ref<'a>(this: *const Protocol) -> Option<&'a EfiCpuArchProtocolImpl> {
     if this.is_null() {
-        panic!("Null pointer passed to get_impl_ref()");
+        return None;
     }
 
-    // SAFETY: this is non-null and points to an EfiCpuArchProtocolImpl instance.
-    unsafe { &*(this as *const EfiCpuArchProtocolImpl) }
+    // SAFETY: `this` is non-null and points to an EfiCpuArchProtocolImpl instance installed by
+    //         Patina via `Box::leak`, so it is properly aligned and valid for the protocol's
+    //         lifetime.
+    Some(unsafe { &*(this as *const EfiCpuArchProtocolImpl) })
 }
 
-fn get_impl_ref_mut<'a>(this: *mut Protocol) -> &'a mut EfiCpuArchProtocolImpl {
+fn get_impl_ref_mut<'a>(this: *mut Protocol) -> Option<&'a mut EfiCpuArchProtocolImpl> {
     if this.is_null() {
-        panic!("Null pointer passed to get_impl_ref_mut()");
+        return None;
     }
 
-    // SAFETY: this is non-null and points to an EfiCpuArchProtocolImpl instance.
-    unsafe { &mut *(this as *mut EfiCpuArchProtocolImpl) }
+    // SAFETY: `this` is non-null and points to an EfiCpuArchProtocolImpl instance installed by
+    //         Patina via `Box::leak`, so it is properly aligned and valid for the protocol's
+    //         lifetime.
+    Some(unsafe { &mut *(this as *mut EfiCpuArchProtocolImpl) })
 }
 
 // EfiCpuArchProtocolImpl function pointers implementations.
@@ -105,9 +110,11 @@ extern "efiapi" fn flush_data_cache(
     length: u64,
     flush_type: CpuFlushType,
 ) -> efi::Status {
-    let cpu = &get_impl_ref(this).cpu;
+    let Some(impl_ref) = get_impl_ref(this) else {
+        return efi::Status::INVALID_PARAMETER;
+    };
 
-    let result = cpu.flush_data_cache(start, length, flush_type);
+    let result = impl_ref.cpu.flush_data_cache(start, length, flush_type);
 
     result.map(|_| efi::Status::SUCCESS).unwrap_or_else(|err| err.into())
 }
@@ -140,9 +147,11 @@ extern "efiapi" fn get_interrupt_state(this: *const Protocol, state: *mut bool) 
 }
 
 extern "efiapi" fn init(this: *const Protocol, init_type: CpuInitType) -> efi::Status {
-    let cpu = &get_impl_ref(this).cpu;
+    let Some(impl_ref) = get_impl_ref(this) else {
+        return efi::Status::INVALID_PARAMETER;
+    };
 
-    let result = cpu.init(init_type);
+    let result = impl_ref.cpu.init(init_type);
 
     result.map(|_| efi::Status::SUCCESS).unwrap_or_else(|err| err.into())
 }
@@ -152,7 +161,10 @@ extern "efiapi" fn register_interrupt_handler(
     interrupt_type: isize,
     interrupt_handler: InterruptHandler,
 ) -> efi::Status {
-    let interrupt_manager = &get_impl_ref(this).interrupt_manager;
+    let Some(impl_ref) = get_impl_ref(this) else {
+        return efi::Status::INVALID_PARAMETER;
+    };
+    let interrupt_manager = &impl_ref.interrupt_manager;
 
     let const_fn_ptr = interrupt_handler as *const ();
     let result = if const_fn_ptr.is_null() {
@@ -177,9 +189,11 @@ extern "efiapi" fn get_timer_value(
     if timer_value.is_null() || timer_period.is_null() {
         return efi::Status::INVALID_PARAMETER;
     }
-    let cpu = &get_impl_ref(this).cpu;
+    let Some(impl_ref) = get_impl_ref(this) else {
+        return efi::Status::INVALID_PARAMETER;
+    };
 
-    let result = cpu.get_timer_value(timer_index);
+    let result = impl_ref.cpu.get_timer_value(timer_index);
 
     match result {
         Ok((value, period)) => {
@@ -313,6 +327,10 @@ mod tests {
 
             let status = flush_data_cache(&protocol.protocol, 0, 0, CpuFlushType::EfiCpuFlushTypeWriteBackInvalidate);
             assert_eq!(status, efi::Status::SUCCESS);
+
+            // Verify the case when `this` is null.
+            let status = flush_data_cache(core::ptr::null(), 0, 0, CpuFlushType::EfiCpuFlushTypeWriteBackInvalidate);
+            assert_eq!(status, efi::Status::INVALID_PARAMETER);
         });
     }
 
@@ -373,6 +391,10 @@ mod tests {
 
             let status = init(&protocol.protocol, CpuInitType::EfiCpuInit);
             assert_eq!(status, efi::Status::SUCCESS);
+
+            // Verify the case when `this` is null.
+            let status = init(core::ptr::null(), CpuInitType::EfiCpuInit);
+            assert_eq!(status, efi::Status::INVALID_PARAMETER);
         });
     }
 
@@ -396,6 +418,10 @@ mod tests {
 
             let status = register_interrupt_handler(&protocol.protocol, 0, mock_interrupt_handler);
             assert_eq!(status, efi::Status::SUCCESS);
+
+            // Verify the case when `this` is null.
+            let status = register_interrupt_handler(core::ptr::null(), 0, mock_interrupt_handler);
+            assert_eq!(status, efi::Status::INVALID_PARAMETER);
         });
     }
 
@@ -416,6 +442,16 @@ mod tests {
             let status =
                 get_timer_value(&protocol.protocol, 0, &mut timer_value as *mut _, &mut timer_period as *mut _);
             assert_eq!(status, efi::Status::SUCCESS);
+
+            // Verify the case when `this` is null.
+            let status = get_timer_value(core::ptr::null(), 0, &mut timer_value as *mut _, &mut timer_period as *mut _);
+            assert_eq!(status, efi::Status::INVALID_PARAMETER);
+
+            // Null out-parameters should also be rejected.
+            let status = get_timer_value(&protocol.protocol, 0, core::ptr::null_mut(), &mut timer_period as *mut _);
+            assert_eq!(status, efi::Status::INVALID_PARAMETER);
+            let status = get_timer_value(&protocol.protocol, 0, &mut timer_value as *mut _, core::ptr::null_mut());
+            assert_eq!(status, efi::Status::INVALID_PARAMETER);
         });
     }
 
@@ -492,6 +528,46 @@ mod tests {
             // Now the unregister should succeed
             let result = dxe_interrupt_manager.unregister_exception_handler(ExceptionType::from(0_usize));
             assert!(result.is_ok());
+        });
+    }
+
+    #[test]
+    fn test_get_impl_ref_null_returns_none() {
+        assert!(get_impl_ref(core::ptr::null()).is_none());
+    }
+
+    #[test]
+    fn test_get_impl_ref_returns_some_for_valid_pointer() {
+        with_locked_state(|| {
+            let mut cpu_init = MockEfiCpuInit::new();
+            cpu_init.expect_cache_writeback_granule().return_const(64_u32);
+            let cpu: Service<dyn Cpu> = Service::mock(Box::new(cpu_init));
+            let im: Service<dyn InterruptManager> = Service::mock(Box::new(MockInterruptManager::new()));
+            let protocol = EfiCpuArchProtocolImpl::new(cpu, im);
+
+            let this = &raw const protocol.protocol;
+            let impl_ref = get_impl_ref(this).expect("non-null pointer should yield Some");
+            assert_eq!(&raw const impl_ref.protocol, this);
+        });
+    }
+
+    #[test]
+    fn test_get_impl_ref_mut_null_returns_none() {
+        assert!(get_impl_ref_mut(core::ptr::null_mut()).is_none());
+    }
+
+    #[test]
+    fn test_get_impl_ref_mut_returns_some_for_valid_pointer() {
+        with_locked_state(|| {
+            let mut cpu_init = MockEfiCpuInit::new();
+            cpu_init.expect_cache_writeback_granule().return_const(64_u32);
+            let cpu: Service<dyn Cpu> = Service::mock(Box::new(cpu_init));
+            let im: Service<dyn InterruptManager> = Service::mock(Box::new(MockInterruptManager::new()));
+            let mut protocol = EfiCpuArchProtocolImpl::new(cpu, im);
+
+            let this = &raw mut protocol.protocol;
+            let impl_ref = get_impl_ref_mut(this).expect("non-null pointer should yield Some");
+            assert_eq!(&raw const impl_ref.protocol, this.cast_const());
         });
     }
 }

--- a/patina_dxe_core/src/cpu/hw_interrupt_protocol.rs
+++ b/patina_dxe_core/src/cpu/hw_interrupt_protocol.rs
@@ -284,7 +284,9 @@ impl<'a> EfiHardwareInterruptV2Protocol<'a> {
             hw_interrupt2_protocol.hw_interrupt_handler.aarch64_int.lock().get_interrupt_source_state(interrupt_source);
         match enable {
             Ok(enable) => {
-                unsafe { *state = enable }
+                // SAFETY: `state` is checked to be non-null above. Note that caller-supplied pointer
+                //         alignment is not guaranteed.
+                unsafe { state.write_unaligned(enable) }
                 efi::Status::SUCCESS
             }
             Err(err) => err.into(),
@@ -314,7 +316,7 @@ impl<'a> EfiHardwareInterruptV2Protocol<'a> {
         interrupt_source: u64,
         trigger_type: *mut HardwareInterrupt2TriggerType,
     ) -> efi::Status {
-        if this.is_null() {
+        if this.is_null() || trigger_type.is_null() {
             return efi::Status::INVALID_PARAMETER;
         }
 
@@ -323,7 +325,9 @@ impl<'a> EfiHardwareInterruptV2Protocol<'a> {
         let level = hw_interrupt2_protocol.hw_interrupt_handler.aarch64_int.lock().get_trigger_type(interrupt_source);
         match level {
             Ok(level) => {
-                unsafe { *trigger_type = level.into() }
+                // SAFETY: `trigger_type` is a caller-supplied out-pointer
+                //         its alignment is not guaranteed.
+                unsafe { trigger_type.write_unaligned(level.into()) }
                 efi::Status::SUCCESS
             }
             Err(err) => err.into(),

--- a/patina_dxe_core/src/pi_dispatcher/fv.rs
+++ b/patina_dxe_core/src/pi_dispatcher/fv.rs
@@ -535,7 +535,7 @@ impl<P: PlatformInfo> FvProtocolData<P> {
         };
 
         // SAFETY: caller must provide valid pointers for num_bytes and buffer. They are null-checked above.
-        let bytes_to_read = unsafe { *num_bytes };
+        let bytes_to_read = unsafe { num_bytes.read_unaligned() };
 
         let data = match Self::instance().fvb_read(protocol, lba, offset, bytes_to_read) {
             Err(err) => return err.into(),

--- a/patina_dxe_core/src/protocols.rs
+++ b/patina_dxe_core/src/protocols.rs
@@ -72,7 +72,7 @@ extern "efiapi" fn install_protocol_interface(
     };
 
     // SAFETY: Caller must ensure that handle is a valid pointer. It is checked for null above.
-    unsafe { *handle = installed_handle };
+    unsafe { handle.write_unaligned(installed_handle) };
 
     efi::Status::SUCCESS
 }
@@ -267,7 +267,7 @@ extern "efiapi" fn register_protocol_notify(
         Err(err) => err.into(),
         Ok(new_registration) => {
             // SAFETY: Caller must ensure that registration is a valid pointer. It is checked for null above.
-            unsafe { *registration = new_registration };
+            unsafe { registration.write_unaligned(new_registration) };
             efi::Status::SUCCESS
         }
     }
@@ -537,7 +537,8 @@ unsafe extern "C" fn install_multiple_protocol_interfaces(handle: *mut efi::Hand
         // SAFETY: Variadic argument list is controlled by the caller and accessed in order.
         let interface: *mut c_void = unsafe { args.arg() };
         // SAFETY: protocol is checked for null above before dereferencing.
-        if unsafe { *protocol } == efi::protocols::device_path::PROTOCOL_GUID
+        //         The caller-supplied pointer may be unaligned.
+        if unsafe { protocol.read_unaligned() } == efi::protocols::device_path::PROTOCOL_GUID
             && let Ok((remaining_path, handle)) = core_locate_device_path(
                 efi::protocols::device_path::PROTOCOL_GUID,
                 interface as *const efi::protocols::device_path::Protocol,
@@ -562,7 +563,7 @@ unsafe extern "C" fn install_multiple_protocol_interfaces(handle: *mut efi::Hand
                 //on error, attempt to uninstall all the previously installed interfaces. best-effort, errors are ignored.
                 for (protocol, interface) in interfaces_to_uninstall_on_error {
                     // SAFETY: handle is validated for null above.
-                    let handle_value = unsafe { *handle };
+                    let handle_value = unsafe { handle.read_unaligned() };
                     let _ = uninstall_protocol_interface(handle_value, protocol, interface);
                 }
                 return err;
@@ -598,7 +599,7 @@ unsafe extern "C" fn uninstall_multiple_protocol_interfaces(handle: efi::Handle,
                 //on error, attempt to re-install all the previously uninstall interfaces. best-effort, errors are ignored.
                 for (protocol, interface) in interfaces_to_reinstall_on_error {
                     // SAFETY: protocol was checked for null when building interfaces_to_uninstall.
-                    let protocol = *(unsafe { protocol.as_mut().expect("previously null-checked pointer is null.") });
+                    let protocol = unsafe { protocol.read_unaligned() };
                     let _ = core_install_protocol_interface(Some(handle), protocol, interface);
                 }
                 return efi::Status::INVALID_PARAMETER;


### PR DESCRIPTION
## Description

Makes a few changes to improve FFI safety noticed while reviewing the r-efi v6.0.0 PR (pre-existing problems that can be fixed in this PR before v6.0.0 integration).

I tried to find places where null checks and unaligned pointer accesses were not used and should be. Some places may have been missed if they didn't match a search pattern used.

Also, I added tests within reason. In particular, there is a large code coverage gap in `components/patina_acpi/src/acpi_protocol.rs` and `patina_dxe_core/src/protocols.rs` which I did not address since the lines modified are insignificant relative to the surrounding code already lacking coverage.

---

**Treat C FFI pointers as unaligned consistently**

Several UEFI protocol entry points dereference caller-supplied
pointers directly (`*ptr` or `ptr.as_mut()`). This can be undefined
behavior when the C caller passes an unaligned address.

The UEFI ABI does not guarantee that out-parameters or input
structures meet Rust's natural alignment for the pointee type, so
most loads and stores through a raw FFI pointer must go through
`read_unaligned()` / `write_unaligned()`.

While we've followed this pattern in the past, some cases were missed
that are updated in this change.

Also adds a Pointer Alignment section to the FFI Authoring doc (ffi.md)
that describes the rationale along with a few examples.

---

**Improve FFI pointer validation in a couple of places**

Two FFI entry points dereferenced caller-supplied pointers without
validating them:

  - patina_dxe_core: `copy_mem()` and `set_mem()` called
    `core::ptr::copy()` / `slice::from_raw_parts_mut()` on a null
    pointer, if the caller passed one, with a non-zero length.
  - patina_adv_logger: `adv_log_write()` constructed a slice from
    `buffer` and a reference from `this` with no validation.

The boot services functions now `debug_assert!()` on null with a
non-zero length to catch caller bugs clearly in debug builds, then
fall through to a safe early return in release. Since the function
does not return a value, this prevents a panic from propagating across
the FFI boundary.

`adv_log_write()` now returns `EFI_INVALID_PARAMETER` when `this` is
null or when `buffer` is null. The SAFETY comments are updated to reflect
the new invariants.

---

**cpu_arch_protocol: Prevent panic on null `this` pointers**

CPU Arch Protocol functions call a common helper to convert the raw
`this` pointer to a reference. Before, the helper panicked on null
pointers. This commit changes the helper to return `None` on null
pointers, so that the FFI entry points can return
`EFI_INVALID_PARAMETER` instead of panicking across the FFI
boundary.

---

**patina_adv_logger: Add unit tests to components.rs**

There are currently no unit tests for this module. Though the test
support needed to write tests without much overhead are in place,
such as UartNull.

This commit adds some basic tests for `adv_log_write` that verify the
pointer validation logic and calls to write the message when
expectations are valid.

---

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [x] Includes tests?
- [x] Includes documentation?

## How This Was Tested

- `cargo make all`
- QEMU platform boot to EFI shell

## Integration Instructions

- N/A