### PR TITLE
patina_dxe_core: Fix test check for new goblin

### DIFF
--- a/patina_dxe_core/src/pi_dispatcher/image.rs
+++ b/patina_dxe_core/src/pi_dispatcher/image.rs
@@ -1803,9 +1803,9 @@ mod tests {
                 core::ptr::null_mut(),
                 Some(image.as_slice()),
             );
-            // Check for either load error or unsupported. On aarch64, goblin will report parse
-            // the resources as well and fail due to the invalidate directory table size and
-            // unsupported will be returned.
+            // Check for either load error or unsupported. On aarch64, goblin will parse
+            // the resources section as well and fail due to the invalidate directory table size,
+            // returning unsupported.
             assert!(matches!(
                 status,
                 Err(ImageStatus::LoadError(EfiError::LoadError)) | Err(ImageStatus::LoadError(EfiError::Unsupported))

--- a/patina_dxe_core/src/pi_dispatcher/image.rs
+++ b/patina_dxe_core/src/pi_dispatcher/image.rs
@@ -1804,7 +1804,7 @@ mod tests {
                 Some(image.as_slice()),
             );
             // Check for either load error or unsupported. On aarch64, goblin will parse
-            // the resources section as well and fail due to the invalidate directory table size,
+            // the resources section as well and fail due to the invalid directory table size,
             // returning unsupported.
             assert!(matches!(
                 status,

--- a/patina_dxe_core/src/pi_dispatcher/image.rs
+++ b/patina_dxe_core/src/pi_dispatcher/image.rs
@@ -1803,7 +1803,13 @@ mod tests {
                 core::ptr::null_mut(),
                 Some(image.as_slice()),
             );
-            assert!(matches!(status, Err(ImageStatus::LoadError(EfiError::LoadError))));
+            // Check for either load error or unsupported. On aarch64, goblin will report parse
+            // the resources as well and fail due to the invalidate directory table size and
+            // unsupported will be returned.
+            assert!(matches!(
+                status,
+                Err(ImageStatus::LoadError(EfiError::LoadError)) | Err(ImageStatus::LoadError(EfiError::Unsupported))
+            ));
         });
     }
 


### PR DESCRIPTION
## Description

The updated goblin added some internal checks for PE consistency that is failing for aarch64 with our test binary. This commit updates the check to allow for either the patina or the goblin failures to be accepted.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [x] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Local test execution

## Integration Instructions

N/A
