### PR TITLE
[REBASE & FF] Use CRLF for Log Messages

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -80,6 +80,14 @@ See `docs/src/dev/principles/unsafe.md` for the full safety philosophy
 See `docs/src/dev/principles/error-handling.md` for error
 propagation patterns and examples.
 
+## Logging
+
+- Use the `log` crate for structured logging.
+- Log at appropriate levels: `trace`, `debug`, `info`, `warn`, `error`.
+- Include relevant context in log messages.
+- Do not log in hot paths or have entry/exit logs.
+- Prefer using `patina::writelncrlf` for formatting strings that will be logged over `writeln!`.
+
 ## Component Model
 
 Patina uses dependency injection through component entry point function signatures.

--- a/components/patina_mm/src/component/communicator.rs
+++ b/components/patina_mm/src/component/communicator.rs
@@ -27,6 +27,7 @@ use patina::{
         service::{IntoService, Service},
     },
     pi::protocols::communication::EfiMmCommunicateHeader,
+    writelncrlf,
 };
 
 use alloc::vec::Vec;
@@ -255,11 +256,11 @@ impl MmCommunicator {
 
 impl<E: MmExecutor + 'static> Debug for MmCommunicator<E> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        writeln!(f, "MM Communicator:")?;
+        writelncrlf!(f, "MM Communicator:")?;
         for buffer in self.comm_buffers.borrow().iter() {
-            writeln!(f, "Comm Buffer: {buffer:?}")?;
+            writelncrlf!(f, "Comm Buffer: {buffer:?}")?;
         }
-        writeln!(f, "MM Executor Set: {}", self.mm_executor.is_some())?;
+        writelncrlf!(f, "MM Executor Set: {}", self.mm_executor.is_some())?;
         Ok(())
     }
 }

--- a/components/patina_mm/src/config.rs
+++ b/components/patina_mm/src/config.rs
@@ -23,7 +23,7 @@ use core::{fmt, pin::Pin, ptr::NonNull};
 
 use patina::{
     BinaryGuid, Guid, base::UEFI_PAGE_MASK, management_mode::MmCommBufferStatus,
-    pi::protocols::communication::EfiMmCommunicateHeader,
+    pi::protocols::communication::EfiMmCommunicateHeader, writelncrlf,
 };
 
 /// Management Mode (MM) Configuration
