### PR TITLE
Move Patina QEMU PR Validation workflows to patina-devops main branch

### DIFF
--- a/.github/workflows/patina-qemu-pr-validation-pending.yml
+++ b/.github/workflows/patina-qemu-pr-validation-pending.yml
@@ -32,7 +32,7 @@ permissions:
 jobs:
   notify-pending:
     name: Run
-    uses: OpenDevicePartnership/patina-devops/.github/workflows/PatinaQemuPrValidationPending.yml@patina_e2e_plat_validation
+    uses: OpenDevicePartnership/patina-devops/.github/workflows/PatinaQemuPrValidationPending.yml@main
     with:
       head-sha: ${{ github.event.pull_request.head.sha }}
       pr-number: ${{ github.event.pull_request.number }}

--- a/.github/workflows/patina-qemu-pr-validation-post.yml
+++ b/.github/workflows/patina-qemu-pr-validation-post.yml
@@ -20,7 +20,7 @@ permissions:
 
 jobs:
   post-process:
-    uses: OpenDevicePartnership/patina-devops/.github/workflows/PatinaQemuPrValidationPost.yml@patina_e2e_plat_validation
+    uses: OpenDevicePartnership/patina-devops/.github/workflows/PatinaQemuPrValidationPost.yml@main
     with:
       conclusion: ${{ github.event.workflow_run.conclusion }}
       head-sha: ${{ github.event.workflow_run.head_sha }}

--- a/.github/workflows/patina-qemu-pr-validation.yml
+++ b/.github/workflows/patina-qemu-pr-validation.yml
@@ -119,7 +119,7 @@ jobs:
     name: Run Patina QEMU Validation
     needs: [prepare]
     if: needs.prepare.result == 'success' && needs.prepare.outputs.skip != 'true'
-    uses: OpenDevicePartnership/patina-devops/.github/workflows/PatinaQemuPrValidation.yml@patina_e2e_plat_validation
+    uses: OpenDevicePartnership/patina-devops/.github/workflows/PatinaQemuPrValidation.yml@main
     with:
       head-sha: ${{ github.event.workflow_run.head_sha }}
       patina-ref: ${{ github.event.workflow_run.head_sha }}


### PR DESCRIPTION
## Description

The workflows were previously using a branch dedicated to creating the workflow. All of the changes are in main now, so the workflows can use the main branch instead.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

- All of the changes in the branch previously being used `patina_e2e_plat_validation`

## Integration Instructions

- N/A