### PR TITLE
[REBASE & FF] Run Clippy/Check on UEFI Target Triples

### DIFF
--- a/core/patina_internal_cpu/src/interrupts/x64/idt.rs
+++ b/core/patina_internal_cpu/src/interrupts/x64/idt.rs
@@ -93,7 +93,7 @@ pub fn initialize_idt() {
     }
     #[cfg(target_os = "uefi")]
     {
-        let idtr = Idtr { limit: (core::mem::size_of::<Idt>() - 1) as u16, base: IDT.0.get() as *mut Idt as u64 };
+        let idtr = Idtr { limit: (core::mem::size_of::<Idt>() - 1) as u16, base: IDT.0.get() as u64 };
         // SAFETY: Loading our fully initialized IDT.
         unsafe { core::arch::asm!("lidt [{}]", in(reg) &idtr, options(nostack)) };
     }

--- a/core/patina_stacktrace/src/stacktrace.rs
+++ b/core/patina_stacktrace/src/stacktrace.rs
@@ -269,6 +269,7 @@ impl StackTrace {
                     // layout is as follows: [fp] [lr] are saved on the stack in
                     // that order, typically via stp x29, x30, [sp, #-16]!
                     let prev_pc = unsafe { read_pointer64(fp + 8)? }; // deref lr
+                    // SAFETY: See preceding safety comment — reading the saved fp from the same stack frame.
                     let prev_fp = unsafe { read_pointer64(fp)? };
                     log::warn!("     {i:>2} {:016X}      {:016X}       {image_name}+{pc_rva:X}", fp, prev_pc);
 

--- a/docs/src/background/rust_tools.md
+++ b/docs/src/background/rust_tools.md
@@ -25,6 +25,14 @@ The table below shows the comprehensive tool suite used in Patina compared to tr
 | **Test Coverage** | `cargo-llvm-cov` | gcov, OpenCppCoverage | Integrated coverage collection |
 | **Undefined Behavior Analysis** | `cargo miri` | Valgrind, UBSan | Catches memory safety issues in unsafe code |
 
+## Definitions
+
+CI Features: The set of all features in a crate that should be tested in CI against a `no_std` build. This only omits
+the features that require `std`.
+
+Default Features: The features for a given crate that are in the `default` feature, i.e. the features that are enabled
+by default when building a crate.
+
 ## The cargo Ecosystem: Central Command Hub
 
 ### Tooling Strategy
@@ -460,6 +468,38 @@ words:
 - [CSpell Configuration](https://cspell.org/docs/getting-started)
 - [Patina Configuration](https://github.com/OpenDevicePartnership/patina/blob/main/cspell.yml)
 
+### cargo-check (Fast Compilation Without Code Generation)
+
+**Purpose**: Fast build checking, use by Rust Analyzer to aid in development
+
+**Value**:
+
+- **Compiler Integration**: Leverages Rust's compiler infrastructure to do a quick build check
+- **Rust Analyzer Integration**: Allows a quick dev inner loop with Rust Analyzer reporting results in near real time
+
+**Comparison to C Development**:
+
+Code is written and later built fully to test, harder to have near real time results as code
+is being written.
+
+**Coverage in Patina**:
+
+Patina runs check against the UEFI targets and test code. `std` is not done separately from
+tests because this is a small set of Patina code and is expected to be built with the normal
+build commands. The `--all-features` parameter can only be used for `std/tests` because it pulls in
+std which conflicts with the `no_std` build. As such, the ci_features are tested for the
+`no_std` builds to test all features that do not require `std`.
+
+|                    | aarch64-unknown-uefi | x86_64-unknown-uefi | std | test |
+|:------------------:|:--------------------:|:-------------------:|:---:|:----:|
+| All Features       |                      |                     |     |  X   |
+| CI Features        |          X           |          X          |     |  X   |
+| No Default Features|                      |                     |  X  |  X   |
+
+**Further Documentation**:
+
+- [cargo-check docs](https://doc.rust-lang.org/cargo/commands/cargo-check.html)
+
 ### clippy (Static Analysis and Linting)
 
 **Purpose**: Advanced static analysis tool that catches bugs, performance issues, and style problems beyond what the
@@ -512,14 +552,17 @@ warning: this loop could be written as a `for` loop
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#while_let_loop
 ```
 
-**Configuration in Patina**:
+**Coverage in Patina**:
 
-```toml
-# Makefile.toml clippy configuration
-[tasks.clippy]
-command = "cargo"
-args = ["clippy", "--all-targets", "--all-features", "--", "-D", "warnings"]
-```
+Patina runs clippy against the UEFI targets and std (primarily for tests).
+The `--all-features` parameter can only be used for std/tests because it pulls in
+std which conflicts with the no-std build. As such, the ci_features are tested for the
+no_std builds to test all features that do not require std.
+
+|              | aarch64-unknown-uefi | x86_64-unknown-uefi | std | test |
+|:------------:|:--------------------:|:-------------------:|:---:|:----:|
+| All Features |                      |                     |  X  |  X   |
+| CI Features  |          X           |          X          |  X  |  X   |
 
 **Further Documentation**:
 

--- a/patina_dxe_core/src/cpu/hw_interrupt_protocol.rs
+++ b/patina_dxe_core/src/cpu/hw_interrupt_protocol.rs
@@ -1,5 +1,5 @@
 use crate::tpl_mutex::TplMutex;
-use alloc::{boxed::Box, format, vec, vec::Vec};
+use alloc::{boxed::Box, vec, vec::Vec};
 use patina_internal_cpu::interrupts::{
     ExceptionContext, InterruptHandler, InterruptManager, gic_manager::AArch64InterruptInitializer,
 };
@@ -165,6 +165,7 @@ impl<'a> EfiHardwareInterruptProtocol<'a> {
     }
 }
 
+// SAFETY: The struct is repr(C) and the PROTOCOL_GUID correctly identifies the protocol.
 unsafe impl ProtocolInterface for EfiHardwareInterruptProtocol<'_> {
     const PROTOCOL_GUID: BinaryGuid = HARDWARE_INTERRUPT_PROTOCOL;
 }
@@ -357,6 +358,7 @@ impl<'a> EfiHardwareInterruptV2Protocol<'a> {
     }
 }
 
+// SAFETY: The struct is repr(C) and the PROTOCOL_GUID correctly identifies the protocol.
 unsafe impl ProtocolInterface for EfiHardwareInterruptV2Protocol<'_> {
     const PROTOCOL_GUID: BinaryGuid = HARDWARE_INTERRUPT_PROTOCOL_V2;
 }
@@ -399,7 +401,7 @@ impl InterruptHandler for HwInterruptProtocolHandler {
 
         if raw_value >= self.handlers.len() as u32 {
             match raw_value {
-                1021 | 1022 | 1023 => {
+                1021..=1023 => {
                     // The special interrupt do not need to be acknowledged
                 }
                 _ => {
@@ -411,7 +413,7 @@ impl InterruptHandler for HwInterruptProtocolHandler {
 
         let rw_handler = self.handlers[raw_value as usize]
             .try_read()
-            .expect(&format!("Failed to read lock in exception handler for interrupt ID 0x{:x}", raw_value));
+            .unwrap_or_else(|| panic!("Failed to read lock in exception handler for interrupt ID 0x{:x}", raw_value));
 
         if let Some(handler) = *rw_handler {
             handler(raw_value as u64, context);
@@ -456,14 +458,14 @@ impl HwInterruptProtocolHandler {
             }
 
             // Interrupt disabled, now remove the handler
-            if let Some(mut rw_handler) = self.handlers[interrupt_source as usize].try_write() {
+            if let Some(mut rw_handler) = self.handlers[interrupt_source].try_write() {
                 *rw_handler = None;
             } else {
                 return efi::Status::DEVICE_ERROR;
             }
         } else {
             // Register the interrupt handler
-            if let Some(mut rw_handler) = self.handlers[interrupt_source as usize].try_write() {
+            if let Some(mut rw_handler) = self.handlers[interrupt_source].try_write() {
                 *rw_handler = handler;
             } else {
                 return efi::Status::DEVICE_ERROR;

--- a/patina_dxe_core/src/gcd/spin_locked_gcd.rs
+++ b/patina_dxe_core/src/gcd/spin_locked_gcd.rs
@@ -564,7 +564,7 @@ impl GCD {
         log::trace!(target: "allocations", "[{}]   Memory Type: {:?}", function!(), memory_type);
         log::trace!(target: "allocations", "[{}]   Alignment: {:#x}", function!(), alignment);
         log::trace!(target: "allocations", "[{}]   Image Handle: {:#x?}", function!(), image_handle);
-        log::trace!(target: "allocations", "[{}]   Device Handle: {:#x?}\n", function!(), device_handle.unwrap_or(ptr::null_mut()));
+        log::trace!(target: "allocations", "[{}]   Device Handle: {:#x?}\n", function!(), device_handle.unwrap_or_default());
 
         match allocate_type {
             AllocateType::BottomUp(max_address) => gcd.allocate_bottom_up(
@@ -702,7 +702,7 @@ impl GCD {
         log::trace!(target: "allocations", "[{}]   Length: {:#x}", function!(), len);
         log::trace!(target: "allocations", "[{}]   Align Shift: {:#x}", function!(), align_shift);
         log::trace!(target: "allocations", "[{}]   Image Handle: {:#x?}", function!(), image_handle);
-        log::trace!(target: "allocations", "[{}]   Device Handle: {:#x?}\n", function!(), device_handle.unwrap_or(ptr::null_mut()));
+        log::trace!(target: "allocations", "[{}]   Device Handle: {:#x?}\n", function!(), device_handle.unwrap_or_default());
 
         let memory_blocks = &mut self.memory_blocks;
         let alignment = 1 << align_shift;
@@ -788,7 +788,7 @@ impl GCD {
         log::trace!(target: "allocations", "[{}]   Length: {:#x}", function!(), len);
         log::trace!(target: "allocations", "[{}]   Align Shift: {:#x}", function!(), align_shift);
         log::trace!(target: "allocations", "[{}]   Image Handle: {:#x?}", function!(), image_handle);
-        log::trace!(target: "allocations", "[{}]   Device Handle: {:#x?}\n", function!(), device_handle.unwrap_or(ptr::null_mut()));
+        log::trace!(target: "allocations", "[{}]   Device Handle: {:#x?}\n", function!(), device_handle.unwrap_or_default());
 
         let memory_blocks = &mut self.memory_blocks;
 
@@ -860,7 +860,7 @@ impl GCD {
         log::trace!(target: "allocations", "[{}]   Memory Type: {:?}", function!(), memory_type);
         log::trace!(target: "allocations", "[{}]   Align Shift: {:#x}", function!(), align_shift);
         log::trace!(target: "allocations", "[{}]   Image Handle: {:#x?}", function!(), image_handle);
-        log::trace!(target: "allocations", "[{}]   Device Handle: {:#x?}\n", function!(), device_handle.unwrap_or(ptr::null_mut()));
+        log::trace!(target: "allocations", "[{}]   Device Handle: {:#x?}\n", function!(), device_handle.unwrap_or_default());
 
         // allocate_address allows allocating page 0. This is needed to let Patina DXE Core allocate it for null
         // pointer detection very early in the boot process. Any future allocate at address will fail because it is
@@ -1558,7 +1558,7 @@ impl IoGCD {
         log::trace!(target: "allocations", "[{}]   IO Type: {:?}", function!(), io_type);
         log::trace!(target: "allocations", "[{}]   Alignment: {:#x}", function!(), alignment);
         log::trace!(target: "allocations", "[{}]   Image Handle: {:#x?}", function!(), image_handle);
-        log::trace!(target: "allocations", "[{}]   Device Handle: {:#x?}\n", function!(), device_handle.unwrap_or(ptr::null_mut()));
+        log::trace!(target: "allocations", "[{}]   Device Handle: {:#x?}\n", function!(), device_handle.unwrap_or_default());
 
         match allocate_type {
             AllocateType::BottomUp(max_address) => self.allocate_bottom_up(
@@ -1600,7 +1600,7 @@ impl IoGCD {
         log::trace!(target: "allocations", "[{}]   Length: {:#x}", function!(), len);
         log::trace!(target: "allocations", "[{}]   Alignment: {:#x}", function!(), alignment);
         log::trace!(target: "allocations", "[{}]   Image Handle: {:#x?}", function!(), image_handle);
-        log::trace!(target: "allocations", "[{}]   Device Handle: {:#x?}\n", function!(), device_handle.unwrap_or(ptr::null_mut()));
+        log::trace!(target: "allocations", "[{}]   Device Handle: {:#x?}\n", function!(), device_handle.unwrap_or_default());
 
         if self.io_blocks.capacity() == 0 {
             self.init_io_blocks()?;
@@ -1662,7 +1662,7 @@ impl IoGCD {
         log::trace!(target: "allocations", "[{}]   Length: {:#x}", function!(), len);
         log::trace!(target: "allocations", "[{}]   Align Shift: {:#x}", function!(), align_shift);
         log::trace!(target: "allocations", "[{}]   Image Handle: {:#x?}", function!(), image_handle);
-        log::trace!(target: "allocations", "[{}]   Device Handle: {:#x?}\n", function!(), device_handle.unwrap_or(ptr::null_mut()));
+        log::trace!(target: "allocations", "[{}]   Device Handle: {:#x?}\n", function!(), device_handle.unwrap_or_default());
 
         if self.io_blocks.capacity() == 0 {
             self.init_io_blocks()?;
@@ -1731,7 +1731,7 @@ impl IoGCD {
         log::trace!(target: "allocations", "[{}]   IO Type: {:?}", function!(), io_type);
         log::trace!(target: "allocations", "[{}]   Alignment: {:#x}", function!(), alignment);
         log::trace!(target: "allocations", "[{}]   Image Handle: {:#x?}", function!(), image_handle);
-        log::trace!(target: "allocations", "[{}]   Device Handle: {:#x?}\n", function!(), device_handle.unwrap_or(ptr::null_mut()));
+        log::trace!(target: "allocations", "[{}]   Device Handle: {:#x?}\n", function!(), device_handle.unwrap_or_default());
 
         if self.io_blocks.capacity() == 0 {
             self.init_io_blocks()?;

--- a/patina_dxe_core/src/pi_dispatcher.rs
+++ b/patina_dxe_core/src/pi_dispatcher.rs
@@ -638,8 +638,7 @@ impl DispatcherContext {
 
                 let fv_device_path =
                     PROTOCOL_DB.get_interface_for_handle(handle, efi::protocols::device_path::PROTOCOL_GUID);
-                let fv_device_path =
-                    fv_device_path.unwrap_or(core::ptr::null_mut()) as *mut efi::protocols::device_path::Protocol;
+                let fv_device_path = fv_device_path.unwrap_or_default() as *mut efi::protocols::device_path::Protocol;
 
                 // SAFETY: this code assumes that the fv_address from FVB protocol yields a pointer to a real FV,
                 // and that the memory backing the FVB is essentially permanent while the dispatcher is running (i.e.

--- a/patina_dxe_core/src/pi_dispatcher/fv.rs
+++ b/patina_dxe_core/src/pi_dispatcher/fv.rs
@@ -301,7 +301,7 @@ impl<P: PlatformInfo> FvProtocolData<P> {
             read: Self::fvb_read_efiapi,
             write: Self::fvb_write_efiapi,
             erase_blocks: Self::fvb_erase_blocks_efiapi,
-            parent_handle: parent_handle.unwrap_or(core::ptr::null_mut()),
+            parent_handle: parent_handle.unwrap_or_default(),
         })
     }
 
@@ -314,7 +314,7 @@ impl<P: PlatformInfo> FvProtocolData<P> {
             write_file: Self::fv_write_file_efiapi,
             get_next_file: Self::fv_get_next_file_efiapi,
             key_size: size_of::<usize>() as u32,
-            parent_handle: parent_handle.unwrap_or(core::ptr::null_mut()),
+            parent_handle: parent_handle.unwrap_or_default(),
             get_info: Self::fv_get_info_efiapi,
             set_info: Self::fv_set_info_efiapi,
         })

--- a/patina_dxe_core/src/protocol_db.rs
+++ b/patina_dxe_core/src/protocol_db.rs
@@ -101,8 +101,8 @@ impl OpenProtocolInformation {
 impl From<OpenProtocolInformation> for efi::OpenProtocolInformationEntry {
     fn from(item: OpenProtocolInformation) -> Self {
         efi::OpenProtocolInformationEntry {
-            agent_handle: item.agent_handle.unwrap_or(core::ptr::null_mut()),
-            controller_handle: item.controller_handle.unwrap_or(core::ptr::null_mut()),
+            agent_handle: item.agent_handle.unwrap_or_default(),
+            controller_handle: item.controller_handle.unwrap_or_default(),
             attributes: item.attributes,
             open_count: item.open_count,
         }

--- a/patina_dxe_core/src/runtime.rs
+++ b/patina_dxe_core/src/runtime.rs
@@ -122,7 +122,7 @@ pub fn add_runtime_event(
         event_type,
         notify_tpl,
         notify_function: function,
-        context: context.unwrap_or(ptr::null_mut()),
+        context: context.unwrap_or_default(),
         event,
         link: list_entry::Entry { forward_link: ptr::null_mut(), back_link: ptr::null_mut() },
     });

--- a/sdk/patina/src/boot_services.rs
+++ b/sdk/patina/src/boot_services.rs
@@ -1212,7 +1212,7 @@ impl BootServices for StandardBootServices {
         protocol: &'static efi::Guid,
         interface: *mut c_void,
     ) -> Result<efi::Handle, efi::Status> {
-        let mut handle = handle.unwrap_or(ptr::null_mut());
+        let mut handle = handle.unwrap_or_default();
         // SAFETY: See safety comment in create_event_unchecked for details on corner cases around external modifications.
         let install_protocol_interface =
             unsafe { efi_boot_services_fn!(*self.as_mut_ptr(), install_protocol_interface) };
@@ -1439,8 +1439,8 @@ impl BootServices for StandardBootServices {
         let disconnect_controller = unsafe { efi_boot_services_fn!(*self.as_mut_ptr(), disconnect_controller) };
         match disconnect_controller(
             controller_handle,
-            driver_image_handle.unwrap_or(ptr::null_mut()),
-            child_handle.unwrap_or(ptr::null_mut()),
+            driver_image_handle.unwrap_or_default(),
+            child_handle.unwrap_or_default(),
         ) {
             s if s.is_error() => Err(s),
             _ => Ok(()),

--- a/sdk/patina/src/boot_services/global_allocator.rs
+++ b/sdk/patina/src/boot_services/global_allocator.rs
@@ -27,7 +27,7 @@ impl<T: BootServices> Deref for BootServicesGlobalAllocator<T> {
 impl<T: BootServices> BootServicesGlobalAllocator<T> {
     unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
         match layout.align() {
-            0..=8 => self.allocate_pool(EfiMemoryType::BootServicesData, layout.size()).unwrap_or(ptr::null_mut()),
+            0..=8 => self.allocate_pool(EfiMemoryType::BootServicesData, layout.size()).unwrap_or_default(),
             _ => {
                 let Ok((extended_layout, tracker_offset)) = layout.extend(Layout::new::<*mut *mut u8>()) else {
                     return ptr::null_mut();


### PR DESCRIPTION
## Description

Currently the clippy/check configuration is expecting that --all-targets is building for x86_64-unknown-uefi and aarch64-unknown-uefi. However, --all-targets means build lib, docs, test, bin, etc, not target triples. As such, various clippy and check errors are missed in architecture specific code. This adds new steps to cargo make clippy/check to check the architectures. It leaves linting the std code as well because --all-features cannot be used in no-std; it attempts to include std as a feature. Short of manually listing all features, this seemed the best way to get coverage, though it does increase clippy/check times.

Open to other suggestions on how to implement this or to drop the std checking (nice to keep for tests for use in rust-analyzer). With this PR, times increase (all times in seconds, cargo clean run before each invocation):

|        | New | Original |
|--------|-------|--------|
| Clippy | 46    | 17     |
| Check      | 49    | 39     |

>**Note:** The Makefile.toml change will be dropped from this PR and brought to all applicable makefiles in patina-devops. It is here for convenience for anyone who wants to test this change before recommending a different path.

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Running `cargo make clippy` and `cargo make check`.

## Integration Instructions

N/A.
