### PR TITLE
patina_internal_cpu: Serialize a missed unit test

### DIFF
--- a/core/patina_internal_cpu/src/interrupts/exception_handling.rs
+++ b/core/patina_internal_cpu/src/interrupts/exception_handling.rs
@@ -155,7 +155,12 @@ mod tests {
     }
 
     #[test]
+    #[serial(exception_handlers)]
     fn test_uefi_routine() {
+        // SAFETY: Reset before exercising the callback so that the post-invocation
+        // assertion proves the callback actually fired in this test.
+        unsafe { CALLBACK_INVOKED = false };
+
         let mut context = ExceptionContext(crate::interrupts::stub::ExceptionContextStub {});
         register_exception_handler(NUM_EXCEPTION_TYPES, HandlerType::UefiRoutine(test_callback))
             .expect_err("Allowed invalid exception number!");
@@ -166,7 +171,10 @@ mod tests {
             .expect_err("Allowed double register!");
         exception_handler(CALLBACK_EXCEPTION, &mut context);
         // SAFETY: This is a test only static mutable variable.
-        assert!(unsafe { CALLBACK_INVOKED });
+        unsafe {
+            assert!(CALLBACK_INVOKED);
+            CALLBACK_INVOKED = false;
+        }
         unregister_exception_handler(CALLBACK_EXCEPTION).expect("Failed to unregister handler!");
         unregister_exception_handler(CALLBACK_EXCEPTION).expect_err("Allowed double unregister!");
     }


### PR DESCRIPTION
## Description

Adds the `#[serial]` attribute to the `test_uefi_routine()` unit test since it modifies the global `EXCEPTION_HANDLERS` array (matching neighboring functions that register exception handlers) and the `CALLBACK_INVOKED` global (which is only in the `tests` module), which might be used by other tests in the future.

Also sets `CALLBACK_INVOKED` to `false` at the start of the test so that the test can assert that the callback was flipped to true by the test. Sets it back to `false` when done for clean exit state. This is currently the only test using it, so it's more for future-proofing than anything else.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [x] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

- `cargo make all`

## Integration Instructions

- N/A