### PR TITLE
Minor Test Bug Fix: Initialize GCD before allocating SystemTable

### DIFF
--- a/patina_dxe_core/src/driver_services.rs
+++ b/patina_dxe_core/src/driver_services.rs
@@ -1845,6 +1845,10 @@ mod tests {
     #[test]
     fn test_init_driver_services() {
         with_locked_state(|| {
+            // SAFETY: Test code only - initializing test infrastructure within the global test lock.
+            unsafe {
+                test_support::init_test_gcd(None);
+            }
             let mut st = EfiSystemTable::allocate_new_table();
             init_driver_services(&mut st);
 


### PR DESCRIPTION
## Description

Initialize GCD before allocating SystemTable, otherwise below is the call flow causing stack corruption.

```
test_init_driver_services()
    EfiSystemTable::allocate_new_table()
        EfiRuntimeServicesTable::allocate_new_table()
            Box::new_in(...)
                Box::try_new_uninit_in(...)
                    uefi_allocator::...::allocate()
                        fixed_size_block_allocator::...::allocate()
                            self.allocate_from_gcd()
                                // Attempts to allocate from uninitialized GCD!
```

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

`cargo nextest run driver_services::tests::test_init_driver_services`

## Integration Instructions

NA