### PR TITLE
Improve local mdbook testing [Rebase & FF]

### DIFF
--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -50,5 +50,6 @@ jobs:
     uses: OpenDevicePartnership/patina-devops/.github/workflows/MdbookWorkflow.yml@v0.3.10
     with:
       mdbook-path: "docs"
-      build-cmd: cargo make build-lib
+      build-cmd: cargo make build-mdbook-deps
+      deps-dir: "target/mdbook/deps/"
     secrets: inherit

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,3 +75,10 @@ lzma-rs = { version = "0.3" }
 
 [workspace.lints.clippy]
 undocumented_unsafe_blocks = "warn"
+
+# Profile used to build workspace dependencies for `mdbook test`. Inherits from `dev`
+# but disables LTO so that the resulting rlibs contain machine code and can be linked
+# by `rustdoc --test` when running the doctests embedded in the mdbook.
+[profile.mdbook]
+inherits = "dev"
+lto = false

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -301,6 +301,48 @@ clear = true
 command = "cargo"
 args = ["test", "--doc"]
 
+[tasks.build-mdbook-deps]
+description = """Builds workspace libraries with the `mdbook` profile.
+This is a prerequisite for `cargo make test-mdbook`."""
+clear = true
+env = { RUSTC_PROFILE = "mdbook" }
+command = "cargo"
+args = ["build", "--all-features", "@@split(INDIVIDUAL_PACKAGE_TARGETS, )", "@@split(STD_FLAGS, )"]
+dependencies = ["individual-package-targets"]
+
+[tasks.test-mdbook]
+description = """Builds the mdbook and runs all of its embedded doctests with
+`mdbook test`. Uses the workspace toolchain (from `rust-toolchain.toml`) so the
+doctests link against rlibs built by the same compiler, and points `mdbook test`
+to the mdbook profile `target/mdbook/deps/` directory produced by `build-mdbook-deps`.
+"""
+clear = true
+script_runner = "@duckscript"
+script = '''
+toolchain_file = readfile rust-toolchain.toml
+channel = set "stable"
+lines = split ${toolchain_file} "\n"
+for line in ${lines}
+    trimmed = trim ${line}
+    starts = starts_with ${trimmed} "channel"
+    if ${starts}
+        parts = split ${trimmed} "\""
+        channel = array_get ${parts} 1
+    end
+end
+exec --fail-on-error mdbook build docs
+exec --fail-on-error rustup run ${channel} mdbook test docs -L target/mdbook/deps
+'''
+dependencies = ["build-mdbook-deps"]
+
+[tasks.serve-mdbook]
+description = """Serves the mdbook at http://localhost:3000 with live reload.
+`mdbook serve` rebuilds on source changes. It does not run the embedded doctests
+(use `cargo make test-mdbook` for that)."""
+clear = true
+command = "mdbook"
+args = ["serve", "docs", "--open"]
+
 [tasks.cspell]
 description = "Run cspell for spell checking." # npm install -g cspell@latest
 script = "cspell --quiet  --no-progress --no-summary  --dot --gitignore -e \"{.git/**,.github/**,.vscode/**}\" ."
@@ -342,4 +384,5 @@ dependencies = [
     "coverage",
     "doc-test",
     "doc",
+    "test-mdbook",
 ]

--- a/cspell.yml
+++ b/cspell.yml
@@ -159,6 +159,7 @@ words:
   - regsvr
   - relia
   - reloc
+  - rlibs
   - rposition
   - ruint
   - rustification

--- a/docs/book.toml
+++ b/docs/book.toml
@@ -8,7 +8,7 @@ title = "Developing UEFI with Rust"
 additional-js = ["cdn-assets.js", "mermaid.min.js", "mermaid-init.js"]
 additional-css = ["./mdbook-admonish.css"]
 
-[output.html.playpen]
+[output.html.playground]
 editable = true
 editor = "ace"
 line-numbers = true


### PR DESCRIPTION
## Description

Changes to simplify testing mdbooks.

---

**Simplify local mdbook testing**

Today, trying to run mdbook tests locally is a bit of a pain because:

1. The `dev` profile is used to build dependencies used by code in the mdbook, and it has LTO enabled. This means that the resulting rlibs don't contain machine code and can't be linked by `rustdoc --test` when running the doctests embedded in the mdbook. This results in link errors.
2. mdbook defaults to using the stable toolchain ignoring the `rust-toolchain.toml` file, which means that you have to manually switch to the nightly toolchain before running the tests.
3. The dependencies have to be built separately (`cargo make build-lib`). which are built using the toolchain in `rust-toolchain.toml`.

This is accounted for in CI with manual steps:

https://github.com/OpenDevicePartnership/patina-devops/blob/main/.github/workflows/MdbookWorkflow.yml

This commit simplifies all of this by introducing a new profile specifically for mdbook that inherits from `dev` but disables LTO and adding a `cargo-make` task to build the dependencies using this profile and run `mdbook test` using the toolchain specified in `rust-toolchain.toml`.

Another task was added called `serve-mdbook` to make it easier to open the mdbook locally similar to `doc-open` for the docs.

- Test mdbook code: `cargo make test-mdbook`
- Serve mdbook locally: `cargo make serve-mdbook`

This also has the advantage that mdbook tests are checked during `cargo make all` now.

---

**book.toml: Change playpen to playground**

I could not find "playpen" in the mdbook documentation:

https://rust-lang.github.io/mdBook/

As far as I can tell, "playpen" is a deprecated name for "playground".

This changes the name of the section in book.toml to align with current mdbook documentation.

---

Note: I kept the dedicated job in [ci-workflow.yml](https://github.com/OpenDevicePartnership/patina/blob/main/.github/workflows/ci-workflow.yml) that calls to [patina-devops/MdbookWorkflow.yml](https://github.com/OpenDevicePartnership/patina-devops/blob/main/.github/workflows/MdbookWorkflow.yml) since `all` is not run in CI and having it in a separate job still seems reasonable even though the job itself has some redundancies now. I'll probably make some changes to MdbookWorkflow.yml in a patina-devops PR to remove complexity now handled by the make task.

---

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

- `cargo make test-mdbook`
- `cargo make serve-mdbook`

## Integration Instructions

- N/A