### PR TITLE
[REBASE & FF] Add Stack Overflow Hint in Exception Handlers

### DIFF
--- a/core/patina_internal_cpu/src/cpu/x64/gdt.rs
+++ b/core/patina_internal_cpu/src/cpu/x64/gdt.rs
@@ -119,7 +119,7 @@ const SPARE5_SEL: GdtEntry = GdtEntry {
 /// Size of the 64-bit TSS structure in bytes.
 const TSS_SIZE: usize = 104;
 
-/// Byte offset of IST1 within the TSS (DOUBLE_FAULT_IST_INDEX 0 maps to IST1).
+/// Byte offset of IST1 within the TSS.
 const TSS_IST1_OFFSET: usize = 36;
 
 const STACK_SIZE: usize = 4096 * 5;
@@ -131,7 +131,7 @@ pub(crate) const CODE_SELECTOR: u16 = 7 * 8; // LINEAR_CODE64_SEL at index 7
 const DATA_SELECTOR: u16 = 6 * 8; // LINEAR_DATA64_SEL at index 6
 const TSS_SELECTOR: u16 = 8 * 8; // TSS descriptor at index 8
 
-static mut DOUBLE_FAULT_STACK: [u8; STACK_SIZE] = [0; STACK_SIZE];
+static mut SEPARATE_EXCEPTION_STACK: [u8; STACK_SIZE] = [0; STACK_SIZE];
 static mut TSS: [u8; TSS_SIZE] = [0; TSS_SIZE];
 
 /// Build a 128-bit (two u64) TSS system segment descriptor from base address and limit.
@@ -158,10 +158,10 @@ fn tss_descriptor(base: u64, limit: u32) -> (u64, u64) {
 
 lazy_static! {
     static ref GDT: [u64; GDT_ENTRY_COUNT] = {
-        // Initialize TSS with double-fault stack in IST1
+        // Initialize TSS with separate exception stack in IST1
         // SAFETY: Single-threaded initialization guaranteed by lazy_static.
         unsafe {
-            let ist_addr = addr_of!(DOUBLE_FAULT_STACK) as u64 + STACK_SIZE as u64;
+            let ist_addr = addr_of!(SEPARATE_EXCEPTION_STACK) as u64 + STACK_SIZE as u64;
             let ist_bytes = ist_addr.to_ne_bytes();
             core::ptr::copy_nonoverlapping(
                 ist_bytes.as_ptr(),

--- a/core/patina_internal_cpu/src/interrupts.rs
+++ b/core/patina_internal_cpu/src/interrupts.rs
@@ -159,7 +159,7 @@ pub(crate) trait EfiSystemContextFactory {
 }
 
 /// Trait for dumping stack trace for architecture specific context.
-pub(crate) trait EfiExceptionStackTrace {
+pub(crate) trait EfiExceptionInfoDump {
     /// Dump the stack trace for architecture specific context.
     fn dump_stack_trace(&self);
 

--- a/core/patina_internal_cpu/src/interrupts/aarch64.rs
+++ b/core/patina_internal_cpu/src/interrupts/aarch64.rs
@@ -28,7 +28,7 @@ impl super::EfiSystemContextFactory for ExceptionContextAArch64 {
     }
 }
 
-impl super::EfiExceptionStackTrace for ExceptionContextAArch64 {
+impl super::EfiExceptionInfoDump for ExceptionContextAArch64 {
     fn dump_stack_trace(&self) {
         let stack_frame = StackFrame { pc: self.elr, sp: self.sp, fp: self.fp };
         // SAFETY: Called during exception handling with CPU context registers.

--- a/core/patina_internal_cpu/src/interrupts/aarch64/interrupt_manager.rs
+++ b/core/patina_internal_cpu/src/interrupts/aarch64/interrupt_manager.rs
@@ -15,7 +15,7 @@ use patina::{
 use patina_paging::PageTable;
 
 use crate::interrupts::{
-    EfiExceptionStackTrace, EfiSystemContext, HandlerType, InterruptManager, aarch64::ExceptionContextAArch64,
+    EfiExceptionInfoDump, EfiSystemContext, HandlerType, InterruptManager, aarch64::ExceptionContextAArch64,
     disable_interrupts, enable_interrupts,
 };
 

--- a/core/patina_internal_cpu/src/interrupts/aarch64/interrupt_manager.rs
+++ b/core/patina_internal_cpu/src/interrupts/aarch64/interrupt_manager.rs
@@ -168,12 +168,25 @@ extern "efiapi" fn synchronous_exception_handler(_exception_type: isize, context
     let ec = (aarch64_context.esr >> 26) & 0x3F;
     let iss = aarch64_context.esr & 0xFFFFFF;
     let page_fault = ec == 0x20 || ec == 0x21 || ec == 0x24 || ec == 0x25;
+    let far_valid = (iss & bit!(10)) == 0;
+
+    let sp_page = aarch64_context.sp & !UEFI_PAGE_MASK as u64;
+    let far_page = aarch64_context.far & !UEFI_PAGE_MASK as u64;
+    let same_or_below = (far_page == sp_page) || (far_page == (sp_page.wrapping_sub(UEFI_PAGE_SIZE as u64)));
+
     if ec == 0x20 || ec == 0x21 {
-        // Instruction Abort from a lower EL or same EL
+        // Instruction Abort from a lower EL or same EL.
         log::error!("Page Fault (Instruction Abort)");
     } else if ec == 0x24 || ec == 0x25 {
-        // Data Abort from a lower EL or same EL
-        log::error!("Page Fault (Data Abort)");
+        // Data Abort from a lower EL or same EL.
+        // Stack overflows cause page faults, let's give a hint if it looks like one.
+        // The heuristic we are using is that stack overflow will either have FAR on the same page
+        // as SP or directly below it. Sometimes SP is decremented first, sometimes second.
+        if far_valid && same_or_below {
+            log::error!("Page Fault (Stack Overflow)");
+        } else {
+            log::error!("Page Fault (Data Abort)");
+        }
     }
 
     log::error!("");
@@ -184,7 +197,7 @@ extern "efiapi" fn synchronous_exception_handler(_exception_type: isize, context
 
     if page_fault {
         // make sure the FAR is valid before we dump the page table
-        if iss & bit!(10) == 0 {
+        if far_valid {
             dump_pte(aarch64_context.far);
         } else {
             log::error!("FAR not valid, not dumping PTE");

--- a/core/patina_internal_cpu/src/interrupts/exception_handling.rs
+++ b/core/patina_internal_cpu/src/interrupts/exception_handling.rs
@@ -11,7 +11,7 @@
 use patina::{error::EfiError, pi::protocols::cpu_arch::EfiExceptionType};
 use spin::rwlock::RwLock;
 
-use crate::interrupts::EfiExceptionStackTrace;
+use crate::interrupts::EfiExceptionInfoDump;
 
 use super::{EfiSystemContextFactory, ExceptionContext, ExceptionType, HandlerType};
 

--- a/core/patina_internal_cpu/src/interrupts/stub.rs
+++ b/core/patina_internal_cpu/src/interrupts/stub.rs
@@ -11,7 +11,7 @@ use patina::{error::EfiError, pi::protocols::cpu_arch::EfiSystemContext};
 
 use crate::interrupts::InterruptManager;
 
-/// Null implementation of the EfiSystemContextFactory and EfiExceptionStackTrace traits.
+/// Null implementation of the EfiSystemContextFactory and EfiExceptionInfoDump traits.
 #[derive(Debug)]
 #[allow(dead_code)]
 pub struct ExceptionContextStub;
@@ -23,7 +23,7 @@ impl super::EfiSystemContextFactory for ExceptionContextStub {
     }
 }
 
-impl super::EfiExceptionStackTrace for ExceptionContextStub {
+impl super::EfiExceptionInfoDump for ExceptionContextStub {
     fn dump_stack_trace(&self) {}
     fn dump_system_context_registers(&self) {}
 }

--- a/core/patina_internal_cpu/src/interrupts/x64.rs
+++ b/core/patina_internal_cpu/src/interrupts/x64.rs
@@ -25,7 +25,7 @@ impl super::EfiSystemContextFactory for ExceptionContextX64 {
     }
 }
 
-impl super::EfiExceptionStackTrace for ExceptionContextX64 {
+impl super::EfiExceptionInfoDump for ExceptionContextX64 {
     fn dump_stack_trace(&self) {
         let stack_frame = StackFrame { pc: self.rip, sp: self.rsp, fp: self.rbp };
         // SAFETY: Called during exception handling with CPU context registers. The exception context

--- a/core/patina_internal_cpu/src/interrupts/x64/idt.rs
+++ b/core/patina_internal_cpu/src/interrupts/x64/idt.rs
@@ -83,8 +83,8 @@ pub fn initialize_idt() {
 
     // Point every vector at its corresponding assembly handler.
     for vector in 0..=255usize {
-        // Use IST 1 for double fault (vector 8) to ensure it has a valid stack
-        let ist_index = if vector == 8 { 1 } else { 0 };
+        // Use IST 1 for double fault (vector 8) and page fault (vector 14) to ensure they have a valid stack.
+        let ist_index = if vector == 8 || vector == 14 { 1 } else { 0 };
         idt.entries.get_mut(vector).expect("vector out of bounds").set_handler(
             get_vector_address(vector),
             cs,

--- a/core/patina_internal_cpu/src/interrupts/x64/interrupt_manager.rs
+++ b/core/patina_internal_cpu/src/interrupts/x64/interrupt_manager.rs
@@ -18,7 +18,7 @@ use patina_mtrr::Mtrr;
 use patina_paging::PageTable;
 use patina_stacktrace::{StackFrame, StackTrace};
 
-use crate::interrupts::{EfiExceptionStackTrace, HandlerType, InterruptManager, x64::ExceptionContextX64};
+use crate::interrupts::{EfiExceptionInfoDump, HandlerType, InterruptManager, x64::ExceptionContextX64};
 
 /// X64 Implementation of the InterruptManager.
 ///

--- a/core/patina_internal_cpu/src/interrupts/x64/interrupt_manager.rs
+++ b/core/patina_internal_cpu/src/interrupts/x64/interrupt_manager.rs
@@ -125,7 +125,21 @@ extern "efiapi" fn page_fault_handler(_exception_type: isize, context: EfiSystem
     // to report. The system is dead anyway.
     let x64_context = unsafe { context.system_context_x64.as_ref().unwrap() };
 
-    log::error!("EXCEPTION: PAGE FAULT");
+    let rsp_page = x64_context.rsp & !UEFI_PAGE_MASK as u64;
+    let cr2_page = x64_context.cr2 & !UEFI_PAGE_MASK as u64;
+    let same_or_below = (cr2_page == rsp_page) || (cr2_page == (rsp_page.wrapping_sub(UEFI_PAGE_SIZE as u64)));
+    let data_access = (x64_context.exception_data & bit!(4)) == 0;
+
+    // Stack overflows cause page faults, let's give a hint if it looks like one.
+    // The heuristic we are using is that stack overflow will either have CR2 on the same page
+    // as RSP or directly below it. Sometimes RSP is decremented first, sometimes second. Stack overflows
+    // are always data access, so ensure that is the case as well.
+    if same_or_below && data_access {
+        log::error!("EXCEPTION: PAGE FAULT STACK OVERFLOW");
+    } else {
+        log::error!("EXCEPTION: PAGE FAULT");
+    }
+
     log::error!("Accessed Address: {:#X?}", x64_context.cr2);
     log::error!("Paging Enabled: {}", x64_context.cr0 & 0x80000000 != 0);
     log::error!("Instruction Pointer: {:#X?}", x64_context.rip);


### PR DESCRIPTION
## Description

Stack overflows show up as page faults in the exception handler, which can be hard to distinguish from other kinds of page faults. This PR contains three commits to provide a hint that a stack overflow occurred.

x64: IDT: Use a Separate Stack for Page Fault Exceptions
--
Currently, only double faults use a separate stack. However, a stack overflow manifests as a page fault, so taking a stack overflow causes a double fault. This makes it harder to reason about what the fault was.

This commit instead using a separate stack for x64 page faults, aligning with the aarch64 side. This is in preparation for giving better information about stack overflows in the exception handlers.

exception handlers: Print Stack Overflow Hint
--
Currently, stack overflows show up as page faults in the exception handlers. This can make it hard to identify when a different page fault has occurred.

This commit introduces a heuristic to hint that a stack overflow likely occurred in the exception handler. It checks if the faulting address is on the same page as or one page lower than the stack pointer. In some cases, the stack pointer is incremented first, then data is written (in which case the faulting address is on the same page as the stack pointer) and in other cases the data is written before the stack pointer is decremented (so the faulting address is on the page below the stack pointer).

A pretty message is then printed to indicate a stack overflow occurred.

internal_cpu: Rename EfiExceptionStackTrace Trait
--
The EfiExceptionStackTrace trait is an internal trait that originally was just used so the common exception handler can use arch specific stack trace dumping.

However, this was expanded to also include dumping a page table walk, so the name is not accurate.

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

In Q35 and SBSA testing stack overflows which now look like:

<img width="1276" height="1007" alt="image" src="https://github.com/user-attachments/assets/b15ba48f-4d45-4341-89bd-4c26845bcee2" />

<img width="1339" height="675" alt="image" src="https://github.com/user-attachments/assets/bf97a47f-2721-4ef2-8fcb-ad3ed52c6aee" />

## Integration Instructions

N/A.