### PR TITLE
[REBASE & FF] Enable Clippy's Deny indexing_slicing Lint

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,6 +74,7 @@ serde_json = { version = "1.0", default-features = false, features = ["alloc"] }
 lzma-rs = { version = "0.3" }
 
 [workspace.lints.clippy]
+indexing_slicing = "deny"
 undocumented_unsafe_blocks = "warn"
 
 # Profile used to build workspace dependencies for `mdbook test`. Inherits from `dev`

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,0 +1,1 @@
+allow-indexing-slicing-in-tests = true

--- a/components/patina_acpi/src/acpi.rs
+++ b/components/patina_acpi/src/acpi.rs
@@ -510,7 +510,10 @@ where
             // Next entry goes after header + existing address entries.
             let entry_offset = ACPI_HEADER_LEN + xsdt_data.n_entries * ACPI_XSDT_ENTRY_SIZE;
             // Fill in the bytes of the new address entry.
-            xsdt_data.slice[entry_offset..entry_offset + ACPI_XSDT_ENTRY_SIZE]
+            xsdt_data
+                .slice
+                .get_mut(entry_offset..entry_offset + ACPI_XSDT_ENTRY_SIZE)
+                .ok_or(AcpiError::XsdtOverflow)?
                 .copy_from_slice(&new_table_addr.to_le_bytes());
 
             // Increase XSDT length by one entry.
@@ -661,6 +664,9 @@ where
                 let start_idx = ACPI_HEADER_LEN + idx * ACPI_XSDT_ENTRY_SIZE; // Find where the target entry starts.
                 let end_idx = ACPI_HEADER_LEN + xsdt_data.n_entries * ACPI_XSDT_ENTRY_SIZE; // Find where the XSDT ends.
 
+                // Validate the full range before mutating.
+                let _ = xsdt_data.slice.get(start_idx..end_idx).ok_or(AcpiError::XsdtOverflow)?;
+
                 // Shift all entries after the one being removed to the left.
                 // [.. before .. | target | <- .. after .. ]
                 // becomes [.. before .. | .. after.. ]
@@ -669,10 +675,13 @@ where
                 // Decrement entries.
                 xsdt_data.n_entries -= 1;
 
-                // Zero out the end of the XSDT.
-                // (After removing and shifting all entries, there is one extra slot at the end.)
-                // This is not technically necessary for correctness but is good practice for consistency.
-                xsdt_data.slice[end_idx - ACPI_XSDT_ENTRY_SIZE..end_idx].iter_mut().for_each(|b| *b = 0);
+                // Zero out the trailing slot freed by the shift.
+                xsdt_data
+                    .slice
+                    .get_mut(end_idx - ACPI_XSDT_ENTRY_SIZE..end_idx)
+                    .ok_or(AcpiError::XsdtOverflow)?
+                    .iter_mut()
+                    .for_each(|b| *b = 0);
 
                 // Decrease XSDT length.
                 xsdt_data.set_length(xsdt_data.get_length()? - ACPI_XSDT_ENTRY_SIZE as u32);
@@ -693,11 +702,12 @@ where
     pub(crate) fn checksum_common_tables(&self) {
         if let Some(ref mut xsdt_data) = *self.xsdt_metadata.lock() {
             // Zero the old checksum byte.
-            xsdt_data.slice[ACPI_CHECKSUM_OFFSET] = 0;
+            *xsdt_data.slice.get_mut(ACPI_CHECKSUM_OFFSET).expect("XSDT has a standard header") = 0;
             // Sum all bytes (wrapping since the checksum is a u8 between 0-255).
             let sum_of_bytes: u8 = xsdt_data.slice.iter().fold(0u8, |acc, &b| acc.wrapping_add(b));
             // Write new checksum: equivalent to -1 * `sum_of_bytes` (so the sum is zero modulo 256).
-            xsdt_data.slice[ACPI_CHECKSUM_OFFSET] = sum_of_bytes.wrapping_neg();
+            *xsdt_data.slice.get_mut(ACPI_CHECKSUM_OFFSET).expect("XSDT has a standard header") =
+                sum_of_bytes.wrapping_neg();
         }
 
         // The RSDP doesn't have a standard header, so it is easier to calculate the checksum manually.
@@ -713,16 +723,22 @@ where
         };
 
         // Zero out old checksums before recalculating.
-        rsdp_bytes[RSDP_CHECKSUM_OFFSET] = 0;
-        rsdp_bytes[RSDP_EXTENDED_CHECKSUM_OFFSET] = 0;
+        *rsdp_bytes.get_mut(RSDP_CHECKSUM_OFFSET).expect("RSDP is large enough for checksum offset") = 0;
+        *rsdp_bytes
+            .get_mut(RSDP_EXTENDED_CHECKSUM_OFFSET)
+            .expect("RSDP is large enough for extended checksum offset") = 0;
 
         // Calculate the `checksum` field (first 20 bytes).
-        let sum20: u8 = rsdp_bytes[..20].iter().fold(0u8, |acc, &b| acc.wrapping_add(b));
-        rsdp_bytes[RSDP_CHECKSUM_OFFSET] = sum20.wrapping_neg();
+        let sum20: u8 =
+            rsdp_bytes.get(..20).expect("RSDP is at least 20 bytes").iter().fold(0u8, |acc, &b| acc.wrapping_add(b));
+        *rsdp_bytes.get_mut(RSDP_CHECKSUM_OFFSET).expect("RSDP is large enough for checksum offset") =
+            sum20.wrapping_neg();
 
         // Calculate the `extended_checksum` (checksums over all bytes).
         let sum_of_bytes: u8 = rsdp_bytes.iter().fold(0u8, |acc, &b| acc.wrapping_add(b));
-        rsdp_bytes[RSDP_EXTENDED_CHECKSUM_OFFSET] = sum_of_bytes.wrapping_neg();
+        *rsdp_bytes
+            .get_mut(RSDP_EXTENDED_CHECKSUM_OFFSET)
+            .expect("RSDP is large enough for extended checksum offset") = sum_of_bytes.wrapping_neg();
     }
 
     /// Publishes ACPI tables after installation.

--- a/components/patina_acpi/src/acpi_table.rs
+++ b/components/patina_acpi/src/acpi_table.rs
@@ -245,8 +245,9 @@ impl AcpiXsdtMetadata {
     pub(crate) fn set_length(&mut self, new_len: u32) {
         // XSDT always starts with header.
         let length_offset = mem::offset_of!(AcpiTableHeader, length);
-        // Write the new length into the correct offset in the header.
-        self.slice[length_offset..length_offset + mem::size_of::<u32>()] // Length is a u32
+        self.slice
+            .get_mut(length_offset..length_offset + mem::size_of::<u32>())
+            .expect("slice contains a full ACPI header")
             .copy_from_slice(&new_len.to_le_bytes());
     }
 
@@ -254,21 +255,24 @@ impl AcpiXsdtMetadata {
     pub(crate) fn set_oem_id(&mut self, new_id: [u8; 6]) {
         let offset = mem::offset_of!(AcpiTableHeader, oem_id);
         let end = offset + mem::size_of::<[u8; 6]>();
-        self.slice[offset..end].copy_from_slice(&new_id);
+        self.slice.get_mut(offset..end).expect("slice contains a full ACPI header").copy_from_slice(&new_id);
     }
 
     /// Set the 8-byte OEM Table ID (bytes 16..24 of the header).
     pub(crate) fn set_oem_table_id(&mut self, new_table_id: [u8; 8]) {
         let offset = mem::offset_of!(AcpiTableHeader, oem_table_id);
         let end = offset + mem::size_of::<[u8; 8]>();
-        self.slice[offset..end].copy_from_slice(&new_table_id);
+        self.slice.get_mut(offset..end).expect("slice contains a full ACPI header").copy_from_slice(&new_table_id);
     }
 
     /// Set the 4-byte OEM Revision (bytes 24..28 of the header).
     pub(crate) fn set_oem_revision(&mut self, new_rev: u32) {
         let offset = mem::offset_of!(AcpiTableHeader, oem_revision);
         let end = offset + mem::size_of::<u32>();
-        self.slice[offset..end].copy_from_slice(&new_rev.to_le_bytes());
+        self.slice
+            .get_mut(offset..end)
+            .expect("slice contains a full ACPI header")
+            .copy_from_slice(&new_rev.to_le_bytes());
     }
 }
 
@@ -561,19 +565,16 @@ impl AcpiTable {
     pub(crate) fn update_checksum(&mut self) -> Result<(), AcpiError> {
         // SAFETY: The construction of `AcpiTable` maintains that `self.length` is the size in memory.
         let bytes = unsafe { self.as_bytes_mut() };
-        let len = bytes.len();
 
-        // Set the checksum field (byte at the specified `offset`) to zero before recalculation.
-        if len > ACPI_CHECKSUM_OFFSET {
-            bytes[ACPI_CHECKSUM_OFFSET] = 0;
+        // Set the checksum field to zero before recalculation.
+        let checksum_byte = bytes.get_mut(ACPI_CHECKSUM_OFFSET).ok_or(AcpiError::InvalidChecksumOffset)?;
+        *checksum_byte = 0;
 
-            // Recalculate checksum.
-            let sum: u8 = bytes.iter().fold(0u8, |sum, &b| sum.wrapping_add(b));
-            bytes[ACPI_CHECKSUM_OFFSET] = (0u8).wrapping_sub(sum);
-            Ok(())
-        } else {
-            Err(AcpiError::InvalidChecksumOffset)
-        }
+        // Recalculate checksum.
+        let sum: u8 = bytes.iter().fold(0u8, |sum, &b| sum.wrapping_add(b));
+        let checksum_byte = bytes.get_mut(ACPI_CHECKSUM_OFFSET).ok_or(AcpiError::InvalidChecksumOffset)?;
+        *checksum_byte = (0u8).wrapping_sub(sum);
+        Ok(())
     }
 
     /// Returns a reference to the entire AcpiTable.
@@ -609,7 +610,6 @@ impl AcpiTable {
 
 #[cfg(test)]
 mod tests {
-    use alloc::boxed::Box;
     use patina::component::service::memory::StdMemoryManager;
 
     use super::*;

--- a/components/patina_adv_logger/src/logger.rs
+++ b/components/patina_adv_logger/src/logger.rs
@@ -311,8 +311,9 @@ where
             return;
         }
 
-        let data = &self.buffer[0..self.buffer_size];
-        self.writer.log_write(self.level, self.hw_print_mask_override, data);
+        if let Some(data) = self.buffer.get(0..self.buffer_size) {
+            self.writer.log_write(self.level, self.hw_print_mask_override, data);
+        }
         self.buffer_size = 0;
     }
 }
@@ -331,8 +332,10 @@ where
             if len > WRITER_BUFFER_SIZE - self.buffer_size {
                 self.flush();
             }
-            self.buffer[self.buffer_size..self.buffer_size + len].copy_from_slice(data);
-            self.buffer_size += len;
+            if let Some(dest) = self.buffer.get_mut(self.buffer_size..self.buffer_size + len) {
+                dest.copy_from_slice(data);
+                self.buffer_size += len;
+            }
         } else {
             // this message is too big to buffer, flush then write the message.
             self.flush();

--- a/components/patina_adv_logger/src/parser.rs
+++ b/components/patina_adv_logger/src/parser.rs
@@ -71,7 +71,7 @@ impl<'a> Parser<'a> {
 
             let msg = entry.get_message();
             out.write(msg).map_err(|_| "Failed to write to output.")?;
-            carry_entry = if !msg.is_empty() && msg[msg.len() - 1] == b'\n' { None } else { Some(entry) };
+            carry_entry = if !msg.is_empty() && msg.last() == Some(&b'\n') { None } else { Some(entry) };
         }
 
         Ok(())

--- a/components/patina_mm/src/component/communicator.rs
+++ b/components/patina_mm/src/component/communicator.rs
@@ -319,7 +319,7 @@ impl<E: MmExecutor + 'static> MmCommunication for MmCommunicator<E> {
         })?;
 
         log::debug!(target: "mm_comm", "Outgoing MM communication request: buffer_id={}, data_size={}, recipient={:?}", id, data_buffer.len(), recipient);
-        log::debug!(target: "mm_comm", "Request Data (hex): {:02X?}", &data_buffer[..core::cmp::min(data_buffer.len(), 64)]);
+        log::debug!(target: "mm_comm", "Request Data (hex): {:02X?}", data_buffer.get(..core::cmp::min(data_buffer.len(), 64)).unwrap_or(data_buffer));
         log::trace!(target: "mm_comm", "Comm buffer before request: {:?}", comm_buffer);
 
         // Set the mailbox status to indicate buffer is valid before triggering MMI

