### PR TITLE
patina_dxe_core: fix CreateEvent and LoadImage UEFI conformance

### DIFF
--- a/patina_dxe_core/src/event_db.rs
+++ b/patina_dxe_core/src/event_db.rs
@@ -326,6 +326,10 @@ impl EventDb {
             return Err(EfiError::OutOfResources);
         }
 
+        // Validate the event type before the runtime/non-runtime split (only the
+        // non-runtime path validates it via Event::new).
+        EventType::try_from(event_type)?;
+
         let runtime =
             (event_type & efi::EVT_RUNTIME) != 0 || event_group == Some(efi::EVENT_GROUP_VIRTUAL_ADDRESS_CHANGE);
 
@@ -940,6 +944,36 @@ mod tests {
             let result = SPIN_LOCKED_EVENT_DB.create_event(
                 efi::EVT_TIMER | efi::EVT_NOTIFY_SIGNAL,
                 efi::TPL_HIGH_LEVEL + 1,
+                Some(test_notify_function),
+                None,
+                None,
+            );
+            assert_eq!(result, Err(EfiError::InvalidParameter));
+        });
+    }
+
+    #[test]
+    fn create_event_with_invalid_runtime_type_combinations_should_fail() {
+        with_locked_state(|| {
+            static SPIN_LOCKED_EVENT_DB: SpinLockedEventDb = SpinLockedEventDb::new();
+
+            // Illegal EVT_RUNTIME combinations must be rejected with EFI_INVALID_PARAMETER,
+            // not routed to the runtime path.
+
+            // EVT_SIGNAL_VIRTUAL_ADDRESS_CHANGE | EVT_NOTIFY_WAIT (0x60000302)
+            let result = SPIN_LOCKED_EVENT_DB.create_event(
+                efi::EVT_SIGNAL_VIRTUAL_ADDRESS_CHANGE | efi::EVT_NOTIFY_WAIT,
+                efi::TPL_NOTIFY,
+                Some(test_notify_function),
+                None,
+                None,
+            );
+            assert_eq!(result, Err(EfiError::InvalidParameter));
+
+            // EVT_SIGNAL_VIRTUAL_ADDRESS_CHANGE | EVT_TIMER (0xE0000202)
+            let result = SPIN_LOCKED_EVENT_DB.create_event(
+                efi::EVT_SIGNAL_VIRTUAL_ADDRESS_CHANGE | efi::EVT_TIMER,
+                efi::TPL_NOTIFY,
                 Some(test_notify_function),
                 None,
                 None,

--- a/patina_dxe_core/src/pi_dispatcher/image.rs
+++ b/patina_dxe_core/src/pi_dispatcher/image.rs
@@ -712,8 +712,10 @@ impl<P: super::PlatformInfo> super::PiDispatcher<P> {
         perf_load_image_begin(core::ptr::null_mut(), create_performance_measurement);
 
         if image.is_none() && file_path.is_none() {
-            log::error!("failed to load image: image is none or device path is null.");
-            return Err(EfiError::InvalidParameter.into());
+            log::error!("failed to load image: both source buffer and device path are null.");
+            // DevicePath is OPTIONAL (UEFI 2.11 §7.4). With neither a source buffer nor a
+            // device path there is nothing to load, so LoadImage returns EFI_NOT_FOUND.
+            return Err(EfiError::NotFound.into());
         }
 
         ImageData::validate_parent(parent_image_handle)?;
@@ -1679,15 +1681,17 @@ mod tests {
     }
 
     #[test]
-    fn load_image_invalid_parameter() {
+    fn load_image_should_fail_with_no_source_or_path() {
         with_locked_state(|| {
             static PI_DISPATCHER: PiDispatcher<MockPlatformInfo> =
                 PiDispatcher::<MockPlatformInfo>::new(patina_ffs_extractors::NullSectionExtractor);
             PI_DISPATCHER.init(&create_dxe_core_hob(), SYSTEM_TABLE.lock().as_mut().unwrap());
 
+            // Per the UEFI Specification (EFI_BOOT_SERVICES.LoadImage()), when both
+            // SourceBuffer and DevicePath are NULL, EFI_NOT_FOUND must be returned.
             let result = PI_DISPATCHER.load_image(false, protocol_db::DXE_CORE_HANDLE, None, None);
 
-            assert!(matches!(result, Err(ImageStatus::LoadError(EfiError::InvalidParameter))));
+            assert!(matches!(result, Err(ImageStatus::LoadError(EfiError::NotFound))));
         });
     }
 


### PR DESCRIPTION
## Summary
Fixes two UEFI conformance failures found via SystemReady ACS (SCT) on AARCH64.

### CreateEvent (`event_db.rs`)
`EventDb::create_event` only validated the event type on the non-runtime path (via `Event::new`). An illegal `EVT_RUNTIME` combination (e.g. `EVT_SIGNAL_VIRTUAL_ADDRESS_CHANGE | EVT_NOTIFY_WAIT`) was routed to the runtime path and accepted. Per the UEFI spec (CreateEvent), such types must return `EFI_INVALID_PARAMETER`. Validation is now performed before the runtime/non-runtime split.

### LoadImage (`pi_dispatcher/image.rs`)
When both `SourceBuffer` and `DevicePath` are NULL, the implementation returned `EFI_INVALID_PARAMETER`. `DevicePath` is OPTIONAL (UEFI 2.11 7.4 / Mantis 2277); with nothing to load, LoadImage must return `EFI_NOT_FOUND`.

## Testing
- Unit tests added/updated in both modules.
- Validated on hardware with SystemReady ACS SCT (`CreateEvent_Conf`, `CreateEventEx_Conf`, `LoadImage_Conf`, `LoadImage_Func`): 19 failures -> 0.