### PR TITLE
Patina: Implement VirtIO serial port and supporting change [FF & REBASE]

### DIFF
--- a/cspell.yml
+++ b/cspell.yml
@@ -177,6 +177,7 @@ words:
   - rdmsr
   - rdram
   - rdtsc
+  - reborrow
   - reentrancy
   - regsvr
   - relia
@@ -223,7 +224,11 @@ words:
   - variadics
   - vcvarsamd
   - vcvarsarm
+  - virtio
+  - virtq
+  - virtqueue
   - vlvesa
+  - vring
   - vtable
   - wakeup
   - wasip

--- a/sdk/patina/src/arch.rs
+++ b/sdk/patina/src/arch.rs
@@ -7,8 +7,73 @@
 //! SPDX-License-Identifier: Apache-2.0
 //!
 
-#[cfg(all(not(test), target_arch = "aarch64"))]
-pub mod aarch64;
+cfg_if::cfg_if! {
+    if #[cfg(test)] {
+        #[coverage(off)]
+        mod null;
+        type Arch = null::NullArch;
+    } else if #[cfg(target_arch = "aarch64")] {
+        #[coverage(off)] // Architecture code cannot be unit tested.
+        pub mod aarch64;
+        type Arch = aarch64::AArch64;
+    } else if #[cfg(target_arch = "x86_64")] {
+        #[coverage(off)] // Architecture code cannot be unit tested.
+        pub mod x64;
+        type Arch = x64::X64;
+    }
+}
 
-#[cfg(all(not(test), target_arch = "x86_64"))]
-pub mod x64;
+#[allow(unused)]
+/// A trait for architecture-specific functionality. It inherits from subtraits
+/// for code organization.
+trait ArchSupport: Interrupts {}
+
+//
+// Interrupts support.
+//
+// Only `with_interrupts_disabled` is being exposed publically for now to
+// avoid misuse of direct interrupt manipulation.
+//
+
+trait Interrupts {
+    fn enable_interrupts();
+    fn disable_interrupts();
+    fn interrupts_enabled() -> bool;
+}
+
+/// Enables CPU interrupts on the current architecture.
+fn enable_interrupts() {
+    <Arch as Interrupts>::enable_interrupts();
+}
+
+/// Disables CPU interrupts on the current architecture.
+fn disable_interrupts() {
+    <Arch as Interrupts>::disable_interrupts();
+}
+
+/// Returns whether CPU interrupts are currently enabled on the current architecture.
+fn interrupts_enabled() -> bool {
+    <Arch as Interrupts>::interrupts_enabled()
+}
+
+/// Executes a closure with CPU interrupts disabled, interrupts will be restored to their
+/// previous state after the closure is executed.
+///
+/// ## Important
+///
+/// This function is only intended for low-level operations, and should not be used in
+/// components. Components should use the TPL (Task Priority Level) to manage interrupts.
+pub(crate) fn with_interrupts_disabled<F, R>(f: F) -> R
+where
+    F: FnOnce() -> R,
+{
+    let enabled = interrupts_enabled();
+    if enabled {
+        disable_interrupts();
+    }
+    let result = f();
+    if enabled {
+        enable_interrupts();
+    }
+    result
+}

--- a/sdk/patina/src/arch/aarch64.rs
+++ b/sdk/patina/src/arch/aarch64.rs
@@ -9,6 +9,10 @@
 //! Portions Copyright 2023 The arm-gic Authors.
 //! arm-gic is dual-licensed under Apache 2.0 and MIT terms.
 
+pub(super) struct AArch64;
+
+impl super::ArchSupport for AArch64 {}
+
 /// Reads and returns the value of the given aarch64 system register.
 #[macro_export]
 macro_rules! read_sysreg {
@@ -126,4 +130,19 @@ macro_rules! write_sysreg {
             }
         }
     };
+}
+
+impl super::Interrupts for AArch64 {
+    fn enable_interrupts() {
+        write_sysreg!(reg daifclr, imm 0x02, "isb sy");
+    }
+
+    fn disable_interrupts() {
+        write_sysreg!(reg daifset, imm 0x02, "isb sy");
+    }
+
+    fn interrupts_enabled() -> bool {
+        let daif = read_sysreg!(daif);
+        daif & 0x80 == 0
+    }
 }

--- a/sdk/patina/src/arch/null.rs
+++ b/sdk/patina/src/arch/null.rs
@@ -1,0 +1,23 @@
+//! No-op `Architecture` implementation for unit tests.
+//!
+//! ## License
+//!
+//! Copyright (c) Microsoft Corporation.
+//!
+//! SPDX-License-Identifier: Apache-2.0
+//!
+
+/// No-op architecture used in unit tests.
+pub(crate) struct NullArch;
+
+impl super::ArchSupport for NullArch {}
+
+impl super::Interrupts for NullArch {
+    fn enable_interrupts() {}
+
+    fn disable_interrupts() {}
+
+    fn interrupts_enabled() -> bool {
+        false
+    }
+}

--- a/sdk/patina/src/arch/x64.rs
+++ b/sdk/patina/src/arch/x64.rs
@@ -7,13 +7,18 @@
 //! SPDX-License-Identifier: Apache-2.0
 //!
 
+use core::arch::asm;
+
+pub(crate) struct X64;
+
+impl super::ArchSupport for X64 {}
+
 /// Writes a byte to an x64 I/O port.
 ///
 /// # Safety
 ///
 /// The caller must ensure `port` is valid for byte writes on this platform and
 /// that the side effects are safe in the current execution context.
