### PR TITLE
patina_dxe_core: install always-enabled silent logger for tests

### DIFF
--- a/patina_dxe_core/src/test_support.rs
+++ b/patina_dxe_core/src/test_support.rs
@@ -636,21 +636,37 @@ pub(crate) fn build_test_hob_list(mem_size: u64) -> *const c_void {
 /// ```powershell
 /// $env:RUST_LOG="debug"; cargo test -p patina_dxe_core allocator::usage_tests::uefi_memory_map -- --nocapture
 /// ```
+///
+/// When `RUST_LOG` is not set, an always-enabled silent logger is installed.This produces no
+/// output but causes `log::log_enabled!()` to return `true`, so the format and dispatch branch
+/// inside each `log::*!` macro still executes during tests and is counted by coverage instrumentation.
 pub(crate) fn init_test_logger() {
     use std::sync::OnceLock;
     static INIT: OnceLock<()> = OnceLock::new();
 
-    INIT.get_or_init(|| {
-        // Default to no logging unless RUST_LOG environment variable is set
-        let mut builder = env_logger::Builder::from_default_env();
+    /// Logger that reports every record as enabled but discards them. Used in tests so
+    /// `log::log_enabled!()` returns `true` without producing any output.
+    struct AlwaysEnabledSilentLogger;
 
-        // If RUST_LOG is not set, default to Off (no logging), otherwise errors
-        // are logged even without --nocapture
-        if std::env::var("RUST_LOG").is_err() {
-            builder.filter_level(log::LevelFilter::Off);
+    impl log::Log for AlwaysEnabledSilentLogger {
+        fn enabled(&self, _metadata: &log::Metadata<'_>) -> bool {
+            true
         }
+        fn log(&self, _record: &log::Record<'_>) {}
+        fn flush(&self) {}
+    }
 
-        builder.init();
+    static SILENT_LOGGER: AlwaysEnabledSilentLogger = AlwaysEnabledSilentLogger;
+
+    INIT.get_or_init(|| {
+        if std::env::var("RUST_LOG").is_ok() {
+            // User asked for output via RUST_LOG, use env_logger.
+            env_logger::Builder::from_default_env().init();
+        } else {
+            // Silent but always-enabled, so log lines are still covered by tests.
+            let _ = log::set_logger(&SILENT_LOGGER);
+            log::set_max_level(log::LevelFilter::Trace);
+        }
     });
 }
 


### PR DESCRIPTION
## Description

`init_test_logger()` is used by various modules to set up logging during tests.

This was originally setup to use `env_logger` when `RUST_LOG` is set allowing simple control of log messages during interactive test runs and providing partial coverage of log messages in tests with the following description given (https://github.com/OpenDevicePartnership/patina/pull/1093):

  > Since Patina relies on the `log::*` API for logging, not
  > configuring a default logger can cause `log::*` calls to appear
  > completely uncovered in llvm-cov reports, slightly reducing
  > overall coverage. Adding a simple environment based logger avoids
  > this issue.

  > Although this change enables coverage for `log::*`,
  > there are still cases that cannot be covered. For example, in the
  > function below, there is no way to get coverage for lines 6 and 7.

  > ```
  > 1   1   fn print() {
  > 2   1       let mut i = 0;
  > 3   11      for _ in 0..10 {
  > 4   10          log::info!(
  > 5   10              "This will be covered {} {}",
  > 6                   i,
  > 7                   "This and the above line will not be covered."
  > 8               );
  > 9   10          i = i + 1;
  > 10          }
  > 11  1   }
  > ```

This commit adds coverage of the log lines.

`init_test_logger` previously defaulted `env_logger` to `LevelFilter::Off` when `RUST_LOG` was unset. That sets `STATIC_MAX_LEVEL` to `Off` and installs a logger whose `enabled()` returns false, so every `log::*!` macro short-circuits before it gets to the formatting and dispatch logic. Under `cargo-llvm-cov` this leaves log call sites flagged as uncovered, even though the surrounding code is exercised by tests.

This change switches the unset-`RUST_LOG` path to a tiny custom `log::Log` implementation that reports every record as enabled but discards it, combined with `set_max_level(Trace)`.

This allows tests to stay silent, but `log_enabled!()` now returns true so the formatting branch of each `log::*!` invocation actually runs and gets counted by coverage.

The `RUST_LOG`-set path is unchanged and still routes through `env_logger` for real output during interactive debugging.

---

This change alone improved existing code coverage by:

- Line Coverage: 85.72% -> 85.95%
- Region Coverage: 84.47% -> 85.33%

---

Before (Left). After (Right).

<img width="1760" height="228" alt="image" src="https://github.com/user-attachments/assets/bb872051-66d4-466f-8d66-3cc2c3bee14c" />

<img width="1866" height="420" alt="image" src="https://github.com/user-attachments/assets/3d9d8495-23f9-408f-bd82-c1ecdbc487ee" />

---

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [x] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

- `cargo make coverage` before and after

## Integration Instructions

- N/A