### PR TITLE
patina_dxe_core: Drop alloc_error_handler feature

### DIFF
--- a/patina_dxe_core/src/allocator.rs
+++ b/patina_dxe_core/src/allocator.rs
@@ -585,12 +585,6 @@ impl AllocatorMap {
     }
 }
 
-#[cfg(target_os = "uefi")]
-#[alloc_error_handler]
-fn alloc_error_handler(layout: alloc::alloc::Layout) -> ! {
-    panic!("allocation error: {:?}", layout)
-}
-
 extern "efiapi" fn allocate_pool(pool_type: efi::MemoryType, size: usize, buffer: *mut *mut c_void) -> efi::Status {
     if buffer.is_null() {
         return efi::Status::INVALID_PARAMETER;

--- a/patina_dxe_core/src/lib.rs
+++ b/patina_dxe_core/src/lib.rs
@@ -60,7 +60,6 @@
 //! SPDX-License-Identifier: Apache-2.0
 //!
 #![cfg_attr(all(not(feature = "std"), not(test)), no_std)]
-#![feature(alloc_error_handler)]
 #![feature(c_variadic)]
 #![feature(allocator_api)]
 #![feature(coverage_attribute)]


### PR DESCRIPTION
## Description

The unstable alloc_error_handler feature is no longer required as the default_alloc_error_handler is stabilized. Patina is not doing anything special in this case, just panicking, so drop the unstable feature.

Closes #807 

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Booting Q35 to shell.

## Integration Instructions

N/A.