--- a/components/patina_mm/src/config.rs
+++ b/components/patina_mm/src/config.rs
@@ -405,12 +405,10 @@ impl CommunicateBuffer {
     ///
     /// Returns `Ok(())` if state verification passes, otherwise returns the appropriate error.
     fn verify_state_consistency(&self) -> Result<(), CommunicateBufferStatus> {
-        if self.len() < Self::MESSAGE_START_OFFSET {
+        let header_slice = self.as_slice().get(..Self::MESSAGE_START_OFFSET).ok_or_else(|| {
             log::error!(target: "mm_comm", "Buffer {} is too small for the communicate header", self.id);
-            return Err(CommunicateBufferStatus::TooSmallForHeader);
-        }
-
-        let header_slice = &self.as_slice()[..Self::MESSAGE_START_OFFSET];
+            CommunicateBufferStatus::TooSmallForHeader
+        })?;
 
         // SAFETY: Buffer size validated, BinaryGuid is repr(transparent) over repr(C) efi::Guid at offset 0.
         // read_unaligned is used because the buffer may not be aligned to the type's requirements.
@@ -499,7 +497,10 @@ impl CommunicateBuffer {
         // Update memory buffer using safe byte operations
         let header = EfiMmCommunicateHeader::new(recipient, self.private_message_length);
         let header_bytes = header.as_bytes();
-        self.as_slice_mut()[..Self::MESSAGE_START_OFFSET].copy_from_slice(header_bytes);
+        self.as_slice_mut()
+            .get_mut(..Self::MESSAGE_START_OFFSET)
+            .ok_or(CommunicateBufferStatus::TooSmallForHeader)?
+            .copy_from_slice(header_bytes);
 
         // Verify state consistency after update
         self.verify_state_consistency()?;
@@ -533,10 +534,15 @@ impl CommunicateBuffer {
         // Update memory buffer using safe byte operations for header
         let header = EfiMmCommunicateHeader::new(Guid::from_ref(&recipient), message.len());
         let header_bytes = header.as_bytes();
-        self.as_slice_mut()[..Self::MESSAGE_START_OFFSET].copy_from_slice(header_bytes);
+        self.as_slice_mut()
+            .get_mut(..Self::MESSAGE_START_OFFSET)
+            .ok_or(CommunicateBufferStatus::TooSmallForHeader)?
+            .copy_from_slice(header_bytes);
 
         // Copy message data
-        self.as_slice_mut()[Self::MESSAGE_START_OFFSET..Self::MESSAGE_START_OFFSET + message.len()]
+        self.as_slice_mut()
+            .get_mut(Self::MESSAGE_START_OFFSET..Self::MESSAGE_START_OFFSET + message.len())
+            .ok_or(CommunicateBufferStatus::TooSmallForMessage)?
             .copy_from_slice(message);
 
         // Verify state consistency after update
@@ -563,14 +569,20 @@ impl CommunicateBuffer {
         let start_offset = Self::MESSAGE_START_OFFSET;
         let end_offset = start_offset + self.private_message_length;
 
-        // Ensure we don't read beyond the buffer
-        if end_offset > self.len() {
-            log::error!(target: "mm_comm", "Buffer {} message extends beyond buffer: end_offset={}, buffer_len={}",
-                self.id, end_offset, self.len());
-            return Err(CommunicateBufferStatus::TooSmallForMessage);
-        }
-
-        let message = self.as_slice()[start_offset..end_offset].to_vec();
+        let message = self
+            .as_slice()
+            .get(start_offset..end_offset)
+            .ok_or_else(|| {
+                log::error!(
+                    target: "mm_comm",
+                    "Buffer {} message extends beyond buffer: end_offset={}, buffer_len={}",
+                    self.id,
+                    end_offset,
+                    self.len()
+                );
+                CommunicateBufferStatus::TooSmallForMessage
+            })?
+            .to_vec();
         log::trace!(target: "mm_comm", "Retrieved message from buffer {}: message_size={}", self.id, message.len());
         Ok(message)
     }

--- a/components/patina_mm/tests/patina_mm_integration.rs
+++ b/components/patina_mm/tests/patina_mm_integration.rs
@@ -8,6 +8,7 @@
 //! Copyright (C) Microsoft Corporation.
 //!
 //! SPDX-License-Identifier: Apache-2.0
+#![allow(clippy::indexing_slicing)]
 
 #[path = "patina_mm_integration/tests_root.rs"]
 mod patina_mm_integration;

--- a/components/patina_performance/src/component/performance.rs
+++ b/components/patina_performance/src/component/performance.rs
@@ -256,7 +256,7 @@ fn fetch_mm_record_chunk(
     }
 
     let actual_size = core::cmp::min(chunk_size, data_resp.boot_record_data().len());
-    Ok(data_resp.boot_record_data()[..actual_size].to_vec())
+    Ok(data_resp.boot_record_data().get(..actual_size).ok_or(MmPerformanceError::ParseError)?.to_vec())
 }
 
 /// Fetches all MM performance record data using chunked requests
@@ -311,14 +311,14 @@ impl<'a> Iterator for PerformanceRecordIterator<'a> {
         let header = match PerformanceRecordHeader::try_from(self.bytes) {
             Ok(h) => h,
             Err(err) => {
-                self.bytes = &self.bytes[1..];
+                self.bytes = self.bytes.get(1..).unwrap_or(&[]);
                 return Some(Err(MmPerformanceError::RecordError(err.into())));
             }
         };
 
         let rec_len = header.length as usize;
         if rec_len < PerformanceRecordHeader::SIZE {
-            self.bytes = &self.bytes[PerformanceRecordHeader::SIZE..];
+            self.bytes = self.bytes.get(PerformanceRecordHeader::SIZE..).unwrap_or(&[]);
             return Some(Err(MmPerformanceError::RecordError(alloc::format!(
                 "Record reports too small length {} (< {})",
                 rec_len,
@@ -327,8 +327,6 @@ impl<'a> Iterator for PerformanceRecordIterator<'a> {
         }
 
         if rec_len > self.bytes.len() {
-            // Consume all remaining bytes since the record claims to be longer
-            // than what we have available (truncated data)
             self.bytes = &[];
             return Some(Err(MmPerformanceError::RecordError(alloc::format!(
                 "Truncated record (needed {}, had {})",
@@ -337,7 +335,7 @@ impl<'a> Iterator for PerformanceRecordIterator<'a> {
             ))));
         }
 
-        let data = &self.bytes[PerformanceRecordHeader::SIZE..rec_len];
+        let data = self.bytes.get(PerformanceRecordHeader::SIZE..rec_len)?;
         let record = GenericPerformanceRecord {
             record_type: header.record_type,
             length: header.length,
@@ -345,7 +343,7 @@ impl<'a> Iterator for PerformanceRecordIterator<'a> {
             data,
         };
 
-        self.bytes = &self.bytes[rec_len..];
+        self.bytes = self.bytes.get(rec_len..).unwrap_or(&[]);
         Some(Ok(record))
     }
 }

--- a/components/patina_performance/src/mm.rs
+++ b/components/patina_performance/src/mm.rs
@@ -54,10 +54,7 @@ impl SmmCommHeader {
 
     /// Write this header into the destination buffer.
     pub fn write_into(&self, dest: &mut [u8]) -> Result<usize, ()> {
-        if dest.len() < SMM_COMM_HEADER_SIZE {
-            return Err(());
-        }
-        dest[..SMM_COMM_HEADER_SIZE].copy_from_slice(self.as_bytes());
+        dest.get_mut(..SMM_COMM_HEADER_SIZE).ok_or(())?.copy_from_slice(self.as_bytes());
         Ok(SMM_COMM_HEADER_SIZE)
     }
 
@@ -193,7 +190,13 @@ impl<const BUFFER_SIZE: usize> GetRecordDataByOffset<BUFFER_SIZE> {
         let mut boot_record_data = [0u8; BUFFER_SIZE];
         let remaining = src.len().saturating_sub(header_consumed);
         let take = core::cmp::min(remaining, BUFFER_SIZE);
-        boot_record_data[..take].copy_from_slice(&src[header_consumed..header_consumed + take]);
+        boot_record_data
+            .get_mut(..take)
+            .ok_or(ParseError::BufferTooSmall { required: take, available: BUFFER_SIZE })?
+            .copy_from_slice(
+                src.get(header_consumed..header_consumed + take)
+                    .ok_or(ParseError::BufferTooSmall { required: header_consumed + take, available: src.len() })?,
+            );
 
         Ok((
             Self {

--- a/core/patina_debugger/src/arch/aarch64.rs
+++ b/core/patina_debugger/src/arch/aarch64.rs
@@ -329,11 +329,10 @@ impl Registers for Aarch64CoreRegs {
 
         macro_rules! read {
             ($t:ty) => {{
-                if offset + core::mem::size_of::<$t>() > bytes.len() {
-                    return Err(());
-                }
+                let end = offset + core::mem::size_of::<$t>();
+                let slice = bytes.get(offset..end).ok_or(())?;
                 let mut array = [0u8; core::mem::size_of::<$t>()];
-                array.copy_from_slice(&bytes[offset..offset + core::mem::size_of::<$t>()]);
+                array.copy_from_slice(slice);
                 offset += 8;
                 <$t>::from_le_bytes(array)
             }};

--- a/core/patina_debugger/src/arch/x64.rs
+++ b/core/patina_debugger/src/arch/x64.rs
@@ -289,11 +289,10 @@ impl Registers for X64CoreRegs {
 
         macro_rules! read {
             ($t:ty) => {{
-                if offset + core::mem::size_of::<$t>() > bytes.len() {
-                    return Err(());
-                }
+                let end = offset + core::mem::size_of::<$t>();
+                let slice = bytes.get(offset..end).ok_or(())?;
                 let mut array = [0u8; core::mem::size_of::<$t>()];
-                array.copy_from_slice(&bytes[offset..offset + core::mem::size_of::<$t>()]);
+                array.copy_from_slice(slice);
                 offset += 8;
                 <$t>::from_le_bytes(array)
             }};
@@ -450,11 +449,11 @@ impl UefiArchRegs for X64CoreRegs {
                 _ => Err(()),
             },
             X64CoreRegId::Fpu(_) => {
-                buf[..4].fill(0);
+                buf.get_mut(..4).ok_or(())?.fill(0);
                 Ok(4)
             }
             X64CoreRegId::St(_) => {
-                buf[..10].fill(0);
+                buf.get_mut(..10).ok_or(())?.fill(0);
                 Ok(10)
             }
         }

--- a/core/patina_debugger/src/dbg_target.rs
+++ b/core/patina_debugger/src/dbg_target.rs
@@ -260,10 +260,10 @@ impl ext::target_description_xml_override::TargetDescriptionXmlOverride for Pati
 
         let start = offset;
         let end = (start + length).min(bytes.len());
-        let copy_bytes: &[u8] = &bytes[start..end];
+        let copy_bytes = bytes.get(start..end).ok_or(())?;
 
         let copy_len = copy_bytes.len().min(buf.len());
-        buf[..copy_len].copy_from_slice(&copy_bytes[..copy_len]);
+        buf.get_mut(..copy_len).ok_or(())?.copy_from_slice(copy_bytes.get(..copy_len).ok_or(())?);
         Ok(copy_len)
     }
 }

--- a/core/patina_debugger/src/dbg_target/monitor.rs
+++ b/core/patina_debugger/src/dbg_target/monitor.rs
@@ -203,7 +203,7 @@ impl<const N: usize> Write for MonitorBuffer<'_, N> {
                 return Ok(());
             } else {
                 // Adjust the data to skip the start offset.
-                data = &data[self.start_offset..];
+                data = data.get(self.start_offset..).ok_or(core::fmt::Error)?;
                 len = data.len();
                 self.start_offset = 0; // Reset start offset after using it.
             }
@@ -215,8 +215,10 @@ impl<const N: usize> Write for MonitorBuffer<'_, N> {
             if len > N - self.pos {
                 self.flush();
             }
-            self.buffer[self.pos..self.pos + len].copy_from_slice(data);
-            self.pos += len;
+            if let Some(dest) = self.buffer.get_mut(self.pos..self.pos + len) {
+                dest.copy_from_slice(data);
+                self.pos += len;
+            }
         } else {
             // this message is too big to buffer, flush then write the message.
             self.flush();

--- a/core/patina_debugger/src/lib.rs
+++ b/core/patina_debugger/src/lib.rs
@@ -331,7 +331,7 @@ pub fn add_monitor_command<F>(cmd: &'static str, _description: Option<&'static s
 where
     F: Fn(&mut core::str::SplitWhitespace<'_>, &mut dyn core::fmt::Write) + Send + Sync + 'static,
 {
-    if let Some(_) = DEBUGGER.get() {
+    if DEBUGGER.get().is_some() {
         log::warn!("Dynamic monitor commands require the 'alloc' feature. Will not add command: {cmd}");
     }
 }

--- a/core/patina_internal_collections/src/node.rs
+++ b/core/patina_internal_collections/src/node.rs
@@ -74,18 +74,17 @@ where
 
         if !storage.data.is_empty() {
             Self::build_linked_list(storage.data);
-            storage.available.set(storage.data[0].as_mut_ptr());
+            // first() is safe: is_empty() check above guarantees at least one element.
+            storage.available.set(storage.data.first().expect("non-empty data").as_mut_ptr());
         }
 
         storage
     }
 
     fn build_linked_list(buffer: &[Node<D>]) {
-        let mut node = &buffer[0];
-        for next in buffer.iter().skip(1) {
+        for [node, next] in buffer.array_windows::<2>() {
             node.set_right(Some(next));
             next.set_left(Some(node));
-            node = next;
         }
     }
 
@@ -235,49 +234,56 @@ where
         if self.capacity() == 0 {
             self.data = buffer;
             Self::build_linked_list(self.data);
-            self.available.set(self.data[0].as_mut_ptr());
+            // if the buffer is empty, we set the available list to null as is expected
+            self.available.set(self.data.first().map(|n| n.as_mut_ptr()).unwrap_or_default());
             return;
         }
 
         // Copy the data from the old buffer to the new buffer. Update the pointers to the new buffer
         for i in 0..self.len() {
-            let old = &self.data[i];
+            let old = self.data.get(i).expect("i < self.len() <= self.capacity() <= self.data.len()");
 
             // SAFETY: Nodes at indices 0..self.len() are "in use" and have initialized data.
-            // We copy the initialized data from old to new.
+            // We copy the initialized data from old to new. This mutable borrow must complete
+            // before we take shared references to buffer elements below.
             unsafe {
                 let old_data = old.data();
-                buffer[i].data = MaybeUninit::new(*old_data);
+                let new_node_mut = buffer.get_mut(i).expect("i < self.len() <= self.capacity() <= buffer.len()");
+                new_node_mut.data = MaybeUninit::new(*old_data);
             }
-            buffer[i].set_color(old.color());
+
+            let new_node = buffer.get(i).expect("i is in bounds");
+            new_node.set_color(old.color());
 
             if let Some(left) = old.left() {
                 let idx = self.idx(left.as_mut_ptr());
-                buffer[i].set_left(Some(&buffer[idx]));
+                new_node.set_left(buffer.get(idx));
             } else {
-                buffer[i].set_left(None);
+                new_node.set_left(None);
             }
 
             if let Some(right) = old.right() {
                 let idx = self.idx(right.as_mut_ptr());
-                buffer[i].set_right(Some(&buffer[idx]));
+                new_node.set_right(buffer.get(idx));
             } else {
-                buffer[i].set_right(None);
+                new_node.set_right(None);
             }
 
             if let Some(parent) = old.parent() {
                 let idx = self.idx(parent.as_mut_ptr());
-                buffer[i].set_parent(Some(&buffer[idx]));
+                new_node.set_parent(buffer.get(idx));
             } else {
-                buffer[i].set_parent(None);
+                new_node.set_parent(None);
             }
         }
 
         let idx = if !self.available.get().is_null() { self.idx(self.available.get()) } else { self.len() };
 
-        if idx < buffer.len() {
-            Self::build_linked_list(&buffer[idx..]);
-            self.available.set(buffer[idx].as_mut_ptr());
+        if let Some(tail) = buffer.get(idx..) {
+            Self::build_linked_list(tail);
+            if let Some(first) = buffer.get(idx) {
+                self.available.set(first.as_mut_ptr());
+            }
         } else {
             self.available.set(core::ptr::null_mut());
         }

--- a/core/patina_internal_collections/src/sorted_slice.rs
+++ b/core/patina_internal_collections/src/sorted_slice.rs
@@ -46,7 +46,7 @@ where
         };
 
         self.slice.copy_within(idx..self.len(), idx + 1);
-        self.slice[idx] = element;
+        *self.slice.get_mut(idx).ok_or(Error::OutOfSpace)? = element;
         self.item_count += 1;
         Ok(idx)
     }
@@ -72,12 +72,13 @@ where
             }
         }
 
-        let Err(idx) = self.search(elements[0]) else {
+        let first = *elements.first().ok_or(Error::NotSorted)?;
+        let Err(idx) = self.search(first) else {
             return Err(Error::AlreadyExists);
         };
 
         if let Some(next) = self.get(idx) {
-            let last = elements[elements.len() - 1];
+            let last = *elements.last().ok_or(Error::NotSorted)?;
             match last.key().cmp(next.key()) {
                 core::cmp::Ordering::Equal => return Err(Error::AlreadyExists),
                 core::cmp::Ordering::Greater => return Err(Error::NotSorted),
@@ -86,7 +87,7 @@ where
         }
 
         self.slice.copy_within(idx..self.len(), idx + elements.len());
-        self.slice[idx..idx + elements.len()].copy_from_slice(elements);
+        self.slice.get_mut(idx..idx + elements.len()).ok_or(Error::OutOfSpace)?.copy_from_slice(elements);
         self.item_count += elements.len();
         Ok(idx)
     }
@@ -105,7 +106,7 @@ where
         if idx >= self.item_count {
             return None;
         }
-        let item = self.slice[idx];
+        let item = *self.slice.get(idx)?;
         self.slice.copy_within(idx + 1..self.len(), idx);
         self.item_count -= 1;
         Some(item)
@@ -123,17 +124,28 @@ where
     ///
     /// Returns the exact datum if it exists, or the closest datum that is greater than the key if it does not.
     pub fn search_with_key(&self, key: &T::Key) -> Result<&T, &T> {
-        self.binary_search_by_key(&key, |e| e.key()).map(|idx| &self[idx]).map_err(|idx| &self[idx])
+        assert!(!self.is_empty());
+        match self.binary_search_by_key(&key, |e| e.key()) {
+            Ok(idx) => Ok(self.get(idx).expect("binary_search Ok index is always in bounds")),
+            Err(idx) => {
+                // Clamp to last valid index when binary_search returns past-the-end.
+                let idx = idx.min(self.len().saturating_sub(1));
+                Err(self.get(idx).expect("slice is non-empty for binary_search Err"))
+            }
+        }
     }
 
     /// Returns a mutable reference to a datum.
     ///
     /// Returns the exact datum if it exists, or the closest datum that is greater than the key if it does not.
     pub fn search_with_key_mut(&mut self, key: &T::Key) -> Result<&mut T, &mut T> {
-        let index = self.binary_search_by_key(&key, |e| e.key());
-        match index {
-            Ok(idx) => Ok(&mut self[idx]),
-            Err(idx) => Err(&mut self[idx]),
+        match self.binary_search_by_key(&key, |e| e.key()) {
+            Ok(idx) => Ok(self.get_mut(idx).expect("binary_search Ok index is always in bounds")),
+            Err(idx) => {
+                // Clamp to last valid index when binary_search returns past-the-end.
+                let idx = idx.min(self.len().saturating_sub(1));
+                Err(self.get_mut(idx).expect("slice is non-empty for binary_search Err"))
+            }
         }
     }
 
@@ -152,14 +164,14 @@ impl<T> core::ops::Deref for SortedSlice<'_, T> {
     type Target = [T];
 
     fn deref(&self) -> &Self::Target {
-        &self.slice[..self.item_count]
+        self.slice.get(..self.item_count).expect("item_count <= slice.len()")
     }
 }
 
 // TODO Maybe adding manually the interesting function and add a way to mutate element that validate that is still sorted after.
 impl<T> core::ops::DerefMut for SortedSlice<'_, T> {
     fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.slice[..self.item_count]
+        self.slice.get_mut(..self.item_count).expect("item_count <= slice.len()")
     }
 }
 

--- a/core/patina_internal_cpu/src/interrupts/aarch64/gic_manager.rs
+++ b/core/patina_internal_cpu/src/interrupts/aarch64/gic_manager.rs
@@ -225,7 +225,7 @@ impl AArch64InterruptInitializer {
             let redistributor = self.gic_v3.redistributor(self.cpu_r_idx).expect("Invalid redistributor");
             let mut context = GicRedistributorContext::<{ Self::MAX_REDISTRIBUTOR_PPI }>::default();
             redistributor.save(&mut context).map_err(|_| EfiError::DeviceError)?;
-            Ok(context.isenabler()[index] & bit != 0)
+            Ok(context.isenabler().get(index).ok_or(EfiError::InvalidParameter)? & bit != 0)
         } else {
             // arm-gic does not presently provide a way to directly read the interrupt state for a given interrupt.
             // so save the current distributor context and read the ISENABLER from there.
@@ -233,7 +233,7 @@ impl AArch64InterruptInitializer {
             let mut context =
                 GicDistributorContext::<{ Self::MAX_DISTRIBUTOR_SPI }, { Self::MAX_DISTRIBUTOR_ESPI }>::default();
             distributor.save(&mut context).map_err(|_| EfiError::DeviceError)?;
-            Ok(context.isenabler()[index] & bit != 0)
+            Ok(context.isenabler().get(index).ok_or(EfiError::InvalidParameter)? & bit != 0)
         }
     }
 
@@ -257,7 +257,7 @@ impl AArch64InterruptInitializer {
             let redistributor = self.gic_v3.redistributor(self.cpu_r_idx).expect("Invalid redistributor");
             let mut context = GicRedistributorContext::<{ Self::MAX_REDISTRIBUTOR_PPI }>::default();
             redistributor.save(&mut context).map_err(|_| EfiError::DeviceError)?;
-            context.icfgr()[index] & bit != 0
+            context.icfgr().get(index).ok_or(EfiError::InvalidParameter)? & bit != 0
         } else {
             // arm-gic does not presently provide a way to directly read the interrupt state for a given interrupt.
             // so save the current distributor context and read the ICFGR from there.
@@ -265,7 +265,7 @@ impl AArch64InterruptInitializer {
             let mut context =
                 GicDistributorContext::<{ Self::MAX_DISTRIBUTOR_SPI }, { Self::MAX_DISTRIBUTOR_ESPI }>::default();
             distributor.save(&mut context).map_err(|_| EfiError::DeviceError)?;
-            context.icfgr()[index] & bit != 0
+            context.icfgr().get(index).ok_or(EfiError::InvalidParameter)? & bit != 0
         };
 
         Ok(if level { Trigger::Level } else { Trigger::Edge })

--- a/core/patina_internal_cpu/src/interrupts/exception_handling.rs
+++ b/core/patina_internal_cpu/src/interrupts/exception_handling.rs
@@ -51,11 +51,7 @@ pub(crate) fn register_exception_handler(exception_type: ExceptionType, handler:
         return Err(EfiError::InvalidParameter);
     }
 
-    if exception_type >= NUM_EXCEPTION_TYPES {
-        return Err(EfiError::InvalidParameter);
-    }
-
-    let mut entry = EXCEPTION_HANDLERS[exception_type].write();
+    let mut entry = EXCEPTION_HANDLERS.get(exception_type).ok_or(EfiError::InvalidParameter)?.write();
     if !(*entry).is_none() {
         return Err(EfiError::AlreadyStarted);
     }
@@ -72,11 +68,7 @@ pub(crate) fn register_exception_handler(exception_type: ExceptionType, handler:
 /// Returns [`InvalidParameter`](EfiError::InvalidParameter) if no callback currently exists.
 ///
 pub(crate) fn unregister_exception_handler(exception_type: ExceptionType) -> Result<(), EfiError> {
-    if exception_type >= NUM_EXCEPTION_TYPES {
-        return Err(EfiError::InvalidParameter);
-    }
-
-    let mut entry = EXCEPTION_HANDLERS[exception_type].write();
+    let mut entry = EXCEPTION_HANDLERS.get(exception_type).ok_or(EfiError::InvalidParameter)?.write();
     if (*entry).is_none() {
         return Err(EfiError::InvalidParameter);
     }
@@ -99,8 +91,11 @@ pub(crate) fn unregister_exception_handler(exception_type: ExceptionType) -> Res
 ///
 #[unsafe(no_mangle)]
 extern "efiapi" fn exception_handler(exception_type: usize, context: &mut ExceptionContext) {
-    let handler_lock =
-        EXCEPTION_HANDLERS[exception_type].try_read().expect("Failed to read lock in exception handler!");
+    let handler_lock = EXCEPTION_HANDLERS
+        .get(exception_type)
+        .unwrap_or_else(|| panic!("Invalid exception type: {exception_type}"))
+        .try_read()
+        .expect("Failed to read lock in exception handler!");
 
     match *handler_lock {
         HandlerType::UefiRoutine(handler) => {

--- a/core/patina_internal_cpu/src/interrupts/x64/idt.rs
+++ b/core/patina_internal_cpu/src/interrupts/x64/idt.rs
@@ -85,7 +85,11 @@ pub fn initialize_idt() {
     for vector in 0..=255usize {
         // Use IST 1 for double fault (vector 8) to ensure it has a valid stack
         let ist_index = if vector == 8 { 1 } else { 0 };
-        idt.entries[vector].set_handler(get_vector_address(vector), cs, ist_index);
+        idt.entries.get_mut(vector).expect("vector out of bounds").set_handler(
+            get_vector_address(vector),
+            cs,
+            ist_index,
+        );
     }
 
     if IDT.0.get() as usize >= SIZE_4GB {

--- a/core/patina_internal_depex/src/lib.rs
+++ b/core/patina_internal_depex/src/lib.rs
@@ -80,7 +80,10 @@ fn uuid_from_slice(slice: Option<&[u8]>) -> Option<Uuid> {
 impl<'a> From<&'a [u8]> for Opcode {
     /// Creates an Opcode from a byte slice.
     fn from(bytes: &'a [u8]) -> Self {
-        match bytes[0] {
+        let Some(&first_byte) = bytes.first() else {
+            return Opcode::Unknown;
+        };
+        match first_byte {
             0x00 => match uuid_from_slice(bytes.get(1..GUID_SIZE + 1)) {
                 Some(uuid) => Opcode::Before(uuid),
                 None => Opcode::Malformed { opcode: 0x00, len: bytes.len() - 1 },
@@ -171,7 +174,7 @@ impl Depex {
                         return false;
                     }
 
-                    if self.expression.len() == 2 && self.expression[1] != Opcode::End {
+                    if self.expression.len() == 2 && self.expression.get(1) != Some(&Opcode::End) {
                         debug_assert!(
                             false,
                             "Invalid BEFORE or AFTER with additional opcodes {:#x?}.",
@@ -321,7 +324,7 @@ impl Iterator for DepexParser {
             return None;
         }
 
-        let opcode = Opcode::from(&self.expression[self.index..]);
+        let opcode = Opcode::from(self.expression.get(self.index..)?);
         self.index += opcode.byte_size();
         Some(opcode)
     }

--- a/core/patina_stacktrace/src/aarch64/runtime_function.rs
+++ b/core/patina_stacktrace/src/aarch64/runtime_function.rs
@@ -84,8 +84,10 @@ impl<'a> RuntimeFunction<'a> {
             // values), mapping each chunk to those two integers, filtering the
             // chunks that fall within the given RVA range, and constructing
             // `RuntimeFunction` instances from the results.
-            let runtime_function = pe.bytes
-                [exception_table_rva as usize..(exception_table_rva + exception_table_size) as usize]
+            let runtime_function = pe
+                .bytes
+                .get(exception_table_rva as usize..(exception_table_rva + exception_table_size) as usize)
+                .ok_or(Error::Malformed { module: pe.image_name, reason: "Exception table RVA out of bounds" })?
                 .chunks(core::mem::size_of::<u32>() * 2) // 2 u32
                 .map(|ele| {
                     let func_start_rva = ele.read32(0).expect("chunk is 8 bytes, offset 0 is valid");
@@ -101,9 +103,11 @@ impl<'a> RuntimeFunction<'a> {
                         // bytes, divided by 4.
                         0 => {
                             let xdata_rva = unwind_info as usize;
-                            let xdata_header = &pe.bytes[xdata_rva..xdata_rva + 4];
-                            let xdata_header = xdata_header.read32(0).expect("xdata header slice is 4 bytes");
-                            (xdata_header & 0x3FFFF) * 4
+                            pe.bytes
+                                .get(xdata_rva..xdata_rva + 4)
+                                .and_then(|h| h.read32(0).ok())
+                                .map(|h| (h & 0x3FFFF) * 4)
+                                .expect("valid unwind_info should point to a valid .xdata record with at least 4 bytes")
                         }
                         // Packed unwind data used with a single prolog and epilog
                         // at the beginning and end of the scope. The length of the

--- a/core/patina_stacktrace/src/aarch64/unwind.rs
+++ b/core/patina_stacktrace/src/aarch64/unwind.rs
@@ -183,7 +183,9 @@ impl<'a> UnwindInfo<'a> {
             // 0. Packed unwind data not used; remaining bits point to an `.xdata` record.
             0 => {
                 let xdata_rva = unwind_info as usize;
-                let xdata = &bytes[xdata_rva..];
+                let xdata = bytes
+                    .get(xdata_rva..)
+                    .ok_or(Error::Malformed { module: image_name, reason: "xdata RVA out of bounds" })?;
                 let xdata_header: u32 = xdata.read32(0)?;
                 let function_length = (xdata_header & 0x3FFFF) * 4;
                 let mut unwind_code_words = ((xdata_header >> 27) & 0x1F) as u16;
@@ -226,7 +228,9 @@ impl<'a> UnwindInfo<'a> {
                 let unwind_code_rva_end = unwind_code_rva_begin + unwind_code_words as usize * 4;
 
                 // create the unwind code slice
-                let unwind_codes = &bytes[unwind_code_rva_begin..unwind_code_rva_end];
+                let unwind_codes = bytes
+                    .get(unwind_code_rva_begin..unwind_code_rva_end)
+                    .ok_or(Error::Malformed { module: image_name, reason: "Unwind code range out of bounds" })?;
 
                 if e == 1 {
                     epilog_count = 1;
@@ -437,15 +441,6 @@ impl fmt::Display for UnwindCode {
 }
 
 impl UnwindCode {
-    #[inline]
-    fn ensure_in_bounds(unwind_codes: &[u8], index: usize) -> StResult<()> {
-        if index < unwind_codes.len() {
-            Ok(())
-        } else {
-            Err(Error::UnwindCodeOutOfBounds { module: None, requested: index, available: unwind_codes.len() })
-        }
-    }
-
     /// Returns the previous stack frame for packed unwind codes.
     ///
     /// # Safety
@@ -600,11 +595,19 @@ impl UnwindCode {
         let mut prev_pc = stack_frame.pc;
         let mut prev_fp = stack_frame.fp;
 
+        let at = |idx: usize| -> StResult<u8> {
+            unwind_codes.get(idx).copied().ok_or(Error::UnwindCodeOutOfBounds {
+                module: None,
+                requested: idx,
+                available: unwind_codes.len(),
+            })
+        };
+
         log::debug!("    > IN(unpacked): {}", stack_frame); // debug
 
         // The main unwind decode logic
         while i < unwind_codes.len() {
-            let byte = unwind_codes[i];
+            let byte = at(i)?;
             if (byte >> 5) & 0b111 == 0b000 {
                 // AllocS(u8) -> 000xxxxx
                 // 000xxxxx: allocate small stack with size < 512 (2^5 * 16).
@@ -670,8 +673,8 @@ impl UnwindCode {
                 // AllocM(u16) -> 11000xxx'xxxxxxxx
                 // 11000xxx'xxxxxxxx: allocate large stack with size < 32K (2^11 * 16).
 
-                Self::ensure_in_bounds(unwind_codes, i + 1)?;
-                let x = (((byte & 0b111) as u16) << 8) | unwind_codes[i + 1] as u16;
+                let b1 = at(i + 1)?;
+                let x = (((byte & 0b111) as u16) << 8) | b1 as u16;
                 log::debug!("    > {}", UnwindCode::AllocM(x)); // debug
 
                 prev_sp += x as u64 * 16; // deallocate space on the stack
@@ -682,9 +685,9 @@ impl UnwindCode {
                 // 110010xx'xxzzzzzz: save x(19+#X) pair at [sp+#Z*8], offset <= 504
                 // example: stp   x19,x20,[sp,#0x80]
 
-                Self::ensure_in_bounds(unwind_codes, i + 1)?;
-                let x = ((byte & 0b11) << 2) | ((unwind_codes[i + 1] >> 6) & 0b11);
-                let z = unwind_codes[i + 1] & 0b00111111;
+                let b1 = at(i + 1)?;
+                let x = ((byte & 0b11) << 2) | ((b1 >> 6) & 0b11);
+                let z = b1 & 0b00111111;
                 log::debug!("    > {}", UnwindCode::SaveRegP(x, z)); // debug
 
                 i += 2;
@@ -692,9 +695,9 @@ impl UnwindCode {
                 // SaveRegPX(u8, u8) -> 110011xx'xxzzzzzz
                 // 110011xx'xxzzzzzz: save pair x(19+#X) at [sp-(#Z+1)*8]!, pre-indexed offset >= -512
 
-                Self::ensure_in_bounds(unwind_codes, i + 1)?;
-                let x = ((byte & 0b11) << 2) | ((unwind_codes[i + 1] >> 6) & 0b11);
-                let z = unwind_codes[i + 1] & 0b00111111;
+                let b1 = at(i + 1)?;
+                let x = ((byte & 0b11) << 2) | ((b1 >> 6) & 0b11);
+                let z = b1 & 0b00111111;
                 log::debug!("    > {}", UnwindCode::SaveRegPX(x, z)); // debug
 
                 prev_sp += (z as u64 + 1) * 8; // pre increment the offset
@@ -705,9 +708,9 @@ impl UnwindCode {
                 // 110100xx'xxzzzzzz: save reg x(19+#X) at [sp+#Z*8], offset <= 504
                 // example: str   lr,[sp,#0x90] or str   x30,[sp,#0x90]
 
-                Self::ensure_in_bounds(unwind_codes, i + 1)?;
-                let x = ((byte & 0b11) << 2) | ((unwind_codes[i + 1] >> 6) & 0b11);
-                let z = unwind_codes[i + 1] & 0b00111111;
+                let b1 = at(i + 1)?;
+                let x = ((byte & 0b11) << 2) | ((b1 >> 6) & 0b11);
+                let z = b1 & 0b00111111;
                 log::debug!("    > {}", UnwindCode::SaveReg(x, z)); // debug
 
                 // Sometimes the LR alone can be saved using SaveReg unwind code.
@@ -727,9 +730,9 @@ impl UnwindCode {
                 // SaveRegX(u8, u8) -> 1101010x'xxxzzzzz
                 // 1101010x'xxxzzzzz: save reg x(19+#X) at [sp-(#Z+1)*8]!, pre-indexed offset >= -256
 
-                Self::ensure_in_bounds(unwind_codes, i + 1)?;
-                let x = ((byte & 0b1) << 3) | ((unwind_codes[i + 1] >> 5) & 0b111);
-                let z = unwind_codes[i + 1] & 0b00011111;
+                let b1 = at(i + 1)?;
+                let x = ((byte & 0b1) << 3) | ((b1 >> 5) & 0b111);
+                let z = b1 & 0b00011111;
                 log::debug!("    > {}", UnwindCode::SaveRegX(x, z)); // debug
 
                 // Sometimes the LR alone can be saved using SaveRegX unwind code.
@@ -752,9 +755,9 @@ impl UnwindCode {
                 // 1101011x'xxzzzzzz: save pair <x(19+2*#X),lr> at [sp+#Z*8], offset <= 504
                 // example: stp x19, lr, [sp,#0x90]
 
-                Self::ensure_in_bounds(unwind_codes, i + 1)?;
-                let x = ((byte & 0b1) << 2) | ((unwind_codes[i + 1] >> 6) & 0b11);
-                let z = unwind_codes[i + 1] & 0b00111111;
+                let b1 = at(i + 1)?;
+                let x = ((byte & 0b1) << 2) | ((b1 >> 6) & 0b11);
+                let z = b1 & 0b00111111;
                 log::debug!("    > {}", UnwindCode::SaveLrPair(x, z)); // debug
 
                 // no pre decrement of sp
@@ -771,9 +774,9 @@ impl UnwindCode {
                 // SaveFRegP(u8, u8) -> 1101100x'xxzzzzzz
                 // 1101100x'xxzzzzzz: save pair d(8+#X) at [sp+#Z*8], offset <= 504
 
-                Self::ensure_in_bounds(unwind_codes, i + 1)?;
-                let x = ((byte & 0b1) << 2) | ((unwind_codes[i + 1] >> 6) & 0b11);
-                let z = unwind_codes[i + 1] & 0b00111111;
+                let b1 = at(i + 1)?;
+                let x = ((byte & 0b1) << 2) | ((b1 >> 6) & 0b11);
+                let z = b1 & 0b00111111;
                 log::debug!("    > {}", UnwindCode::SaveFRegP(x, z)); // debug
 
                 i += 2;
@@ -781,9 +784,9 @@ impl UnwindCode {
                 // SaveFRegPX(u8, u8) -> 1101101x'xxzzzzzz
                 // 1101101x'xxzzzzzz: save pair d(8+#X) at [sp-(#Z+1)*8]!, pre-indexed offset >= -512
 
-                Self::ensure_in_bounds(unwind_codes, i + 1)?;
-                let x = ((byte & 0b1) << 2) | ((unwind_codes[i + 1] >> 6) & 0b11);
-                let z = unwind_codes[i + 1] & 0b00111111;
+                let b1 = at(i + 1)?;
+                let x = ((byte & 0b1) << 2) | ((b1 >> 6) & 0b11);
+                let z = b1 & 0b00111111;
                 log::debug!("    > {}", UnwindCode::SaveFRegPX(x, z)); // debug
 
                 i += 2;
@@ -791,9 +794,9 @@ impl UnwindCode {
                 // SaveFReg(u8, u8) -> 1101110x'xxzzzzzz
                 // 1101110x'xxzzzzzz: save reg d(8+#X) at [sp+#Z*8], offset <= 504
 
-                Self::ensure_in_bounds(unwind_codes, i + 1)?;
-                let x = ((byte & 0b1) << 2) | ((unwind_codes[i + 1] >> 6) & 0b11);
-                let z = unwind_codes[i + 1] & 0b00111111;
+                let b1 = at(i + 1)?;
+                let x = ((byte & 0b1) << 2) | ((b1 >> 6) & 0b11);
+                let z = b1 & 0b00111111;
                 log::debug!("    > {}", UnwindCode::SaveFReg(x, z)); // debug
 
                 i += 2;
@@ -801,9 +804,9 @@ impl UnwindCode {
                 // SaveFRegX(u8, u8) -> 11011110'xxxzzzzz
                 // 11011110'xxxzzzzz: save reg d(8+#X) at [sp-(#Z+1)*8]!, pre-indexed offset >= -256
 
-                Self::ensure_in_bounds(unwind_codes, i + 1)?;
-                let x = (unwind_codes[i + 1] >> 5) & 0b111;
-                let z = unwind_codes[i + 1] & 0b0011111;
+                let b1 = at(i + 1)?;
+                let x = (b1 >> 5) & 0b111;
+                let z = b1 & 0b0011111;
                 log::debug!("    > {}", UnwindCode::SaveFRegX(x, z)); // debug
 
                 prev_sp += (z as u64 + 1) * 8; // pre increment the offset
@@ -813,8 +816,7 @@ impl UnwindCode {
                 // AllocZ(u32) -> 11011111'zzzzzzzz
                 // 11011111'zzzzzzzz: allocate stack with size z * SVE-VL
 
-                Self::ensure_in_bounds(unwind_codes, i + 1)?;
-                let x = unwind_codes[i + 1] as u32;
+                let x = at(i + 1)? as u32;
                 log::debug!("    > {}", UnwindCode::AllocZ(x)); // debug
 
                 i += 2;
@@ -822,10 +824,10 @@ impl UnwindCode {
                 // AllocL(u32) -> 11100000'xxxxxxxx'xxxxxxxx'xxxxxxxx
                 // 11100000'xxxxxxxx'xxxxxxxx'xxxxxxxx: allocate large stack with size < 256M (2^24 * 16)
 
-                Self::ensure_in_bounds(unwind_codes, i + 3)?;
-                let x = ((unwind_codes[i + 1] as u32) << 16)
-                    | ((unwind_codes[i + 2] as u32) << 8)
-                    | (unwind_codes[i + 3] as u32);
+                let b1 = at(i + 1)?;
+                let b2 = at(i + 2)?;
+                let b3 = at(i + 3)?;
+                let x = ((b1 as u32) << 16) | ((b2 as u32) << 8) | (b3 as u32);
                 log::debug!("    > {}", UnwindCode::AllocL(x)); // debug
 
                 prev_sp += x as u64 * 16; // pre increment the offset
@@ -843,8 +845,7 @@ impl UnwindCode {
                 // AddFp(u8) -> 11100010'xxxxxxxx
                 // 11100010'xxxxxxxx: set up x29 with add x29,sp,#x*8
 
-                Self::ensure_in_bounds(unwind_codes, i + 1)?;
-                let x = unwind_codes[i + 1];
+                let x = at(i + 1)?;
                 log::debug!("    > {}", UnwindCode::AddFp(x)); // debug
 
                 prev_sp = prev_fp - (x as u64 * 8); // restore sp from fp
@@ -944,37 +945,37 @@ impl UnwindCode {
             } else if byte == 0b11111000 {
                 // Reserved12(u8) -> 11111000'yyyyyyyy
 
-                Self::ensure_in_bounds(unwind_codes, i + 1)?;
-                let y = unwind_codes[i + 1];
+                let y = at(i + 1)?;
                 log::debug!("    > {}", UnwindCode::Reserved12(y)); // debug
 
                 i += 2;
             } else if byte == 0b11111001 {
                 // Reserved13(u16) -> 11111001'yyyyyyyy'yyyyyyyy
 
-                Self::ensure_in_bounds(unwind_codes, i + 2)?;
-                let y = ((unwind_codes[i + 1] as u16) << 8) | (unwind_codes[i + 2] as u16);
+                let b1 = at(i + 1)?;
+                let b2 = at(i + 2)?;
+                let y = ((b1 as u16) << 8) | (b2 as u16);
                 log::debug!("    > {}", UnwindCode::Reserved13(y)); // debug
 
                 i += 3;
             } else if byte == 0b11111010 {
                 // Reserved14(u32) -> 11111010'yyyyyyyy'yyyyyyyy'yyyyyyyy
 
-                Self::ensure_in_bounds(unwind_codes, i + 3)?;
-                let y = ((unwind_codes[i + 1] as u32) << 16)
-                    | ((unwind_codes[i + 2] as u32) << 8)
-                    | (unwind_codes[i + 3] as u32);
+                let b1 = at(i + 1)?;
+                let b2 = at(i + 2)?;
+                let b3 = at(i + 3)?;
+                let y = ((b1 as u32) << 16) | ((b2 as u32) << 8) | (b3 as u32);
                 log::debug!("    > {}", UnwindCode::Reserved14(y)); // debug
 
                 i += 4;
             } else if byte == 0b11111011 {
                 // Reserved15(u32) -> 11111011'yyyyyyyy'yyyyyyyy'yyyyyyyy'yyyyyyyy
 
-                Self::ensure_in_bounds(unwind_codes, i + 4)?;
-                let y = ((unwind_codes[i + 1] as u32) << 24)
-                    | ((unwind_codes[i + 2] as u32) << 16)
-                    | ((unwind_codes[i + 3] as u32) << 8)
-                    | (unwind_codes[i + 4] as u32);
+                let b1 = at(i + 1)?;
+                let b2 = at(i + 2)?;
+                let b3 = at(i + 3)?;
+                let b4 = at(i + 4)?;
+                let y = ((b1 as u32) << 24) | ((b2 as u32) << 16) | ((b3 as u32) << 8) | (b4 as u32);
                 log::debug!("    > {}", UnwindCode::Reserved15(y)); // debug
 
                 i += 5;

--- a/core/patina_stacktrace/src/byte_reader.rs
+++ b/core/patina_stacktrace/src/byte_reader.rs
@@ -16,35 +16,39 @@ pub(crate) trait ByteReader {
 
 impl ByteReader for [u8] {
     fn read8(&self, index: usize) -> StResult<u8> {
-        if index + 1 > self.len() {
-            return Err(Error::OutOfBoundsRead { module: None, index });
-        }
-        let slice = &self[index..index + 1];
-        Ok(u8::from_le_bytes([slice[0]]))
+        let bytes: [u8; 1] = self
+            .get(index..index + 1)
+            .ok_or(Error::OutOfBoundsRead { module: None, index })?
+            .try_into()
+            .map_err(|_| Error::OutOfBoundsRead { module: None, index })?;
+        Ok(u8::from_le_bytes(bytes))
     }
 
     fn read16(&self, index: usize) -> StResult<u16> {
-        if index + 2 > self.len() {
-            return Err(Error::OutOfBoundsRead { module: None, index });
-        }
-        let slice = &self[index..index + 2];
-        Ok(u16::from_le_bytes([slice[0], slice[1]]))
+        let bytes: [u8; 2] = self
+            .get(index..index + 2)
+            .ok_or(Error::OutOfBoundsRead { module: None, index })?
+            .try_into()
+            .map_err(|_| Error::OutOfBoundsRead { module: None, index })?;
+        Ok(u16::from_le_bytes(bytes))
     }
 
     fn read32(&self, index: usize) -> StResult<u32> {
-        if index + 4 > self.len() {
-            return Err(Error::OutOfBoundsRead { module: None, index });
-        }
-        let slice = &self[index..index + 4];
-        Ok(u32::from_le_bytes([slice[0], slice[1], slice[2], slice[3]]))
+        let bytes: [u8; 4] = self
+            .get(index..index + 4)
+            .ok_or(Error::OutOfBoundsRead { module: None, index })?
+            .try_into()
+            .map_err(|_| Error::OutOfBoundsRead { module: None, index })?;
+        Ok(u32::from_le_bytes(bytes))
     }
 
     fn _read64(&self, index: usize) -> StResult<u64> {
-        if index + 8 > self.len() {
-            return Err(Error::OutOfBoundsRead { module: None, index });
-        }
-        let slice = &self[index..index + 8];
-        Ok(u64::from_le_bytes([slice[0], slice[1], slice[2], slice[3], slice[4], slice[5], slice[6], slice[7]]))
+        let bytes: [u8; 8] = self
+            .get(index..index + 8)
+            .ok_or(Error::OutOfBoundsRead { module: None, index })?
+            .try_into()
+            .map_err(|_| Error::OutOfBoundsRead { module: None, index })?;
+        Ok(u64::from_le_bytes(bytes))
     }
 
     fn read8_with(&self, index: &mut usize) -> StResult<u8> {

--- a/core/patina_stacktrace/src/x64/runtime_function.rs
+++ b/core/patina_stacktrace/src/x64/runtime_function.rs
@@ -54,12 +54,18 @@ impl<'a> RuntimeFunction<'a> {
 
     /// Parses the unwind info referenced by this runtime function entry.
     pub fn get_unwind_info(&self) -> StResult<UnwindInfo<'_>> {
-        UnwindInfo::parse(&self.image_base[self.unwind_info as usize..], self.image_name).map_err(|_| {
-            Error::UnwindInfoNotFound {
+        UnwindInfo::parse(
+            self.image_base.get(self.unwind_info as usize..).ok_or(Error::UnwindInfoNotFound {
                 module: self.image_name,
                 image_base: self.image_base.as_ptr() as u64,
                 unwind_info: self.unwind_info,
-            }
+            })?,
+            self.image_name,
+        )
+        .map_err(|_| Error::UnwindInfoNotFound {
+            module: self.image_name,
+            image_base: self.image_base.as_ptr() as u64,
+            unwind_info: self.unwind_info,
         })
     }
 
@@ -85,8 +91,10 @@ impl<'a> RuntimeFunction<'a> {
         // by breaking the section into 12-byte chunks, mapping each chunk to
         // three u32 values, filtering the chunks that fall within the given RVA
         // range, and constructing `RuntimeFunction` instances from the results.
-        let runtime_function = pe.bytes
-            [exception_table_rva as usize..(exception_table_rva + exception_table_size) as usize]
+        let runtime_function = pe
+            .bytes
+            .get(exception_table_rva as usize..(exception_table_rva + exception_table_size) as usize)
+            .ok_or(Error::Malformed { module: pe.image_name, reason: "Exception table RVA out of bounds" })?
             .chunks(core::mem::size_of::<u32>() * 3) // 3 u32
             .map(|ele| {
                 (

--- a/core/patina_stacktrace/src/x64/unwind.rs
+++ b/core/patina_stacktrace/src/x64/unwind.rs
@@ -67,7 +67,9 @@ impl<'a> UnwindInfo<'a> {
         }
 
         // Extract the unwind codes (each unwind code is two bytes).
-        let unwind_codes: &[u8] = &bytes[offset..offset + count_of_unwind_codes as usize * 2];
+        let unwind_codes: &[u8] = bytes
+            .get(offset..offset + count_of_unwind_codes as usize * 2)
+            .ok_or(Error::Malformed { module: image_name, reason: "Malformed unwind code bytes" })?;
         Ok(Self {
             unwind_info_bytes: bytes,
             image_name,

--- a/patina_dxe_core/src/allocator.rs
+++ b/patina_dxe_core/src/allocator.rs
@@ -895,7 +895,9 @@ extern "efiapi" fn get_memory_map(
         }
     }
 
-    log::debug!(target: "efi_memory_map", "EFI_MEMORY_MAP: \n{:?}", MemoryDescriptorSlice(&buffer[..actual_count]));
+    log::debug!(target: "efi_memory_map", "EFI_MEMORY_MAP: \n{:?}", MemoryDescriptorSlice(
+        buffer.get(..actual_count).expect("actual_count <= buffer.len() from populate_efi_memory_map")
+    ));
 
     if log::log_enabled!(target: "memory_bin", log::Level::Debug) {
         dump_memory_bin_stats();

--- a/patina_dxe_core/src/allocator/fixed_size_block_allocator.rs
+++ b/patina_dxe_core/src/allocator/fixed_size_block_allocator.rs
@@ -47,6 +47,8 @@ pub enum FixedSizeBlockAllocatorError {
     InvalidLayout,
     /// The memory region provided to extend the allocator was invalid.
     InvalidExpansion,
+    /// An internal error occurred.
+    InternalError,
 }
 
 const ALIGNMENT: usize = 0x1000;
@@ -232,20 +234,23 @@ impl FixedSizeBlockAllocator {
     ///
     /// Returns [`FixedSizeBlockAllocatorError::OutOfMemory`] when the allocator doesn't have enough memory.
     /// Returns [`FixedSizeBlockAllocatorError::InvalidLayout`] when the layout provided is invalid.
+    /// Returns [`FixedSizeBlockAllocatorError::InternalError`] when an internal error occurs.
     pub fn alloc(&mut self, layout: Layout) -> Result<NonNull<[u8]>, FixedSizeBlockAllocatorError> {
         self.stats.pool_allocation_calls += 1;
 
         match list_index(&layout) {
             Some(index) => {
-                match self.list_heads[index].take() {
+                let head = self.list_heads.get_mut(index).ok_or(FixedSizeBlockAllocatorError::InternalError)?;
+                match head.take() {
                     Some(node) => {
-                        self.list_heads[index] = node.next.take();
+                        let head = self.list_heads.get_mut(index).ok_or(FixedSizeBlockAllocatorError::InternalError)?;
+                        *head = node.next.take();
                         let ptr: NonNull<u8> = NonNull::from(node).cast();
                         Ok(NonNull::slice_from_raw_parts(ptr, layout.size()))
                     }
                     None => {
                         // no block exists in list => allocate new block
-                        let block_size = BLOCK_SIZES[index];
+                        let block_size = *BLOCK_SIZES.get(index).ok_or(FixedSizeBlockAllocatorError::InternalError)?;
                         // only works if all block sizes are a power of 2
                         let block_align = block_size;
                         let layout = match Layout::from_size_align(block_size, block_align) {
@@ -282,9 +287,11 @@ impl FixedSizeBlockAllocator {
         self.stats.pool_free_calls += 1;
         match list_index(&layout) {
             Some(index) => {
-                let new_node = BlockListNode { next: self.list_heads[index].take() };
+                let head = self.list_heads.get_mut(index).expect("list_index guarantees valid index");
+                let new_node = BlockListNode { next: head.take() };
+                let block_size = *BLOCK_SIZES.get(index).expect("list_index guarantees valid index");
                 // verify that block has size and alignment required for storing node
-                if size_of::<BlockListNode>() > BLOCK_SIZES[index] || align_of::<BlockListNode>() > BLOCK_SIZES[index] {
+                if size_of::<BlockListNode>() > block_size || align_of::<BlockListNode>() > block_size {
                     // Should never reach this statement under normal operation since BlockListNode is a single pointer and all block sizes are >= 8 bytes,
                     // Failure indicates corruption of the allocator's internal state.
                     panic!("FSB deallocating block too small to store BlockListNode.");
@@ -293,7 +300,8 @@ impl FixedSizeBlockAllocator {
                 // SAFETY: new_node_ptr points to memory returned by alloc for this layout.
                 unsafe {
                     new_node_ptr.write(new_node);
-                    self.list_heads[index] = Some(&mut *new_node_ptr);
+                    let head = self.list_heads.get_mut(index).expect("list_index guarantees valid index");
+                    *head = Some(&mut *new_node_ptr);
                 }
             }
             None => {

--- a/patina_dxe_core/src/cpu/hw_interrupt_protocol.rs
+++ b/patina_dxe_core/src/cpu/hw_interrupt_protocol.rs
@@ -411,7 +411,10 @@ impl InterruptHandler for HwInterruptProtocolHandler {
             return;
         }
 
-        let rw_handler = self.handlers[raw_value as usize]
+        let rw_handler = self
+            .handlers
+            .get(raw_value as usize)
+            .unwrap_or_else(|| panic!("Invalid interrupt source index 0x{:x}", raw_value))
             .try_read()
             .unwrap_or_else(|| panic!("Failed to read lock in exception handler for interrupt ID 0x{:x}", raw_value));
 
@@ -440,7 +443,7 @@ impl HwInterruptProtocolHandler {
             return efi::Status::INVALID_PARAMETER;
         }
 
-        if let Some(rw_handler) = self.handlers[interrupt_source].try_read() {
+        if let Some(rw_handler) = self.handlers.get(interrupt_source).expect("bounds checked above").try_read() {
             // Use read access to test the state of the handler
             if handler.is_none() && (*rw_handler).is_none() {
                 return efi::Status::INVALID_PARAMETER;
@@ -458,14 +461,16 @@ impl HwInterruptProtocolHandler {
             }
 
             // Interrupt disabled, now remove the handler
-            if let Some(mut rw_handler) = self.handlers[interrupt_source].try_write() {
+            if let Some(mut rw_handler) = self.handlers.get(interrupt_source).expect("bounds checked above").try_write()
+            {
                 *rw_handler = None;
             } else {
                 return efi::Status::DEVICE_ERROR;
             }
         } else {
             // Register the interrupt handler
-            if let Some(mut rw_handler) = self.handlers[interrupt_source].try_write() {
+            if let Some(mut rw_handler) = self.handlers.get(interrupt_source).expect("bounds checked above").try_write()
+            {
                 *rw_handler = handler;
             } else {
                 return efi::Status::DEVICE_ERROR;

--- a/patina_dxe_core/src/debugger_reload.rs
+++ b/patina_dxe_core/src/debugger_reload.rs
@@ -166,8 +166,11 @@ fn decompress_image(compressed_image: &[u8], out: &mut dyn core::fmt::Write) -> 
 
     // Get the decompressed size. By spec it will be the second u32 in the compressed image.
     let decompressed_size = {
-        u32::from_le_bytes([compressed_image[4], compressed_image[5], compressed_image[6], compressed_image[7]])
-            as usize
+        let bytes: [u8; 4] = compressed_image
+            .get(4..8)
+            .and_then(|s| s.try_into().ok())
+            .expect("compressed_image.len() >= 8 checked above");
+        u32::from_le_bytes(bytes) as usize
     };
 
     let decompressed_image = alloc::boxed::Box::leak(alloc::vec![0u8; decompressed_size].into_boxed_slice());

--- a/patina_dxe_core/src/filesystems.rs
+++ b/patina_dxe_core/src/filesystems.rs
@@ -126,12 +126,12 @@ impl SimpleFile<'_> {
 
         EfiError::status_to_result(status)?;
 
-        if file_size > file_buffer.len() {
-            return Err(EfiError::DeviceError);
-        }
-
         //in case the read somehow returned fewer bytes than indicated by get_size, truncate the vector returned to the
         //actual read size.
-        if file_size < file_buffer.len() { Ok(file_buffer[0..file_size].to_vec()) } else { Ok(file_buffer) }
+        if file_size < file_buffer.len() {
+            Ok(file_buffer.get(0..file_size).ok_or(EfiError::DeviceError)?.to_vec())
+        } else {
+            Ok(file_buffer)
+        }
     }
 }

--- a/patina_dxe_core/src/gcd/spin_locked_gcd.rs
+++ b/patina_dxe_core/src/gcd/spin_locked_gcd.rs
@@ -1167,11 +1167,11 @@ impl GCD {
         let mut write_idx = 0;
 
         for read_idx in 0..descriptors.len() {
-            let current = descriptors[read_idx];
+            let current = *descriptors.get(read_idx).expect("read_idx < descriptors.len()");
 
             // Try to merge with the previous descriptor
             if write_idx > 0 {
-                let prev = &mut descriptors[write_idx - 1];
+                let prev = descriptors.get_mut(write_idx - 1).expect("write_idx <= read_idx < descriptors.len()");
                 if prev.r#type == current.r#type
                     && prev.attribute == current.attribute
                     && prev.physical_start + uefi_pages_to_size!(prev.number_of_pages as usize) as u64
@@ -1199,7 +1199,7 @@ impl GCD {
             }
 
             if write_idx != read_idx {
-                descriptors[write_idx] = current;
+                *descriptors.get_mut(write_idx).expect("write_idx <= read_idx < descriptors.len()") = current;
             }
             write_idx += 1;
         }
@@ -1315,15 +1315,14 @@ impl GCD {
                     attribute: attributes,
                 };
 
-                ensure!(write_idx < buffer.len(), EfiError::BufferTooSmall);
-                buffer[write_idx] = new_descriptor;
+                *buffer.get_mut(write_idx).ok_or(EfiError::BufferTooSmall)? = new_descriptor;
                 write_idx += 1;
             }
             current = blocks.next_idx(idx);
         }
 
         // Merge consecutive descriptors with the same type and attributes
-        Ok(Self::merge_blocks_in_place(&mut buffer[..write_idx]))
+        Ok(Self::merge_blocks_in_place(buffer.get_mut(..write_idx).ok_or(EfiError::BufferTooSmall)?))
     }
 
     //Note: truncated strings here are expected and are for alignment with EDK2 reference prints.
@@ -1361,7 +1360,7 @@ impl Display for GCD {
                     writelncrlf!(
                         f,
                         "{}  {:016x?}-{:016x?} {:016x?} {:016x?} {:016x?} {:016x?}",
-                        GCD::GCD_MEMORY_TYPE_NAMES[mem_type_str_idx],
+                        GCD::GCD_MEMORY_TYPE_NAMES.get(mem_type_str_idx).expect("mem_type_str_idx bounded by min()"),
                         descriptor.base_address,
                         descriptor.base_address + descriptor.length - 1,
                         descriptor.capabilities,
@@ -1926,7 +1925,7 @@ impl Display for IoGCD {
                     writelncrlf!(
                         f,
                         "{}  {:016x?}-{:016x?}{}",
-                        IoGCD::GCD_IO_TYPE_NAMES[io_type_str_idx],
+                        IoGCD::GCD_IO_TYPE_NAMES.get(io_type_str_idx).expect("io_type_str_idx bounded by min()"),
                         descriptor.base_address,
                         descriptor.base_address + descriptor.length - 1,
                         { if descriptor.image_handle == INVALID_HANDLE { "" } else { "*" } }

--- a/patina_dxe_core/src/memory_bin.rs
+++ b/patina_dxe_core/src/memory_bin.rs
@@ -327,7 +327,8 @@ impl MemoryBinManager {
             }
 
             let entry_size = uefi_pages_to_size!(entry.number_of_pages as usize) as u64;
-            let stats = &mut self.statistics[mem_type as usize];
+            let stats =
+                self.statistics.get_mut(mem_type as usize).expect("Defined memory types should be in statistics");
             stats.maximum_address = top - 1;
             top -= entry_size;
 
@@ -366,20 +367,24 @@ impl MemoryBinManager {
     /// in the memory type information array.
     fn finalize_information_index(&mut self, memory_type_info: &[EFiMemoryTypeInformation]) {
         for mem_type in 0..EFI_MAX_MEMORY_TYPE {
+            let stats = self.statistics.get_mut(mem_type).expect("All defined memory types should be in statistics");
             for (index, entry) in memory_type_info.iter().enumerate() {
                 if mem_type == entry.memory_type as usize {
-                    self.statistics[mem_type].information_index = index;
+                    stats.information_index = index;
                 }
             }
-            self.statistics[mem_type].current_number_of_pages = 0;
+            stats.current_number_of_pages = 0;
         }
         log::trace!(target: LOG_TARGET, "Bin stats: finalized information indices, reset current_number_of_pages to 0 for all types");
     }
 
     /// Copies memory type information entries into the fixed-size array.
     fn copy_memory_type_info(&mut self, memory_type_info: &[EFiMemoryTypeInformation]) {
-        let count = memory_type_info.len().min(MAX_MEMORY_TYPE_INFO_ENTRIES);
-        self.memory_type_information[..count].copy_from_slice(&memory_type_info[..count]);
+        let count = memory_type_info.len().min(self.memory_type_information.len());
+        let src = memory_type_info.get(..count).expect("Failed to get source slice");
+        let dest = self.memory_type_information.get_mut(..count).expect("Failed to get destination slice");
+
+        dest.copy_from_slice(src);
         self.memory_type_information_count = count;
 
         if log::log_enabled!(target: LOG_TARGET, log::Level::Trace) {
@@ -389,13 +394,15 @@ impl MemoryBinManager {
                 count
             );
 
-            for entry in &self.memory_type_information[..count] {
-                log::trace!(
-                    target: LOG_TARGET,
-                    "  Bin table: {} pages={}",
-                    memory_type_name(entry.memory_type),
-                    entry.number_of_pages
-                );
+            if let Some(entries) = self.memory_type_information.get(..count) {
+                for entry in entries {
+                    log::trace!(
+                        target: LOG_TARGET,
+                        "  Bin table: {} pages={}",
+                        memory_type_name(entry.memory_type),
+                        entry.number_of_pages
+                    );
+                }
             }
         }
     }
@@ -411,18 +418,18 @@ impl MemoryBinManager {
         }
 
         let type_idx = memory_type as usize;
-        if type_idx >= EFI_MAX_MEMORY_TYPE || !self.statistics[type_idx].special {
+        let Some(stats) = self.statistics.get_mut(type_idx).filter(|s| s.special) else {
             return;
-        }
+        };
 
         let aligned_pages = align_pages_to_granularity(pages, Self::granularity_for_type(memory_type));
-        self.statistics[type_idx].current_number_of_pages += aligned_pages;
+        stats.current_number_of_pages += aligned_pages;
         log::debug!(
             target: LOG_TARGET,
             "PEI seed: {} +{} pages. total={}",
             memory_type_name(memory_type),
             pages,
-            self.statistics[type_idx].current_number_of_pages
+            stats.current_number_of_pages
         );
     }
 
@@ -431,11 +438,7 @@ impl MemoryBinManager {
     /// Returns 0 for invalid memory types.
     #[cfg(test)]
     pub(crate) fn current_pages_for_type(&self, memory_type: efi::MemoryType) -> u64 {
-        let type_idx = memory_type as usize;
-        if type_idx >= EFI_MAX_MEMORY_TYPE {
-            return 0;
-        }
-        self.statistics[type_idx].current_number_of_pages
+        self.statistics.get(memory_type as usize).map_or(0, |s| s.current_number_of_pages)
     }
 
     /// Returns an iterator over all active bins: `(memory_type, base_address, max_address, pages)`.
@@ -463,39 +466,38 @@ impl MemoryBinManager {
         }
 
         let type_idx = memory_type as usize;
-        if type_idx >= EFI_MAX_MEMORY_TYPE || !self.statistics[type_idx].special {
+        let Some(stats) = self.statistics.get_mut(type_idx).filter(|s| s.special) else {
             return;
-        }
+        };
 
         let aligned_pages = align_pages_to_granularity(pages, Self::granularity_for_type(memory_type));
-        let prev = self.statistics[type_idx].current_number_of_pages;
-        self.statistics[type_idx].current_number_of_pages += aligned_pages;
+        let prev = stats.current_number_of_pages;
+        stats.current_number_of_pages += aligned_pages;
+        let current = stats.current_number_of_pages;
+        let info_idx = stats.information_index;
 
         log::trace!(
             target: LOG_TARGET,
             "Bin stats: {} current_pages {} -> {} (alloc +{} aligned to {})",
             memory_type_name(memory_type),
             prev,
-            self.statistics[type_idx].current_number_of_pages,
+            current,
             pages,
             aligned_pages
         );
 
         // Update peak tracking: if current exceeds previous peak, update for BDS
-        let info_idx = self.statistics[type_idx].information_index;
-        if info_idx < self.memory_type_information_count
-            && self.statistics[type_idx].current_number_of_pages
-                > self.memory_type_information[info_idx].number_of_pages as u64
+        if let Some(mti_entry) = self.memory_type_information.get_mut(info_idx)
+            && current > mti_entry.number_of_pages as u64
         {
-            let prev_peak = self.memory_type_information[info_idx].number_of_pages;
-            self.memory_type_information[info_idx].number_of_pages =
-                self.statistics[type_idx].current_number_of_pages as u32;
+            let prev_peak = mti_entry.number_of_pages;
+            mti_entry.number_of_pages = current as u32;
             log::trace!(
                 target: LOG_TARGET,
                 "Bin table: {} pages {} -> {} (peak update)",
                 memory_type_name(memory_type),
                 prev_peak,
-                self.memory_type_information[info_idx].number_of_pages
+                mti_entry.number_of_pages
             );
         }
     }
@@ -509,21 +511,20 @@ impl MemoryBinManager {
         }
 
         let type_idx = memory_type as usize;
-        if type_idx >= EFI_MAX_MEMORY_TYPE || !self.statistics[type_idx].special {
+        let Some(stats) = self.statistics.get_mut(type_idx).filter(|s| s.special) else {
             return;
-        }
+        };
 
         let aligned_pages = align_pages_to_granularity(pages, Self::granularity_for_type(memory_type));
-        let prev = self.statistics[type_idx].current_number_of_pages;
-        self.statistics[type_idx].current_number_of_pages =
-            self.statistics[type_idx].current_number_of_pages.saturating_sub(aligned_pages);
+        let prev = stats.current_number_of_pages;
+        stats.current_number_of_pages = stats.current_number_of_pages.saturating_sub(aligned_pages);
 
         log::trace!(
             target: LOG_TARGET,
             "Bin stats: {} current_pages {} -> {} (free -{} aligned to {})",
             memory_type_name(memory_type),
             prev,
-            self.statistics[type_idx].current_number_of_pages,
+            stats.current_number_of_pages,
             pages,
             aligned_pages
         );
@@ -547,15 +548,15 @@ impl MemoryBinManager {
             return count;
         }
 
+        let buffer_len = buffer.len();
         let mut current_count = count;
 
         for mem_type in 0..(EFI_MAX_MEMORY_TYPE as u32) {
-            let stats = &self.statistics[mem_type as usize];
-
             // Only process special types with actual bin pages
-            if stats.number_of_pages == 0 || !stats.special {
+            let Some(stats) = self.statistics.get(mem_type as usize).filter(|s| s.special && s.number_of_pages > 0)
+            else {
                 continue;
-            }
+            };
 
             let bin_start = stats.base_address;
             let bin_end = stats.maximum_address;
@@ -578,16 +579,14 @@ impl MemoryBinManager {
                 let mut did_modify = false;
 
                 for i in 0..entry_count {
-                    if buffer[i].r#type != efi::CONVENTIONAL_MEMORY {
+                    let Some(entry) =
+                        buffer.get_mut(i).filter(|e| e.r#type == efi::CONVENTIONAL_MEMORY && e.number_of_pages > 0)
+                    else {
                         continue;
-                    }
+                    };
 
-                    if buffer[i].number_of_pages == 0 {
-                        continue;
-                    }
-
-                    let entry_start = buffer[i].physical_start;
-                    let entry_end = entry_start + uefi_pages_to_size!(buffer[i].number_of_pages as usize) as u64 - 1;
+                    let entry_start = entry.physical_start;
+                    let entry_end = entry_start + uefi_pages_to_size!(entry.number_of_pages as usize) as u64 - 1;
 
                     // No overlap
                     if entry_end < bin_start || entry_start > bin_end {
@@ -596,7 +595,7 @@ impl MemoryBinManager {
 
                     // Case 1: Entry completely within bin
                     if entry_start >= bin_start && entry_end <= bin_end {
-                        Self::set_descriptor_type(&mut buffer[i], mem_type, stats.runtime);
+                        Self::set_descriptor_type(entry, mem_type, stats.runtime);
                         did_modify = true;
                         break;
                     }
@@ -607,10 +606,10 @@ impl MemoryBinManager {
                         // prevented if the buffer-sizing precondition is violated.
                         let extra_needed = if entry_end > bin_end { 2 } else { 1 };
                         debug_assert!(
-                            current_count + extra_needed <= buffer.len(),
+                            current_count + extra_needed <= buffer_len,
                             "apply_bin_descriptors: buffer is too small, caller must reserve max_additional_descriptors()"
                         );
-                        if current_count + extra_needed > buffer.len() {
+                        if current_count + extra_needed > buffer_len {
                             log::error!(
                                 target: LOG_TARGET,
                                 "Buffer is too small for memory bin descriptor split, leaving entry as EfiConventionalMemory."
@@ -620,27 +619,26 @@ impl MemoryBinManager {
 
                         // Shrink original entry to end at bin start
                         let pre_bin_pages = uefi_size_to_pages!((bin_start - entry_start) as usize);
-                        buffer[i].number_of_pages = pre_bin_pages as u64;
+                        entry.number_of_pages = pre_bin_pages as u64;
 
                         // Insert new entry for in-bin portion
                         current_count = Self::insert_descriptor_after(buffer, current_count, i);
                         let new_idx = i + 1;
-                        buffer[new_idx].physical_start = bin_start;
-                        buffer[new_idx].number_of_pages =
-                            uefi_size_to_pages!((entry_end - bin_start + 1) as usize) as u64;
-                        Self::set_descriptor_type(&mut buffer[new_idx], mem_type, stats.runtime);
+                        let new_entry = buffer.get_mut(new_idx).expect("Newly inserted entry not found");
+                        new_entry.physical_start = bin_start;
+                        new_entry.number_of_pages = uefi_size_to_pages!((entry_end - bin_start + 1) as usize) as u64;
+                        Self::set_descriptor_type(new_entry, mem_type, stats.runtime);
 
                         // If entry also extends past bin end, split again
                         if entry_end > bin_end {
-                            buffer[new_idx].number_of_pages =
-                                uefi_size_to_pages!((bin_end - bin_start + 1) as usize) as u64;
+                            new_entry.number_of_pages = uefi_size_to_pages!((bin_end - bin_start + 1) as usize) as u64;
 
                             current_count = Self::insert_descriptor_after(buffer, current_count, new_idx);
                             let post_idx = new_idx + 1;
-                            buffer[post_idx].physical_start = bin_end + 1;
-                            buffer[post_idx].number_of_pages =
-                                uefi_size_to_pages!((entry_end - bin_end) as usize) as u64;
-                            Self::set_descriptor_type(&mut buffer[post_idx], efi::CONVENTIONAL_MEMORY, false);
+                            let post_entry = buffer.get_mut(post_idx).expect("Failed to get post-bin entry");
+                            post_entry.physical_start = bin_end + 1;
+                            post_entry.number_of_pages = uefi_size_to_pages!((entry_end - bin_end) as usize) as u64;
+                            Self::set_descriptor_type(post_entry, efi::CONVENTIONAL_MEMORY, false);
                         }
 
                         did_modify = true;
@@ -650,10 +648,10 @@ impl MemoryBinManager {
                     // Case 3: Entry ends after bin (entry_start >= bin_start implied here)
                     if entry_end > bin_end {
                         debug_assert!(
-                            current_count < buffer.len(),
+                            current_count < buffer_len,
                             "apply_bin_descriptors: buffer is too small, caller must reserve max_additional_descriptors() slack"
                         );
-                        if current_count + 1 > buffer.len() {
+                        if current_count + 1 > buffer_len {
                             log::error!(
                                 target: LOG_TARGET,
                                 "Buffer is too small for memory bin descriptor split, leaving entry as EfiConventionalMemory."
@@ -662,15 +660,16 @@ impl MemoryBinManager {
                         }
 
                         // Shrink original entry to cover only the in-bin portion
-                        buffer[i].number_of_pages = uefi_size_to_pages!((bin_end - entry_start + 1) as usize) as u64;
-                        Self::set_descriptor_type(&mut buffer[i], mem_type, stats.runtime);
+                        entry.number_of_pages = uefi_size_to_pages!((bin_end - entry_start + 1) as usize) as u64;
+                        Self::set_descriptor_type(entry, mem_type, stats.runtime);
 
                         // Insert new entry for the post-bin portion
                         current_count = Self::insert_descriptor_after(buffer, current_count, i);
                         let post_idx = i + 1;
-                        buffer[post_idx].physical_start = bin_end + 1;
-                        buffer[post_idx].number_of_pages = uefi_size_to_pages!((entry_end - bin_end) as usize) as u64;
-                        Self::set_descriptor_type(&mut buffer[post_idx], efi::CONVENTIONAL_MEMORY, false);
+                        let post_entry = buffer.get_mut(post_idx).expect("Failed to get newly created post-bin entry");
+                        post_entry.physical_start = bin_end + 1;
+                        post_entry.number_of_pages = uefi_size_to_pages!((entry_end - bin_end) as usize) as u64;
+                        Self::set_descriptor_type(post_entry, efi::CONVENTIONAL_MEMORY, false);
 
                         did_modify = true;
                         break;
@@ -699,7 +698,9 @@ impl MemoryBinManager {
     ///
     /// Contains peak usage data that BDS can use to recommend next-boot bin sizes.
     pub(crate) fn memory_type_information(&self) -> &[EFiMemoryTypeInformation] {
-        &self.memory_type_information[..self.memory_type_information_count]
+        self.memory_type_information
+            .get(..self.memory_type_information_count)
+            .expect("Memory Type Info count should be correct")
     }
 
     /// Returns the maximum number of additional descriptors that bin splitting could add.
@@ -731,8 +732,10 @@ impl MemoryBinManager {
     fn insert_descriptor_after(buffer: &mut [efi::MemoryDescriptor], count: usize, after_idx: usize) -> usize {
         // Shift entries after `after_idx` right by one
         buffer.copy_within((after_idx + 1)..count, after_idx + 2);
-        // Copy the current entry as a template for the new one
-        buffer[after_idx + 1] = buffer[after_idx];
+        // Copy the current entry as a template for the new one. copy_within will panic if the range is invalid.
+        let source = buffer.get(after_idx).copied().expect("Failed to get source entry");
+        let dest = buffer.get_mut(after_idx + 1).expect("Failed to get destination entry");
+        *dest = source;
         count + 1
     }
 
@@ -746,19 +749,24 @@ impl MemoryBinManager {
 
         let mut write_idx = 0;
         for read_idx in 1..count {
-            let prev_end = buffer[write_idx].physical_start
-                + uefi_pages_to_size!(buffer[write_idx].number_of_pages as usize) as u64;
+            let write_entry = *buffer.get(write_idx).expect("count should be accurate");
+            let read_entry = *buffer.get(read_idx).expect("count should be correct");
 
-            if buffer[read_idx].r#type == buffer[write_idx].r#type
-                && buffer[read_idx].attribute == buffer[write_idx].attribute
-                && buffer[read_idx].physical_start == prev_end
+            let prev_end =
+                write_entry.physical_start + uefi_pages_to_size!(write_entry.number_of_pages as usize) as u64;
+
+            if read_entry.r#type == write_entry.r#type
+                && read_entry.attribute == write_entry.attribute
+                && read_entry.physical_start == prev_end
             {
                 // Merge into the current entry
-                buffer[write_idx].number_of_pages += buffer[read_idx].number_of_pages;
+                let write_entry = buffer.get_mut(write_idx).expect("count should be accurate");
+                write_entry.number_of_pages += read_entry.number_of_pages;
             } else {
                 write_idx += 1;
                 if write_idx != read_idx {
-                    buffer[write_idx] = buffer[read_idx];
+                    let write_entry = buffer.get_mut(write_idx).expect("count should be accurate");
+                    *write_entry = read_entry;
                 }
             }
         }

--- a/patina_dxe_core/src/memory_manager.rs
+++ b/patina_dxe_core/src/memory_manager.rs
@@ -213,6 +213,7 @@ fn allow_allocations_for_type(memory_type: EfiMemoryType) -> Result<(), MemoryEr
 
 #[patina_test]
 #[coverage(off)]
+#[allow(clippy::indexing_slicing)]
 fn memory_manager_allocations_test(mm: Service<dyn MemoryManager>) -> patina_test::error::Result {
     // Allocate a page, and make sure it is accessible.
     let result = mm.allocate_pages(1, AllocationOptions::new());

--- a/patina_dxe_core/src/pecoff.rs
+++ b/patina_dxe_core/src/pecoff.rs
@@ -204,7 +204,7 @@ impl UefiPeInfo {
     /// Parses a bytes buffer containing the filename.
     fn read_filename(bytes: &[u8]) -> error::Result<Option<String>> {
         let filename_end = bytes.iter().position(|&c| c == b'\0').unwrap_or(bytes.len());
-        let mut filename = String::from_utf8_lossy(&bytes[0..filename_end]).into_owned();
+        let mut filename = String::from_utf8_lossy(bytes.get(..filename_end).unwrap_or(bytes)).into_owned();
 
         if filename.ends_with(".pdb") || filename.ends_with(".dll") {
             filename.truncate(filename.len() - 4);
@@ -334,10 +334,14 @@ pub fn relocate_image(
                     let mut value = image.pread_with::<u64>(fixup, LE)?;
                     image.pwrite_with(value.wrapping_add(adjustment), fixup, LE)?;
 
-                    if !prev_reloc_blocks.is_empty()
-                        && prev_reloc_blocks[block_idx].relocations[reloc_idx].value != value
-                    {
-                        continue;
+                    if !prev_reloc_blocks.is_empty() {
+                        let prev_block =
+                            prev_reloc_blocks.get(block_idx).ok_or(error::Error::RelocationBlockLengthMismatch)?;
+                        let prev_reloc =
+                            prev_block.relocations.get(reloc_idx).ok_or(error::Error::RelocationBlockLengthMismatch)?;
+                        if prev_reloc.value != value {
+                            continue;
+                        }
                     }
 
                     value = value.wrapping_add(adjustment);

--- a/patina_dxe_core/src/pi_dispatcher.rs
+++ b/patina_dxe_core/src/pi_dispatcher.rs
@@ -674,8 +674,12 @@ impl DispatcherContext {
                             .find(|x| x.section_type() == Some(ffs::section::Type::UserInterface))
                             .and_then(|x| x.try_content_as_slice().ok())
                             .map(|data| {
-                                let chars: Vec<u16> =
-                                    data.chunks_exact(2).map(|c| u16::from_le_bytes([c[0], c[1]])).collect();
+                                let chars: Vec<u16> = data
+                                    .chunks_exact(2)
+                                    .map(|c| {
+                                        u16::from_le_bytes(c.try_into().expect("chunks_exact(2) guarantees length"))
+                                    })
+                                    .collect();
                                 String::from_utf16_lossy(&chars).trim_end_matches('\0').to_string()
                             });
 

--- a/patina_dxe_core/src/pi_dispatcher/fv.rs
+++ b/patina_dxe_core/src/pi_dispatcher/fv.rs
@@ -709,7 +709,7 @@ impl<P: PlatformInfo> FvProtocolData<P> {
         // SAFETY: local_buffer_ptr is either provided by the caller (and null-checked above), or allocated via allocate pool
         // and is of sufficient size to contain the data.
         let out_buffer = unsafe { slice::from_raw_parts_mut(local_buffer_ptr as *mut u8, copy_size) };
-        out_buffer.copy_from_slice(&file.content()[..copy_size]);
+        out_buffer.copy_from_slice(file.content().get(..copy_size).expect("copy_size <= file.content().len()"));
 
         status
     }
@@ -790,7 +790,9 @@ impl<P: PlatformInfo> FvProtocolData<P> {
         // is of sufficient size to contain the data. We copy the minimum of section_data.len() and local_buffer_size to ensure we do not
         // copy beyond the bounds of either buffer.
         let dest_buffer = unsafe { slice::from_raw_parts_mut(local_buffer_ptr as *mut u8, copy_size) };
-        dest_buffer.copy_from_slice(&section_data[0..dest_buffer.len()]);
+        dest_buffer.copy_from_slice(
+            section_data.get(..dest_buffer.len()).expect("copy_size = min(section_data.len(), local_buffer_size)"),
+        );
 
         //TODO: authentication status not yet supported.
 

--- a/patina_dxe_core/src/pi_dispatcher/image.rs
+++ b/patina_dxe_core/src/pi_dispatcher/image.rs
@@ -129,11 +129,11 @@ impl ImageStack {
 
     #[allow(unused)]
     fn guard(&self) -> &[u8] {
-        &self.stack[..UEFI_PAGE_SIZE]
+        self.stack.get(..UEFI_PAGE_SIZE).expect("stack is always > UEFI_PAGE_SIZE")
     }
 
     fn body(&self) -> &[u8] {
-        &self.stack[UEFI_PAGE_SIZE..]
+        self.stack.get(UEFI_PAGE_SIZE..).expect("stack is always > UEFI_PAGE_SIZE")
     }
 }
 
@@ -250,17 +250,17 @@ impl PrivateImageData {
 
         let Some((resource_section_offset, resource_section_size)) = result else { return Ok(()) };
 
-        if resource_section_offset + resource_section_size > loaded_image.len() {
-            let pe_file_name = self.pe_info.filename_or("Unknown");
-            log_debug_assert!(
-                "HII Resource Section offset {:#X} and size {:#X} are out of bounds for image {pe_file_name}.",
-                resource_section_offset,
-                resource_section_size
-            );
-            return Err(EfiError::LoadError);
-        }
-
-        let resource_section = &loaded_image[resource_section_offset..resource_section_offset + resource_section_size];
+        let resource_section = loaded_image
+            .get(resource_section_offset..resource_section_offset + resource_section_size)
+            .ok_or_else(|| {
+                let pe_file_name = self.pe_info.filename_or("Unknown");
+                log_debug_assert!(
+                    "HII Resource Section offset {:#X} and size {:#X} are out of bounds for image {pe_file_name}.",
+                    resource_section_offset,
+                    resource_section_size
+                );
+                EfiError::LoadError
+            })?;
         let size = resource_section.len();
 
         let alignment = usize::try_from(self.pe_info.section_alignment).map_err(|_| EfiError::LoadError)?;
@@ -274,7 +274,7 @@ impl PrivateImageData {
 
         let mut bytes = CoreMemoryManager.allocate_pages(page_count, options)?.into_boxed_slice::<u8>();
 
-        bytes[..resource_section.len()].copy_from_slice(resource_section);
+        bytes.get_mut(..resource_section.len()).ok_or(EfiError::LoadError)?.copy_from_slice(resource_section);
 
         self.hii_resource_section = Some(bytes);
         Ok(())

--- a/patina_dxe_core/src/pi_dispatcher/section_decompress.rs
+++ b/patina_dxe_core/src/pi_dispatcher/section_decompress.rs
@@ -42,20 +42,23 @@ impl<E: SectionExtractor> CoreExtractor<E> {
             _ => return Err(FirmwareFileSystemError::Unsupported),
         };
 
-        //sanity check the src data
-        if src.len() < 8 {
-            Err(FirmwareFileSystemError::DataCorrupt)?;
-        }
-
-        let compressed_size =
-            u32::from_le_bytes(src[0..4].try_into().map_err(|_| FirmwareFileSystemError::DataCorrupt)?) as usize;
+        let compressed_size = u32::from_le_bytes(
+            src.get(0..4)
+                .ok_or(FirmwareFileSystemError::DataCorrupt)?
+                .try_into()
+                .map_err(|_| FirmwareFileSystemError::DataCorrupt)?,
+        ) as usize;
         if compressed_size > src.len() {
             Err(FirmwareFileSystemError::DataCorrupt)?;
         }
 
         // allocate a buffer to hold the decompressed data
-        let decompressed_size =
-            u32::from_le_bytes(src[4..8].try_into().map_err(|_| FirmwareFileSystemError::DataCorrupt)?) as usize;
+        let decompressed_size = u32::from_le_bytes(
+            src.get(4..8)
+                .ok_or(FirmwareFileSystemError::DataCorrupt)?
+                .try_into()
+                .map_err(|_| FirmwareFileSystemError::DataCorrupt)?,
+        ) as usize;
         let mut decompressed_buffer = vec![0u8; decompressed_size];
 
         // execute decompress

--- a/patina_dxe_core/src/protocol_db.rs
+++ b/patina_dxe_core/src/protocol_db.rs
@@ -510,7 +510,7 @@ impl ProtocolDb {
         self.validate_handle(handle)?;
 
         let key = handle as usize;
-        Ok(self.handles[&key].keys().map(|&OrdGuid(guid)| guid).collect())
+        Ok(self.handles.get(&key).ok_or(EfiError::InvalidParameter)?.keys().map(|&OrdGuid(guid)| guid).collect())
     }
 
     fn register_protocol_notify(&mut self, protocol: efi::Guid, event: efi::Event) -> Result<*mut c_void, EfiError> {
@@ -550,7 +550,8 @@ impl ProtocolDb {
     fn next_handle_for_registration(&mut self, registration: *mut c_void) -> Option<efi::Handle> {
         for (_, v) in self.notifications.iter_mut() {
             if let Some(index) = v.iter().position(|notify| notify.registration == registration)
-                && let Some(handle) = v[index].fresh_handles.pop_first()
+                && let Some(entry) = v.get_mut(index)
+                && let Some(handle) = entry.fresh_handles.pop_first()
             {
                 return Some(handle);
             }
@@ -563,7 +564,9 @@ impl ProtocolDb {
             return Vec::new();
         }
 
-        let handles = &self.handles[&(parent_handle as usize)];
+        let Some(handles) = self.handles.get(&(parent_handle as usize)) else {
+            return Vec::new();
+        };
         let mut child_handles: Vec<efi::Handle> = handles
             .iter()
             .flat_map(|(_, instance)| {

--- a/sdk/patina/examples/basic_guid_usage.rs
+++ b/sdk/patina/examples/basic_guid_usage.rs
@@ -212,9 +212,8 @@ fn demonstrate_practical_usage() {
 
     for config_line in config_guid_strings {
         let parts: Vec<&str> = config_line.split(": ").collect();
-        if parts.len() == 2 {
-            let name = parts[0];
-            match OwnedGuid::try_from_string(parts[1]) {
+        if let (Some(&name), Some(&guid_str)) = (parts.first(), parts.get(1)) {
+            match OwnedGuid::try_from_string(guid_str) {
                 Ok(guid) => println!("    [CONFIG] Parsed '{}' -> {}", name, guid),
                 Err(e) => println!("    [ERROR] Failed to parse '{}': {}", name, e),
             }

--- a/sdk/patina/examples/brotli.rs
+++ b/sdk/patina/examples/brotli.rs
@@ -47,21 +47,23 @@ impl SectionExtractor for BrotliSectionExtractor {
             && guid_header.section_definition_guid == guid::BROTLI_SECTION
         {
             let data = section.section_data();
-            let out_size = u64::from_le_bytes(data[0..8].try_into().unwrap());
-            let _scratch_size = u64::from_le_bytes(data[8..16].try_into().unwrap());
+            let out_size =
+                u64::from_le_bytes(data.get(0..8).expect("brotli header requires 16 bytes").try_into().unwrap());
+            let _scratch_size =
+                u64::from_le_bytes(data.get(8..16).expect("brotli header requires 16 bytes").try_into().unwrap());
 
             let mut brotli_state = BrotliState::new(
                 HeapAllocator::<u8> { default_value: 0 },
                 HeapAllocator::<u32> { default_value: 0 },
                 HeapAllocator::<HuffmanCode> { default_value: Default::default() },
             );
-            let in_data = &data[16..];
+            let in_data = data.get(16..).expect("brotli data follows 16-byte header");
             let mut out_data = vec![0u8; out_size as usize];
             let mut out_data_size = 0;
             let result = BrotliDecompressStream(
                 &mut in_data.len(),
                 &mut 0,
-                &data[16..],
+                in_data,
                 &mut out_data.len(),
                 &mut 0,
                 out_data.as_mut_slice(),

--- a/sdk/patina/src/base/guid.rs
+++ b/sdk/patina/src/base/guid.rs
@@ -427,7 +427,7 @@ impl<'a> Guid<'a> {
         let mut add_hex = |value: u32, digits: usize| {
             for i in (0..digits).rev() {
                 let nibble = ((value >> (i * 4)) & 0xF) as u8;
-                result[pos] = match nibble {
+                *result.get_mut(pos).expect("GUID hex output fits in EXPECTED_HEX_CHARS") = match nibble {
                     0..=9 => (b'0' + nibble) as char,
                     10..=15 => (b'A' + nibble - 10) as char,
                     _ => unreachable!(),
@@ -561,6 +561,7 @@ impl<'a> TryFrom<&'a str> for OwnedGuid {
 }
 
 /// Macro to generate the boilerplate for parsing ASCII hex strings (as byte slices) to their numeric values.
+#[allow(clippy::indexing_slicing)] // idx = $i + j where j < $count; callers ensure $i + $count <= array length.
 macro_rules! parse_hex {
     ($chars:expr, $i:expr, $count:expr, $ty:ty) => {{
         let mut value: $ty = 0;
@@ -574,6 +575,9 @@ macro_rules! parse_hex {
     }};
 }
 
+// All byte accesses are guarded by `while i < s.len()` and `char_count < EXPECTED_HEX_CHARS`.
+// .get() cannot be used here because it is not const-stable.
+#[allow(clippy::indexing_slicing)]
 const fn guid_from_str(s: &str) -> core::result::Result<r_efi::efi::Guid, GuidError> {
     let mut chars = [' '; EXPECTED_HEX_CHARS];
     let mut char_count = 0;

--- a/sdk/patina/src/component/hob.rs
+++ b/sdk/patina/src/component/hob.rs
@@ -208,7 +208,11 @@ impl<T: FromHob + 'static> Deref for Hob<'_, T> {
     type Target = T;
 
     fn deref(&self) -> &Self::Target {
-        self.value[0].downcast_ref::<T>().expect("Failed to downcast Hob value")
+        self.value
+            .first()
+            .expect("Hob must have at least one value")
+            .downcast_ref::<T>()
+            .expect("Failed to downcast Hob value")
     }
 }
 

--- a/sdk/patina/src/component/storage.rs
+++ b/sdk/patina/src/component/storage.rs
@@ -64,7 +64,9 @@ impl<V> SparseVec<V> {
         if index >= self.values.len() {
             self.values.resize_with(index + 1, || None);
         }
-        self.values[index] = Some(value);
+
+        let slot = self.values.get_mut(index).expect("inserted value should be in bounds");
+        *slot = Some(value);
     }
 }
 

--- a/sdk/patina/src/device_path/node_defs.rs
+++ b/sdk/patina/src/device_path/node_defs.rs
@@ -318,6 +318,8 @@ impl Acpi {
 
     /// Converts and compresses the 7-character text argument into its corresponding 4-byte numeric EISA ID encoding.
     /// <https://uefi.org/specs/ACPI/6.5_A/19_ASL_Reference.html#asl-macros>
+    // bytes[] indexing is safe: EISA IDs are always exactly 7 ASCII characters.
+    #[allow(clippy::indexing_slicing)]
     pub const fn eisa_id(hid: &str) -> u32 {
         let bytes = hid.as_bytes();
 
@@ -382,11 +384,16 @@ impl TryFromCtx<'_, scroll::Endian> for Bios {
         let mut offset = 0;
         let device_type = buffer.gread_with::<u16>(&mut offset, ctx)?;
         let status_flag = buffer.gread_with::<u16>(&mut offset, ctx)?;
-        let end_str_idx = &buffer[offset..]
+        let remaining =
+            buffer.get(offset..).ok_or(scroll::Error::TooBig { size: buffer.len() + 1, len: buffer.len() })?;
+        let end_str_idx = remaining
             .iter()
             .position(|c| c == &0)
             .ok_or(scroll::Error::TooBig { size: buffer.len() + 1, len: buffer.len() })?;
-        let description_str = String::from_utf8_lossy(&buffer[offset..offset + end_str_idx]).to_string();
+        let description_str = String::from_utf8_lossy(
+            remaining.get(..end_str_idx).ok_or(scroll::Error::TooBig { size: buffer.len() + 1, len: buffer.len() })?,
+        )
+        .to_string();
         Ok((Self { device_type, status_flag, description_str }, offset))
     }
 }

--- a/sdk/patina/src/device_path/parse_node.rs
+++ b/sdk/patina/src/device_path/parse_node.rs
@@ -139,7 +139,12 @@ impl<'a> TryFromCtx<'a, scroll::Endian> for UnknownDevicePathNode<'a> {
         if header.length > from.len() {
             return Err(scroll::Error::TooBig { size: header.length, len: from.len() });
         }
-        let this = UnknownDevicePathNode { header, data: &from[offset..header.length] };
+        let this = UnknownDevicePathNode {
+            header,
+            data: from
+                .get(offset..header.length)
+                .ok_or(scroll::Error::TooBig { size: header.length, len: from.len() })?,
+        };
         Ok((this, header.length))
     }
 }

--- a/sdk/patina/src/device_path/paths.rs
+++ b/sdk/patina/src/device_path/paths.rs
@@ -60,7 +60,8 @@ impl DevicePathBuf {
         // No allocation will be done here, handled by the `try_reserve`.
         self.buffer.resize(writing_start_offset + header.length, 0);
 
-        let writing_buffer = &mut self.buffer.as_mut_slice()[writing_start_offset..];
+        let writing_buffer =
+            self.buffer.as_mut_slice().get_mut(writing_start_offset..).expect("buffer was just resized to fit");
         match node.write_into(writing_buffer) {
             Ok(nb_byte_written) => debug_assert_eq!(header.length, nb_byte_written),
             Err(_) => debug_assert!(false, "Unexpected error, buffer should be large enough at that point."),
@@ -238,7 +239,7 @@ impl DevicePath {
             let header = self.buffer.pread_with::<crate::device_path::parse_node::Header>(idx, scroll::LE).unwrap();
             idx += header.length;
         }
-        let end_buffer = &self.buffer[idx..];
+        let end_buffer = self.buffer.get(idx..).expect("idx is within device path bounds");
         // SAFETY: The slice `end_buffer` is a valid trailing portion of the device path that contains
         // the last n nodes including the end node. DevicePath is repr(transparent) over [u8], so this cast is
         // considered valid.

--- a/sdk/patina/src/device_path/walker.rs
+++ b/sdk/patina/src/device_path/walker.rs
@@ -281,8 +281,8 @@ pub fn concat_device_path_to_boxed_slice(
     let b_slice = device_path_as_slice(b)?;
     let end_path_size = core::mem::size_of::<efi::protocols::device_path::End>();
     let mut out_bytes = vec![0u8; a_slice.len() + b_slice.len() - end_path_size];
-    out_bytes[..a_slice.len()].copy_from_slice(a_slice);
-    out_bytes[a_slice.len() - end_path_size..].copy_from_slice(b_slice);
+    out_bytes.get_mut(..a_slice.len()).ok_or(efi::Status::BAD_BUFFER_SIZE)?.copy_from_slice(a_slice);
+    out_bytes.get_mut(a_slice.len() - end_path_size..).ok_or(efi::Status::BAD_BUFFER_SIZE)?.copy_from_slice(b_slice);
     Ok(out_bytes.into_boxed_slice())
 }
 

--- a/sdk/patina/src/performance/record.rs
+++ b/sdk/patina/src/performance/record.rs
@@ -116,7 +116,9 @@ pub trait PerformanceRecord {
 
         // Write the complete header
         let header_bytes: [u8; mem::size_of::<PerformanceRecordHeader>()] = header.into();
-        buff[start..start + PERFORMANCE_RECORD_HEADER_SIZE].copy_from_slice(&header_bytes);
+        buff.get_mut(start..start + PERFORMANCE_RECORD_HEADER_SIZE)
+            .ok_or(Error::Serialization)?
+            .copy_from_slice(&header_bytes);
 
         Ok(record_size)
     }
@@ -166,7 +168,7 @@ impl<T: AsRef<[u8]>> PerformanceRecord for GenericPerformanceRecord<T> {
         if data.len() > remaining {
             return Err(Error::Serialization);
         }
-        buff[*offset..*offset + data.len()].copy_from_slice(data);
+        buff.get_mut(*offset..*offset + data.len()).ok_or(Error::Serialization)?.copy_from_slice(data);
         *offset += data.len();
         Ok(())
     }
@@ -214,7 +216,7 @@ impl PerformanceRecordBuffer {
         if buffer.len() < size {
             return Err(Error::BufferTooSmall);
         }
-        buffer[..size].clone_from_slice(current_buffer);
+        buffer.get_mut(..size).ok_or(Error::BufferTooSmall)?.clone_from_slice(current_buffer);
         *self = Self::Published(buffer, size);
         Ok(())
     }
@@ -223,7 +225,7 @@ impl PerformanceRecordBuffer {
     pub fn buffer(&self) -> &[u8] {
         match &self {
             Self::Unpublished(b) => b.as_slice(),
-            Self::Published(b, len) => &b[..*len],
+            Self::Published(b, len) => b.get(..*len).unwrap_or(b),
         }
     }
 
@@ -294,8 +296,8 @@ impl<'a> Iterator for Iter<'a> {
         let length = self.buffer.gread::<u8>(&mut offset).unwrap();
         let revision = self.buffer.gread::<u8>(&mut offset).unwrap();
 
-        let data = &self.buffer[offset..length as usize];
-        self.buffer = &self.buffer[length as usize..];
+        let data = self.buffer.get(offset..length as usize)?;
+        self.buffer = self.buffer.get(length as usize..)?;
         Some(GenericPerformanceRecord::new(record_type, length, revision, data))
     }
 }
@@ -360,13 +362,11 @@ impl DynamicStringEventRecordData {
 
     /// Get the string portion from the full record data
     pub fn extract_string(full_data: &[u8]) -> &str {
-        if full_data.len() <= core::mem::size_of::<Self>() {
+        let Some(string_bytes) = full_data.get(core::mem::size_of::<Self>()..) else {
             return "";
-        }
-        let string_bytes = &full_data[core::mem::size_of::<Self>()..];
-        // Find the null terminator
+        };
         let string_len = string_bytes.iter().position(|&b| b == 0).unwrap_or(string_bytes.len());
-        core::str::from_utf8(&string_bytes[..string_len]).unwrap_or("<invalid UTF-8>")
+        core::str::from_utf8(string_bytes.get(..string_len).unwrap_or(string_bytes)).unwrap_or("<invalid UTF-8>")
     }
 }
 
@@ -406,13 +406,11 @@ impl DualGuidStringEventRecordData {
 
     /// Get the string portion from the full record data
     pub fn extract_string(full_data: &[u8]) -> &str {
-        if full_data.len() <= core::mem::size_of::<Self>() {
+        let Some(string_bytes) = full_data.get(core::mem::size_of::<Self>()..) else {
             return "";
-        }
-        let string_bytes = &full_data[core::mem::size_of::<Self>()..];
-        // Find the null terminator
+        };
         let string_len = string_bytes.iter().position(|&b| b == 0).unwrap_or(string_bytes.len());
-        core::str::from_utf8(&string_bytes[..string_len]).unwrap_or("<invalid UTF-8>")
+        core::str::from_utf8(string_bytes.get(..string_len).unwrap_or(string_bytes)).unwrap_or("<invalid UTF-8>")
     }
 }
 
@@ -496,13 +494,11 @@ impl GuidQwordStringEventRecordData {
 
     /// Get the string portion from the full record data
     pub fn extract_string(full_data: &[u8]) -> &str {
-        if full_data.len() <= core::mem::size_of::<Self>() {
+        let Some(string_bytes) = full_data.get(core::mem::size_of::<Self>()..) else {
             return "";
-        }
-        let string_bytes = &full_data[core::mem::size_of::<Self>()..];
-        // Find the null terminator
+        };
         let string_len = string_bytes.iter().position(|&b| b == 0).unwrap_or(string_bytes.len());
-        core::str::from_utf8(&string_bytes[..string_len]).unwrap_or("<invalid UTF-8>")
+        core::str::from_utf8(string_bytes.get(..string_len).unwrap_or(string_bytes)).unwrap_or("<invalid UTF-8>")
     }
 }
 

--- a/sdk/patina/src/performance/record/extended.rs
+++ b/sdk/patina/src/performance/record/extended.rs
@@ -314,7 +314,7 @@ fn ensure_space(buff: &[u8], offset: usize, needed: usize) -> Result<(), Error> 
 
 fn write_bytes(dest: &mut [u8], offset: &mut usize, src: &[u8]) -> Result<(), Error> {
     ensure_space(dest, *offset, src.len())?;
-    dest[*offset..*offset + src.len()].copy_from_slice(src);
+    dest.get_mut(*offset..*offset + src.len()).ok_or(Error::Serialization)?.copy_from_slice(src);
     *offset += src.len();
     Ok(())
 }

--- a/sdk/patina/src/performance/record/hob.rs
+++ b/sdk/patina/src/performance/record/hob.rs
@@ -49,7 +49,13 @@ impl FromHob for HobPerformanceData {
             log::error!("Performance: error while parsing HobPerformanceRecordBuffer, return default value.");
             return Self::default();
         };
-        let records_data_buffer = bytes[offset..offset + size_of_all_entries as usize].to_vec();
+        let records_data_buffer = bytes
+            .get(offset..offset + size_of_all_entries as usize)
+            .unwrap_or_else(|| {
+                debug_assert!(false, "Performance: records_data_buffer slice out of bounds");
+                &[]
+            })
+            .to_vec();
 
         Self { load_image_count, records_data_buffer }
     }

--- a/sdk/patina/src/performance/table.rs
+++ b/sdk/patina/src/performance/table.rs
@@ -177,7 +177,7 @@ impl FirmwareBasicBootPerfTable for FBPT {
             .map_err(|_| Error::BufferTooSmall)?;
 
         debug_assert_eq!(Self::size_of_empty_table(), offset);
-        self.other_records.report(&mut fbpt_buffer[offset..])?;
+        self.other_records.report(fbpt_buffer.get_mut(offset..).ok_or(Error::BufferTooSmall)?)?;
 
         self._length.1.store(length_ptr, Ordering::Relaxed);
         Ok(self.fbpt_address)

--- a/sdk/patina/src/pi/fw_fs.rs
+++ b/sdk/patina/src/pi/fw_fs.rs
@@ -196,17 +196,12 @@ impl<'a> FirmwareVolume<'a> {
             Err(efi::Status::VOLUME_CORRUPTED)?;
         }
 
-        // header_length: buffer must be large enough to hold the header.
-        if (fv_header.header_length as usize) > buffer.len() {
-            Err(efi::Status::VOLUME_CORRUPTED)?;
-        }
-
         // checksum: fv header must sum to zero (and must be multiple of 2 bytes)
         if fv_header.header_length & 0x01 != 0 {
             Err(efi::Status::VOLUME_CORRUPTED)?;
         }
 
-        let header_slice = &buffer[..fv_header.header_length as usize];
+        let header_slice = buffer.get(..fv_header.header_length as usize).ok_or(efi::Status::VOLUME_CORRUPTED)?;
         let sum: Wrapping<u16> =
             header_slice.chunks_exact(2).map(|x| Wrapping(u16::from_le_bytes(x.try_into().unwrap()))).sum();
 
@@ -246,24 +241,25 @@ impl<'a> FirmwareVolume<'a> {
         let ext_header = {
             if fv_header.ext_header_offset != 0 {
                 let ext_header_offset = fv_header.ext_header_offset as usize;
-                if ext_header_offset + mem::size_of::<fv::ExtHeader>() > buffer.len() {
-                    Err(efi::Status::VOLUME_CORRUPTED)?;
-                }
+                let ext_header_slice = buffer
+                    .get(ext_header_offset..ext_header_offset + mem::size_of::<fv::ExtHeader>())
+                    .ok_or(efi::Status::VOLUME_CORRUPTED)?;
 
-                // SAFETY: The size is validated to contain ExtHeader and slice bounds checked
-                let ext_header = unsafe { &*(buffer[ext_header_offset..].as_ptr() as *const fv::ExtHeader) };
+                // SAFETY: .get() above guarantees the slice contains a full ExtHeader.
+                let ext_header = unsafe { &*(ext_header_slice.as_ptr() as *const fv::ExtHeader) };
                 let ext_header_end = ext_header_offset + ext_header.ext_header_size as usize;
-                if ext_header_end > buffer.len() {
-                    Err(efi::Status::VOLUME_CORRUPTED)?;
-                }
-                Some(FirmwareVolumeExtHeader { header: *ext_header, data: &buffer[ext_header_offset..ext_header_end] })
+                let ext_header_data =
+                    buffer.get(ext_header_offset..ext_header_end).ok_or(efi::Status::VOLUME_CORRUPTED)?;
+                Some(FirmwareVolumeExtHeader { header: *ext_header, data: ext_header_data })
             } else {
                 None
             }
         };
 
         //block map must fit within the fv header (which is checked above to guarantee it is within the fv_data buffer).
-        let block_map = &buffer[mem::size_of::<fv::Header>()..fv_header.header_length as usize];
+        let block_map = buffer
+            .get(mem::size_of::<fv::Header>()..fv_header.header_length as usize)
+            .ok_or(efi::Status::VOLUME_CORRUPTED)?;
 
         //block map should be a multiple of 8 in size
         if block_map.len() & 0x7 != 0 {
@@ -273,8 +269,10 @@ impl<'a> FirmwareVolume<'a> {
         let mut block_map = block_map
             .chunks_exact(8)
             .map(|x| fv::BlockMapEntry {
-                num_blocks: u32::from_le_bytes(x[..4].try_into().unwrap()),
-                length: u32::from_le_bytes(x[4..].try_into().unwrap()),
+                num_blocks: u32::from_le_bytes(
+                    x.get(..4).expect("chunks_exact(8) guarantees 8 bytes").try_into().unwrap(),
+                ),
+                length: u32::from_le_bytes(x.get(4..).expect("chunks_exact(8) guarantees 8 bytes").try_into().unwrap()),
             })
             .collect::<Vec<_>>();
 
@@ -343,7 +341,10 @@ impl<'a> FirmwareVolume<'a> {
 
     /// Returns an iterator of the files in this FV.
     pub fn file_iter(&self) -> impl Iterator<Item = Result<File<'a>, efi::Status>> {
-        FvFileIterator::new(&self.data[self.data_offset..], self.erase_byte)
+        FvFileIterator::new(
+            self.data.get(self.data_offset..).expect("data_offset validated in FirmwareVolume::new()"),
+            self.erase_byte,
+        )
     }
 
     /// returns the (linear block offset from FV base, block_size, remaining_blocks) given an LBA.
@@ -454,19 +455,12 @@ impl<'a> File<'a> {
             } else {
                 //extended header with 64-bit size
                 let extended_size_length = mem::size_of::<u64>();
-                if buffer[header_size..].len() < extended_size_length {
-                    Err(efi::Status::VOLUME_CORRUPTED)?;
-                }
-                let size =
-                    u64::from_le_bytes(buffer[header_size..header_size + extended_size_length].try_into().unwrap());
+                let extended_size_bytes =
+                    buffer.get(header_size..header_size + extended_size_length).ok_or(efi::Status::VOLUME_CORRUPTED)?;
+                let size = u64::from_le_bytes(extended_size_bytes.try_into().unwrap());
                 (header_size + extended_size_length, size as u64)
             }
         };
-
-        // Verify that the total size of the file fits within the buffer.
-        if size as usize > buffer.len() {
-            Err(efi::Status::VOLUME_CORRUPTED)?;
-        }
 
         // Interpreting the state field requires knowledge of the EFI_FVB_ERASE_POLARITY from the FV header, which is not
         // available here unless the constructor API is modified to specify it. So it is inferred based on the state of
@@ -487,7 +481,8 @@ impl<'a> File<'a> {
         }
 
         //Verify the header checksum.
-        let header_sum: Wrapping<u8> = buffer[..header_size].iter().map(|&x| Wrapping(x)).sum();
+        let header_bytes = buffer.get(..header_size).ok_or(efi::Status::VOLUME_CORRUPTED)?;
+        let header_sum: Wrapping<u8> = header_bytes.iter().map(|&x| Wrapping(x)).sum();
         // integrity_check_file and state are assumed to be zero for checksum, so subtract them here.
         let header_sum = header_sum.wrapping_sub(&Wrapping(file_header.integrity_check_file));
         let header_sum = header_sum.wrapping_sub(&Wrapping(file_header.state));
@@ -497,7 +492,8 @@ impl<'a> File<'a> {
 
         //Verify the file data checksum.
         if file_header.attributes & ffs::attributes::raw::CHECKSUM != 0 {
-            let data_sum: Wrapping<u8> = buffer[header_size..size as usize].iter().map(|&x| Wrapping(x)).sum();
+            let data_bytes = buffer.get(header_size..size as usize).ok_or(efi::Status::VOLUME_CORRUPTED)?;
+            let data_sum: Wrapping<u8> = data_bytes.iter().map(|&x| Wrapping(x)).sum();
             if data_sum != Wrapping(0u8) {
                 Err(efi::Status::VOLUME_CORRUPTED)?;
             }
@@ -509,7 +505,7 @@ impl<'a> File<'a> {
         }
 
         Ok(Self {
-            data: &buffer[..size as usize],
+            data: buffer.get(..size as usize).ok_or(efi::Status::VOLUME_CORRUPTED)?,
             name: file_header.name,
             file_type: file_header.file_type,
             attributes: file_header.attributes,
@@ -592,7 +588,7 @@ impl<'a> File<'a> {
 
     /// Returns the raw data from the file (without extracting any sections), not including the header.
     pub fn content(&self) -> &[u8] {
-        &self.data[self.header_size..self.size as usize]
+        self.data.get(self.header_size..self.size as usize).expect("header_size and size validated in File::new()")
     }
 
     /// Returns the raw data for the file, including the header.
@@ -634,7 +630,12 @@ impl<'a> File<'a> {
             // RAW files have no sections
             FileSectionIterator::new(&[], extractor)
         } else {
-            FileSectionIterator::new(&self.data[self.header_size..self.size as usize], extractor)
+            FileSectionIterator::new(
+                self.data
+                    .get(self.header_size..self.size as usize)
+                    .expect("header_size and size validated in File::new()"),
+                extractor,
+            )
         }
     }
 }
@@ -720,7 +721,8 @@ impl Section {
                 let size =
                     buffer.get(header_end..header_end + mem::size_of::<u32>()).ok_or(efi::Status::VOLUME_CORRUPTED)?;
 
-                let size = u32::from_le_bytes([size[0], size[1], size[2], size[3]]);
+                let size: [u8; 4] = size.try_into().map_err(|_| efi::Status::VOLUME_CORRUPTED)?;
+                let size = u32::from_le_bytes(size);
                 (size as usize, header_end + mem::size_of::<u32>())
             } else {
                 //standard header
@@ -897,19 +899,14 @@ impl<'a> Iterator for FvFileIterator<'a> {
         if self.error {
             return None;
         }
-        if self.next_offset > self.buffer.len() {
+        let remaining = self.buffer.get(self.next_offset..)?;
+        if remaining.len() < mem::size_of::<file::Header>() {
             return None;
         }
-        if self.buffer[self.next_offset..].len() < mem::size_of::<file::Header>() {
+        if remaining.get(..mem::size_of::<file::Header>())?.iter().all(|&x| x == self.erase_byte) {
             return None;
         }
-        if self.buffer[self.next_offset..self.next_offset + mem::size_of::<file::Header>()]
-            .iter()
-            .all(|&x| x == self.erase_byte)
-        {
-            return None;
-        }
-        let result = File::new(&self.buffer[self.next_offset..]);
+        let result = File::new(remaining);
         if let Ok(ref file) = result {
             // per the PI spec, "Given a file F, the next file FvHeader is located at the next 8-byte aligned firmware volume
             // offset following the last byte the file F"
@@ -961,14 +958,11 @@ impl Iterator for FileSectionIterator<'_> {
             return Some(result);
         }
 
-        if self.next_offset > self.buffer.len() {
+        let remaining = self.buffer.get(self.next_offset..)?;
+        if remaining.len() < mem::size_of::<ffs::section::Header>() {
             return None;
         }
-
-        if self.buffer[self.next_offset..].len() < mem::size_of::<ffs::section::Header>() {
-            return None;
-        }
-        let result = Section::new(&self.buffer[self.next_offset..]);
+        let result = Section::new(remaining);
         if let Ok(ref section) = result {
             if section.is_encapsulation() {
                 // attempt to extract the encapsulated section.

--- a/sdk/patina/src/pi/serializable.rs
+++ b/sdk/patina/src/pi/serializable.rs
@@ -104,7 +104,7 @@ pub trait Interval: Clone + Ord {
         let mut sorted = intervals.to_vec();
         sorted.sort();
 
-        let mut result = vec![sorted[0].clone()];
+        let mut result = vec![(*sorted.first().expect("intervals is non-empty")).clone()];
         for current in sorted.into_iter().skip(1) {
             let last = result.last_mut().expect("Intervals should not be empty here.");
             if let Some(merged) = last.try_merge(current) {

--- a/sdk/patina/src/runtime_services.rs
+++ b/sdk/patina/src/runtime_services.rs
@@ -406,7 +406,7 @@ impl RuntimeServices for StandardRuntimeServices {
         if next_name.len() < prev_name.len() {
             next_name.resize(prev_name.len(), 0);
         }
-        next_name[..prev_name.len()].clone_from_slice(prev_name);
+        next_name.get_mut(..prev_name.len()).ok_or(efi::Status::BAD_BUFFER_SIZE)?.clone_from_slice(prev_name);
         next_namespace.clone_from(prev_namespace);
 
         let mut next_name_size: usize = next_name.len();
@@ -431,7 +431,7 @@ impl RuntimeServices for StandardRuntimeServices {
                 next_name.resize(next_name_size, 0);
 
                 // Reset fields which may have been overwritten
-                next_name[..prev_name.len()].clone_from_slice(prev_name);
+                next_name.get_mut(..prev_name.len()).ok_or(efi::Status::BAD_BUFFER_SIZE)?.clone_from_slice(prev_name);
                 next_namespace.clone_from(prev_namespace);
             } else if status.is_error() {
                 return Err(status);

--- a/sdk/patina_ffs/src/file.rs
+++ b/sdk/patina_ffs/src/file.rs
@@ -99,11 +99,6 @@ impl<'a> FileRef<'a> {
             }
         };
 
-        // Verify that the total size of the file fits within the buffer.
-        if size > buffer.len() {
-            Err(FirmwareFileSystemError::InvalidHeader)?;
-        }
-
         // Verify the state field.
         // Interpreting the state field requires knowledge of the EFI_FVB_ERASE_POLARITY from the FV header, which is not
         // available here unless the constructor API is modified to specify it. So it is inferred based on the state of
@@ -127,7 +122,8 @@ impl<'a> FileRef<'a> {
         }
 
         // Verify the file header checksum.
-        let sum = buffer[..content_offset].iter().fold(0u8, |sum, val| sum.wrapping_add(*val));
+        let header_bytes = buffer.get(..content_offset).ok_or(FirmwareFileSystemError::InvalidHeader)?;
+        let sum = header_bytes.iter().fold(0u8, |sum, val| sum.wrapping_add(*val));
         let sum = sum.wrapping_sub(header.state);
         let sum = sum.wrapping_sub(header.integrity_check_file);
         if sum != 0 {
@@ -140,12 +136,19 @@ impl<'a> FileRef<'a> {
                 Err(FirmwareFileSystemError::InvalidHeader)?;
             }
         } else {
-            let sum = buffer[content_offset..size].iter().fold(0u8, |sum, val| sum.wrapping_add(*val));
+            let data_bytes = buffer.get(content_offset..size).ok_or(FirmwareFileSystemError::DataCorrupt)?;
+            let sum = data_bytes.iter().fold(0u8, |sum, val| sum.wrapping_add(*val));
             if sum != 0 {
                 Err(FirmwareFileSystemError::DataCorrupt)?;
             }
         }
-        Ok(Self { data: &buffer[..size], header, erase_polarity, size, content_offset })
+        Ok(Self {
+            data: buffer.get(..size).ok_or(FirmwareFileSystemError::InvalidHeader)?,
+            header,
+            erase_polarity,
+            size,
+            content_offset,
+        })
     }
 
     /// Total serialized size of the file in bytes (header + content).
@@ -165,7 +168,7 @@ impl<'a> FileRef<'a> {
 
     /// The file payload bytes (sections area), excluding the header.
     pub fn content(&self) -> &[u8] {
-        &self.data[self.content_offset..]
+        self.data.get(self.content_offset..).expect("content_offset validated in FileRef::new()")
     }
 
     /// Byte offset from the start of the file to the beginning of content.
@@ -218,8 +221,9 @@ impl<'a> FileRef<'a> {
     ///
     /// Returns a flattened list of sections; nested containers are expanded.
     pub fn sections(&self) -> Result<Vec<Section>, FirmwareFileSystemError> {
-        let sections = SectionIterator::new(&self.data[self.content_offset..])
-            .collect::<Result<Vec<_>, FirmwareFileSystemError>>()?;
+        let sections =
+            SectionIterator::new(self.data.get(self.content_offset..).ok_or(FirmwareFileSystemError::DataCorrupt)?)
+                .collect::<Result<Vec<_>, FirmwareFileSystemError>>()?;
         Ok(sections.iter().flat_map(|x| x.sections().cloned().collect::<Vec<_>>()).collect())
     }
 
@@ -263,14 +267,15 @@ impl<'a> FileRef<'a> {
         &self,
         extractor: &dyn SectionExtractor,
     ) -> Result<Vec<Section>, FirmwareFileSystemError> {
-        let sections = SectionIterator::new(&self.data[self.content_offset..])
-            .map(|mut x| {
-                if let Ok(ref mut section) = x {
-                    section.extract(extractor)?;
-                }
-                x
-            })
-            .collect::<Result<Vec<_>, FirmwareFileSystemError>>()?;
+        let sections =
+            SectionIterator::new(self.data.get(self.content_offset..).ok_or(FirmwareFileSystemError::DataCorrupt)?)
+                .map(|mut x| {
+                    if let Ok(ref mut section) = x {
+                        section.extract(extractor)?;
+                    }
+                    x
+                })
+                .collect::<Result<Vec<_>, FirmwareFileSystemError>>()?;
         Ok(sections.iter().flat_map(|x| x.sections().cloned().collect::<Vec<_>>()).collect())
     }
 }

--- a/sdk/patina_ffs/src/section.rs
+++ b/sdk/patina_ffs/src/section.rs
@@ -296,9 +296,9 @@ impl Section {
                 (ext_header.extended_size as usize, ext_header_size)
             } else {
                 //standard header.
-                let mut size = vec![0x00u8; 4];
-                size[0..3].copy_from_slice(&section_header.size);
-                let size = u32::from_le_bytes(size.try_into().unwrap()) as usize;
+                let mut size = [0x00u8; 4];
+                size.get_mut(0..3).expect("4-byte array has indices 0..3").copy_from_slice(&section_header.size);
+                let size = u32::from_le_bytes(size) as usize;
                 (size, core::mem::size_of::<section::Header>())
             }
         };
@@ -318,7 +318,10 @@ impl Section {
                 }
                 // SAFETY: buffer is large enough to hold the compression header.
                 let compression_header = unsafe {
-                    ptr::read_unaligned(buffer[section_data_offset..].as_ptr() as *const section::header::Compression)
+                    ptr::read_unaligned(
+                        buffer.get(section_data_offset..).ok_or(FirmwareFileSystemError::InvalidHeader)?.as_ptr()
+                            as *const section::header::Compression,
+                    )
                 };
                 let content_size: u32 = (section_size - (section_data_offset + compression_header_size))
                     .try_into()
@@ -336,7 +339,10 @@ impl Section {
                 }
                 // SAFETY: buffer is large enough to hold the GuidDefined header.
                 let guid_defined_header = unsafe {
-                    ptr::read_unaligned(buffer[section_data_offset..].as_ptr() as *const section::header::GuidDefined)
+                    ptr::read_unaligned(
+                        buffer.get(section_data_offset..).ok_or(FirmwareFileSystemError::InvalidHeader)?.as_ptr()
+                            as *const section::header::GuidDefined,
+                    )
                 };
 
                 // Verify that buffer has enough storage for guid-specific fields.
@@ -345,7 +351,10 @@ impl Section {
                     Err(FirmwareFileSystemError::InvalidHeader)?;
                 }
 
-                let guid_specific_data = buffer[section_data_offset + guid_header_size..data_offset].to_vec();
+                let guid_specific_data = buffer
+                    .get(section_data_offset + guid_header_size..data_offset)
+                    .ok_or(FirmwareFileSystemError::InvalidHeader)?
+                    .to_vec();
                 let content_size: u32 =
                     (section_size - data_offset).try_into().map_err(|_| FirmwareFileSystemError::InvalidHeader)?;
                 (SectionHeader::GuidDefined(guid_defined_header, guid_specific_data, content_size), data_offset)
@@ -358,7 +367,10 @@ impl Section {
                 }
                 // SAFETY: buffer is large enough to hold the version header.
                 let version_header = unsafe {
-                    ptr::read_unaligned(buffer[section_data_offset..].as_ptr() as *const section::header::Version)
+                    ptr::read_unaligned(
+                        buffer.get(section_data_offset..).ok_or(FirmwareFileSystemError::InvalidHeader)?.as_ptr()
+                            as *const section::header::Version,
+                    )
                 };
                 let content_size: u32 = (section_size - (section_data_offset + version_header_size))
                     .try_into()
@@ -374,7 +386,8 @@ impl Section {
                 // SAFETY: buffer is large enough to hold the freeform header type
                 let freeform_header = unsafe {
                     ptr::read_unaligned(
-                        buffer[section_data_offset..].as_ptr() as *const section::header::FreeformSubtypeGuid
+                        buffer.get(section_data_offset..).ok_or(FirmwareFileSystemError::InvalidHeader)?.as_ptr()
+                            as *const section::header::FreeformSubtypeGuid,
                     )
                 };
                 let content_size: u32 = (section_size - (section_data_offset + freeform_subtype_size))
@@ -398,11 +411,16 @@ impl Section {
             SectionHeader::Compression(_, _) | SectionHeader::GuidDefined(_, _, _) => {
                 SectionData::Encapsulation(EncapsulationSectionData {
                     sub_sections: Vec::new(),
-                    data: buffer[content_offset..section_size].to_vec(),
+                    data: buffer
+                        .get(content_offset..section_size)
+                        .ok_or(FirmwareFileSystemError::InvalidHeader)?
+                        .to_vec(),
                     extracted: false,
                 })
             }
-            _ => SectionData::Leaf(LeafSectionData { data: buffer[content_offset..section_size].to_vec() }),
+            _ => SectionData::Leaf(LeafSectionData {
+                data: buffer.get(content_offset..section_size).ok_or(FirmwareFileSystemError::InvalidHeader)?.to_vec(),
+            }),
         };
 
         Ok(Section { header, data: section_data, dirty: false })
@@ -633,7 +651,8 @@ impl Iterator for SectionIterator<'_> {
             return None;
         }
 
-        let result = Section::new_from_buffer(&self.data[self.next_offset..]);
+        let remaining = self.data.get(self.next_offset..)?;
+        let result = Section::new_from_buffer(remaining);
         match result {
             Ok(ref section) => {
                 let section_size = section.size().expect("Section must be composed");

--- a/sdk/patina_ffs/src/volume.rs
+++ b/sdk/patina_ffs/src/volume.rs
@@ -84,18 +84,13 @@ impl<'a> VolumeRef<'a> {
             Err(FirmwareFileSystemError::InvalidHeader)?;
         }
 
-        // Header length must fit inside the buffer.
-        if header_length > buffer.len() {
-            Err(FirmwareFileSystemError::InvalidHeader)?;
-        }
-
         // Header length must be a multiple of 2
         if header_length & 0x01 != 0 {
             Err(FirmwareFileSystemError::InvalidHeader)?;
         }
 
         // Header checksum must be correct
-        let header_slice = &buffer[..header_length];
+        let header_slice = buffer.get(..header_length).ok_or(FirmwareFileSystemError::InvalidHeader)?;
         let sum = header_slice
             .chunks_exact(2)
             .fold(0u16, |sum, value| sum.wrapping_add(u16::from_le_bytes(value.try_into().unwrap())));
@@ -134,13 +129,11 @@ impl<'a> VolumeRef<'a> {
         let ext_header = {
             if fv_header.ext_header_offset != 0 {
                 let ext_header_offset = fv_header.ext_header_offset as usize;
-                if ext_header_offset + mem::size_of::<fv::ExtHeader>() > buffer.len() {
-                    Err(FirmwareFileSystemError::InvalidHeader)?;
-                }
-
-                //Safety: previous check ensures that fv_data is large enough to contain the ext_header
-                let ext_header =
-                    unsafe { ptr::read_unaligned(buffer[ext_header_offset..].as_ptr() as *const fv::ExtHeader) };
+                let ext_header_slice = buffer
+                    .get(ext_header_offset..ext_header_offset + mem::size_of::<fv::ExtHeader>())
+                    .ok_or(FirmwareFileSystemError::InvalidHeader)?;
+                // SAFETY: .get() above guarantees the slice contains a full ExtHeader.
+                let ext_header = unsafe { ptr::read_unaligned(ext_header_slice.as_ptr() as *const fv::ExtHeader) };
                 let ext_header_end = ext_header_offset + ext_header.ext_header_size as usize;
                 if ext_header_end > buffer.len() {
                     Err(FirmwareFileSystemError::InvalidHeader)?;
@@ -152,7 +145,9 @@ impl<'a> VolumeRef<'a> {
         };
 
         //block map must fit within the fv header (which is checked above to guarantee it is within the fv_data buffer).
-        let block_map = &buffer[mem::size_of::<fv::Header>()..fv_header.header_length as usize];
+        let block_map = buffer
+            .get(mem::size_of::<fv::Header>()..fv_header.header_length as usize)
+            .ok_or(FirmwareFileSystemError::InvalidHeader)?;
 
         //block map should be a multiple of 8 in size
         if block_map.len() & 0x7 != 0 {
@@ -162,8 +157,10 @@ impl<'a> VolumeRef<'a> {
         let mut block_map = block_map
             .chunks_exact(8)
             .map(|x| fv::BlockMapEntry {
-                num_blocks: u32::from_le_bytes(x[..4].try_into().unwrap()),
-                length: u32::from_le_bytes(x[4..].try_into().unwrap()),
+                num_blocks: u32::from_le_bytes(
+                    x.get(..4).expect("chunks_exact(8) guarantees 8 bytes").try_into().unwrap(),
+                ),
+                length: u32::from_le_bytes(x.get(4..).expect("chunks_exact(8) guarantees 8 bytes").try_into().unwrap()),
             })
             .collect::<Vec<_>>();
 
@@ -261,7 +258,11 @@ impl<'a> VolumeRef<'a> {
             let header_size = mem::size_of_val(&ext_header);
             let ext_header_data_start = self.fv_header.ext_header_offset as usize + header_size;
             let ext_header_end = ext_header_data_start + ext_header.ext_header_size as usize - header_size;
-            let header_data = self.data[ext_header_data_start..ext_header_end].to_vec();
+            let header_data = self
+                .data
+                .get(ext_header_data_start..ext_header_end)
+                .expect("ext_header offsets validated during VolumeRef::new()")
+                .to_vec();
             (ext_header, header_data)
         })
     }
@@ -329,7 +330,11 @@ impl<'a> VolumeRef<'a> {
     ///
     /// PAD files are filtered out per PI spec. Parsing errors are surfaced as iterator items.
     pub fn files(&self) -> impl Iterator<Item = Result<FileRef<'a>, FirmwareFileSystemError>> {
-        FileRefIter::new(&self.data[self.content_offset..], self.erase_byte()).filter(|x| {
+        FileRefIter::new(
+            self.data.get(self.content_offset..).expect("content_offset validated during VolumeRef::new()"),
+            self.erase_byte(),
+        )
+        .filter(|x| {
             //Per PI spec 1.8A, V3, section 2.1.4.1.8: "Standard firmware file system services will not return the
             //handle of any PAD files, nor will they permit explicit creation of such files."
             //Pad files are ignored on read, and will be inserted on serialization as needed to honor alignment
@@ -387,19 +392,14 @@ impl<'a> Iterator for FileRefIter<'a> {
         if self.error {
             return None;
         }
-        if self.next_offset > self.data.len() {
+        let remaining = self.data.get(self.next_offset..)?;
+        if remaining.len() < mem::size_of::<file::Header>() {
             return None;
         }
-        if self.data[self.next_offset..].len() < mem::size_of::<file::Header>() {
+        if remaining.get(..mem::size_of::<file::Header>())?.iter().all(|&x| x == self.erase_byte) {
             return None;
         }
-        if self.data[self.next_offset..self.next_offset + mem::size_of::<file::Header>()]
-            .iter()
-            .all(|&x| x == self.erase_byte)
-        {
-            return None;
-        }
-        let result = FileRef::new(&self.data[self.next_offset..]);
+        let result = FileRef::new(remaining);
         if let Ok(ref file) = result {
             // per the PI spec, "Given a file F, the next file FvHeader is located at the next 8-byte aligned firmware volume
             // offset following the last byte the file F"
@@ -654,7 +654,9 @@ impl Volume {
             ext_header_offset.try_into().map_err(|_| FirmwareFileSystemError::InvalidHeader)?;
 
         // calculate the checksum.
-        let checksum = fv_buffer[..header_len]
+        let checksum = fv_buffer
+            .get(..header_len)
+            .ok_or(FirmwareFileSystemError::InvalidHeader)?
             .chunks_exact(2)
             //in the fv_buffer the following 3 fields are still set to zero, so manually add them to the checksum calculation.
             .chain(fv_header.fv_length.to_le_bytes().chunks_exact(2))
@@ -665,12 +667,16 @@ impl Volume {
 
         //re-write the updated fv_header into the front of the fv_buffer.
         // SAFETY: fv_header is repr(C) so it is safe to treat as a byte array.
-        fv_buffer[..mem::size_of_val(&fv_header)]
+        fv_buffer
+            .get_mut(..mem::size_of_val(&fv_header))
+            .ok_or(FirmwareFileSystemError::InvalidHeader)?
             .copy_from_slice(unsafe { from_raw_parts(&raw mut fv_header as *mut u8, mem::size_of_val(&fv_header)) });
 
         // verify the checksum
         debug_assert_eq!(
-            fv_buffer[..header_len]
+            fv_buffer
+                .get(..header_len)
+                .expect("header_len is within fv_buffer")
                 .chunks_exact(2)
                 .fold(0u16, |sum, value| sum.wrapping_add(u16::from_le_bytes(value.try_into().unwrap()))),
             0

--- a/sdk/patina_ffs_extractors/src/brotli.rs
+++ b/sdk/patina_ffs_extractors/src/brotli.rs
@@ -68,21 +68,31 @@ impl SectionExtractor for BrotliSectionExtractor {
             && guid_header.section_definition_guid == fw_fs::guid::BROTLI_SECTION
         {
             let data = section.try_content_as_slice()?;
-            let out_size = u64::from_le_bytes(data[0..8].try_into().unwrap());
-            let _scratch_size = u64::from_le_bytes(data[8..16].try_into().unwrap());
+            let out_size = u64::from_le_bytes(
+                data.get(0..8)
+                    .ok_or(FirmwareFileSystemError::DataCorrupt)?
+                    .try_into()
+                    .map_err(|_| FirmwareFileSystemError::DataCorrupt)?,
+            );
+            let _scratch_size = u64::from_le_bytes(
+                data.get(8..16)
+                    .ok_or(FirmwareFileSystemError::DataCorrupt)?
+                    .try_into()
+                    .map_err(|_| FirmwareFileSystemError::DataCorrupt)?,
+            );
 
             let mut brotli_state = BrotliState::new(
                 HeapAllocator::<u8> { default_value: 0 },
                 HeapAllocator::<u32> { default_value: 0 },
                 HeapAllocator::<HuffmanCode> { default_value: Default::default() },
             );
-            let in_data = &data[16..];
+            let in_data = data.get(16..).ok_or(FirmwareFileSystemError::DataCorrupt)?;
             let mut out_data = vec![0u8; out_size as usize];
             let mut out_data_size = 0;
             let result = BrotliDecompressStream(
                 &mut in_data.len(),
                 &mut 0,
-                &data[16..],
+                in_data,
                 &mut out_data.len(),
                 &mut 0,
                 out_data.as_mut_slice(),

--- a/sdk/patina_macro/src/smbios_record_macro.rs
+++ b/sdk/patina_macro/src/smbios_record_macro.rs
@@ -146,7 +146,7 @@ pub(crate) fn smbios_record_derive(item: TokenStream) -> TokenStream {
                     if matches!(&*type_array.elem,
                         syn::Type::Path(elem_path)
                             if elem_path.path.segments.len() == 1 &&
-                               elem_path.path.segments[0].ident == "u8"));
+                               elem_path.path.segments.first().is_some_and(|s| s.ident == "u8")));
 
             // Add field size to structured size calculation.
             // This relies on size_of matching the serialized layout, which is

--- a/sdk/patina_macro/src/validate_params_macro.rs
+++ b/sdk/patina_macro/src/validate_params_macro.rs
@@ -454,8 +454,8 @@ pub(crate) fn check_param_conflicts(func: &ItemFn) -> Result<(), TokenStream> {
     // Check for conflicts
     for i in 0..params.len() {
         for j in (i + 1)..params.len() {
-            let (idx1, type1, name1, span1) = &params[i];
-            let (idx2, type2, name2, span2) = &params[j];
+            let Some((idx1, type1, name1, span1)) = params.get(i) else { continue };
+            let Some((idx2, type2, name2, span2)) = params.get(j) else { continue };
 
             if let Some(conflict_msg) = type1.conflicts_with(type2) {
                 // Build a detailed error message with parameter information


### PR DESCRIPTION
## Description

This enables an optional clippy lint to disallow direct slice indexing. First, all instances in the codebase are fixed or explicitly allowed.

The only places they are explicitly allowed are:
- In const functions because .get() is [currently not const](https://github.com/rust-lang/rust/issues/143775). An unstable feature could be enabled to allow this, but because const functions are evaluated at build time, it did not seem worthwhile to enable
- In test code

Each crate was updated separately to make any future bisects easier to identify where an issue occurred and to allow reviewers to focus on crates they care about.

- [x] Impacts functionality?
- [x] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Unit tests, booting to Win/Linux on Q35/SBSA and Windows on a physical Intel platform.

## Integration Instructions

Clippy will now fail when direct slice indexing is used. Developers must either use .get() (preferred) or disable the lint at the smallest level possible if it is not possible to use .get().
