### PR TITLE
patina_debugger: Do not initialize the transport by default

### DIFF
--- a/core/patina_debugger/README.md
+++ b/core/patina_debugger/README.md
@@ -44,8 +44,8 @@ The self-hosted debugger is lightweight and tightly integrated with Patina, offe
 ## Platform Integration
 
 1. Instantiate a `PatinaDebugger` with the platform UART configuration (for example, `Uart16550::Io { base: 0x3F8 }`).
-2. Apply any policy overrides such as `.with_force_enable`, `.with_log_policy`, or `.without_transport_init` when
-   logging shares the transport.
+2. Apply any policy overrides such as `.with_force_enable`, `.with_log_policy`, or `.with_transport_init` when
+   if the debugger must initialize the transport.
 3. Register the debugger using `patina_debugger::set_debugger(&DEBUGGER)` before the Patina DXE Core starts dispatching
    components.
 4. Call `patina_debugger::initialize(&mut interrupt_manager)` during platform bring-up so the core installs exception
@@ -79,7 +79,8 @@ In addition, active examples are available in the
 
 Instantiate the static `PatinaDebugger` struct to match your device. The main configuration is
 setting the debugger transport, usually a serial port. If only one serial port is available, it may
-be shared with logging. In this case use `without_transport_init()` to avoid port contention.
+be shared with logging. The the debugger uses a separate transport `with_transport_init` ensures the
+debugger will call initialize for the `SerialIO` implementation.
 
 Example setup:
 
@@ -92,7 +93,6 @@ const _ENABLE_DEBUGGER: bool = false;
 #[cfg(feature = "build_debugger")]
 static DEBUGGER: patina_debugger::PatinaDebugger<UartPl011> =
     patina_debugger::PatinaDebugger::new(UartPl011::new(0x6000_0000))
-        .without_transport_init()
         .with_force_enabled(_ENABLE_DEBUGGER);
 ```
 

--- a/core/patina_debugger/src/debugger.rs
+++ b/core/patina_debugger/src/debugger.rs
@@ -77,8 +77,8 @@ where
     exception_types: &'static [usize],
     /// Controls what the debugger does with logging.
     log_policy: DebuggerLoggingPolicy,
-    /// Whether initializing the transport should be skipped.
-    no_transport_init: bool,
+    /// Whether the transport will be initialized.
+    transport_init: bool,
     /// Debugger enabled state.
     enabled: AtomicBool,
     /// Debugger Initialized state
@@ -120,7 +120,7 @@ impl<T: SerialIO> PatinaDebugger<T> {
         PatinaDebugger {
             transport,
             log_policy: DebuggerLoggingPolicy::SuspendLogging,
-            no_transport_init: false,
+            transport_init: false,
             exception_types: SystemArch::DEFAULT_EXCEPTION_TYPES,
             enabled: AtomicBool::new(false),
             initialized: AtomicBool::new(false),
@@ -156,8 +156,21 @@ impl<T: SerialIO> PatinaDebugger<T> {
 
     /// Prevents the debugger from initializing the transport. This is suggested in
     /// cases where the transport is shared with the logging device.
-    pub const fn without_transport_init(mut self) -> Self {
-        self.no_transport_init = true;
+    ///
+    /// ## DEPRECATED
+    ///
+    /// The transport is no longer initialized by default. This function has no effect and is deprecated. It will be
+    /// removed in a future version.
+    ///
+    #[deprecated(note = "This function has no effect and is deprecated. It will be removed in a future version.")]
+    pub const fn without_transport_init(self) -> Self {
+        self
+    }
+
+    /// Enables the debugger to initialize the transport. This is typically only required if the transport is not shared
+    /// with the logging device. Initializing the transport when it is shared may lead to unexpected behavior.
+    pub const fn with_transport_init(mut self, init: bool) -> Self {
+        self.transport_init = init;
         self
     }
 
@@ -343,7 +356,7 @@ impl<T: SerialIO> Debugger for PatinaDebugger<T> {
         log::info!("Initializing debugger.");
 
         // Initialize the underlying transport.
-        if !self.no_transport_init {
+        if self.transport_init {
             self.transport.init();
         }
 

--- a/core/patina_debugger/src/debugger.rs
+++ b/core/patina_debugger/src/debugger.rs
@@ -154,23 +154,25 @@ impl<T: SerialIO> PatinaDebugger<T> {
         self
     }
 
-    /// Prevents the debugger from initializing the transport. This is suggested in
-    /// cases where the transport is shared with the logging device.
+    /// Deprecated API that previously prevented the debugger from initializing the transport. This is now the default
+    /// behavior and so this function now has no effect and should not be used. This will be removed in a future version.
     ///
     /// ## DEPRECATED
     ///
     /// The transport is no longer initialized by default. This function has no effect and is deprecated. It will be
-    /// removed in a future version.
+    /// removed in a future version. For implementations that require transport initialization, use `with_transport_init`.
     ///
-    #[deprecated(note = "This function has no effect and is deprecated. It will be removed in a future version.")]
+    #[deprecated(
+        note = "This function has no effect and is deprecated. It will be removed in a future version. This call may be safely removed."
+    )]
     pub const fn without_transport_init(self) -> Self {
         self
     }
 
     /// Enables the debugger to initialize the transport. This is typically only required if the transport is not shared
     /// with the logging device. Initializing the transport when it is shared may lead to unexpected behavior.
-    pub const fn with_transport_init(mut self, init: bool) -> Self {
-        self.transport_init = init;
+    pub const fn with_transport_init(mut self) -> Self {
+        self.transport_init = true;
         self
     }
 


### PR DESCRIPTION
## Description

This change removes the default behavior to initialize the debugger transport serial port. Most systems will use a shared transport, and so the re-initialization is at best unnecessary. In some scenarios the Patina serial transport initialization may stomp on the existing configuration. This has caused confusion on multiple platforms during enablement. It is best to just skip unless requested. This commit inverts the default, deprecates `without_transport_init`, and introduces `with_transport_init` for the rare platforms that require this.

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Tested that Q35 & SBSA debuggers still function

## Integration Instructions

Platforms using `without_transport_init()` may safely drop that function call. There are no known platforms that require transport initialization, but if so those should now call `with_transport_init()` as needed.
