### PR TITLE
component: Normalize core::any::type_name output (1.89.0 MSRV compat)

### DIFF
--- a/sdk/patina/src/component.rs
+++ b/sdk/patina/src/component.rs
@@ -142,6 +142,7 @@ pub mod params;
 pub mod service;
 mod storage;
 mod struct_component;
+mod type_name;
 
 use crate::error::Result;
 

--- a/sdk/patina/src/component/hob.rs
+++ b/sdk/patina/src/component/hob.rs
@@ -271,7 +271,7 @@ impl<'h, T: FromHob + 'static> Iterator for HobIter<'h, T> {
             return Some(
                 any_box
                     .downcast_ref::<T>()
-                    .unwrap_or_else(|| panic!("Hob should be of type {}", core::any::type_name::<T>())),
+                    .unwrap_or_else(|| panic!("Hob should be of type {}", super::type_name::normalized::<T>())),
             );
         }
         None

--- a/sdk/patina/src/component/metadata.rs
+++ b/sdk/patina/src/component/metadata.rs
@@ -28,7 +28,7 @@ pub struct MetaData {
 impl MetaData {
     /// Creates a new metadata object for a component.
     pub fn new<S>() -> Self {
-        Self { access: Access::new(), name: Cow::from(core::any::type_name::<S>()), error_message: None }
+        Self { access: Access::new(), name: Cow::from(super::type_name::normalized::<S>()), error_message: None }
     }
 
     /// Returns the name of the component, including the module path.

--- a/sdk/patina/src/component/params.rs
+++ b/sdk/patina/src/component/params.rs
@@ -154,7 +154,7 @@ pub unsafe trait Param {
         if Self::validate(state, storage) {
             Ok(())
         } else {
-            Err(Cow::from(alloc::format!("{} not available.", core::any::type_name::<Self>())))
+            Err(Cow::from(alloc::format!("{} not available.", super::type_name::normalized::<Self>())))
         }
     }
 
@@ -393,7 +393,9 @@ impl<T: Default + 'static> Deref for Config<'_, T> {
     type Target = T;
 
     fn deref(&self) -> &Self::Target {
-        self.value.downcast_ref().unwrap_or_else(|| panic!("Config should be of type {}", core::any::type_name::<T>()))
+        self.value
+            .downcast_ref()
+            .unwrap_or_else(|| panic!("Config should be of type {}", super::type_name::normalized::<T>()))
     }
 }
 
@@ -431,14 +433,14 @@ unsafe impl<T: Default + 'static> Param for Config<'_, T> {
         if meta.access().has_writes_all_configs() {
             return Err(Cow::from(alloc::format!(
                 "Config<{}> conflicts with a previous &mut Storage access.",
-                core::any::type_name::<T>()
+                super::type_name::normalized::<T>()
             )));
         }
 
         if meta.access().has_config_write(id) {
             return Err(Cow::from(alloc::format!(
                 "Config<{0}> conflicts with a previous ConfigMut<{0}> access.",
-                core::any::type_name::<T>()
+                super::type_name::normalized::<T>()
             )));
         }
 
@@ -492,13 +494,17 @@ impl<T: Default + 'static> Deref for ConfigMut<'_, T> {
     type Target = T;
 
     fn deref(&self) -> &Self::Target {
-        self.value.downcast_ref().unwrap_or_else(|| panic!("Config should be of type {}", core::any::type_name::<T>()))
+        self.value
+            .downcast_ref()
+            .unwrap_or_else(|| panic!("Config should be of type {}", super::type_name::normalized::<T>()))
     }
 }
 
 impl<T: Default + 'static> DerefMut for ConfigMut<'_, T> {
     fn deref_mut(&mut self) -> &mut T {
-        self.value.downcast_mut().unwrap_or_else(|| panic!("Config should be of type {}", core::any::type_name::<T>()))
+        self.value
+            .downcast_mut()
+            .unwrap_or_else(|| panic!("Config should be of type {}", super::type_name::normalized::<T>()))
     }
 }
 
@@ -539,28 +545,28 @@ unsafe impl<T: Default + 'static> Param for ConfigMut<'_, T> {
         if meta.access().has_writes_all_configs() {
             return Err(Cow::from(alloc::format!(
                 "ConfigMut<{}> conflicts with a previous &mut Storage access.",
-                core::any::type_name::<T>()
+                super::type_name::normalized::<T>()
             )));
         }
 
         if meta.access().has_reads_all_configs() {
             return Err(Cow::from(alloc::format!(
                 "ConfigMut<{}> conflicts with a previous &Storage access.",
-                core::any::type_name::<T>()
+                super::type_name::normalized::<T>()
             )));
         }
 
         if meta.access().has_config_write(id) {
             return Err(Cow::from(alloc::format!(
                 "ConfigMut<{0}> conflicts with a previous ConfigMut<{0}> access.",
-                core::any::type_name::<T>()
+                super::type_name::normalized::<T>()
             )));
         }
 
         if meta.access().has_config_read(id) {
             return Err(Cow::from(alloc::format!(
                 "ConfigMut<{0}> conflicts with a previous Config<{0}> access.",
-                core::any::type_name::<T>()
+                super::type_name::normalized::<T>()
             )));
         }
 
@@ -815,7 +821,7 @@ macro_rules! impl_component_param_tuple {
                 let ($($param,)*) = state;
                 $(
                     if !$param::validate($param, _storage) {
-                        return Err(Cow::from(core::any::type_name::<$param>()));
+                        return Err(Cow::from(super::type_name::normalized::<$param>()));
                     }
                 )*
                 Ok(())
@@ -921,7 +927,7 @@ mod tests {
         // Trying to access it with config, validation should fail because it is unlocked.
         assert!(
             Config::<i32>::try_validate(&id, (&storage).into())
-                .is_err_and(|err| err == "patina::component::params::Config<'_, i32> not available.")
+                .is_err_and(|err| err == "patina::component::params::Config<i32> not available.")
         );
     }
 
@@ -935,7 +941,7 @@ mod tests {
 
         assert!(
             ConfigMut::<i32>::try_validate(&id, (&storage).into())
-                .is_err_and(|err| err == "patina::component::params::ConfigMut<'_, i32> not available.")
+                .is_err_and(|err| err == "patina::component::params::ConfigMut<i32> not available.")
         );
     }
 

--- a/sdk/patina/src/component/service.rs
+++ b/sdk/patina/src/component/service.rs
@@ -362,7 +362,7 @@ impl<T: ?Sized + 'static> Deref for Service<T> {
                 // infrastructure evolves and the number of components increases.
                 unreachable!(
                     "Service downcast failed — this indicates a type mismatch in Service<{}> construction",
-                    core::any::type_name::<T>()
+                    super::type_name::normalized::<T>()
                 )
             }
         } else {

--- a/sdk/patina/src/component/struct_component.rs
+++ b/sdk/patina/src/component/struct_component.rs
@@ -87,7 +87,7 @@ where
         debug_assert!(
             self.input.is_some(),
             "{} `input` is `None` during run. Did this component already run?",
-            core::any::type_name::<Self>()
+            super::type_name::normalized::<Self>()
         );
         log::info!("Dispatching {}", self.metadata.name());
         self.func.run(&mut self.input, param_value).map(|_| true)
@@ -203,7 +203,7 @@ mod tests {
         assert!(test_struct.run(&mut storage).is_ok_and(|res| !res));
         assert_eq!(
             test_struct.metadata().error_message(),
-            Some(Cow::from("patina::component::params::ConfigMut<'_, u32>"))
+            Some(Cow::from("patina::component::params::ConfigMut<u32>"))
         );
 
         let mut test_struct = TestStructFail { x: 5 }.into_component();

--- a/sdk/patina/src/component/type_name.rs
+++ b/sdk/patina/src/component/type_name.rs
@@ -1,0 +1,61 @@
+//! Toolchain-stable rendering of [`core::any::type_name`] output.
+//!
+//! The exact string produced by [`core::any::type_name`] is documented as a
+//! best-effort description that may change between compiler versions. In
+//! particular, the formatter's handling of anonymous lifetime parameters
+//! (e.g. `SomeType<'_, T>` vs. `SomeType<T>`) has varied across rustc releases. The
+//! helpers in this module normalize the rendering so component diagnostics
+//! (and the tests that assert against them) compare equal regardless of which
+//! toolchain produced them.
+//!
+//! ## License
+//!
+//! Copyright (c) Microsoft Corporation.
+//!
+//! SPDX-License-Identifier: Apache-2.0
+
+use alloc::string::String;
+
+/// Returns the [`core::any::type_name`] of `T` with anonymous lifetime
+/// parameters elided so the result is stable across rustc versions.
+pub(crate) fn normalized<T: ?Sized>() -> String {
+    normalize(core::any::type_name::<T>())
+}
+
+/// Removes anonymous lifetime tokens (`'_`) from a type-name string produced
+/// by [`core::any::type_name`].
+///
+/// Handles the two forms the standard library has been observed to emit:
+///   - `SomeType<'_, T>` -> `SomeType<T>`
+///   - `SomeType<'_>`    -> `SomeType`
+pub(crate) fn normalize(name: &str) -> String {
+    name.replace("<'_, ", "<").replace("<'_>", "")
+}
+
+#[cfg(test)]
+#[coverage(off)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_normalize_strips_leading_anonymous_lifetime() {
+        assert_eq!(normalize("SomeType<'_, u32>"), "SomeType<u32>");
+    }
+
+    #[test]
+    fn test_normalize_strips_sole_anonymous_lifetime() {
+        assert_eq!(normalize("SomeType<'_>"), "SomeType");
+    }
+
+    #[test]
+    fn test_normalize_is_noop_when_no_anonymous_lifetime_present() {
+        assert_eq!(normalize("SomeType<u32>"), "SomeType<u32>");
+        assert_eq!(normalize("path::to::AType"), "path::to::AType");
+    }
+
+    #[test]
+    fn test_normalize_handles_nested_anonymous_lifetimes() {
+        assert_eq!(normalize("Outer<Inner<'_, u8>, '_>"), "Outer<Inner<u8>, '_>");
+        assert_eq!(normalize("Wrap<SomeType<'_>>"), "Wrap<SomeType>");
+    }
+}


### PR DESCRIPTION
## Description

Resolves #1530 

The strings emitted by `core::any::type_name::<T>()` are explicitly best-effort and documented to vary between rustc releases. Per the official documentation:

  > This is intended for diagnostic use. The exact contents and format
  > of the string returned are not specified, other than being
  > best-effort description of the type. For example, amongst the
  > strings that type_name::<Option<String>>() might return are
  > "Option<String>" and "std::option::Option<std::string::String>".

  > The returned string must not be considered to be a unique
  > identifier of a type as multiple types may map to the same type
  > name. Similarly, there is no guarantee that all parts of a type
  > will appear in the returned string. In addition, the output may
  > change between versions of the compiler. For example, lifetime
  > specifiers were omitted in some earlier versions.

  > The current implementation uses the same infrastructure as
  > compiler diagnostics and debuginfo, but this is not guaranteed.

  https://doc.rust-lang.org/beta/core/any/fn.type_name.html

The component infrastructure embeds those strings directly in user-visible diagnostics (error messages, panic payloads, `MetaData::name`) and a handful of unit tests assert against their exact form. These unit tests currently fail on the MSRV 1.89.0 (which means consumers on 1.89.0) also see different strings.

For example, recent/current toolchains render lifetime-parameterized generics as `Config<'_, u32>` while older ones render the same type as `Config<u32>`, and three tests in `component::params` and `component::struct_component` hardcode the more recent rendered form.

This change introduces a small internal helper, `component::type_name`, that wraps `core::any::type_name` and strips anonymous lifetime tokens before returning the string.

This stabilizes user-visible diagnostics, which always read `Config<T>` regardless of which toolchain compiled the build.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [x] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

- 1.89.0 equivalent:
  - `cargo +nightly-2025-06-23 test -p patina`
- Current (1.93.1):
  - `cargo test -p patina`

## Integration Instructions

- N/A