@@ -64,17 +64,23 @@ impl Default for MmCommunicationConfiguration {
 
 impl fmt::Display for MmCommunicationConfiguration {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        writeln!(f, "MM Communication Configuration:")?;
-        writeln!(f, "  ACPI Base: {}", self.acpi_base)?;
-        writeln!(f, "  Command Port: {}", self.cmd_port)?;
-        writeln!(f, "  Data Port: {}", self.data_port)?;
-        writeln!(f, "  Communication Buffers ({}):", self.comm_buffers.len())?;
+        writelncrlf!(f, "MM Communication Configuration:")?;
+        writelncrlf!(f, "  ACPI Base: {}", self.acpi_base)?;
+        writelncrlf!(f, "  Command Port: {}", self.cmd_port)?;
+        writelncrlf!(f, "  Data Port: {}", self.data_port)?;
+        writelncrlf!(f, "  Communication Buffers ({}):", self.comm_buffers.len())?;
 
         if self.comm_buffers.is_empty() {
-            writeln!(f, "    <none>")
+            writelncrlf!(f, "    <none>")
         } else {
             for buffer in &self.comm_buffers {
-                writeln!(f, "    Buffer {:#04X}: ptr={:p}, len=0x{:X}", buffer.id(), buffer.as_ptr(), buffer.len(),)?;
+                writelncrlf!(
+                    f,
+                    "    Buffer {:#04X}: ptr={:p}, len=0x{:X}",
+                    buffer.id(),
+                    buffer.as_ptr(),
+                    buffer.len(),
+                )?;
             }
             Ok(())
         }
@@ -596,7 +602,7 @@ impl CommunicateBuffer {
 #[coverage(off)]
 impl fmt::Debug for CommunicateBuffer {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        writeln!(f, "CommunicateBuffer(id: 0x{:X}. len: 0x{:X})", self.id(), self.len())?;
+        writelncrlf!(f, "CommunicateBuffer(id: 0x{:X}. len: 0x{:X})", self.id(), self.len())?;
         for (i, chunk) in self.as_slice().chunks(16).enumerate() {
             // Print the offset
             write!(f, "{:08X}: ", i * 16)?;
@@ -617,7 +623,7 @@ impl fmt::Debug for CommunicateBuffer {
                     write!(f, ".")?;
                 }
             }
-            writeln!(f, "|")?;
+            writelncrlf!(f, "|")?;
         }
         Ok(())
     }

--- a/components/patina_test/src/service.rs
+++ b/components/patina_test/src/service.rs
@@ -27,6 +27,7 @@ use patina::{
         tpl::Tpl,
     },
     component::{Storage, service::IntoService},
+    writelncrlf,
 };
 
 use r_efi::efi::EVENT_GROUP_READY_TO_BOOT;
@@ -276,18 +277,18 @@ impl Display for Recorder {
         self.with_mut(|records| {
             let mut total_passes = 0;
             let mut total_fails = 0;
-            writeln!(f, "Patina on-system unit-test results:")?;
+            writelncrlf!(f, "Patina on-system unit-test results:")?;
             for (name, record) in records.iter() {
                 total_passes += record.pass;
                 total_fails += record.fail;
                 if record.fail == 0 && record.pass == 0 {
-                    writeln!(f, "  {name} ... not triggered")?;
+                    writelncrlf!(f, "  {name} ... not triggered")?;
                     continue;
                 }
                 if record.fail == 0 {
-                    writeln!(f, "  {name} ... ok ({} passes)", record.pass)?;
+                    writelncrlf!(f, "  {name} ... ok ({} passes)", record.pass)?;
                 } else {
-                    writeln!(
+                    writelncrlf!(
                         f,
                         "  {name} ... fail ({} fails, {} passes): {}",
                         record.fail,
@@ -296,7 +297,7 @@ impl Display for Recorder {
                     )?;
                 }
             }
-            writeln!(f, "Patina on-system unit-test result totals: {total_passes} passes, {total_fails} fails")?;
+            writelncrlf!(f, "Patina on-system unit-test result totals: {total_passes} passes, {total_fails} fails")?;
 
             Ok(())
         })

--- a/cspell.yml
+++ b/cspell.yml
@@ -200,6 +200,7 @@ words:
   - wbinvd
   - windbg
   - withf
+  - writelncrlf
   - wrmsr
   - xdata
   - xtask

--- a/docs/src/dxe_core/advanced_logger.md
+++ b/docs/src/dxe_core/advanced_logger.md
@@ -44,12 +44,18 @@ flowchart LR
     patina["Patina"]
     log["Log Crate"]
     logger["Advanced Logger"]
-    serial[["SerialIO"]]
-    memory_log[["Memory Log"]]
+    serial["Serial IO"]
+    memory_log["Memory Log"]
     patina -- log::info!('foo') --> log
     log --> logger
     logger -- 'foo' --> serial
     logger -- entry{'foo'} --> memory_log
+```
+
+```admonish
+ In order to maintain compatibility with a wide range of terminal emulators and log viewers, it is
+ recommended to use `patina::writelncrlf` instead of `writeln` when formatting messages that will
+ be printed via the `log` crate. This will ensure that the log line ending is CRLF. 
 ```
 
 ### Memory Log

--- a/patina_dxe_core/src/allocator.rs
+++ b/patina_dxe_core/src/allocator.rs
@@ -46,7 +46,7 @@ pub use uefi_allocator::UefiAllocator;
 use patina::{
     base::{SIZE_4KB, UEFI_PAGE_MASK, UEFI_PAGE_SIZE},
     error::EfiError,
-    guids, uefi_size_to_pages,
+    guids, uefi_size_to_pages, writelncrlf,
 };
 
 // Type alias for a UefiAllocator with a SpinLockedFixedSizeBlockAllocator
@@ -370,13 +370,17 @@ impl Debug for MemoryDescriptorRef<'_> {
 
 impl Debug for MemoryDescriptorSlice<'_> {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        writeln!(
+        writelncrlf!(
             f,
             "{:<24} {:<20} {:<15} {:<15} {:<20}",
-            "Type", "Physical Start", "Virtual Start", "Number of Pages", "Attributes"
+            "Type",
+            "Physical Start",
+            "Virtual Start",
+            "Number of Pages",
+            "Attributes"
         )?;
         for descriptor in self.0 {
-            writeln!(f, "{:?}", MemoryDescriptorRef(descriptor))?;
+            writelncrlf!(f, "{:?}", MemoryDescriptorRef(descriptor))?;
         }
         Ok(())
     }

--- a/patina_dxe_core/src/allocator/fixed_size_block_allocator.rs
+++ b/patina_dxe_core/src/allocator/fixed_size_block_allocator.rs
@@ -31,7 +31,7 @@ use patina::{
     base::{UEFI_PAGE_SHIFT, UEFI_PAGE_SIZE, align_up},
     error::EfiError,
     pi::{dxe_services::GcdMemoryType, hob::EFiMemoryTypeInformation},
-    uefi_pages_to_size, uefi_size_to_pages,
+    uefi_pages_to_size, uefi_size_to_pages, writelncrlf,
 };
 use r_efi::efi;
 
@@ -437,12 +437,12 @@ impl FixedSizeBlockAllocator {
 
 impl Display for FixedSizeBlockAllocator {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        writeln!(f, "Memory Type: {:x?}", self.memory_type())?;
-        writeln!(f, "Allocation Ranges:")?;
+        writelncrlf!(f, "Memory Type: {:x?}", self.memory_type())?;
+        writelncrlf!(f, "Allocation Ranges:")?;
         for node in AllocatorIterator::new(self.allocators) {
             // SAFETY: node is produced by AllocatorIterator and points to a valid AllocatorListNode.
             let allocator = unsafe { &mut (*node).allocator };
-            writeln!(
+            writelncrlf!(
                 f,
                 "  PhysRange: {:#x}-{:#x}, Size: {:#x}, Used: {:#x} Free: {:#x}",
                 align_down_size(allocator.bottom() as usize, 0x1000), //account for AllocatorListNode
@@ -452,15 +452,15 @@ impl Display for FixedSizeBlockAllocator {
                 allocator.free(),
             )?;
         }
-        writeln!(f, "Bucket Range: {:x?}", self.reserved_range)?;
-        writeln!(f, "Allocation Stats:")?;
-        writeln!(f, "  pool_allocation_calls: {}", self.stats.pool_allocation_calls)?;
-        writeln!(f, "  pool_free_calls: {}", self.stats.pool_free_calls)?;
-        writeln!(f, "  page_allocation_calls: {}", self.stats.page_allocation_calls)?;
-        writeln!(f, "  page_free_calls: {}", self.stats.page_free_calls)?;
-        writeln!(f, "  reserved_size: {}", self.stats.reserved_size)?;
-        writeln!(f, "  reserved_used: {}", self.stats.reserved_used)?;
-        writeln!(f, "  claimed_pages: {}", self.stats.claimed_pages)?;
+        writelncrlf!(f, "Bucket Range: {:x?}", self.reserved_range)?;
+        writelncrlf!(f, "Allocation Stats:")?;
+        writelncrlf!(f, "  pool_allocation_calls: {}", self.stats.pool_allocation_calls)?;
+        writelncrlf!(f, "  pool_free_calls: {}", self.stats.pool_free_calls)?;
+        writelncrlf!(f, "  page_allocation_calls: {}", self.stats.page_allocation_calls)?;
+        writelncrlf!(f, "  page_free_calls: {}", self.stats.page_free_calls)?;
+        writelncrlf!(f, "  reserved_size: {}", self.stats.reserved_size)?;
+        writelncrlf!(f, "  reserved_used: {}", self.stats.reserved_used)?;
+        writelncrlf!(f, "  claimed_pages: {}", self.stats.claimed_pages)?;
         Ok(())
     }
 }

--- a/patina_dxe_core/src/allocator/uefi_allocator.rs
+++ b/patina_dxe_core/src/allocator/uefi_allocator.rs
@@ -8,7 +8,7 @@
 //!
 //! SPDX-License-Identifier: Apache-2.0
 //!
-use patina::error::EfiError;
+use patina::{error::EfiError, writelncrlf};
 use r_efi::efi;
 
 use super::{AllocationStatistics, AllocationStrategy, PageAllocator};
@@ -274,7 +274,7 @@ where
     A: PageAllocator + GlobalAlloc + Allocator + Display + Sync + Send,
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        writeln!(f, "Memory Type: {}", string_for_memory_type(self.memory_type()))?;
+        writelncrlf!(f, "Memory Type: {}", string_for_memory_type(self.memory_type()))?;
         self.allocator.fmt(f)
     }
 }
@@ -652,18 +652,18 @@ mod tests {
             assert_eq!(
                 std::format!("{ua}"),
                 concat!(
-                    "Memory Type: BootServices Data\n",
-                    "Memory Type: 4\n",
-                    "Allocation Ranges:\n",
-                    "Bucket Range: None\n",
-                    "Allocation Stats:\n",
-                    "  pool_allocation_calls: 0\n",
-                    "  pool_free_calls: 0\n",
-                    "  page_allocation_calls: 0\n",
-                    "  page_free_calls: 0\n",
-                    "  reserved_size: 0\n",
-                    "  reserved_used: 0\n",
-                    "  claimed_pages: 0\n"
+                    "Memory Type: BootServices Data\r\n",
+                    "Memory Type: 4\r\n",
+                    "Allocation Ranges:\r\n",
+                    "Bucket Range: None\r\n",
+                    "Allocation Stats:\r\n",
+                    "  pool_allocation_calls: 0\r\n",
+                    "  pool_free_calls: 0\r\n",
+                    "  page_allocation_calls: 0\r\n",
+                    "  page_free_calls: 0\r\n",
+                    "  reserved_size: 0\r\n",
+                    "  reserved_used: 0\r\n",
+                    "  claimed_pages: 0\r\n"
                 )
             );
         });

--- a/patina_dxe_core/src/config_tables/memory_attributes_table.rs
+++ b/patina_dxe_core/src/config_tables/memory_attributes_table.rs
@@ -22,6 +22,7 @@ use crate::{
     gcd::MemoryProtectionPolicy,
     systemtables,
 };
+use patina::writelncrlf;
 use r_efi::efi;
 
 // create a wrapper struct so that we can create an install method on it. That way, we can have the install function
@@ -66,17 +67,17 @@ impl Debug for MemoryAttributesTable {
         // SAFETY: mat.entry points to number_of_entries descriptors in the MAT.
         let entries = unsafe { slice::from_raw_parts(mat.entry.as_ptr(), mat.number_of_entries as usize) };
 
-        writeln!(f, "MemoryAttributesTable {{")?;
-        writeln!(f, "  version: {:#X}", mat.version)?;
-        writeln!(f, "  number_of_entries: {:#X}", mat.number_of_entries)?;
-        writeln!(f, "  descriptor_size: {:#X}", mat.descriptor_size)?;
-        writeln!(f, "  reserved: {:#X}", mat.reserved)?;
-        writeln!(f, "  entries: [")?;
+        writelncrlf!(f, "MemoryAttributesTable {{")?;
+        writelncrlf!(f, "  version: {:#X}", mat.version)?;
+        writelncrlf!(f, "  number_of_entries: {:#X}", mat.number_of_entries)?;
+        writelncrlf!(f, "  descriptor_size: {:#X}", mat.descriptor_size)?;
+        writelncrlf!(f, "  reserved: {:#X}", mat.reserved)?;
+        writelncrlf!(f, "  entries: [")?;
 
-        writeln!(f, "{:?}", MemoryDescriptorSlice(entries))?;
+        writelncrlf!(f, "{:?}", MemoryDescriptorSlice(entries))?;
 
-        writeln!(f, "  ]")?;
-        writeln!(f, "}}")
+        writelncrlf!(f, "  ]")?;
+        writelncrlf!(f, "}}")
     }
 }
 

--- a/patina_dxe_core/src/debugger_reload.rs
+++ b/patina_dxe_core/src/debugger_reload.rs
@@ -19,7 +19,7 @@ use patina::{
     component::service::memory::{AllocationOptions, MemoryManager, PageAllocationStrategy},
     guids,
     pi::hob::{self},
-    uefi_size_to_pages,
+    uefi_size_to_pages, writelncrlf,
 };
 
 use crate::{memory_manager::CoreMemoryManager, pecoff};
@@ -51,7 +51,7 @@ pub fn tear_down_debugger_reload() {
 /// extension and so is not intended to be human friendly.
 fn reload_monitor(args: &mut core::str::SplitWhitespace<'_>, out: &mut dyn core::fmt::Write) {
     if TEAR_DOWN.load(core::sync::atomic::Ordering::Relaxed) {
-        let _ = writeln!(out, "Only supported at initial breakpoint");
+        let _ = writelncrlf!(out, "Only supported at initial breakpoint");
         return;
     }
 
@@ -63,7 +63,7 @@ fn reload_monitor(args: &mut core::str::SplitWhitespace<'_>, out: &mut dyn core:
             load_command(args, out);
         }
         _ => {
-            let _ = writeln!(out, "Unknown command");
+            let _ = writelncrlf!(out, "Unknown command");
         }
     }
 }
@@ -76,18 +76,18 @@ fn allocate_buffer_command(args: &mut core::str::SplitWhitespace<'_>, out: &mut 
         Some(size_str) => match size_str.parse::<usize>() {
             Ok(size) => size,
             Err(_) => {
-                let _ = writeln!(out, "Invalid buffer size");
+                let _ = writelncrlf!(out, "Invalid buffer size");
                 return;
             }
         },
         None => {
-            let _ = writeln!(out, "Usage: reload alloc_buffer <size>");
+            let _ = writelncrlf!(out, "Usage: reload alloc_buffer <size>");
             return;
         }
     };
 
     if buffer_size == 0 {
-        let _ = writeln!(out, "Buffer size must be greater than 0");
+        let _ = writelncrlf!(out, "Buffer size must be greater than 0");
         return;
     }
 
@@ -95,13 +95,13 @@ fn allocate_buffer_command(args: &mut core::str::SplitWhitespace<'_>, out: &mut 
     let pages = match CoreMemoryManager.allocate_pages(uefi_size_to_pages!(buffer_size), AllocationOptions::new()) {
         Ok(pages) => pages,
         Err(err) => {
-            let _ = writeln!(out, "Failed to allocate reload buffer: {:?}", err);
+            let _ = writelncrlf!(out, "Failed to allocate reload buffer: {:?}", err);
             return;
         }
     };
 
     let address = pages.into_raw_ptr::<u8>().expect("Page allocation size check failed for u8") as usize;
-    let _ = write!(out, "{:x}", address);
+    let _ = writelncrlf!(out, "{:x}", address);
 }
 
 /// Implements the "reload load" command. This command loads the core image from the specified address and size.
@@ -111,12 +111,12 @@ fn load_command(args: &mut core::str::SplitWhitespace<'_>, out: &mut dyn core::f
         Some(addr_str) => match addr_str.parse::<usize>() {
             Ok(addr) => addr,
             Err(_) => {
-                let _ = writeln!(out, "Invalid address");
+                let _ = writelncrlf!(out, "Invalid address");
                 return;
             }
         },
         None => {
-            let _ = writeln!(out, "No address provided");
+            let _ = writelncrlf!(out, "No address provided");
             return;
         }
     };
@@ -125,18 +125,18 @@ fn load_command(args: &mut core::str::SplitWhitespace<'_>, out: &mut dyn core::f
         Some(size_str) => match size_str.parse::<usize>() {
             Ok(size) => size,
             Err(_) => {
-                let _ = writeln!(out, "Invalid size");
+                let _ = writelncrlf!(out, "Invalid size");
                 return;
             }
         },
         None => {
-            let _ = writeln!(out, "No size provided");
+            let _ = writelncrlf!(out, "No size provided");
             return;
         }
     };
 
     if address == 0 || size == 0 {
-        let _ = writeln!(out, "Address and size must be greater than 0");
+        let _ = writelncrlf!(out, "Address and size must be greater than 0");
         return;
     }
 
@@ -160,7 +160,7 @@ fn load_command(args: &mut core::str::SplitWhitespace<'_>, out: &mut dyn core::f
 /// fails.
 fn decompress_image(compressed_image: &[u8], out: &mut dyn core::fmt::Write) -> Option<&'static [u8]> {
     if compressed_image.len() < 8 {
-        let _ = writeln!(out, "Compressed image size too small");
+        let _ = writelncrlf!(out, "Compressed image size too small");
         return None;
     }
 
@@ -174,7 +174,7 @@ fn decompress_image(compressed_image: &[u8], out: &mut dyn core::fmt::Write) -> 
     if let Err(error) =
         decompress_into_with_algo(compressed_image, decompressed_image, DecompressionAlgorithm::UefiDecompress)
     {
-        let _ = writeln!(out, "Failed to decompress image: {:?}", error);
+        let _ = writelncrlf!(out, "Failed to decompress image: {:?}", error);
         return None;
     }
 
@@ -187,7 +187,7 @@ fn core_reload(image: &[u8], out: &mut dyn core::fmt::Write) {
     let pe_info = match pecoff::UefiPeInfo::parse(image) {
         Ok(info) => info,
         Err(err) => {
-            let _ = writeln!(out, "Failed to parse PE image: {:?}", err);
+            let _ = writelncrlf!(out, "Failed to parse PE image: {:?}", err);
             return;
         }
     };
@@ -200,7 +200,7 @@ fn core_reload(image: &[u8], out: &mut dyn core::fmt::Write) {
     ) {
         Ok(pages) => pages,
         Err(err) => {
-            let _ = writeln!(out, "Failed to allocate load buffer: {:?}", err);
+            let _ = writelncrlf!(out, "Failed to allocate load buffer: {:?}", err);
             return;
         }
     };
@@ -208,14 +208,14 @@ fn core_reload(image: &[u8], out: &mut dyn core::fmt::Write) {
     // Step 2: load the image.
     let loaded_image = alloc.leak_as_slice::<u8>();
     if let Err(error) = pecoff::load_image(&pe_info, image, loaded_image) {
-        let _ = writeln!(out, "Failed to load image. {:?}", error);
+        let _ = writelncrlf!(out, "Failed to load image. {:?}", error);
         return;
     }
 
     // Step 3: relocate the image.
     let loaded_image_addr = loaded_image.as_ptr() as usize;
     if let Err(error) = pecoff::relocate_image(&pe_info, loaded_image_addr, loaded_image, &Vec::new()) {
-        let _ = writeln!(out, "Failed to relocate image. {:?}", error);
+        let _ = writelncrlf!(out, "Failed to relocate image. {:?}", error);
         return;
     }
 
@@ -224,7 +224,7 @@ fn core_reload(image: &[u8], out: &mut dyn core::fmt::Write) {
     let (hob_list, stack_ptr) = match fixup_hob_list(loaded_image_addr, image_size, entry_point) {
         Ok(hob_list) => hob_list,
         Err(error) => {
-            let _ = writeln!(out, "Failed to fixup HOB list: {}", error);
+            let _ = writelncrlf!(out, "Failed to fixup HOB list: {}", error);
             return;
         }
     };

--- a/patina_dxe_core/src/gcd/spin_locked_gcd.rs
+++ b/patina_dxe_core/src/gcd/spin_locked_gcd.rs
@@ -19,7 +19,7 @@ use patina::{
         dxe_services::{self, GcdMemoryType, MemorySpaceDescriptor},
         hob::{self, EFiMemoryTypeInformation},
     },
-    uefi_pages_to_size, uefi_size_to_pages,
+    uefi_pages_to_size, uefi_size_to_pages, writelncrlf,
 };
 use patina_internal_collections::{Error as SliceError, Rbt, SliceKey, node_size};
 use r_efi::efi;
@@ -1341,11 +1341,11 @@ impl GCD {
 
 impl Display for GCD {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        writeln!(
+        writelncrlf!(
             f,
             "GCDMemType Range                             Capabilities     Attributes       ImageHandle      DeviceHandle"
         )?;
-        writeln!(
+        writelncrlf!(
             f,
             "========== ================================= ================ ================ ================ ================"
         )?;
@@ -1358,7 +1358,7 @@ impl Display for GCD {
                 MemoryBlock::Allocated(descriptor) | MemoryBlock::Unallocated(descriptor) => {
                     let mem_type_str_idx =
                         usize::min(descriptor.memory_type as usize, Self::GCD_MEMORY_TYPE_NAMES.len() - 1);
-                    writeln!(
+                    writelncrlf!(
                         f,
                         "{}  {:016x?}-{:016x?} {:016x?} {:016x?} {:016x?} {:016x?}",
                         GCD::GCD_MEMORY_TYPE_NAMES[mem_type_str_idx],
@@ -1913,8 +1913,8 @@ impl IoGCD {
 
 impl Display for IoGCD {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        writeln!(f, "GCDIoType  Range                            ")?;
-        writeln!(f, "========== =================================")?;
+        writelncrlf!(f, "GCDIoType  Range                            ")?;
+        writelncrlf!(f, "========== =================================")?;
 
         let blocks = &self.io_blocks;
         let mut current = blocks.first_idx();
@@ -1923,7 +1923,7 @@ impl Display for IoGCD {
             match ib {
                 IoBlock::Allocated(descriptor) | IoBlock::Unallocated(descriptor) => {
                     let io_type_str_idx = usize::min(descriptor.io_type as usize, Self::GCD_IO_TYPE_NAMES.len() - 1);
-                    writeln!(
+                    writelncrlf!(
                         f,
                         "{}  {:016x?}-{:016x?}{}",
                         IoGCD::GCD_IO_TYPE_NAMES[io_type_str_idx],
@@ -2985,14 +2985,14 @@ impl SpinLockedGcd {
 impl Display for SpinLockedGcd {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         if let Some(gcd) = self.memory.try_lock() {
-            writeln!(f, "\n{gcd}")?;
+            writelncrlf!(f, "\n{gcd}")?;
         } else {
-            writeln!(f, "Locked: {:?}", self.memory.try_lock())?;
+            writelncrlf!(f, "Locked: {:?}", self.memory.try_lock())?;
         }
         if let Some(gcd) = self.io.try_lock() {
-            writeln!(f, "\n{gcd}")?;
+            writelncrlf!(f, "\n{gcd}")?;
         } else {
-            writeln!(f, "Locked: {:?}", self.io.try_lock())?;
+            writelncrlf!(f, "Locked: {:?}", self.io.try_lock())?;
         }
         Ok(())
     }
@@ -3000,8 +3000,8 @@ impl Display for SpinLockedGcd {
 
 impl core::fmt::Debug for SpinLockedGcd {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        writeln!(f, "{:?}", self.memory.try_lock())?;
-        writeln!(f, "{:?}", self.io.try_lock())?;
+        writelncrlf!(f, "{:?}", self.memory.try_lock())?;
+        writelncrlf!(f, "{:?}", self.io.try_lock())?;
         Ok(())
     }
 }

--- a/sdk/patina/src/base.rs
+++ b/sdk/patina/src/base.rs
@@ -383,6 +383,29 @@ macro_rules! signature {
             | (($h as u64) << 56)
     };
 }
+
+/// Writes a line to the Writer target, followed by CRLF.
+///
+/// # Examples
+///
+/// ```rust
+/// use patina::writelncrlf;
+/// use std::fmt::Write;
+/// let mut s = String::new();
+/// writelncrlf!(&mut s, "Hello, World {}!", 42).unwrap();
+/// assert_eq!(s, "Hello, World 42!\r\n");
+/// ```
+///
+/// # Note
+/// This macro is typically used to format logs messages to maintain
+/// compatibility with a wide range of terminal emulators and log viewers.
+#[macro_export]
+macro_rules! writelncrlf {
+    ($target:expr, $($arg:tt)*) => {
+        write!($target, $($arg)*).and_then(|()| write!($target, "\r\n"))
+    };
+}
+
 #[cfg(test)]
 #[coverage(off)]
 mod tests {
@@ -509,5 +532,28 @@ mod tests {
 
         let b5: u128 = bit!(50);
         assert_eq!(b5, 0x0004_0000_0000_0000u128);
+    }
+
+    #[test]
+    fn test_writelncrlf() {
+        use std::fmt::Write;
+        let mut s = String::new();
+        writelncrlf!(&mut s, "Hello, World!").unwrap();
+        assert_eq!(s, "Hello, World!\r\n");
+
+        writelncrlf!(&mut s, "Another line!").unwrap();
+        assert_eq!(s, "Hello, World!\r\nAnother line!\r\n");
+
+        writelncrlf!(&mut s, "A line with CRLF in it!\r\n").unwrap();
+        assert_eq!(s, "Hello, World!\r\nAnother line!\r\nA line with CRLF in it!\r\n\r\n");
+
+        writelncrlf!(&mut s, "Just LF!\n").unwrap();
+        assert_eq!(s, "Hello, World!\r\nAnother line!\r\nA line with CRLF in it!\r\n\r\nJust LF!\n\r\n");
+
+        writelncrlf!(&mut s, "A line with args: {}", 42).unwrap();
+        assert_eq!(
+            s,
+            "Hello, World!\r\nAnother line!\r\nA line with CRLF in it!\r\n\r\nJust LF!\n\r\nA line with args: 42\r\n"
+        );
     }
 }

--- a/sdk/patina/src/log.rs
+++ b/sdk/patina/src/log.rs
@@ -39,6 +39,8 @@
 mod serial_logger;
 pub use serial_logger::Logger as SerialLogger;
 
+use crate::writelncrlf;
+
 /// Enum to describe the format of the log message.
 pub enum Format {
     /// Standard text format containing the log level and message.
@@ -59,7 +61,7 @@ impl Format {
         //       writing.
         match self {
             Format::Standard if record.level() == log::Level::Trace => {
-                writeln!(
+                writelncrlf!(
                     target,
                     "TRACE - {}:{}: {}",
                     record.file().unwrap_or("unknown"),
@@ -69,31 +71,75 @@ impl Format {
                 .expect("Printing to serial failed");
             }
             Format::Standard => {
-                writeln!(target, "{} - {}", record.level(), record.args()).expect("Printing to serial failed");
+                writelncrlf!(target, "{} - {}", record.level(), record.args()).expect("Printing to serial failed");
             }
             Format::Json => {
-                write!(
+                writelncrlf!(
                     target,
                     "{}",
-                    format_args!("{{\"level\": \"{}\" \"message\": \"{}\"}}\n", record.level(), record.args())
+                    format_args!("{{\"level\": \"{}\" \"message\": \"{}\"}}", record.level(), record.args())
                 )
                 .expect("Printing to serial failed");
             }
             Format::VerboseJson => {
-                write!(
+                writelncrlf!(
                     target,
                     "{}",
                     format_args!(
-            "{{\"level\": \"{}\", \"target\": \"{}\", \"message\": \"{}\", \"file\": \"{}\", \"line\": \"{}\"}}\n",
-            record.level(),
-            record.target(),
-            record.args(),
-            record.file().unwrap_or("unknown"),
-            record.line().unwrap_or(0)
-          )
+                        "{{\"level\": \"{}\", \"target\": \"{}\", \"message\": \"{}\", \"file\": \"{}\", \"line\": \"{}\"}}",
+                        record.level(),
+                        record.target(),
+                        record.args(),
+                        record.file().unwrap_or("unknown"),
+                        record.line().unwrap_or(0)
+                    )
                 )
                 .expect("Printing to serial failed");
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Format;
+    use alloc::string::String;
+
+    /// Writes a log record through the given Format into a String buffer and returns it.
+    fn format_record(format: &Format, level: log::Level, target: &str, message: &str) -> String {
+        let mut buf = String::new();
+        let args = format_args!("{message}");
+        let record =
+            log::Record::builder().args(args).level(level).target(target).file(Some("test.rs")).line(Some(42)).build();
+        format.write(&mut buf, &record);
+        buf
+    }
+
+    #[test]
+    fn test_format_standard_ends_with_crlf() {
+        let output = format_record(&Format::Standard, log::Level::Info, "test", "hello");
+        assert!(output.ends_with("\r\n"), "expected CRLF line ending, got: {:?}", output);
+        assert!(!output.ends_with("\n\r\n"), "should not have bare LF before CRLF");
+    }
+
+    #[test]
+    fn test_format_standard_trace_ends_with_crlf() {
+        let output = format_record(&Format::Standard, log::Level::Trace, "test", "verbose");
+        assert!(output.ends_with("\r\n"), "expected CRLF line ending, got: {:?}", output);
+        assert!(output.starts_with("TRACE - test.rs:42:"));
+    }
+
+    #[test]
+    fn test_format_json_ends_with_crlf() {
+        let output = format_record(&Format::Json, log::Level::Warn, "test", "warning");
+        assert!(output.ends_with("\r\n"), "expected CRLF line ending, got: {:?}", output);
+    }
+
+    #[test]
+    fn test_format_verbose_json_ends_with_crlf() {
+        let output = format_record(&Format::VerboseJson, log::Level::Error, "my_target", "oops");
+        assert!(output.ends_with("\r\n"), "expected CRLF line ending, got: {:?}", output);
+        assert!(output.contains("my_target"));
+        assert!(output.contains("test.rs"));
     }
 }


### PR DESCRIPTION
## Description

Currently Patina only uses LF for log message line endings. In some terminal emulators, the implicit CR is not added and so the logs look stilted, e.g.

```text
INFO - Some Log Message
                                            INFO - Oops, no CR
```

This contains two commits to fix that. One is in the SDK to convert strings printed with log::<level>!() to have CRLF as the line ending. The other is use write!() with CRLF explicitly stated instead of writeln!() as that only does LF.

Note: This matches edk2 behavior and C drivers using DEBUG(()) already get CRLF as their line ending: https://github.com/tianocore/edk2/blob/b03a21a63e3bd001f52c527e5a57feddb53a690b/MdePkg/Library/BasePrintLib/PrintLibInternal.c#L1107-L1136

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

On a physical ARM64 platform where the terminal emulator does not implicitly add CR.

## Integration Instructions

N/A.
