### PR TITLE
Update Corosensei to latest upstream release 0.3.4

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,7 +55,7 @@ spin = { version = "^0.9" }
 syn = { version = "2" }
 time = { version = "0.3.47" }
 uart_16550 = { version = "^0.3.2" }
-corosensei = { version = "0.3.3", default-features = false }
+corosensei = { version = "0.3.4", default-features = false }
 uuid = { version = "1.8", default-features = false }
 zerocopy = { version = "0.8" }
 zerocopy-derive = { version = "0.8" }


### PR DESCRIPTION
## Description

Updates Corosensei dependency to latest upstream release 0.3.4. This includes support for SEH opcodes on aarch64-unknown-uefi that allows for proper stack unwinding through the corosensei co-routine used for start_image. 

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Confirmed build and boot on hardware and QemuSbsa. Confirmed stack unwinding on SBSA unwinds through start_image properly.

## Integration Instructions

N/A