### PR TITLE
uart: bump uart_16550 dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,7 +54,7 @@ scroll = { version = "0.13", default-features = false, features = ["derive"]}
 spin = { version = "0.12" }
 syn = { version = "2" }
 time = { version = "0.3.49" }
-uart_16550 = { version = "0.3.2" }
+uart_16550 = { version = "0.6.0" }
 corosensei = { version = "0.3.4", default-features = false }
 uuid = { version = "1.23", default-features = false }
 zerocopy = { version = "0.8" }

--- a/core/patina_debugger/README.md
+++ b/core/patina_debugger/README.md
@@ -43,7 +43,8 @@ The self-hosted debugger is lightweight and tightly integrated with Patina, offe
 
 ## Platform Integration
 
-1. Instantiate a `PatinaDebugger` with the platform UART configuration (for example, `Uart16550::Io { base: 0x3F8 }`).
+1. Instantiate a `PatinaDebugger` with the platform UART configuration (for example,
+   `unsafe { Uart16550::new_port(0x3F8) }`).
 2. Apply any policy overrides such as `.with_force_enable`, `.with_log_policy`, or `.with_transport_init` when
    if the debugger must initialize the transport.
 3. Register the debugger using `patina_debugger::set_debugger(&DEBUGGER)` before the Patina DXE Core starts dispatching

--- a/docs/src/dev/principles/abstractions.md
+++ b/docs/src/dev/principles/abstractions.md
@@ -60,9 +60,11 @@ a simple stdio writer.
 ``` rust
 # extern crate log;
 # extern crate core;
+# extern crate spin;
 # extern crate uart_16550;
 // The starting abstraction point, the `Log` trait
 use log::Log;
+use spin::Mutex;
 use std::io::{Read, Write};
 
 /// Our Abstraction point for implementing different ways to perform a serial write
@@ -75,23 +77,23 @@ pub trait SerialIO {
 
 pub struct SerialLogger<S>
 where
-    S: SerialIO + Send + Sync,
+    S: SerialIO + Send,
 {
     /// An implementation of the abstraction point
-    serial: S,
+    serial: Mutex<S>,
     /// Will not log messages above this level
     max_level: log::LevelFilter,
 }
 
 impl<S> SerialLogger<S>
 where
-    S: SerialIO + Send + Sync,
+    S: SerialIO + Send,
 {
     pub const fn new(
         serial: S,
         max_level: log::LevelFilter,
     ) -> Self {
-        Self { serial, max_level }
+        Self { serial: Mutex::new(serial), max_level }
     }
 }
 
@@ -99,7 +101,7 @@ where
 // be implemented to complete the interface implementation
 impl<S> Log for SerialLogger<S>
 where
-    S: SerialIO + Send + Sync,
+    S: SerialIO + Send,
 {
     fn enabled(&self, metadata: &log::Metadata) -> bool {
         return metadata.level().to_level_filter() <= self.max_level
@@ -109,7 +111,7 @@ where
         let formatted = format!("{} - {}\n", record.level(), record.args());
         // We know our "serial" object must have the "write" function, we just don't know the
         // implementation details, which is fine.
-        self.serial.write(&formatted.into_bytes());
+        self.serial.lock().write(&formatted.into_bytes());
     }
 
     fn flush(&self) {}
@@ -142,40 +144,32 @@ impl SerialIO for Terminal {
     }
 }
 
-use uart_16550::MmioSerialPort;
-struct Uart16550(usize);
+use core::ptr::{NonNull, with_exposed_provenance_mut};
+use uart_16550::backend::MmioBackend;
+use uart_16550::{Config, Uart16550};
 
-impl Uart16550 {
-    fn new(addr: usize) -> Self {
-        Self(addr)
-    }
-}
+struct MmioUart(Mutex<Uart16550<MmioBackend>>);
 
-impl SerialIO for Uart16550 {
+impl SerialIO for MmioUart {
     fn init(&self) {
-        unsafe { MmioSerialPort::new(self.0).init() };
+        self.0
+            .lock()
+            .init(Config::default())
+            .expect("UART 16550 MMIO device initialization must succeed");
     }
 
     fn write(&self, buffer: &[u8]) {
-        let mut port = unsafe { MmioSerialPort::new(self.0) };
-
-        for b in buffer {
-            port.send(*b);
-        }
+        self.0.lock().send_bytes_exact(buffer);
     }
 
     fn read(&self) -> u8 {
-        let mut port = unsafe { MmioSerialPort::new(self.0) };
-        port.receive()
+        let mut byte = [0];
+        self.0.lock().receive_bytes_exact(&mut byte);
+        byte[0]
     }
 
     fn try_read(&self) -> Option<u8> {
-        let mut port = unsafe { MmioSerialPort::new(self.0) };
-        if let Ok(value) = port.try_receive() {
-            Some(value)
-        } else {
-            None
-        }
+        self.0.lock().try_receive_byte().ok()
     }
 }
 
@@ -183,6 +177,14 @@ impl SerialIO for Uart16550 {
 fn main() {
     let terminal_logger = SerialLogger::new(Terminal, log::LevelFilter::Trace);
 
-    let uart16550_logger = SerialLogger::new(Uart16550::new(0x4000), log::LevelFilter::Trace);
+    let uart16550_logger = SerialLogger::new(
+        MmioUart(Mutex::new(unsafe {
+            let base = NonNull::new(with_exposed_provenance_mut::<u8>(0x4000))
+                .expect("UART 16550 MMIO base address must be non-null");
+            Uart16550::new_mmio(base, 1)
+                .expect("UART 16550 MMIO base address and register stride must be valid")
+        })),
+        log::LevelFilter::Trace,
+    );
 }
 ```

