### PR TITLE
patina_test: Gate component doctest on the test-runner feature (MSRV 1.89.0 compat)

### DIFF
--- a/components/patina_test/src/component.rs
+++ b/components/patina_test/src/component.rs
@@ -23,7 +23,11 @@ use patina::component::{Storage, component};
 ///
 /// # Example
 ///
-/// ```rust
+/// The `patina_test::component` module is only public when the `test-runner` feature is enabled
+/// (or when building docs). Gate the doctest's code fence on the `test-runner` feature so it compiles
+/// and runs when the feature is on, and is silently skipped otherwise.
+#[cfg_attr(feature = "test-runner", doc = "```rust")]
+#[cfg_attr(not(feature = "test-runner"), doc = "```ignore")]
 /// use patina_test::component::{TestRunner, Filter};
 ///
 /// let runner = TestRunner::default()


### PR DESCRIPTION
## Description

The `component` module is only public when `feature = "test-runner"` is enabled (or when rustdoc is generating docs with `cfg(doc)`).

The `Filter` doctest in components/patina_test/src/component.rs imports from it.

`cargo test --doc` fails prior to 1.92.0 with: "E0603: module `component` is private"

The behavior appears to have changed somewhere between the 2025-09-16 (fail) and 2025-12-04 (pass) nightly releases specifically.

It appears the logic to discover what's reachable changed such that rustdoc only extracts doctests from items that are reachable in the same configuration the library is built with.

The current MSRV is 1.89.0, so this change uses `cfg_attr` to ignore the test when the `test-runner` feature is not enabled this allows the doctest to be compiled and run when the feature is enabled and gives compatibility with older toolchains.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

**BEFORE**

- `cargo +nightly-2025-09-19 test -p patina_test`

    ```
    ---- components\patina_test\src\component.rs - component::Filter (line 26) stdout ----
    error[E0603]: module `component` is private
      --> components\patina_test\src\component.rs:28:18
       |
     5 | use patina_test::component::{TestRunner, Filter};
       |                  ^^^^^^^^^ private module
       |
    note: the module `component` is defined here
      --> C:\src\patina\components\patina_test\src\lib.rs:21:1
       |
    21 | mod component;
       | ^^^^^^^^^^^^^
    
    error[E0603]: module `component` is private
      --> components\patina_test\src\component.rs:28:18
       |
     5 | use patina_test::component::{TestRunner, Filter};
       |                  ^^^^^^^^^               ------ enum `Filter` is not publicly re-exported
       |                  |
       |                  private module
       |
    note: the module `component` is defined here
      --> C:\src\patina\components\patina_test\src\lib.rs:21:1
       |
    21 | mod component;
       | ^^^^^^^^^^^^^
    ```

- `cargo +nightly-2025-12-12 test -p patina_test`
    `all doctests ran in 1.15s; merged doctests compilation took 1.05s`

**AFTER**

Both commands pass.

## Integration Instructions

- N/A