### PR TITLE
Ensure cache consistency when changing to uncached memory [FF & REBASE] 

### DIFF
--- a/core/patina_debugger/src/memory.rs
+++ b/core/patina_debugger/src/memory.rs
@@ -193,6 +193,13 @@ mod tests {
             fn install_page_table(&mut self) -> Result<(), PtError>;
             fn query_memory_region(&self, address: u64, size: u64) -> Result<MemoryAttributes, (PtError, CacheAttributeValue)>;
             fn dump_page_tables(&self, address: u64, size: u64) -> Result<(), PtError>;
+            fn handle_cacheability_change(
+                &self,
+                address: u64,
+                size: u64,
+                old_cache_attributes: MemoryAttributes,
+                new_cache_attributes: MemoryAttributes,
+            );
         }
     }
 

--- a/core/patina_internal_cpu/src/cpu.rs
+++ b/core/patina_internal_cpu/src/cpu.rs
@@ -18,7 +18,7 @@ use patina::{
 use r_efi::efi;
 
 #[cfg(target_arch = "aarch64")]
-mod aarch64;
+pub(crate) mod aarch64;
 #[cfg(not(target_os = "uefi"))]
 mod stub;
 #[cfg(target_arch = "x86_64")]

--- a/core/patina_internal_cpu/src/cpu/aarch64.rs
+++ b/core/patina_internal_cpu/src/cpu/aarch64.rs
@@ -6,7 +6,9 @@
 //!
 //! SPDX-License-Identifier: Apache-2.0
 //!
+mod cache;
 mod cpu;
 
+pub(crate) use cache::flush_data_cache_range;
 #[allow(unused)]
 pub use cpu::EfiCpuAarch64;

--- a/core/patina_internal_cpu/src/cpu/aarch64/cache.rs
+++ b/core/patina_internal_cpu/src/cpu/aarch64/cache.rs
@@ -1,0 +1,118 @@
+//! AArch64 data cache maintenance primitives.
+//!
+//! ## License
+//!
+//! Copyright (c) Microsoft Corporation.
+//!
+//! SPDX-License-Identifier: Apache-2.0
+//!
+#[cfg(not(test))]
+use core::arch::asm;
+use patina::pi::protocols::cpu_arch::CpuFlushType;
+use r_efi::efi;
+
+fn clean_data_entry_by_mva(_mva: efi::PhysicalAddress) {
+    #[cfg(not(test))]
+    // SAFETY: Cleaning the data cache has no impact on safety invariants.
+    unsafe {
+        asm!("dc cvac, {}", in(reg) _mva, options(nostack, preserves_flags));
+    }
+}
+
+fn invalidate_data_cache_entry_by_mva(_mva: efi::PhysicalAddress) {
+    #[cfg(not(test))]
+    // SAFETY: Invalidating the data cache does not impact safety checks. It
+    // does have the potential to corrupt memory if used incorrectly, but the caller is
+    // expected to ensure that they are using this function correctly.
+    unsafe {
+        asm!("dc ivac, {}", in(reg) _mva, options(nostack, preserves_flags));
+    }
+}
+
+fn clean_and_invalidate_data_entry_by_mva(_mva: efi::PhysicalAddress) {
+    #[cfg(not(test))]
+    // SAFETY: Cleaning and invalidating the data cache does not impact safety invariants.
+    unsafe {
+        asm!("dc civac, {}", in(reg) _mva, options(nostack, preserves_flags));
+    }
+}
+
+fn data_cache_line_len() -> u64 {
+    #[cfg(test)]
+    let ctr_el0 = 0x0004_0000; // Provides line size of 64 in test mode
+
+    #[cfg(not(test))]
+    // SAFETY: Reading ctr_el0 has no impact on safety invariants
+    let ctr_el0 = unsafe {
+        let ctr_el0: u64;
+        asm!("mrs {}, ctr_el0", out(reg) ctr_el0);
+        ctr_el0
+    };
+
+    4 << ((ctr_el0 >> 16) & 0xf)
+}
+
+/// Performs a data cache maintenance operation over the virtual address range
+/// `[start, start + length)` according to `op`, followed by a single `dsb sy`
+/// barrier. A no-op if `length` is zero.
+pub(crate) fn flush_data_cache_range(start: efi::PhysicalAddress, length: u64, op: CpuFlushType) {
+    if length == 0 {
+        return;
+    }
+
+    let cacheline_size = data_cache_line_len();
+    let cacheline_mask = cacheline_size - 1;
+    let mut aligned_addr = start & !cacheline_mask;
+    let end_addr = match start.checked_add(length) {
+        Some(end_addr) => end_addr,
+        None => {
+            debug_assert!(false, "Cache range overflow");
+            return;
+        }
+    };
+
+    while aligned_addr < end_addr {
+        match op {
+            CpuFlushType::EfiCpuFlushTypeWriteBack => clean_data_entry_by_mva(aligned_addr),
+            CpuFlushType::EfiCpuFlushTypeInvalidate => invalidate_data_cache_entry_by_mva(aligned_addr),
+            CpuFlushType::EfiCpuFlushTypeWriteBackInvalidate => clean_and_invalidate_data_entry_by_mva(aligned_addr),
+        }
+
+        match aligned_addr.checked_add(cacheline_size) {
+            Some(next) => aligned_addr = next,
+            None => break,
+        }
+    }
+
+    #[cfg(not(test))]
+    // we have a data barrier after all cache lines have had the operation performed on them as an optimization
+    // SAFETY: a data barrier has no impact on safety invariants.
+    unsafe {
+        asm!("dsb sy", options(nostack));
+    }
+}
+
+#[cfg(test)]
+#[coverage(off)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_data_cache_line_len() {
+        // Always uses 64 for tests.
+        assert_eq!(data_cache_line_len(), 64);
+    }
+
+    #[test]
+    fn test_all_clean_types() {
+        flush_data_cache_range(0, 0x1000, CpuFlushType::EfiCpuFlushTypeWriteBack);
+        flush_data_cache_range(0, 0x1000, CpuFlushType::EfiCpuFlushTypeInvalidate);
+        flush_data_cache_range(0, 0x1000, CpuFlushType::EfiCpuFlushTypeWriteBackInvalidate);
+    }
+
+    #[test]
+    fn test_clean_overflow() {
+        // Should be handled gracefully.
+        flush_data_cache_range(0xFFFFFFFFFFFFF000, 0xFFFFFFFFFFFFF000, CpuFlushType::EfiCpuFlushTypeWriteBack);
+    }
+}