--- a/sdk/patina/src/log.rs
+++ b/sdk/patina/src/log.rs
@@ -18,7 +18,8 @@
 //!    Format::Standard,
 //!    &[("crate1::module", log::LevelFilter::Off)],
 //!    log::LevelFilter::Trace,
-//!    Uart16550::new(Interface::Io(0x3F8)),
+//!    // SAFETY: The platform owns the UART I/O port for serial logging.
+//!    unsafe { Uart16550::new_port(0x3F8) },
 //! );
 //!
 //! let uart_pl011_logger = SerialLogger::new(

--- a/sdk/patina/src/serial/uart.rs
+++ b/sdk/patina/src/serial/uart.rs
@@ -29,8 +29,10 @@ impl super::SerialIO for UartNull {
 cfg_if::cfg_if! {
     if #[cfg(all(target_arch = "x86_64", any(target_os = "uefi", feature = "doc")))] {
 
-        use uart_16550::MmioSerialPort;
-        use uart_16550::SerialPort as IoSerialPort;
+        use core::ptr::{NonNull as PtrNonNull, with_exposed_provenance_mut};
+        use spin::Mutex;
+        use uart_16550::backend::{MmioBackend, PioBackend};
+        use uart_16550::{Config, Uart16550 as Uart16550Device};
 
         /// Returns the Current Privilege Level (CPL) from the CS selector.
         fn current_privilege_level() -> u16 {
@@ -64,44 +66,81 @@ cfg_if::cfg_if! {
         #[derive(Debug)]
         pub enum Uart16550 {
             /// The I/O interface for the Uart16550 serial port.
-            Io {
-                /// The base address of the UART control registers.
-                base: u16
-            },
+            Io(Mutex<Uart16550Device<PioBackend>>),
             /// The Memory Mapped I/O interface for the Uart16550 serial port.
-            Mmio {
-                /// The base address of the UART control registers.
-                base: usize,
-                /// The number of bytes between consecutive registers.
-                reg_stride: usize
-            },
+            Mmio(Mutex<Uart16550Device<MmioBackend>>),
+        }
+
+        impl Uart16550 {
+            /// Constructs a UART backed by x86 port I/O.
+            ///
+            /// # Safety
+            ///
+            /// The base port must be valid and safe to access for the lifetime
+            /// of the returned wrapper.
+            pub unsafe fn new_port(base: u16) -> Self {
+                // SAFETY: The caller guarantees that `base` is valid for UART port I/O.
+                let uart = unsafe { Uart16550Device::new_port(base) }
+                    .expect("UART 16550 I/O base address must allow access to all registers");
+                Self::Io(Mutex::new(uart))
+            }
+
+            /// Constructs a UART backed by memory-mapped I/O.
+            ///
+            /// # Safety
+            ///
+            /// The base address must be valid and safe to access for the
+            /// lifetime of the returned wrapper.
+            pub unsafe fn new_mmio(base: usize, reg_stride: u8) -> Self {
+                let base = PtrNonNull::new(with_exposed_provenance_mut::<u8>(base))
+                    .expect("UART 16550 MMIO base address must be non-null");
+                // SAFETY: The caller guarantees that `base` is valid for UART MMIO access.
+                let uart = unsafe { Uart16550Device::new_mmio(base, reg_stride) }
+                    .expect("UART 16550 MMIO base address and register stride must be valid");
+                Self::Mmio(Mutex::new(uart))
+            }
         }
 
         impl super::SerialIO for Uart16550 {
             fn init(&self) {
-                match self {
-                    Uart16550::Io { base } => {
-                        // SAFETY: The base address is provided during Uart16550 construction and is assumed to be valid for I/O port access.
-                        let mut serial_port = unsafe { IoSerialPort::new(*base) };
-                        serial_port.init();
+                let init = || match self {
+                    Uart16550::Io(uart) => {
+                        let mut uart = uart
+                            .try_lock()
+                            .expect("UART 16550 I/O device lock must not be re-entered");
+                        uart.init(Config::default())
+                            .expect("UART 16550 I/O device initialization must succeed");
                     }
-                    Uart16550::Mmio { base, reg_stride } => {
-                        // SAFETY: The base address and stride are provided during Uart16550 construction and are assumed to be valid for MMIO access.
-                        let mut serial_port = unsafe { MmioSerialPort::new_with_stride(*base, *reg_stride) };
-                        serial_port.init();
+                    Uart16550::Mmio(uart) => {
+                        let mut uart = uart
+                            .try_lock()
+                            .expect("UART 16550 MMIO device lock must not be re-entered");
+                        uart.init(Config::default())
+                            .expect("UART 16550 MMIO device initialization must succeed");
                     }
+                };
+
+                if current_privilege_level() == 0 {
+                    // CPL is 0, so cli/sti are permitted.
+                    without_interrupts(init);
+                } else {
+                    init();
                 }
             }
 
             fn write(&self, buffer: &[u8]) {
                 match self {
-                    Uart16550::Io { base } => {
-                        // SAFETY: The base address is provided during Uart16550 construction and is assumed to be valid for I/O port access.
-                        let mut serial_port = unsafe { IoSerialPort::new(*base) };
-                        let mut send = || {
-                            for b in buffer {
-                                serial_port.send(*b);
-                            }
+                    Uart16550::Io(uart) => {
+                        let send = || {
+                            let Some(mut uart) = uart.try_lock() else {
+                                debug_assert!(
+                                    false,
+                                    "UART 16550 I/O device lock must not be re-entered",
+                                );
+                                return;
+                            };
+
+                            uart.send_bytes_exact(buffer);
                         };
                         if current_privilege_level() == 0 {
                             // CPL is 0, so cli/sti are permitted.
@@ -110,13 +149,17 @@ cfg_if::cfg_if! {
                             send();
                         }
                     }
-                    Uart16550::Mmio { base, reg_stride } => {
-                        // SAFETY: The base address and stride are provided during Uart16550 construction and are assumed to be valid for MMIO access.
-                        let mut serial_port = unsafe { MmioSerialPort::new_with_stride(*base, *reg_stride) };
-                        let mut send = || {
-                            for b in buffer {
-                                serial_port.send(*b);
-                            }
+                    Uart16550::Mmio(uart) => {
+                        let send = || {
+                            let Some(mut uart) = uart.try_lock() else {
+                                debug_assert!(
+                                    false,
+                                    "UART 16550 MMIO device lock must not be re-entered",
+                                );
+                                return;
+                            };
+
+                            uart.send_bytes_exact(buffer);
                         };
                         if current_privilege_level() == 0 {
                             // CPL is 0, so cli/sti are permitted.
@@ -130,30 +173,42 @@ cfg_if::cfg_if! {
 
             fn read(&self) -> u8 {
                 match self {
-                    Uart16550::Io { base } => {
-                        // SAFETY: The base address is provided during Uart16550 construction and is assumed to be valid for I/O port access.
-                        let mut serial_port = unsafe { IoSerialPort::new(*base) };
-                        serial_port.receive()
+                    Uart16550::Io(uart) => {
+                        let Some(mut uart) = uart.try_lock() else {
+                            debug_assert!(
+                                false,
+                                "UART 16550 I/O device lock must not be re-entered",
+                            );
+                            return 0;
+                        };
+
+                        let mut byte = [0];
+                        uart.receive_bytes_exact(&mut byte);
+                        byte[0]
                     }
-                    Uart16550::Mmio { base, reg_stride } => {
-                        // SAFETY: The base address and stride are provided during Uart16550 construction and are assumed to be valid for MMIO access.
-                        let mut serial_port = unsafe { MmioSerialPort::new_with_stride(*base, *reg_stride) };
-                        serial_port.receive()
+                    Uart16550::Mmio(uart) => {
+                        let Some(mut uart) = uart.try_lock() else {
+                            debug_assert!(
+                                false,
+                                "UART 16550 MMIO device lock must not be re-entered",
+                            );
+                            return 0;
+                        };
+
+                        let mut byte = [0];
+                        uart.receive_bytes_exact(&mut byte);
+                        byte[0]
                     }
                 }
             }
 
             fn try_read(&self) -> Option<u8> {
                 match self {
-                    Uart16550::Io { base } => {
-                        // SAFETY: The base address is provided during Uart16550 construction and is assumed to be valid for I/O port access.
-                        let mut serial_port = unsafe { IoSerialPort::new(*base) };
-                        serial_port.try_receive().ok()
+                    Uart16550::Io(uart) => {
+                        uart.try_lock().and_then(|mut uart| uart.try_receive_byte().ok())
                     }
-                    Uart16550::Mmio { base, reg_stride } => {
-                        // SAFETY: The base address and stride are provided during Uart16550 construction and are assumed to be valid for MMIO access.
-                        let mut serial_port = unsafe { MmioSerialPort::new_with_stride(*base, *reg_stride) };
-                        serial_port.try_receive().ok()
+                    Uart16550::Mmio(uart) => {
+                        uart.try_lock().and_then(|mut uart| uart.try_receive_byte().ok())
                     }
                 }
             }
@@ -219,7 +274,10 @@ cfg_if::cfg_if! {
                 // SAFETY: The base address is required by the safety contract of new() to point
                 // to a PL011 register block that is mapped as device memory.
                 unsafe {
-                    UniqueMmioPointer::new(NonNull::new(self.base_address as *mut Pl011Registers).unwrap())
+                    UniqueMmioPointer::new(
+                        NonNull::new(self.base_address as *mut Pl011Registers)
+                            .expect("PL011 base address must be non-null"),
+                    )
                 }
             }
 

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -541,7 +541,7 @@ version = "1.19.0"
 criteria = "safe-to-run"
 
 [[exemptions.uart_16550]]
-version = "0.3.2"
+version = "0.6.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.uint]]


### PR DESCRIPTION
## Description

Since v0.5.0, the crate got a major overhaul with a focus to work on physical hardware next to VMs. I've bumped the dependency to 0.6.0.

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

I simply bumped the crate without major testing (I am relying on the CI). I am the author of `uart_16550` and tested this in various VMs (QEMU, Cloud Hypervisor) and also on real x86 hardware. I just bumped the dependency here in a straight forward way.

## Integration Instructions

- N/A