-#[coverage(off)]
 pub unsafe fn io_out8(port: u16, value: u8) {
     // SAFETY: Guaranteed by caller.
     unsafe {
@@ -27,11 +32,37 @@ pub unsafe fn io_out8(port: u16, value: u8) {
 }
 
 /// Reads the time-stamp counter.
-#[coverage(off)]
 pub fn rdtsc() -> u64 {
     let lo: u32;
     let hi: u32;
     // SAFETY: `rdtsc` reads a CPU counter and does not violate memory safety.
     unsafe { core::arch::asm!("rdtsc", out("eax") lo, out("edx") hi, options(nostack, nomem)) };
     ((hi as u64) << 32) | lo as u64
+}
+
+impl super::Interrupts for X64 {
+    fn enable_interrupts() {
+        // SAFETY: Enabling interrupts via `sti` does not violate memory safety; the caller is
+        // responsible for ensuring the system is ready to service interrupts.
+        unsafe {
+            asm!("sti", options(nostack, nomem, preserves_flags));
+        }
+    }
+
+    fn disable_interrupts() {
+        // SAFETY: Disabling interrupts via `cli` does not violate memory safety.
+        unsafe {
+            asm!("cli", options(nostack, nomem, preserves_flags));
+        }
+    }
+
+    fn interrupts_enabled() -> bool {
+        let eflags: u64;
+        const IF: u64 = 0x200;
+        // SAFETY: Reading RFLAGS via a push and pop has no side effects.
+        unsafe {
+            asm!("pushfq; pop {}", out(reg) eflags);
+        }
+        eflags & IF != 0
+    }
 }

--- a/sdk/patina/src/serial.rs
+++ b/sdk/patina/src/serial.rs
@@ -20,6 +20,7 @@ pub trait SerialIO: Sync {
 }
 
 pub mod uart;
+pub mod virtio;
 
 #[cfg(feature = "std")]
 mod std;

--- a/sdk/patina/src/serial/virtio.rs
+++ b/sdk/patina/src/serial/virtio.rs
@@ -1,0 +1,282 @@
+//! [`SerialIO`](crate::serial::SerialIO) implementation for a virtio-console device on the virtio-MMIO transport.
+//!
+//! ## License
+//!
+//! Copyright (C) Microsoft Corporation.
+//!
+//! SPDX-License-Identifier: Apache-2.0
+//!
+
+// The internal virtio infrastructure is being left private for now. It's written to be re-usable,
+// but until there is a known use-case, don't expose a public API for it.
+mod mmio;
+mod queue;
+
+use spin::Mutex;
+
+use mmio::VirtioMmio;
+use queue::VirtQueue;
+
+/// Virtio device id for a console device.
+const VIRTIO_ID_CONSOLE: u32 = 3;
+
+/// Receive virt queue index.
+const RX_QUEUE: u32 = 0;
+/// Transmit virt queue index.
+const TX_QUEUE: u32 = 1;
+
+struct State<const N: usize, const B: usize> {
+    initialized: bool,
+    transport: VirtioMmio,
+    rx: VirtQueue<N, B>,
+    tx: VirtQueue<N, B>,
+    rx_block_offset: usize,
+}
+
+impl<const N: usize, const B: usize> State<N, B> {
+    const unsafe fn new(base_address: usize) -> Self {
+        Self {
+            initialized: false,
+            // SAFETY: forwarded from the caller of this function.
+            transport: unsafe { VirtioMmio::new(base_address) },
+            rx: VirtQueue::new(),
+            tx: VirtQueue::new(),
+            rx_block_offset: 0,
+        }
+    }
+}
+
+/// A [`SerialIO`](crate::serial::SerialIO) implementation for a virtio-console
+/// device attached via the virtio-MMIO transport.
+pub struct VirtioSerial<const N: usize = 8, const B: usize = 128> {
+    state: Mutex<State<N, B>>,
+}
+
+impl<const N: usize, const B: usize> VirtioSerial<N, B> {
+    /// Constructs a new instance for a virtio-MMIO device at the given base
+    /// address. [`SerialIO::init`](crate::serial::SerialIO::init) must be
+    /// called before any I/O.
+    ///
+    /// # Safety
+    ///
+    /// `base_address` must point to an appropriately mapped virtio-MMIO register
+    /// window for a virtio-console. This address must be exclusively used by
+    /// this instance.
+    pub const unsafe fn new(base_address: usize) -> Self {
+        // SAFETY: forwarded from caller.
+        Self { state: Mutex::new(unsafe { State::new(base_address) }) }
+    }
+}
+
+impl<const N: usize, const B: usize> crate::serial::SerialIO for VirtioSerial<N, B> {
+    fn init(&self) {
+        crate::arch::with_interrupts_disabled(|| {
+            let Some(mut guard) = self.state.try_lock() else {
+                return;
+            };
+            let state: &mut State<N, B> = &mut guard;
+            if state.initialized {
+                return;
+            }
+
+            if state.transport.begin_init(VIRTIO_ID_CONSOLE).is_err() {
+                return;
+            }
+            if state.transport.configure_queue(RX_QUEUE, &state.rx).is_err()
+                || state.transport.configure_queue(TX_QUEUE, &state.tx).is_err()
+            {
+                state.transport.set_failed();
+                return;
+            }
+            state.transport.set_driver_ok();
+            state.rx.rx_clean();
+            state.transport.notify(RX_QUEUE);
+            state.initialized = true;
+        });
+    }
+
+    fn write(&self, buffer: &[u8]) {
+        crate::arch::with_interrupts_disabled(|| {
+            let Some(mut guard) = self.state.try_lock() else {
+                return;
+            };
+            let state: &mut State<N, B> = &mut guard;
+            if !state.initialized {
+                return;
+            }
+
+            let mut offset = 0;
+            while offset < buffer.len() {
+                // Spin until a block is available in the queue.
+                let take = loop {
+                    let remaining = buffer.get(offset..).expect("offset < buffer.len()");
+                    if let Some(n) = state.tx.tx_try_submit(remaining) {
+                        break n;
+                    }
+                    core::hint::spin_loop();
+                };
+                offset += take;
+                state.transport.notify(TX_QUEUE);
+            }
+        });
+    }
+
+    fn read(&self) -> u8 {
+        loop {
+            if let Some(b) = self.try_read() {
+                return b;
+            }
+            core::hint::spin_loop();
+        }
+    }
+
+    fn try_read(&self) -> Option<u8> {
+        crate::arch::with_interrupts_disabled(|| {
+            let mut guard = self.state.try_lock()?;
+            let state: &mut State<N, B> = &mut guard;
+            if !state.initialized {
+                return None;
+            }
+
+            // Get the next byte of the next RX block.
+            let data = state.rx.rx_peek()?;
+            let byte = *data.get(state.rx_block_offset).expect("rx_block_offset < data.len()");
+            state.rx_block_offset += 1;
+
+            // Release this block if all its data is consumed.
+            if state.rx_block_offset >= data.len() {
+                state.rx_block_offset = 0;
+                state.rx.rx_release();
+                state.transport.notify(RX_QUEUE);
+            }
+            Some(byte)
+        })
+    }
+}
+
+#[cfg(test)]
+#[coverage(off)]
+mod tests {
+    #![allow(clippy::indexing_slicing)]
+
+    use super::*;
+    use crate::serial::SerialIO;
+    use alloc::vec::Vec;
+    use mmio::VirtioMmioRegs;
+
+    fn test_instance<const N: usize, const B: usize>(regs: &VirtioMmioRegs) -> VirtioSerial<N, B> {
+        // SAFETY: `regs` outlives the returned `VirtioSerial`.
+        let serial = unsafe { VirtioSerial::<N, B>::new(core::ptr::from_ref(regs) as usize) };
+
+        // Skip device-handshake initialization.
+        let mut guard = serial.state.lock();
+        guard.rx.rx_clean();
+        guard.initialized = true;
+        drop(guard);
+
+        serial
+    }
+
+    #[test]
+    fn test_virtio_serial_write_single_descriptor() {
+        let regs = VirtioMmioRegs::new_fake(VIRTIO_ID_CONSOLE);
+        let serial: VirtioSerial<4, 16> = test_instance(&regs);
+        serial.write(b"hello");
+        let chunks = serial.state.lock().tx.test_drain_tx();
+        assert_eq!(chunks.len(), 1);
+        assert_eq!(chunks[0], b"hello");
+    }
+
+    #[test]
+    fn test_virtio_serial_write_spans_multiple_descriptors() {
+        // B = 4 forces chunking.
+        let regs = VirtioMmioRegs::new_fake(VIRTIO_ID_CONSOLE);
+        let serial: VirtioSerial<4, 4> = test_instance(&regs);
+        serial.write(b"abcdefghij");
+        let chunks = serial.state.lock().tx.test_drain_tx();
+        let combined: Vec<u8> = chunks.into_iter().flatten().collect();
+        assert_eq!(combined, b"abcdefghij");
+    }
+
+    #[test]
+    fn test_virtio_serial_write_reuses_slots_after_drain() {
+        // Two 8-byte writes through an 8-byte (N * B) queue.
+        let regs = VirtioMmioRegs::new_fake(VIRTIO_ID_CONSOLE);
+        let serial: VirtioSerial<2, 4> = test_instance(&regs);
+        serial.write(b"abcdefgh");
+        let first = serial.state.lock().tx.test_drain_tx();
+        let first_combined: Vec<u8> = first.into_iter().flatten().collect();
+        assert_eq!(first_combined, b"abcdefgh");
+
+        serial.write(b"ABCDEFGH");
+        let second = serial.state.lock().tx.test_drain_tx();
+        let second_combined: Vec<u8> = second.into_iter().flatten().collect();
+        assert_eq!(second_combined, b"ABCDEFGH");
+    }
+
+    #[test]
+    fn test_virtio_serial_try_read_empty() {
+        let regs = VirtioMmioRegs::new_fake(VIRTIO_ID_CONSOLE);
+        let serial: VirtioSerial<4, 16> = test_instance(&regs);
+        assert_eq!(serial.try_read(), None);
+    }
+
+    #[test]
+    fn test_virtio_serial_read_single_block() {
+        let regs = VirtioMmioRegs::new_fake(VIRTIO_ID_CONSOLE);
+        let serial: VirtioSerial<4, 16> = test_instance(&regs);
+        let supplied = serial.state.lock().rx.test_supply_rx(b"world");
+        assert_eq!(supplied, Some(5));
+        let mut got = Vec::new();
+        for _ in 0..5 {
+            got.push(serial.read());
+        }
+        assert_eq!(got, b"world");
+        assert_eq!(serial.try_read(), None);
+    }
+
+    #[test]
+    fn test_virtio_serial_read_spans_multiple_blocks() {
+        let regs = VirtioMmioRegs::new_fake(VIRTIO_ID_CONSOLE);
+        let serial: VirtioSerial<4, 4> = test_instance(&regs);
+        assert_eq!(serial.state.lock().rx.test_supply_rx(b"foo"), Some(3));
+        assert_eq!(serial.state.lock().rx.test_supply_rx(b"bar"), Some(3));
+        let mut got = Vec::new();
+        for _ in 0..6 {
+            got.push(serial.read());
+        }
+        assert_eq!(got, b"foobar");
+    }
+
+    #[test]
+    fn test_virtio_serial_tx_reap_reclaims_completed_slots() {
+        let regs = VirtioMmioRegs::new_fake(VIRTIO_ID_CONSOLE);
+        let serial: VirtioSerial<2, 4> = test_instance(&regs);
+
+        // Fill both TX descriptors, then drain to mark them used.
+        serial.write(b"00001111");
+        let drained = serial.state.lock().tx.test_drain_tx();
+        assert_eq!(drained.len(), 2);
+        assert_eq!(drained[0], b"0000");
+        assert_eq!(drained[1], b"1111");
+
+        // This write would spin forever if `tx_reap` didn't reclaim slots.
+        serial.write(b"2222");
+        let after = serial.state.lock().tx.test_drain_tx();
+        assert_eq!(after.len(), 1);
+        assert_eq!(after[0], b"2222");
+    }
+
+    #[test]
+    fn test_virtio_serial_read_truncates_to_buffer_size() {
+        // 5-byte payload truncated to B = 4.
+        let regs = VirtioMmioRegs::new_fake(VIRTIO_ID_CONSOLE);
+        let serial: VirtioSerial<4, 4> = test_instance(&regs);
+        assert_eq!(serial.state.lock().rx.test_supply_rx(b"abcde"), Some(4));
+        let mut got = Vec::new();
+        for _ in 0..4 {
+            got.push(serial.read());
+        }
+        assert_eq!(got, b"abcd");
+    }
+}

--- a/sdk/patina/src/serial/virtio/mmio.rs
+++ b/sdk/patina/src/serial/virtio/mmio.rs
@@ -1,0 +1,375 @@
+//! virtio-MMIO (version 2 / virtio 1.x) transport.
+//!
+//! Provides the device-agnostic register-block handshake, queue programming,
+//! and notification primitives shared by any virtio device riding on the
+//! virtio-MMIO transport.
+//!
+//! ## License
+//!
+//! Copyright (C) Microsoft Corporation.
+//!
+//! SPDX-License-Identifier: Apache-2.0
+//!
+
+use core::{
+    ptr::NonNull,
+    sync::atomic::{Ordering, fence},
+};
+
+use crate::mmio::{
+    UniqueMmioPointer, field,
+    fields::{ReadPure, ReadPureWrite, WriteOnly},
+};
+
+use super::queue::VirtQueue;
+
+/// Magic value read from offset 0.
+const VIRTIO_MMIO_MAGIC: u32 = crate::signature!('v', 'i', 'r', 't');
+/// Modern virtio-MMIO transport version.
+const VIRTIO_MMIO_VERSION: u32 = 2;
+
+// Bits in the status register.
+const STATUS_ACKNOWLEDGE: u32 = crate::bit!(0);
+const STATUS_DRIVER: u32 = crate::bit!(1);
+const STATUS_DRIVER_OK: u32 = crate::bit!(2);
+const STATUS_FEATURES_OK: u32 = crate::bit!(3);
+const STATUS_FAILED: u32 = crate::bit!(7);
+
+/// `VIRTIO_F_VERSION_1` lives at bit 32 in the device-features bitmap. It is
+/// written into the high (selector = 1) 32-bit word as bit 0. Acknowledging
+/// this feature is required for a modern (1.x) virtio driver.
+const VIRTIO_F_VERSION_1_HIGH_WORD: u32 = crate::bit!(0);
+
+/// Virtio-MMIO register layout. Reads are side-effect free for every register
+/// here; only writes affect device state.
+#[repr(C)]
+pub(super) struct VirtioMmioRegs {
+    /// 0x000 Magic value, must equal [`VIRTIO_MMIO_MAGIC`].
+    magic_value: ReadPure<u32>,
+    /// 0x004 Transport version.
+    version: ReadPure<u32>,
+    /// 0x008 Device id.
+    device_id: ReadPure<u32>,
+    /// 0x00C Vendor id.
+    vendor_id: ReadPure<u32>,
+    /// 0x010 Device features.
+    device_features: ReadPure<u32>,
+    /// 0x014 Device features selector.
+    device_features_sel: WriteOnly<u32>,
+    _reserved0: [u32; 2],
+    /// 0x020 Driver features.
+    driver_features: WriteOnly<u32>,
+    /// 0x024 Driver features selector.
+    driver_features_sel: WriteOnly<u32>,
+    _reserved1: [u32; 2],
+    /// 0x030 Queue selector.
+    queue_sel: WriteOnly<u32>,
+    /// 0x034 Maximum supported queue size for the selected queue.
+    queue_num_max: ReadPure<u32>,
+    /// 0x038 Queue size to use for the selected queue.
+    queue_num: WriteOnly<u32>,
+    _reserved2: [u32; 2],
+    /// 0x044 Queue ready flag for the selected queue.
+    queue_ready: ReadPureWrite<u32>,
+    _reserved3: [u32; 2],
+    /// 0x050 Queue notify: write the queue index to kick the device.
+    queue_notify: WriteOnly<u32>,
+    _reserved4: [u32; 3],
+    /// 0x060 Interrupt status.
+    interrupt_status: ReadPure<u32>,
+    /// 0x064 Interrupt acknowledge.
+    interrupt_ack: WriteOnly<u32>,
+    _reserved5: [u32; 2],
+    /// 0x070 Device status.
+    status: ReadPureWrite<u32>,
+    _reserved6: [u32; 3],
+    /// 0x080 Descriptor table physical address (low 32 bits).
+    queue_desc_low: WriteOnly<u32>,
+    /// 0x084 Descriptor table physical address (high 32 bits).
+    queue_desc_high: WriteOnly<u32>,
+    _reserved7: [u32; 2],
+    /// 0x090 Driver ring physical address (low 32 bits).
+    queue_driver_low: WriteOnly<u32>,
+    /// 0x094 Driver ring physical address (high 32 bits).
+    queue_driver_high: WriteOnly<u32>,
+    _reserved8: [u32; 2],
+    /// 0x0A0 Device ring physical address (low 32 bits).
+    queue_device_low: WriteOnly<u32>,
+    /// 0x0A4 Device ring physical address (high 32 bits).
+    queue_device_high: WriteOnly<u32>,
+}
+
+/// Errors returned by the virtio-MMIO init / queue-configuration routines.
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub(super) enum InitError {
+    /// Magic value, transport version, or device id did not match expectations.
+    UnsupportedDevice,
+    /// The device rejected the negotiated feature bits.
+    FeaturesRejected,
+    /// The device's `queue_num_max` was below the requested queue size, or
+    /// the queue was already in use by another driver.
+    QueueUnavailable,
+}
+
+/// A virtio-MMIO transport at a fixed base address.
+#[derive(Debug)]
+pub(super) struct VirtioMmio {
+    regs: UniqueMmioPointer<'static, VirtioMmioRegs>,
+}
+
+// SAFETY: `VirtioMmio` owns a unique pointer to a device-memory MMIO window
+// All device-touching methods take `&mut self`, so there is no concurrent
+// access through the same instance.
+unsafe impl Send for VirtioMmio {}
+
+impl VirtioMmio {
+    /// Constructs a new transport for the virtio-MMIO device at the given
+    /// base address.
+    ///
+    /// # Safety
+    ///
+    /// `base_address` must be a non-null address of an appropriately mapped
+    /// virtio-MMIO register window which is present and exclusively owned for
+    /// the lifetime of the returned structure.
+    pub(super) const unsafe fn new(base_address: usize) -> Self {
+        let ptr = NonNull::new(base_address as *mut VirtioMmioRegs).expect("Caller provided NULL address.");
+
+        // SAFETY: forwarded from the caller of this function. They are responsible for ensuring the address
+        // is exclusively owned.
+        Self { regs: unsafe { UniqueMmioPointer::new(ptr) } }
+    }
+
+    /// Initializes the virtio-MMIO device using the standard init handshake.
+    pub(super) fn begin_init(&mut self, expected_device_id: u32) -> Result<(), InitError> {
+        let mut regs = self.regs.reborrow();
+
+        if field!(regs, magic_value).read() != VIRTIO_MMIO_MAGIC
+            || field!(regs, version).read() != VIRTIO_MMIO_VERSION
+            || field!(regs, device_id).read() != expected_device_id
+        {
+            return Err(InitError::UnsupportedDevice);
+        }
+
+        // Reset, then wait for `status` to read back as 0 before continuing.
+        field!(regs, status).write(0);
+        while field!(regs, status).read() != 0 {
+            core::hint::spin_loop();
+        }
+        field!(regs, status).write(STATUS_ACKNOWLEDGE);
+        field!(regs, status).write(STATUS_ACKNOWLEDGE | STATUS_DRIVER);
+
+        // Read device features before writing the subset we accept. We
+        // require VIRTIO_F_VERSION_1 (bit 32, bit 0 of the high word).
+        field!(regs, device_features_sel).write(1);
+        let device_features_high = field!(regs, device_features).read();
+        if device_features_high & VIRTIO_F_VERSION_1_HIGH_WORD == 0 {
+            field!(regs, status).write(STATUS_ACKNOWLEDGE | STATUS_DRIVER | STATUS_FAILED);
+            return Err(InitError::FeaturesRejected);
+        }
+
+        // Acknowledge VIRTIO_F_VERSION_1 and nothing else.
+        field!(regs, driver_features_sel).write(0);
+        field!(regs, driver_features).write(0);
+        field!(regs, driver_features_sel).write(1);
+        field!(regs, driver_features).write(VIRTIO_F_VERSION_1_HIGH_WORD);
+
+        field!(regs, status).write(STATUS_ACKNOWLEDGE | STATUS_DRIVER | STATUS_FEATURES_OK);
+        if field!(regs, status).read() & STATUS_FEATURES_OK == 0 {
+            field!(regs, status).write(STATUS_ACKNOWLEDGE | STATUS_DRIVER | STATUS_FAILED);
+            return Err(InitError::FeaturesRejected);
+        }
+
+        Ok(())
+    }
+
+    /// Programs the device with the addresses of the three rings for a
+    /// virt queue and marks it ready.
+    pub(super) fn configure_queue<const N: usize, const B: usize>(
+        &mut self,
+        index: u32,
+        queue: &VirtQueue<N, B>,
+    ) -> Result<(), InitError> {
+        let mut regs = self.regs.reborrow();
+        field!(regs, queue_sel).write(index);
+        if field!(regs, queue_ready).read() != 0 {
+            // Already initialized by something else.
+            return Err(InitError::QueueUnavailable);
+        }
+        let max = field!(regs, queue_num_max).read();
+        if max < N as u32 {
+            return Err(InitError::QueueUnavailable);
+        }
+        field!(regs, queue_num).write(N as u32);
+
+        let desc_pa = queue.desc_addr();
+        let avail_pa = queue.avail_addr();
+        let used_pa = queue.used_addr();
+
+        field!(regs, queue_desc_low).write(desc_pa as u32);
+        field!(regs, queue_desc_high).write((desc_pa >> 32) as u32);
+        field!(regs, queue_driver_low).write(avail_pa as u32);
+        field!(regs, queue_driver_high).write((avail_pa >> 32) as u32);
+        field!(regs, queue_device_low).write(used_pa as u32);
+        field!(regs, queue_device_high).write((used_pa >> 32) as u32);
+
+        field!(regs, queue_ready).write(1);
+        Ok(())
+    }
+
+    /// Sets `STATUS_DRIVER_OK`, completing the init handshake.
+    pub(super) fn set_driver_ok(&mut self) {
+        let mut regs = self.regs.reborrow();
+        field!(regs, status).write(STATUS_ACKNOWLEDGE | STATUS_DRIVER | STATUS_FEATURES_OK | STATUS_DRIVER_OK);
+    }
+
+    /// Sets `STATUS_FAILED`.
+    pub(super) fn set_failed(&mut self) {
+        let mut regs = self.regs.reborrow();
+        let current = field!(regs, status).read();
+        field!(regs, status).write(current | STATUS_FAILED);
+    }
+
+    /// Notifies the device that new entries are available on `queue_index`.
+    /// Issues a SeqCst fence before the write so all prior queue updates are
+    /// visible to the device.
+    pub(super) fn notify(&mut self, queue_index: u32) {
+        fence(Ordering::SeqCst);
+        let mut regs = self.regs.reborrow();
+        field!(regs, queue_notify).write(queue_index);
+    }
+}
+
+#[cfg(test)]
+#[coverage(off)]
+impl VirtioMmioRegs {
+    pub(super) fn new_fake(device_id: u32) -> Self {
+        // SAFETY: This is a fake register set, the state will be initialized later.
+        let mut regs: Self = unsafe { core::mem::zeroed() };
+        let mut ptr = UniqueMmioPointer::from(&mut regs);
+        // SAFETY: This is a fake register set, the MMIO semantics can be ignored.
+        unsafe {
+            field!(ptr, magic_value).write_unsafe(ReadPure(VIRTIO_MMIO_MAGIC));
+            field!(ptr, version).write_unsafe(ReadPure(VIRTIO_MMIO_VERSION));
+            field!(ptr, device_id).write_unsafe(ReadPure(device_id));
+            field!(ptr, device_features).write_unsafe(ReadPure(VIRTIO_F_VERSION_1_HIGH_WORD));
+            field!(ptr, queue_num_max).write_unsafe(ReadPure(8));
+        }
+        regs
+    }
+}
+
+#[cfg(test)]
+#[coverage(off)]
+mod tests {
+    use super::*;
+
+    const TEST_DEVICE_ID: u32 = 3;
+
+    fn make_transport(regs: &mut VirtioMmioRegs) -> VirtioMmio {
+        let addr = core::ptr::from_mut(regs) as usize;
+        // SAFETY: `addr` is non-null and `regs` outlives the returned transport.
+        unsafe { VirtioMmio::new(addr) }
+    }
+
+    #[test]
+    fn test_begin_init() {
+        let mut regs = VirtioMmioRegs::new_fake(TEST_DEVICE_ID);
+        let mut t = make_transport(&mut regs);
+        assert_eq!(t.begin_init(TEST_DEVICE_ID), Ok(()));
+        assert_eq!(regs.status.0, STATUS_ACKNOWLEDGE | STATUS_DRIVER | STATUS_FEATURES_OK);
+        assert_eq!(regs.driver_features_sel.0, 1);
+        assert_eq!(regs.driver_features.0, VIRTIO_F_VERSION_1_HIGH_WORD);
+    }
+
+    #[test]
+    fn test_rejects_bad_magic() {
+        let mut regs = VirtioMmioRegs::new_fake(TEST_DEVICE_ID);
+        regs.magic_value = ReadPure(0xDEADBEEF);
+        let mut t = make_transport(&mut regs);
+        assert_eq!(t.begin_init(TEST_DEVICE_ID), Err(InitError::UnsupportedDevice));
+    }
+
+    #[test]
+    fn test_rejects_bad_version() {
+        let mut regs = VirtioMmioRegs::new_fake(TEST_DEVICE_ID);
+        regs.version = ReadPure(1);
+        let mut t = make_transport(&mut regs);
+        assert_eq!(t.begin_init(TEST_DEVICE_ID), Err(InitError::UnsupportedDevice));
+    }
+
+    #[test]
+    fn test_rejects_wrong_device_id() {
+        let mut regs = VirtioMmioRegs::new_fake(TEST_DEVICE_ID);
+        let mut t = make_transport(&mut regs);
+        assert_eq!(t.begin_init(TEST_DEVICE_ID + 1), Err(InitError::UnsupportedDevice));
+    }
+
+    #[test]
+    fn test_rejects_when_v1_unsupported() {
+        let mut regs = VirtioMmioRegs::new_fake(TEST_DEVICE_ID);
+        regs.device_features = ReadPure(0);
+        let mut t = make_transport(&mut regs);
+        assert_eq!(t.begin_init(TEST_DEVICE_ID), Err(InitError::FeaturesRejected));
+        assert_ne!(regs.status.0 & STATUS_FAILED, 0);
+    }
+
+    #[test]
+    fn test_configure_queue() {
+        let mut regs = VirtioMmioRegs::new_fake(TEST_DEVICE_ID);
+        let queue: VirtQueue<8, 16> = VirtQueue::new();
+        let mut t = make_transport(&mut regs);
+        assert_eq!(t.configure_queue(1, &queue), Ok(()));
+        assert_eq!(regs.queue_sel.0, 1);
+        assert_eq!(regs.queue_num.0, 8);
+        assert_eq!(regs.queue_ready.0, 1);
+        let desc = (regs.queue_desc_low.0 as u64) | ((regs.queue_desc_high.0 as u64) << 32);
+        let avail = (regs.queue_driver_low.0 as u64) | ((regs.queue_driver_high.0 as u64) << 32);
+        let used = (regs.queue_device_low.0 as u64) | ((regs.queue_device_high.0 as u64) << 32);
+        assert_eq!(desc, queue.desc_addr());
+        assert_eq!(avail, queue.avail_addr());
+        assert_eq!(used, queue.used_addr());
+    }
+
+    #[test]
+    fn test_configure_queue_rejects_too_small() {
+        // Fake reports queue_num_max = 8, but we ask for N = 16.
+        let mut regs = VirtioMmioRegs::new_fake(TEST_DEVICE_ID);
+        let queue: VirtQueue<16, 16> = VirtQueue::new();
+        let mut t = make_transport(&mut regs);
+        assert_eq!(t.configure_queue(0, &queue), Err(InitError::QueueUnavailable));
+    }
+
+    #[test]
+    fn test_configure_queue_rejects_when_already_in_use() {
+        let mut regs = VirtioMmioRegs::new_fake(TEST_DEVICE_ID);
+        regs.queue_ready = ReadPureWrite(1);
+        let queue: VirtQueue<8, 16> = VirtQueue::new();
+        let mut t = make_transport(&mut regs);
+        assert_eq!(t.configure_queue(0, &queue), Err(InitError::QueueUnavailable));
+    }
+
+    #[test]
+    fn test_virtio_set_driver_ok() {
+        let mut regs = VirtioMmioRegs::new_fake(TEST_DEVICE_ID);
+        let mut t = make_transport(&mut regs);
+        t.set_driver_ok();
+        assert_eq!(regs.status.0, STATUS_ACKNOWLEDGE | STATUS_DRIVER | STATUS_FEATURES_OK | STATUS_DRIVER_OK);
+    }
+
+    #[test]
+    fn test_set_failed() {
+        let mut regs = VirtioMmioRegs::new_fake(TEST_DEVICE_ID);
+        regs.status = ReadPureWrite(STATUS_ACKNOWLEDGE | STATUS_DRIVER);
+        let mut t = make_transport(&mut regs);
+        t.set_failed();
+        assert_eq!(regs.status.0, STATUS_ACKNOWLEDGE | STATUS_DRIVER | STATUS_FAILED);
+    }
+
+    #[test]
+    fn test_notify_writes_queue_index() {
+        let mut regs = VirtioMmioRegs::new_fake(TEST_DEVICE_ID);
+        let mut t = make_transport(&mut regs);
+        t.notify(7);
+        assert_eq!(regs.queue_notify.0, 7);
+    }
+}

--- a/sdk/patina/src/serial/virtio/queue.rs
+++ b/sdk/patina/src/serial/virtio/queue.rs
@@ -1,0 +1,316 @@
+//! Split virtqueue data structures.
+//!
+//! A split virtqueue is the shared-memory channel between the driver and the
+//! device. It consists of three regions plus a pool of data buffers:
+//!
+//! - [`DescTable`]: array of `N` [`VirtqDesc`] entries. Each describes one
+//!   buffer (physical address, length, flags). The driver fills these in.
+//! - [`AvailRing`]: driver-to-device ring. The driver appends descriptor
+//!   indices it wants the device to process and bumps `idx`.
+//! - [`UsedRing`]: device-to-driver ring. The device appends
+//!   [`VirtqUsedElem`] entries (descriptor index + bytes written) for
+//!   completed requests and bumps `idx`.
+//! - `buffers`: one fixed-size data buffer per descriptor slot.
+//!
+//! TX flow: pick a free desc slot, copy bytes into its buffer, publish via
+//! `avail`, kick the device, reap completions from `used`.
+//!
+//! RX flow: pre-publish all descs as device-writable via `avail`; the device
+//! fills buffers and posts entries on `used`; consume them, then re-publish
+//! the desc to receive more.
+//!
+//! ## License
+//!
+//! Copyright (C) Microsoft Corporation.
+//!
+//! SPDX-License-Identifier: Apache-2.0
+//!
+
+// All array/slice indexing in this module uses `% N` (descriptor and ring slot
+// modulo the queue size) or fixed-size copies bounded by `min(B, ...)`, so the
+// indices are always in range by construction.
+#![allow(clippy::indexing_slicing)]
+
+use core::sync::atomic::{Ordering, fence};
+
+// Descriptor flag bits.
+const VRING_DESC_F_WRITE: u16 = crate::bit!(1);
+
+/// A single descriptor in the descriptor table.
+#[repr(C)]
+#[derive(Copy, Clone)]
+struct VirtqDesc {
+    addr: u64,
+    len: u32,
+    flags: u16,
+    next: u16,
+}
+
+impl VirtqDesc {
+    const ZERO: Self = Self { addr: 0, len: 0, flags: 0, next: 0 };
+}
+
+/// Descriptor table. Must be 16-byte aligned per the virtio specification.
+#[repr(C, align(16))]
+struct DescTable<const N: usize>([VirtqDesc; N]);
+
+impl<const N: usize> DescTable<N> {
+    const fn new() -> Self {
+        Self([VirtqDesc::ZERO; N])
+    }
+}
+
+/// Driver (available) ring. Must be 2-byte aligned.
+#[repr(C, align(2))]
+struct AvailRing<const N: usize> {
+    flags: u16,
+    idx: u16,
+    ring: [u16; N],
+    used_event: u16,
+}
+
+impl<const N: usize> AvailRing<N> {
+    const fn new() -> Self {
+        Self { flags: 0, idx: 0, ring: [0; N], used_event: 0 }
+    }
+}
+
+/// A single entry in the used ring.
+#[repr(C)]
+#[derive(Copy, Clone)]
+struct VirtqUsedElem {
+    id: u32,
+    len: u32,
+}
+
+impl VirtqUsedElem {
+    const ZERO: Self = Self { id: 0, len: 0 };
+}
+
+/// Device (used) ring. Must be 4-byte aligned.
+#[repr(C, align(4))]
+struct UsedRing<const N: usize> {
+    flags: u16,
+    idx: u16,
+    ring: [VirtqUsedElem; N],
+    avail_event: u16,
+}
+
+impl<const N: usize> UsedRing<N> {
+    const fn new() -> Self {
+        Self { flags: 0, idx: 0, ring: [VirtqUsedElem::ZERO; N], avail_event: 0 }
+    }
+}
+
+/// A complete split virtqueue: descriptor table, available ring, used ring,
+/// and a pool of fixed-size data buffers (one per descriptor slot).
+///
+/// `N` is the number of descriptors (must be a power of two per the virtio
+/// spec) and `B` is the per-descriptor buffer size in bytes.
+#[repr(C, align(16))]
+pub(super) struct VirtQueue<const N: usize, const B: usize> {
+    desc: DescTable<N>,
+    avail: AvailRing<N>,
+    used: UsedRing<N>,
+
+    // Implementation state. Below here, the fields are not spec defined.
+    //
+    buffers: [[u8; B]; N],
+    last_used_idx: u16,
+    next_desc: u16,
+    rx_held: Option<(u16, u32)>,
+}
+
+impl<const N: usize, const B: usize> VirtQueue<N, B> {
+    /// Compile-time validation of the queue size.
+    const VALIDATE_QUEUE: () = {
+        assert!(N > 0, "VirtQueue: N must be greater than zero");
+        assert!(B > 0, "VirtQueue: B must be greater than zero");
+        assert!(N.is_power_of_two(), "VirtQueue: N must be a power of two");
+        assert!(N <= 0x8000, "VirtQueue: N must be <= 0x8000");
+    };
+
+    /// Constructs an empty virt queue.
+    pub(super) const fn new() -> Self {
+        // Force evaluation of the compile-time queue-size check.
+        let () = Self::VALIDATE_QUEUE;
+        Self {
+            desc: DescTable::new(),
+            avail: AvailRing::new(),
+            used: UsedRing::new(),
+            buffers: [[0; B]; N],
+            last_used_idx: 0,
+            next_desc: 0,
+            rx_held: None,
+        }
+    }
+
+    /// Posts every descriptor as an RX buffer. Call once after the device
+    /// has been brought to `DRIVER_OK` and before the first receive. The
+    /// caller must notify the device afterwards.
+    pub(super) fn rx_clean(&mut self) {
+        for i in 0..N {
+            self.rx_post(i as u16);
+        }
+    }
+
+    /// Returns the next RX block ready to be read, or `None` if the device
+    /// has not posted any data. Call [`Self::rx_release`] to return the
+    /// descriptor to the device once done.
+    pub(super) fn rx_peek(&mut self) -> Option<&[u8]> {
+        if self.rx_held.is_none() {
+            loop {
+                let (desc, len) = self.rx_pop()?;
+                if len == 0 {
+                    // Spurious empty completion: re-arm and try again.
+                    self.rx_post(desc);
+                    continue;
+                }
+                let len = core::cmp::min(len as usize, B) as u32;
+                self.rx_held = Some((desc, len));
+                break;
+            }
+        }
+        let (desc, len) = self.rx_held?;
+        let idx = (desc as usize) % N;
+        Some(&self.buffers[idx][..len as usize])
+    }
+
+    /// Releases the currently held RX block back to the device. The caller
+    /// must notify the device afterwards. No-op if no block is held.
+    pub(super) fn rx_release(&mut self) {
+        if let Some((desc, _)) = self.rx_held.take() {
+            self.rx_post(desc);
+        }
+    }
+
+    /// Posts a single RX descriptor: the device will fill its buffer with up
+    /// to `B` received bytes.
+    fn rx_post(&mut self, desc_idx: u16) {
+        let idx = (desc_idx as usize) % N;
+        let addr = self.buffers[idx].as_ptr() as u64;
+        self.desc.0[idx] = VirtqDesc { addr, len: B as u32, flags: VRING_DESC_F_WRITE, next: 0 };
+        self.publish_avail(desc_idx);
+    }
+
+    /// Pops the next entry from the used ring, or returns `None` if no
+    /// completions are pending. Returns `(descriptor index, bytes filled)`.
+    fn rx_pop(&mut self) -> Option<(u16, u32)> {
+        fence(Ordering::SeqCst);
+        if self.last_used_idx == self.used.idx {
+            return None;
+        }
+        let elem_pos = (self.last_used_idx as usize) % N;
+        let elem = self.used.ring[elem_pos];
+        self.last_used_idx = self.last_used_idx.wrapping_add(1);
+        Some((elem.id as u16, elem.len))
+    }
+
+    /// Tries to publish up to `B` bytes from `data` on the next round-robin
+    /// TX descriptor. Returns the number of bytes consumed, or `None` if all
+    /// slots are still owned by the device.
+    pub(super) fn tx_try_submit(&mut self, data: &[u8]) -> Option<usize> {
+        if data.is_empty() {
+            return Some(0);
+        }
+
+        let desc_idx = (self.next_desc as usize) % N;
+        if self.desc.0[desc_idx].len != 0 {
+            // Slot looks busy: drain any completions the device has posted
+            // and retry.
+            self.tx_reap();
+            if self.desc.0[desc_idx].len != 0 {
+                return None;
+            }
+        }
+
+        let take = core::cmp::min(B, data.len());
+        self.buffers[desc_idx][..take].copy_from_slice(&data[..take]);
+        let buf_addr = self.buffers[desc_idx].as_ptr() as u64;
+        // Driver-to-device data, no NEXT.
+        self.desc.0[desc_idx] = VirtqDesc { addr: buf_addr, len: take as u32, flags: 0, next: 0 };
+
+        self.publish_avail(desc_idx as u16);
+        self.next_desc = self.next_desc.wrapping_add(1);
+        Some(take)
+    }
+
+    /// Reaps any TX descriptors the device has returned via the used ring.
+    fn tx_reap(&mut self) {
+        fence(Ordering::SeqCst);
+        let used_idx = self.used.idx;
+        while self.last_used_idx != used_idx {
+            let elem_pos = (self.last_used_idx as usize) % N;
+            let elem = self.used.ring[elem_pos];
+            let d = (elem.id as usize) % N;
+            self.desc.0[d].len = 0;
+            self.last_used_idx = self.last_used_idx.wrapping_add(1);
+        }
+    }
+
+    /// Physical address of the descriptor table. For use by the transport
+    /// when programming the device.
+    pub(super) fn desc_addr(&self) -> u64 {
+        self.desc.0.as_ptr() as u64
+    }
+
+    /// Physical address of the available (driver) ring.
+    pub(super) fn avail_addr(&self) -> u64 {
+        core::ptr::from_ref(&self.avail) as u64
+    }
+
+    /// Physical address of the used (device) ring.
+    pub(super) fn used_addr(&self) -> u64 {
+        core::ptr::from_ref(&self.used) as u64
+    }
+
+    /// Publishes a descriptor index on the available ring with full
+    /// SeqCst ordering on either side of the index update.
+    fn publish_avail(&mut self, desc_idx: u16) {
+        let avail_idx = self.avail.idx;
+        let ring_pos = (avail_idx as usize) % N;
+        self.avail.ring[ring_pos] = desc_idx;
+        fence(Ordering::SeqCst);
+        self.avail.idx = avail_idx.wrapping_add(1);
+        fence(Ordering::SeqCst);
+    }
+}
+
+#[cfg(test)]
+#[coverage(off)]
+impl<const N: usize, const B: usize> VirtQueue<N, B> {
+    pub(super) fn test_drain_tx(&mut self) -> alloc::vec::Vec<alloc::vec::Vec<u8>> {
+        use alloc::vec::Vec;
+        fence(Ordering::SeqCst);
+        let mut out = Vec::new();
+        while self.used.idx != self.avail.idx {
+            let pos = (self.used.idx as usize) % N;
+            let desc_idx = self.avail.ring[pos];
+            let i = (desc_idx as usize) % N;
+            let len = self.desc.0[i].len as usize;
+            out.push(self.buffers[i][..len].to_vec());
+            self.used.ring[pos] = VirtqUsedElem { id: desc_idx as u32, len: len as u32 };
+            fence(Ordering::SeqCst);
+            self.used.idx = self.used.idx.wrapping_add(1);
+        }
+        fence(Ordering::SeqCst);
+        out
+    }
+
+    pub(super) fn test_supply_rx(&mut self, data: &[u8]) -> Option<usize> {
+        fence(Ordering::SeqCst);
+        if self.used.idx == self.avail.idx {
+            return None;
+        }
+        let pos = (self.used.idx as usize) % N;
+        let desc_idx = self.avail.ring[pos];
+        let i = (desc_idx as usize) % N;
+        let take = core::cmp::min(B, data.len());
+        self.buffers[i][..take].copy_from_slice(&data[..take]);
+        self.used.ring[pos] = VirtqUsedElem { id: desc_idx as u32, len: take as u32 };
+        fence(Ordering::SeqCst);
+        self.used.idx = self.used.idx.wrapping_add(1);
+        fence(Ordering::SeqCst);
+        Some(take)
+    }
+}


### PR DESCRIPTION
## Description

### Patina: Implement interrupt support for arch module

This commit implements basic interrupt management support in the Patina
SDK. This is needed for some low level implementations such as SerialIO
implementations where the TPL may not be available or accessible.

This commit also creates an abstraction model for the architecture-specific
implementations in the arch module. This uses an internal trait-based
approach to provide a consistent interface across different architectures.
These implementations are then exposed to static wrapper functions.

### Patina: Implement VirtIO console based SerialIO

The commit adds a new SerialIO implementation for a VirtIO console based
on a VirtIO MMIO transport. VirtIO devices are common for virtualized
environments such as QEMU, and a SerialIO implementation allows for greater
flexibility in those environments.

The implementation adds generic support for the basic VirtIO queue and
MMIO operations, but that is left as internal to this implementation for
the time being.
- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

- [x] ArmVirt debug transport
- [x] Unit Tests

## Integration Instructions

N/A
