### PR TITLE
[x64] Do not issue `cli` if interrupt is not enabled

### DIFF
--- a/sdk/patina/src/serial/uart.rs
+++ b/sdk/patina/src/serial/uart.rs
@@ -32,26 +32,28 @@ cfg_if::cfg_if! {
         use uart_16550::MmioSerialPort;
         use uart_16550::SerialPort as IoSerialPort;
 
+        /// Returns the Current Privilege Level (CPL) from the CS selector.
+        fn current_privilege_level() -> u16 {
+            let cs: u16;
+            // SAFETY: Reading the CS register has no side effects.
+            unsafe { core::arch::asm!("mov {0:x}, cs", out(reg) cs, options(nostack, nomem)); }
+            cs & 0b11
+        }
+
         /// Runs `f` with CPU interrupts disabled, restoring the previous interrupt state afterward.
-        ///
-        /// If interrupts were already disabled on entry, this is a no-op around `f`: interrupts
-        /// are neither disabled nor re-enabled.
         fn without_interrupts<F, R>(f: F) -> R
         where
             F: FnOnce() -> R,
         {
             let flags: u64;
-            // SAFETY: Reading RFLAGS has no side effects.
+            // SAFETY: Reading RFLAGS and disabling interrupts around the closure is safe because we restore
+            // interrupts afterwards, but only if they were previously enabled.
             unsafe {
-                core::arch::asm!("pushfq; pop {0}", out(reg) flags, options(nomem));
-            }
-            let interrupts_enabled = flags & (1 << 9) != 0;
-            if interrupts_enabled {
-                // SAFETY: Disabling interrupts is safe; we restore them after the closure.
-                unsafe { core::arch::asm!("cli", options(nostack, nomem)); }
+                core::arch::asm!("pushfq; pop {0}; cli", out(reg) flags, options(nomem));
             }
             let result = f();
-            if interrupts_enabled {
+            // Restore interrupts only if they were previously enabled (IF bit).
+            if flags & (1 << 9) != 0 {
                 // SAFETY: Re-enabling interrupts that were enabled before.
                 unsafe { core::arch::asm!("sti", options(nostack, nomem)); }
             }
@@ -96,20 +98,32 @@ cfg_if::cfg_if! {
                     Uart16550::Io { base } => {
                         // SAFETY: The base address is provided during Uart16550 construction and is assumed to be valid for I/O port access.
                         let mut serial_port = unsafe { IoSerialPort::new(*base) };
-                        without_interrupts(|| {
+                        let mut send = || {
                             for b in buffer {
                                 serial_port.send(*b);
                             }
-                        });
+                        };
+                        if current_privilege_level() == 0 {
+                            // SAFETY: CPL is 0, so cli/sti are permitted.
+                            without_interrupts(send);
+                        } else {
+                            send();
+                        }
                     }
                     Uart16550::Mmio { base, reg_stride } => {
                         // SAFETY: The base address and stride are provided during Uart16550 construction and are assumed to be valid for MMIO access.
                         let mut serial_port = unsafe { MmioSerialPort::new_with_stride(*base, *reg_stride) };
-                        without_interrupts(|| {
+                        let mut send = || {
                             for b in buffer {
                                 serial_port.send(*b);
                             }
-                        });
+                        };
+                        if current_privilege_level() == 0 {
+                            // SAFETY: CPL is 0, so cli/sti are permitted.
+                            without_interrupts(send);
+                        } else {
+                            send();
+                        }
                     }
                 }
             }

--- a/sdk/patina/src/serial/uart.rs
+++ b/sdk/patina/src/serial/uart.rs
@@ -26,6 +26,7 @@ impl super::SerialIO for UartNull {
     }
 }
 
+
 cfg_if::cfg_if! {
     if #[cfg(all(target_arch = "x86_64", any(target_os = "uefi", feature = "doc")))] {
 
@@ -33,19 +34,25 @@ cfg_if::cfg_if! {
         use uart_16550::SerialPort as IoSerialPort;
 
         /// Runs `f` with CPU interrupts disabled, restoring the previous interrupt state afterward.
+        ///
+        /// If interrupts were already disabled on entry, this is a no-op around `f`: interrupts
+        /// are neither disabled nor re-enabled.
         fn without_interrupts<F, R>(f: F) -> R
         where
             F: FnOnce() -> R,
         {
             let flags: u64;
-            // SAFETY: Reading RFLAGS and disabling interrupts around the closure is safe because we restore
-            // interrupts afterwards, but only if they were previously enabled.
+            // SAFETY: Reading RFLAGS has no side effects.
             unsafe {
-                core::arch::asm!("pushfq; pop {0}; cli", out(reg) flags, options(nomem));
+                core::arch::asm!("pushfq; pop {0}", out(reg) flags, options(nomem));
+            }
+            let interrupts_enabled = flags & (1 << 9) != 0;
+            if interrupts_enabled {
+                // SAFETY: Disabling interrupts is safe; we restore them after the closure.
+                unsafe { core::arch::asm!("cli", options(nostack, nomem)); }
             }
             let result = f();
-            // Restore interrupts only if they were previously enabled (IF bit).
-            if flags & (1 << 9) != 0 {
+            if interrupts_enabled {
                 // SAFETY: Re-enabling interrupts that were enabled before.
                 unsafe { core::arch::asm!("sti", options(nostack, nomem)); }
             }

--- a/sdk/patina/src/serial/uart.rs
+++ b/sdk/patina/src/serial/uart.rs
@@ -104,7 +104,7 @@ cfg_if::cfg_if! {
                             }
                         };
                         if current_privilege_level() == 0 {
-                            // SAFETY: CPL is 0, so cli/sti are permitted.
+                            // CPL is 0, so cli/sti are permitted.
                             without_interrupts(send);
                         } else {
                             send();
@@ -119,7 +119,7 @@ cfg_if::cfg_if! {
                             }
                         };
                         if current_privilege_level() == 0 {
-                            // SAFETY: CPL is 0, so cli/sti are permitted.
+                            // CPL is 0, so cli/sti are permitted.
                             without_interrupts(send);
                         } else {
                             send();

--- a/sdk/patina/src/serial/uart.rs
+++ b/sdk/patina/src/serial/uart.rs
@@ -26,7 +26,6 @@ impl super::SerialIO for UartNull {
     }
 }
 
-
 cfg_if::cfg_if! {
     if #[cfg(all(target_arch = "x86_64", any(target_os = "uefi", feature = "doc")))] {
 


### PR DESCRIPTION
## Description

The module could be used in the user environment, and `cli` will cause #GP.

This change will check on the interrupt state and opt out the `cli` if it is already disabled.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

This was tested for building the uart module for ring 3 module and booted to OS desktop properly.

## Integration Instructions

N/A
