### PR TITLE
rust-toolchain: Update nightly toolchain (1.95.0) [Rebase & FF]

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,35 +173,9 @@ cargo make patina-test -p patina
 
 ## Rust Version Updates
 
-Rust is released on a regular six week cadence. The Rust project maintains a site with
-[dates for upcoming releases](https://forge.rust-lang.org/). While there is no hard requirement to update the Rust
-version used by Patina in a given timeframe, it is recommended to do so at least once per quarter. Updates to the
-latest stable version should not happen immediately after the stable version release as Patina consumers may need time
-to update their internal toolchains to migrate to the latest stable version.
-
-A pull request that updates the Rust version should always be created against the `main` branch. The pull request should
-include the `OpenDevicePartnership/patina-contributors` team as reviewers and remain open for at least three full
-business days to ensure that stakeholders have an opportunity to review and provide feedback.
-
-### Updating the Minimum Supported Rust Version
-
-The Rust toolchain used in this repo is specified in `rust-toolchain.toml`. The minimum supported Rust version for the
-crates in the workspace is specified in the `rust-version` field of each crate's `Cargo.toml` file. When updating the
-Rust toolchain version, the minimum supported Rust version should be evaluated to determine if it also needs to be
-updated.
-
-A non-exhaustive list of reasons the minimum version might need to change includes:
-
-1. An unstable feature has been stabilized and the corresponding `#![feature(...)]` has been removed
-2. A feature introduced in the release is immediately being used in the repository
-
-> Note: If the minimum supported Rust version does need to change, please add a comment explaining wny. Note that
-> formatting and linting changes to satisfy tools like rustfmt or clippy do not alone necessitate a minimum Rust
-> version change.
-
-A quick way to check if the minimum supported Rust version needs to change is to keep the changes made for the new
-release in your workspace and then revert the Rust toolchain to the previous version. If the project fails to build,
-then the minimum supported Rust version needs to be updated.
+Patina has a defined process that must be followed when updating the Rust or toolchain version used in the project. This
+sets clear expectations for developers and consumers. The update process can be found in the [Rust Version Update Process](https://opendevicepartnership.github.io/patina/dev/rust_version_update_process.html)
+page in the mdbook. If you are updating the toolchain version, you must follow that process.
 
 ## Coverage
 

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -40,6 +40,7 @@
 - [Process for Unstable Features](dev/unstable.md)
 - [RFC Lifecycle](rfc_lifecycle.md)
 - [RFC Template](rfc/template.md)
+- [Rust and Toolchain Version Update Process](dev/rust_version_update_process.md)
 - [Testing](dev/testing.md)
   - [Integration Testing](dev/testing/integration.md)
   - [Mocking](dev/testing/mock.md)

--- a/docs/src/dev/rust_version_update_process.md
+++ b/docs/src/dev/rust_version_update_process.md
@@ -1,0 +1,64 @@
+# Patina Rust and Toolchain Version Update Process
+
+```admonish tip title="TL;DR"
+- **Cadence:** Update at least once per quarter. Do not jump to a new stable release the day it ships.
+- **Toolchain are specified in:** `rust-toolchain.toml` (nightly channel) and the `rust-version` field in each crate's `Cargo.toml`.
+- **Nightly selection:** Use the "Branched from master" date for the target stable release from [releases.rs](https://releases.rs/).
+- **Review:** Open the PR against `main`, add the `OpenDevicePartnership/patina-contributors` team, and leave it open for at least three full business days.
+```
+
+Rust is released on a regular six week cadence. The Rust project maintains a site with
+[dates for upcoming releases](https://forge.rust-lang.org/). While there is no hard requirement to update the Rust
+version used by Patina in a given timeframe, it is recommended to do so at least once per quarter. Updates to the
+latest stable version should not happen immediately after the stable version release as Patina consumers may need time
+to update their internal toolchains to migrate to the latest stable version.
+
+A pull request that updates the Rust version should always be created against the `main` branch. The pull request should
+include the `OpenDevicePartnership/patina-contributors` team as reviewers and remain open for at least three full
+business days to ensure that stakeholders have an opportunity to review and provide feedback.
+
+## Updating the Minimum Supported Rust Version
+
+The Rust toolchain used in this repo is specified in `rust-toolchain.toml`. The minimum supported Rust version for the
+crates in the workspace is specified in the `rust-version` field of each crate's `Cargo.toml` file. When updating the
+Rust toolchain version, the minimum supported Rust version should be evaluated to determine if it also needs to be
+updated.
+
+A non-exhaustive list of reasons the minimum version might need to change includes:
+
+1. An unstable feature has been stabilized and the corresponding `#![feature(...)]` has been removed
+2. A feature introduced in the release is immediately being used in the repository
+
+```admonish note
+If the minimum supported Rust version does need to change, please add a comment explaining why. Note that
+formatting and linting changes to satisfy tools like rustfmt or clippy do not alone necessitate a minimum Rust
+version change.
+```
+
+A quick way to check if the minimum supported Rust version needs to change is to keep the changes made for the new
+release in your workspace and then revert the Rust toolchain to the previous version. If the project fails to build,
+then the minimum supported Rust version needs to be updated.
+
+## Choosing a Nightly Version
+
+Patina currently builds against nightly Rust since the project depends on a small number of unstable features. Unless
+there is a compelling reason to update the nightly version, it is recommended to continue using the same nightly version
+until the next stable release. The project typically takes the nightly version listed as the "Branched from master" date
+for the release on [releases.rs](https://releases.rs/). For example, the [1.97.0](https://releases.rs/docs/1.97.0/)
+release has a "branched from master on" date of "22 May, 2026".
+
+````admonish tip
+If you need to find the commit that the stable release was branched from, you can use `git` to find the commit hash
+working within the <https://github.com/rust-lang/rust> repository. For example, `git merge-base main 1.95.0` returns
+`67aec36df76a7b67b71a8ee47684467e16f1847e`. `git show 67aec36df76a7b67b71a8ee47684467e16f1847e` returns:
+
+```text
+commit 67aec36df76a7b67b71a8ee47684467e16f1847e
+Merge: 3a70d0349fa 70da8044517
+Author: bors <bors@rust-lang.org>
+Date:   Fri Feb 27 22:04:20 2026 +0000
+```
+
+[releases.rs - 1.95.0](https://releases.rs/docs/1.95.0/) also lists the "Branched from master on" date as
+"27 Feb, 2026".
+````

--- a/patina_dxe_core/src/allocator.rs
+++ b/patina_dxe_core/src/allocator.rs
@@ -708,10 +708,8 @@ pub fn core_allocate_pages(
     // If the memory type is runtime services code or data, we need to install the memory attributes table to reflect
     // the update. The MAT logic will decide if it is a proper time to install the MAT or not.
     match memory_type {
-        efi::RUNTIME_SERVICES_CODE | efi::RUNTIME_SERVICES_DATA => {
-            if res.is_ok() {
-                MemoryAttributesTable::install();
-            }
+        efi::RUNTIME_SERVICES_CODE | efi::RUNTIME_SERVICES_DATA if res.is_ok() => {
+            MemoryAttributesTable::install();
         }
         _ => {}
     }
@@ -777,10 +775,8 @@ pub fn core_free_pages(memory: efi::PhysicalAddress, pages: usize) -> Result<(),
     // If the memory type is runtime services code or data, we need to install the memory attributes table to reflect
     // the update. The MAT logic will decide if it is a proper time to install the MAT or not.
     match memory_type {
-        efi::RUNTIME_SERVICES_CODE | efi::RUNTIME_SERVICES_DATA => {
-            if res.is_ok() {
-                MemoryAttributesTable::install();
-            }
+        efi::RUNTIME_SERVICES_CODE | efi::RUNTIME_SERVICES_DATA if res.is_ok() => {
+            MemoryAttributesTable::install();
         }
         _ => {}
     }

--- a/patina_dxe_core/src/allocator/fixed_size_block_allocator.rs
+++ b/patina_dxe_core/src/allocator/fixed_size_block_allocator.rs
@@ -969,7 +969,7 @@ mod tests {
                 let ranges: Vec<_> = fsb.get_memory_ranges().collect();
                 assert_eq!(ranges.len(), 1);
 
-                let expected_start = allocated_address as usize + size_of::<AllocatorListNode>();
+                let expected_start = allocated_address + size_of::<AllocatorListNode>();
                 let expected_end = expected_start + allocation_size - size_of::<AllocatorListNode>();
                 assert_eq!(ranges[0], expected_start..expected_end);
             });

--- a/patina_dxe_core/src/protocol_db.rs
+++ b/patina_dxe_core/src/protocol_db.rs
@@ -214,7 +214,7 @@ impl ProtocolDb {
 
     fn registered_protocols(&self) -> Vec<efi::Guid> {
         let protocols: BTreeSet<efi::Guid> =
-            self.handles.iter().flat_map(|(_, handle)| handle.keys().map(|&OrdGuid(guid)| guid)).collect();
+            self.handles.values().flat_map(|handle| handle.keys().map(|&OrdGuid(guid)| guid)).collect();
         protocols.into_iter().collect()
     }
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -5,7 +5,7 @@
 # - File Sync Settings: https://github.com/OpenDevicePartnership/patina-devops/blob/main/.sync/Files.yml
 
 [toolchain]
-channel = "nightly-2026-02-13" # One day post 1.93.1
+channel = "nightly-2026-02-27" # Nightly with the shared merge base to the 1.95.0 stable tag
 targets = ["x86_64-unknown-uefi", "aarch64-unknown-uefi"]
 components = ["rust-src", "clippy", "rustfmt", "rust-docs"]
 

--- a/sdk/patina_ffs/src/volume.rs
+++ b/sdk/patina_ffs/src/volume.rs
@@ -1457,7 +1457,7 @@ mod test {
 
         assert_eq!(org_files.len(), round_trip_files.len());
 
-        for (org_file, round_trip_file) in Iterator::zip(org_files.into_iter(), round_trip_files.into_iter()) {
+        for (org_file, round_trip_file) in Iterator::zip(org_files.into_iter(), round_trip_files) {
             let org_file = org_file.map_err(stringify)?;
             let round_trip_file = round_trip_file.map_err(stringify)?;
             assert_eq!(org_file.name(), round_trip_file.name());


### PR DESCRIPTION
## Description

Closes #1519

The previous nightly toolchain was from 2026-02-13, which had partial support for some of the changes that ended up in Rust 1.95.0. This updates the toolchain to the same day the 1.95.0 stable tag was created.

Also fixes clippy issues reported after the update.

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [x] Includes documentation?

## How This Was Tested

- `cargo make all` with the updated toolchain

## Integration Instructions

- N/A