### PR TITLE
pi_dispatcher: Report protocols present for Drivers Not Dispatched

### DIFF
--- a/core/patina_internal_depex/src/lib.rs
+++ b/core/patina_internal_depex/src/lib.rs
@@ -282,6 +282,7 @@ impl Depex {
         false
     }
 
+    /// Returns an iterator over internal opcodes.
     pub fn iter(&self) -> impl Iterator<Item = &Opcode> {
         self.expression.iter()
     }

--- a/core/patina_internal_depex/src/lib.rs
+++ b/core/patina_internal_depex/src/lib.rs
@@ -282,25 +282,8 @@ impl Depex {
         false
     }
 
-    /// Report protocol present status in the DEPEX expression.
-    pub fn report_protocol_present(&self) {
-        for opcode in self.expression.iter() {
-            match opcode {
-                Opcode::Push(guid, present) => {
-                    log::warn!(
-                        target: "patina_dxe_core",
-                        "  {guid:?} : {present}"
-                    );
-                }
-                Opcode::End => {
-                    log::warn!(
-                        target: "patina_dxe_core",
-                        "  {opcode:?}"
-                    );
-                }
-                _ => {}
-            }
-        }
+    pub fn iter(&self) -> impl Iterator<Item = &Opcode> {
+        self.expression.iter()
     }
 
     /// If the depex expression is an associated dependency, it returns the associated dependency.

--- a/core/patina_internal_depex/src/lib.rs
+++ b/core/patina_internal_depex/src/lib.rs
@@ -282,6 +282,27 @@ impl Depex {
         false
     }
 
+    /// Report protocol present status in the DEPEX expression.
+    pub fn report_protocol_present(&self) {
+        for opcode in self.expression.iter() {
+            match opcode {
+                Opcode::Push(guid, present) => {
+                    log::warn!(
+                        target: "patina_dxe_core",
+                        "  {guid:?} : {present}"
+                    );
+                }
+                Opcode::End => {
+                    log::warn!(
+                        target: "patina_dxe_core",
+                        "  {opcode:?}"
+                    );
+                }
+                _ => {}
+            }
+        }
+    }
+
     /// If the depex expression is an associated dependency, it returns the associated dependency.
     pub fn is_associated(&self) -> Option<AssociatedDependency> {
         match self.expression.first() {

--- a/patina_dxe_core/src/pi_dispatcher.rs
+++ b/patina_dxe_core/src/pi_dispatcher.rs
@@ -110,13 +110,34 @@ impl<P: PlatformInfo> PiDispatcher<P> {
 
     /// Displays drivers that were discovered but not dispatched.
     pub fn display_discovered_not_dispatched(&self) {
-        for driver in &self.dispatcher_context.lock().pending_drivers {
+        // Summary report
+        for driver in self.dispatcher_context.lock().pending_drivers.iter() {
             log::warn!(
                 "Driver {} ({:?}) found but not dispatched.",
                 driver.name.as_deref().unwrap_or("Unnamed"),
                 guid_fmt!(driver.file_name)
             );
         }
+
+        // Detail report
+        log::warn!("Begin Detail Report:");
+        for driver in self.dispatcher_context.lock().pending_drivers.iter() {
+            log::warn!(
+                "Driver {} ({:?}) found but not dispatched. Protocols present:",
+                driver.name.as_deref().unwrap_or("Unnamed"),
+                guid_fmt!(driver.file_name)
+            );
+
+            match &driver.depex {
+                Some(depex) => {
+                    depex.report_protocol_present();
+                }
+                _ => {
+                    log::warn!("  No Depex");
+                }
+            }
+        }
+        log::warn!("End Detail Report.");
     }
 
     /// Initializes the dispatcher by registering for FV protocol installation events.

--- a/patina_dxe_core/src/pi_dispatcher.rs
+++ b/patina_dxe_core/src/pi_dispatcher.rs
@@ -120,24 +120,35 @@ impl<P: PlatformInfo> PiDispatcher<P> {
         }
 
         // Detail report
-        log::warn!("Begin Detail Report:");
+        self.detail_report();
+    }
+
+    fn detail_report(&self) {
+        log::debug!("Begin Report of Drivers Not Dispatched:");
         for driver in self.dispatcher_context.lock().pending_drivers.iter() {
-            log::warn!(
+            log::debug!(
                 "Driver {} ({:?}) found but not dispatched. Protocols present:",
                 driver.name.as_deref().unwrap_or("Unnamed"),
                 guid_fmt!(driver.file_name)
             );
 
-            match &driver.depex {
-                Some(depex) => {
-                    depex.report_protocol_present();
+            if let Some(depex) = &driver.depex {
+                for opcode in depex.iter() {
+                    match opcode {
+                        Opcode::Push(guid, present) => {
+                            log::debug!("  {guid:?} : {present}");
+                        }
+                        Opcode::End => {
+                            log::debug!("  {opcode:?}");
+                        }
+                        _ => {}
+                    }
                 }
-                _ => {
-                    log::warn!("  No Depex");
-                }
+            } else {
+                log::debug!("  No Depex");
             }
         }
-        log::warn!("End Detail Report.");
+        log::debug!("End Report of Drivers Not Dispatched.");
     }
 
     /// Initializes the dispatcher by registering for FV protocol installation events.


### PR DESCRIPTION
## Description

`pi_dispatcher.rs` reports protocols present for each "found but not dispatched" driver.

```c
08:12:04.220 : INFO - Finished Dispatching Drivers
08:12:04.221 : WARN - Driver MacAddressEmulationDxe (72AA9388-70DD-4669-8EC1-87444DD62CF3) found but not dispatched.
08:12:04.221 : WARN - Driver DisplayEngine (C09E4CE4-AE29-4340-B941-078871BD89D1) found but not dispatched.
08:12:04.221 : WARN - ..
08:12:04.222 : DEBUG - Begin Report of Drivers Not Dispatched:
08:12:04.224 : DEBUG - Driver MacAddressEmulationDxe (72AA9388-70DD-4669-8EC1-87444DD62CF3) found but not dispatched. Protocols present:
08:12:04.224 : DEBUG -   13a3f0f6-264a-3ef0-f2e0-dec512342f34 : true
08:12:04.224 : DEBUG -   81d1675c-86f6-48df-bd95-9a6e4f0925c3 : true
08:12:04.224 : DEBUG -   e355fc05-37c2-468a-9f52-52e5bf1871d3 : true
08:12:04.224 : DEBUG -   7b9cc1a0-218d-4c1c-9fcf-99f3a34d35f8 : false
08:12:04.224 : DEBUG -   End
08:12:04.224 : DEBUG - Driver DisplayEngine (C09E4CE4-AE29-4340-B941-078871BD89D1) found but not dispatched. Protocols present:
08:12:04.224 : DEBUG -   ef9fc172-a1b2-4693-b327-6d32fc416042 : true
08:12:04.224 : DEBUG -   587e72d7-cc50-4f79-8209-ca291fc1a10f : true
08:12:04.224 : DEBUG -   a770c357-b693-4e6d-a6cf-d21c728e550b : true
08:12:04.232 : DEBUG -   9d400d20-6f35-4268-904f-dc04b1877b62 : false
08:12:04.232 : DEBUG -   13a3f0f6-264a-3ef0-f2e0-dec512342f34 : true
08:12:04.232 : DEBUG -   fc111ae5-f073-4348-aa5c-49124bbfed7b : true
08:12:04.232 : DEBUG -   0fd96974-23aa-4cdc-b9cb-98d17750322a : true
08:12:04.232 : DEBUG -   End
08:12:04.256 : DEBUG - ..
08:12:04.257 : DEBUG - End Report of Drivers Not Dispatched.
08:12:04.257 : [Bds] Entry...
```

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Tested on real hardware.

## Integration Instructions

No action needed.