--- a/core/patina_internal_cpu/src/cpu/aarch64/cpu.rs
+++ b/core/patina_internal_cpu/src/cpu/aarch64/cpu.rs
@@ -29,13 +29,24 @@ impl EfiCpuAarch64 {
     }
 
     // AArch64 related cache functions
-    fn cache_range_operation(&self, _start: efi::PhysicalAddress, _length: u64, _op: CpuFlushType) {
-        let cacheline_alignment = self.data_cache_line_len() - 1;
-        let mut aligned_addr = _start - (_start & cacheline_alignment);
-        let end_addr = _start + _length;
+    fn cache_range_operation(&self, start: efi::PhysicalAddress, length: u64, op: CpuFlushType) {
+        if length == 0 {
+            return;
+        }
 
-        loop {
-            match _op {
+        let cacheline_size = self.data_cache_line_len();
+        let cacheline_mask = cacheline_size - 1;
+        let mut aligned_addr = start & !cacheline_mask;
+        let end_addr = match start.checked_add(length) {
+            Some(end_addr) => end_addr,
+            None => {
+                debug_assert!(false, "Cache range overflow");
+                return;
+            }
+        };
+
+        while aligned_addr < end_addr {
+            match op {
                 CpuFlushType::EfiCpuFlushTypeWriteBack => self.clean_data_entry_by_mva(aligned_addr),
                 CpuFlushType::EfiCpuFlushTypeInvalidate => self.invalidate_data_cache_entry_by_mva(aligned_addr),
                 CpuFlushType::EfiCpuFlushTypeWriteBackInvalidate => {
@@ -43,9 +54,9 @@ impl EfiCpuAarch64 {
                 }
             }
 
-            aligned_addr += cacheline_alignment;
-            if aligned_addr >= end_addr {
-                break;
+            match aligned_addr.checked_add(cacheline_size) {
+                Some(next) => aligned_addr = next,
+                None => break,
             }
         }
 

--- a/core/patina_internal_cpu/src/cpu/aarch64/cpu.rs
+++ b/core/patina_internal_cpu/src/cpu/aarch64/cpu.rs
@@ -6,7 +6,7 @@
 //!
 //! SPDX-License-Identifier: Apache-2.0
 //!
-use crate::cpu::Cpu;
+use crate::cpu::{Cpu, aarch64::cache};
 #[cfg(not(test))]
 use core::arch::asm;
 use patina::{
@@ -28,87 +28,6 @@ impl EfiCpuAarch64 {
         Ok(())
     }
 
-    // AArch64 related cache functions
-    fn cache_range_operation(&self, start: efi::PhysicalAddress, length: u64, op: CpuFlushType) {
-        if length == 0 {
-            return;
-        }
-
-        let cacheline_size = self.data_cache_line_len();
-        let cacheline_mask = cacheline_size - 1;
-        let mut aligned_addr = start & !cacheline_mask;
-        let end_addr = match start.checked_add(length) {
-            Some(end_addr) => end_addr,
-            None => {
-                debug_assert!(false, "Cache range overflow");
-                return;
-            }
-        };
-
-        while aligned_addr < end_addr {
-            match op {
-                CpuFlushType::EfiCpuFlushTypeWriteBack => self.clean_data_entry_by_mva(aligned_addr),
-                CpuFlushType::EfiCpuFlushTypeInvalidate => self.invalidate_data_cache_entry_by_mva(aligned_addr),
-                CpuFlushType::EfiCpuFlushTypeWriteBackInvalidate => {
-                    self.clean_and_invalidate_data_entry_by_mva(aligned_addr)
-                }
-            }
-
-            match aligned_addr.checked_add(cacheline_size) {
-                Some(next) => aligned_addr = next,
-                None => break,
-            }
-        }
-
-        #[cfg(not(test))]
-        // we have a data barrier after all cache lines have had the operation performed on them as an optimization
-        // SAFETY: a data barrier has no impact on safety invariants.
-        unsafe {
-            asm!("dsb sy", options(nostack));
-        }
-    }
-
-    fn clean_data_entry_by_mva(&self, _mva: efi::PhysicalAddress) {
-        #[cfg(not(test))]
-        // SAFETY: Cleaning the data cache has no impact on safety invariants.
-        unsafe {
-            asm!("dc cvac, {}", in(reg) _mva, options(nostack, preserves_flags));
-        }
-    }
-
-    fn invalidate_data_cache_entry_by_mva(&self, _mva: efi::PhysicalAddress) {
-        #[cfg(not(test))]
-        // SAFETY: Invalidating the data cache does not impact safety checks. It
-        // does have the potential to corrupt memory if used incorrectly, but the caller is
-        // expected to ensure that they are using this function correctly.
-        unsafe {
-            asm!("dc ivac, {}", in(reg) _mva, options(nostack, preserves_flags));
-        }
-    }
-
-    fn clean_and_invalidate_data_entry_by_mva(&self, _mva: efi::PhysicalAddress) {
-        #[cfg(not(test))]
-        // SAFETY: Cleaning and invalidating the data cache does not impact safety invariants.
-        unsafe {
-            asm!("dc civac, {}", in(reg) _mva, options(nostack, preserves_flags));
-        }
-    }
-
-    fn data_cache_line_len(&self) -> u64 {
-        #[cfg(test)]
-        let ctr_el0 = 0x0004_0000; // Provides line size of 64 in test mode
-
-        #[cfg(not(test))]
-        // SAFETY: Reading ctr_el0 has no impact on safety invariants
-        let ctr_el0 = unsafe {
-            let ctr_el0: u64;
-            asm!("mrs {}, ctr_el0", out(reg) ctr_el0);
-            ctr_el0
-        };
-
-        4 << ((ctr_el0 >> 16) & 0xf)
-    }
-
     /// Causes the CPU to enter a low power state until the next interrupt.
     // This routine only does bare-metal hardware access, so no coverage.
     #[coverage(off)]
@@ -128,7 +47,7 @@ impl Cpu for EfiCpuAarch64 {
         length: u64,
         flush_type: CpuFlushType,
     ) -> Result<(), EfiError> {
-        self.cache_range_operation(start, length, flush_type);
+        cache::flush_data_cache_range(start, length, flush_type);
         Ok(())
     }
 

--- a/core/patina_internal_cpu/src/paging.rs
+++ b/core/patina_internal_cpu/src/paging.rs
@@ -103,4 +103,20 @@ pub trait PatinaPageTable {
     /// * `address` - The memory address to map.
     /// * `size` - The memory size to map.
     fn dump_page_tables(&self, address: u64, size: u64) -> Result<(), PtError>;
+
+    /// Function to handle a change in the cacheability of a memory region.
+    /// This function is called when the cacheability of a memory region changes.
+    ///
+    /// ## Arguments
+    /// * `address` - The memory address of the region.
+    /// * `size` - The size of the region.
+    /// * `old_cache_attributes` - The old cache attributes for the region.
+    /// * `new_cache_attributes` - The new cache attributes for the region.
+    fn handle_cacheability_change(
+        &self,
+        address: u64,
+        size: u64,
+        old_cache_attributes: MemoryAttributes,
+        new_cache_attributes: MemoryAttributes,
+    );
 }

--- a/core/patina_internal_cpu/src/paging/aarch64.rs
+++ b/core/patina_internal_cpu/src/paging/aarch64.rs
@@ -10,9 +10,19 @@
 //!
 use patina_paging::{MemoryAttributes, PageTable, PagingType, PtError, aarch64::AArch64PageTable};
 
-use crate::paging::{CacheAttributeValue, PatinaPageTable};
+use crate::{
+    cpu::aarch64::flush_data_cache_range,
+    paging::{CacheAttributeValue, PatinaPageTable},
+};
+use patina::pi::protocols::cpu_arch::CpuFlushType;
 use patina_paging::page_allocator::PageAllocator;
 use r_efi::efi;
+
+/// Memory attributes that indicate cached mappings (writeback or write-through).
+const CACHED_ATTRS: MemoryAttributes = MemoryAttributes::Writeback.union(MemoryAttributes::WriteThrough);
+
+/// Memory attributes that indicate uncached mappings (uncached or write-combining).
+const UNCACHED_ATTRS: MemoryAttributes = MemoryAttributes::Uncached.union(MemoryAttributes::WriteCombining);
 
 /// The aarch64 paging implementation. It acts as a bridge between the EFI CPU
 /// Architecture Protocol and the aarch64 paging implementation.
@@ -49,6 +59,21 @@ where
 
     fn dump_page_tables(&self, address: u64, size: u64) -> Result<(), PtError> {
         self.paging.dump_page_tables(address, size)
+    }
+
+    fn handle_cacheability_change(
+        &self,
+        address: u64,
+        size: u64,
+        old_cache_attributes: MemoryAttributes,
+        new_cache_attributes: MemoryAttributes,
+    ) {
+        // If the region was previously cached (WB/WT) and is now uncached (UC/WC),
+        // clean and invalidate the data cache for the range so that any dirty lines
+        // are written back to memory before subsequent accesses bypass the cache.
+        if old_cache_attributes.intersects(CACHED_ATTRS) && new_cache_attributes.intersects(UNCACHED_ATTRS) {
+            flush_data_cache_range(address, size, CpuFlushType::EfiCpuFlushTypeWriteBackInvalidate);
+        }
     }
 }
 
@@ -147,5 +172,11 @@ mod tests {
         let result = paging.query_memory_region(0x1000, 0x1000);
         assert!(result.is_ok());
         assert_eq!(result.unwrap(), MemoryAttributes::Writeback | MemoryAttributes::Uncached);
+    }
+
+    #[test]
+    fn test_handle_cacheability_change() {
+        let paging = EfiCpuPagingAArch64 { paging: MockPageTable::new() };
+        paging.handle_cacheability_change(0x1000, 0x1000, MemoryAttributes::Writeback, MemoryAttributes::Uncached);
     }
 }

--- a/core/patina_internal_cpu/src/paging/null.rs
+++ b/core/patina_internal_cpu/src/paging/null.rs
@@ -51,6 +51,15 @@ where
     fn dump_page_tables(&self, _address: u64, _size: u64) -> Result<(), PtError> {
         Ok(())
     }
+
+    fn handle_cacheability_change(
+        &self,
+        _address: u64,
+        _size: u64,
+        _old_cache_attributes: MemoryAttributes,
+        _new_cache_attributes: MemoryAttributes,
+    ) {
+    }
 }
 
 /// Used to specify that this architecture paging implementation is not supported.

--- a/core/patina_internal_cpu/src/paging/x64.rs
+++ b/core/patina_internal_cpu/src/paging/x64.rs
@@ -94,6 +94,16 @@ where
     fn dump_page_tables(&self, address: u64, size: u64) -> Result<(), PtError> {
         self.paging.dump_page_tables(address, size)
     }
+
+    fn handle_cacheability_change(
+        &self,
+        _address: u64,
+        _size: u64,
+        _old_cache_attributes: MemoryAttributes,
+        _new_cache_attributes: MemoryAttributes,
+    ) {
+        // Cache consistency is already handled by the MTRR library. No further action is needed.
+    }
 }
 
 fn apply_caching_attributes<M: Mtrr>(
@@ -277,5 +287,11 @@ mod tests {
         let result = paging.query_memory_region(0x1000, 0x1000);
         assert!(result.is_ok());
         assert_eq!(result.unwrap(), MemoryAttributes::Writeback | MemoryAttributes::Uncached);
+    }
+
+    #[test]
+    fn test_handle_cacheability_change() {
+        let paging = EfiCpuPagingX64 { paging: MockPageTable::new(), mtrr: MockMtrr::new() };
+        paging.handle_cacheability_change(0x1000, 0x1000, MemoryAttributes::Writeback, MemoryAttributes::Uncached);
     }
 }

--- a/patina_dxe_core/src/gcd/spin_locked_gcd.rs
+++ b/patina_dxe_core/src/gcd/spin_locked_gcd.rs
@@ -2132,6 +2132,16 @@ impl SpinLockedGcd {
                         if let Some(old_cache_attrs) = old_cache_attributes
                             && old_cache_attrs != new_cache_attributes
                         {
+                            // Some cache maintenance may be required after all attributes have been applied to clean
+                            // up any stale cache entries before the memory is accessed. This is done after the attributes
+                            // were applied to ensure no new unexpected cache lines are created.
+                            page_table.handle_cacheability_change(
+                                base_address as u64,
+                                len as u64,
+                                old_cache_attrs,
+                                new_cache_attributes,
+                            );
+
                             // in this case, we had caching attributes for this region and they do not match the newly
                             // set attributes
                             log::trace!(

--- a/patina_dxe_core/src/test_support.rs
+++ b/patina_dxe_core/src/test_support.rs
@@ -173,6 +173,15 @@ impl PatinaPageTable for MockPageTable {
         // No-op for testing
         Ok(())
     }
+
+    fn handle_cacheability_change(
+        &self,
+        _address: u64,
+        _size: u64,
+        _old_cache_attributes: MemoryAttributes,
+        _new_cache_attributes: MemoryAttributes,
+    ) {
+    }
 }
 
 // SAFETY: MockPageTable uses interior mutability for test-only state and is not shared across threads in tests.
@@ -238,6 +247,16 @@ impl PatinaPageTable for MockPageTableWrapper {
 
     fn dump_page_tables(&self, address: u64, size: u64) -> Result<(), PtError> {
         self.inner.borrow().dump_page_tables(address, size)
+    }
+
+    fn handle_cacheability_change(
+        &self,
+        address: u64,
+        size: u64,
+        old_cache_attributes: MemoryAttributes,
+        new_cache_attributes: MemoryAttributes,
+    ) {
+        self.inner.borrow().handle_cacheability_change(address, size, old_cache_attributes, new_cache_attributes)
     }
 }
 


### PR DESCRIPTION
## Description

### patina_internal_cpu: Flush data cache which switching to uncached

When switching memory from a cached normal memory to a uncached or device
memory, the cache lines may stuill exist. Some platforms may snoop this
cache, but this is not guaranteed. To ensure data consistency accross all
platforms, the data cache should be explicitly cleaned.

This commit adds a arc architectural callout for when caching is changed.
For AARCH64 this will flush and invalidate the data cache when chaning
from a cached to a uncached memory type.

### patina_internal_cpu: Fix stride bug in cache operations

The current cache operations for aarch64 is using the cache line size mask
as the stride causing later cache lines to be skipped. This commit cleans
up the variables for clarity and adds input validation.

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Tested on physical and virtual platform 
- [x] Boot to OS
- [x] One off test for cache coherency

## Integration Instructions

N/A
