### PR TITLE
patina_internal_collections: Replace array_windows with windows (MSRV 1.89.0 compat)

### DIFF
--- a/core/patina_internal_collections/src/node.rs
+++ b/core/patina_internal_collections/src/node.rs
@@ -82,9 +82,11 @@ where
     }
 
     fn build_linked_list(buffer: &[Node<D>]) {
-        for [node, next] in buffer.array_windows::<2>() {
-            node.set_right(Some(next));
-            next.set_left(Some(node));
+        for window in buffer.windows(2) {
+            if let [node, next] = window {
+                node.set_right(Some(next));
+                next.set_left(Some(node));
+            }
         }
     }
 


### PR DESCRIPTION
## Description

`array_windows` was introduced in Rust 1.94 and to patina in commit 856bda1, our MSRV is 1.89.

Replace `array_windows` with `windows` and adjust the loop body accordingly to pass the MSRV check.

---

Issue before:

<img width="891" height="353" alt="image" src="https://github.com/user-attachments/assets/9b779f31-376b-4962-b966-a19e8ea94753" />

---

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

- `cargo make all`
- MSRV Check workflow being added in https://[github.com/OpenDevicePartnership/patina/pull/1546](https://github.com/OpenDevicePartnership/patina/pull/1546)

## Integration Instructions

- N/A