### PR TITLE
Update dependencies to latest [Rebase & FF]

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ alloc-no-stdlib = { version = "2.0" }
 arm-gic = { version = "0.8.1" }
 safe-mmio = { version = "0.3.0" }
 bitfield-struct = { version = "0.13" }
-brotli-decompressor = { version = "4.0.0", default-features = false }
+brotli-decompressor = { version = "5.0.3", default-features = false }
 cfg-if = { version = "1" }
 clap = { version = "4.6.1" }
 compile-time = { version = "0.2" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ repository = "https://github.com/OpenDevicePartnership/patina"
 
 [workspace.dependencies]
 alloc-no-stdlib = { version = "2.0" }
-arm-gic = { version = "0.7.2" }
+arm-gic = { version = "0.8.1" }
 safe-mmio = { version = "0.3.0" }
 bitfield-struct = { version = "0.12" }
 brotli-decompressor = { version = "4.0.0", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,6 @@ fixedbitset = { version = "0.5", default-features = false }
 gdbstub = { version = "0.7.10", default-features = false }
 goblin = { version = "0.10.7", default-features = false }
 indoc = { version = "2.0" }
-lazy_static = { version = "1" }
 linked_list_allocator = { version = "0.10" }
 linkme = { version = "0.3.36" }
 log = { version = "0.4", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,23 +10,23 @@ rust-version = "1.89"
 repository = "https://github.com/OpenDevicePartnership/patina"
 
 [workspace.dependencies]
-alloc-no-stdlib = { version = "~2.0" }
+alloc-no-stdlib = { version = "2.0" }
 arm-gic = { version = "0.7.2" }
 safe-mmio = { version = "0.2.5" }
 bitfield-struct = { version = "0.12" }
 brotli-decompressor = { version = "4.0.0", default-features = false }
 cfg-if = { version = "1" }
-clap = { version = '4.5.36' }
+clap = { version = "4.5.36" }
 compile-time = { version = "0.2" }
 crc32fast = { version = "1.4", default-features = false }
 fallible-streaming-iterator = { version = "0.1.9" }
-fixedbitset = { version = "^0.5", default-features = false }
+fixedbitset = { version = "0.5", default-features = false }
 gdbstub = { version = "0.7.3", default-features = false }
-goblin = { version = "~0.10.2", default-features = false }
+goblin = { version = "0.10.2", default-features = false }
 indoc = { version = "2.0" }
-lazy_static = { version = "^1" }
-linked_list_allocator = { version = "^0.10" }
-linkme = { version = "^0.3.29" }
+lazy_static = { version = "1" }
+linked_list_allocator = { version = "0.10" }
+linkme = { version = "0.3.29" }
 log = { version = "0.4", default-features = false }
 memoffset = {version = "0.9.1" }
 mu_rust_helpers = { version = "4.0.0" }
@@ -41,7 +41,7 @@ patina_internal_depex = { version = "22.0.1", path = "core/patina_internal_depex
 patina_lzma_rs = { version = "0.3.1", default-features = false }
 patina_macro = { version = "22.0.1", path = "sdk/patina_macro" }
 patina_mm = { version = "22.0.1", path = "components/patina_mm" }
-patina_mtrr = { version = "^1.1.6" }
+patina_mtrr = { version = "1.1.6" }
 patina_paging = { version = "11.0.2" }
 patina_performance = { version = "22.0.1", path = "components/patina_performance" }
 patina_smbios = { version = "22.0.1", path = "components/patina_smbios" }
@@ -51,17 +51,17 @@ proc-macro2 = { version = "1" }
 quote = { version = "1" }
 r-efi = { version = "6.0.0", default-features = false }
 scroll = { version = "0.13", default-features = false, features = ["derive"]}
-spin = { version = "^0.9" }
+spin = { version = "0.9" }
 syn = { version = "2" }
 time = { version = "0.3.47" }
-uart_16550 = { version = "^0.3.2" }
+uart_16550 = { version = "0.3.2" }
 corosensei = { version = "0.3.4", default-features = false }
 uuid = { version = "1.8", default-features = false }
 zerocopy = { version = "0.8" }
 zerocopy-derive = { version = "0.8" }
 
 # dev dependencies
-criterion = { version = "^0.5" }
+criterion = { version = "0.5" }
 env_logger = "0.11"
 mockall = { version = "0.13.0" }
 rand = { version = "0.10" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ repository = "https://github.com/OpenDevicePartnership/patina"
 [workspace.dependencies]
 alloc-no-stdlib = { version = "2.0" }
 arm-gic = { version = "0.7.2" }
-safe-mmio = { version = "0.2.5" }
+safe-mmio = { version = "0.3.0" }
 bitfield-struct = { version = "0.12" }
 brotli-decompressor = { version = "4.0.0", default-features = false }
 cfg-if = { version = "1" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,7 +61,7 @@ zerocopy = { version = "0.8" }
 zerocopy-derive = { version = "0.8" }
 
 # dev dependencies
-criterion = { version = "0.5" }
+criterion = { version = "0.8" }
 env_logger = "0.11"
 mockall = { version = "0.13.0" }
 rand = { version = "0.10" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,7 +51,7 @@ proc-macro2 = { version = "1" }
 quote = { version = "1" }
 r-efi = { version = "6.0.0", default-features = false }
 scroll = { version = "0.13", default-features = false, features = ["derive"]}
-spin = { version = "0.9" }
+spin = { version = "0.12" }
 syn = { version = "2" }
 time = { version = "0.3.49" }
 uart_16550 = { version = "0.3.2" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ repository = "https://github.com/OpenDevicePartnership/patina"
 alloc-no-stdlib = { version = "2.0" }
 arm-gic = { version = "0.8.1" }
 safe-mmio = { version = "0.3.0" }
-bitfield-struct = { version = "0.12" }
+bitfield-struct = { version = "0.13" }
 brotli-decompressor = { version = "4.0.0", default-features = false }
 cfg-if = { version = "1" }
 clap = { version = "4.6.1" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,7 +63,7 @@ zerocopy-derive = { version = "0.8" }
 # dev dependencies
 criterion = { version = "0.8" }
 env_logger = "0.11"
-mockall = { version = "0.13.0" }
+mockall = { version = "0.14.0" }
 rand = { version = "0.10" }
 ruint = { version = "1.18.0" }
 serial_test = { version = "3.5" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,17 +16,17 @@ safe-mmio = { version = "0.2.5" }
 bitfield-struct = { version = "0.12" }
 brotli-decompressor = { version = "4.0.0", default-features = false }
 cfg-if = { version = "1" }
-clap = { version = "4.5.36" }
+clap = { version = "4.6.1" }
 compile-time = { version = "0.2" }
-crc32fast = { version = "1.4", default-features = false }
+crc32fast = { version = "1.5", default-features = false }
 fallible-streaming-iterator = { version = "0.1.9" }
 fixedbitset = { version = "0.5", default-features = false }
-gdbstub = { version = "0.7.3", default-features = false }
-goblin = { version = "0.10.2", default-features = false }
+gdbstub = { version = "0.7.10", default-features = false }
+goblin = { version = "0.10.7", default-features = false }
 indoc = { version = "2.0" }
 lazy_static = { version = "1" }
 linked_list_allocator = { version = "0.10" }
-linkme = { version = "0.3.29" }
+linkme = { version = "0.3.36" }
 log = { version = "0.4", default-features = false }
 memoffset = {version = "0.9.1" }
 mu_rust_helpers = { version = "4.0.0" }
@@ -38,11 +38,11 @@ patina_ffs_extractors = { version = "22.0.1", path = "sdk/patina_ffs_extractors"
 patina_internal_collections = { version = "22.0.1", path = "core/patina_internal_collections", default-features = false }
 patina_internal_cpu = { version = "22.0.1", path = "core/patina_internal_cpu" }
 patina_internal_depex = { version = "22.0.1", path = "core/patina_internal_depex" }
-patina_lzma_rs = { version = "0.3.1", default-features = false }
+patina_lzma_rs = { version = "0.3.2", default-features = false }
 patina_macro = { version = "22.0.1", path = "sdk/patina_macro" }
 patina_mm = { version = "22.0.1", path = "components/patina_mm" }
 patina_mtrr = { version = "1.1.6" }
-patina_paging = { version = "11.0.2" }
+patina_paging = { version = "11.0.4" }
 patina_performance = { version = "22.0.1", path = "components/patina_performance" }
 patina_smbios = { version = "22.0.1", path = "components/patina_smbios" }
 patina_stacktrace = { version = "22.0.1", path = "core/patina_stacktrace" }
@@ -53,10 +53,10 @@ r-efi = { version = "6.0.0", default-features = false }
 scroll = { version = "0.13", default-features = false, features = ["derive"]}
 spin = { version = "0.9" }
 syn = { version = "2" }
-time = { version = "0.3.47" }
+time = { version = "0.3.49" }
 uart_16550 = { version = "0.3.2" }
 corosensei = { version = "0.3.4", default-features = false }
-uuid = { version = "1.8", default-features = false }
+uuid = { version = "1.23", default-features = false }
 zerocopy = { version = "0.8" }
 zerocopy-derive = { version = "0.8" }
 
@@ -65,8 +65,8 @@ criterion = { version = "0.5" }
 env_logger = "0.11"
 mockall = { version = "0.13.0" }
 rand = { version = "0.10" }
-ruint = { version = "1.17.1" }
-serial_test = { version = "3.0" }
+ruint = { version = "1.18.0" }
+serial_test = { version = "3.5" }
 winapi = { version = "0.3" }
 serde = { version = "1.0", default-features = false, features = ["derive"] }
 serde_yaml = { version = "0.9" }

--- a/core/patina_internal_cpu/Cargo.toml
+++ b/core/patina_internal_cpu/Cargo.toml
@@ -14,7 +14,6 @@ workspace = true
 features = ["doc", "std"]
 
 [dependencies]
-lazy_static = { workspace = true, features = ["spin_no_std"] }
 log = { workspace = true }
 r-efi = { workspace = true }
 patina = { workspace = true }

--- a/core/patina_internal_cpu/src/cpu/x64/gdt.rs
+++ b/core/patina_internal_cpu/src/cpu/x64/gdt.rs
@@ -9,7 +9,6 @@
 #![cfg_attr(test, allow(dead_code))]
 #![cfg_attr(test, allow(unused_imports))]
 use core::ptr::{addr_of, addr_of_mut};
-use lazy_static::lazy_static;
 use patina::base::SIZE_4GB;
 
 struct GdtEntry {
@@ -156,41 +155,35 @@ fn tss_descriptor(base: u64, limit: u32) -> (u64, u64) {
     (low, high)
 }
 
-lazy_static! {
-    static ref GDT: [u64; GDT_ENTRY_COUNT] = {
-        // Initialize TSS with separate exception stack in IST1
-        // SAFETY: Single-threaded initialization guaranteed by lazy_static.
-        unsafe {
-            let ist_addr = addr_of!(SEPARATE_EXCEPTION_STACK) as u64 + STACK_SIZE as u64;
-            let ist_bytes = ist_addr.to_ne_bytes();
-            core::ptr::copy_nonoverlapping(
-                ist_bytes.as_ptr(),
-                addr_of_mut!(TSS).cast::<u8>().add(TSS_IST1_OFFSET),
-                8,
-            );
-        }
+static GDT: spin::LazyLock<[u64; GDT_ENTRY_COUNT]> = spin::LazyLock::new(|| {
+    // Initialize TSS with separate exception stack in IST1
+    // SAFETY: Single-threaded initialization guaranteed by LazyLock.
+    unsafe {
+        let ist_addr = addr_of!(SEPARATE_EXCEPTION_STACK) as u64 + STACK_SIZE as u64;
+        let ist_bytes = ist_addr.to_ne_bytes();
+        core::ptr::copy_nonoverlapping(ist_bytes.as_ptr(), addr_of_mut!(TSS).cast::<u8>().add(TSS_IST1_OFFSET), 8);
+    }
 
-        let tss_base = addr_of!(TSS) as u64;
-        let (tss_low, tss_high) = tss_descriptor(tss_base, (TSS_SIZE - 1) as u32);
+    let tss_base = addr_of!(TSS) as u64;
+    let (tss_low, tss_high) = tss_descriptor(tss_base, (TSS_SIZE - 1) as u32);
 
-        // We need valid 32-bit code segments for MpServices as they start in real mode, go through
-        // protected mode, then switch to long mode. They must come before the TSS entry as the
-        // MpDxe C code matches the TSS selector to the code selector, even though it is not.
-        [
-            NULL_SEL.into(),
-            LINEAR_SEL.into(),
-            LINEAR_CODE_SEL.into(),
-            SYS_DATA_SEL.into(),
-            SYS_CODE_SEL.into(),
-            SYS_CODE16_SEL.into(),
-            LINEAR_DATA64_SEL.into(),
-            LINEAR_CODE64_SEL.into(),
-            tss_low,
-            tss_high,
-            SPARE5_SEL.into(),
-        ]
-    };
-}
+    // We need valid 32-bit code segments for MpServices as they start in real mode, go through
+    // protected mode, then switch to long mode. They must come before the TSS entry as the
+    // MpDxe C code matches the TSS selector to the code selector, even though it is not.
+    [
+        NULL_SEL.into(),
+        LINEAR_SEL.into(),
+        LINEAR_CODE_SEL.into(),
+        SYS_DATA_SEL.into(),
+        SYS_CODE_SEL.into(),
+        SYS_CODE16_SEL.into(),
+        LINEAR_DATA64_SEL.into(),
+        LINEAR_CODE64_SEL.into(),
+        tss_low,
+        tss_high,
+        SPARE5_SEL.into(),
+    ]
+});
 
 #[repr(C, packed)]
 struct GdtPointer {

--- a/core/patina_internal_cpu/src/interrupts/aarch64/gic_manager.rs
+++ b/core/patina_internal_cpu/src/interrupts/aarch64/gic_manager.rs
@@ -1,9 +1,6 @@
 use arm_gic::{
-    IntId, Trigger, UniqueMmioPointer,
-    gicv3::{
-        GicCpuInterface, GicDistributorContext, GicRedistributorContext, GicRedistributorIterator, GicV3,
-        InterruptGroup,
-    },
+    IntId, InterruptGroup, Trigger, UniqueMmioPointer,
+    gicv3::{GicCpuInterface, GicDistributorContext, GicRedistributorContext, GicRedistributorIterator, GicV3},
 };
 use core::ptr::NonNull;
 use patina::error::EfiError;

--- a/deny.toml
+++ b/deny.toml
@@ -60,7 +60,7 @@ ignore = [
     #"a-crate-that-is-yanked@0.1.1", # you can also ignore yanked crate versions if you wish
     #{ crate = "a-crate-that-is-yanked@0.1.1", reason = "you can specify why you are ignoring the yanked crate" },
 
-    # None right now
+    { id = "RUSTSEC-2024-0436", reason = "paste is unmaintained but is only pulled in transitively via arm-gic -> arm-sysregs. It is build-time only" },
 ]
 # If this is true, then cargo deny will use the git executable to fetch advisory database.
 # If this is false, then it uses a built-in git library.

--- a/patina_dxe_core/Cargo.toml
+++ b/patina_dxe_core/Cargo.toml
@@ -19,7 +19,6 @@ bitfield-struct = { workspace = true }
 cfg-if = { workspace = true }
 crc32fast = { workspace = true }
 goblin = { workspace = true, features = ["pe32", "pe64", "te"] }
-lazy_static = { workspace = true, features = ["spin_no_std"] }
 linked_list_allocator = { workspace = true }
 log = { workspace = true }
 mu_rust_helpers = { workspace = true }

--- a/patina_dxe_core/src/cpu/hw_interrupt_protocol.rs
+++ b/patina_dxe_core/src/cpu/hw_interrupt_protocol.rs
@@ -6,10 +6,7 @@ use patina_internal_cpu::interrupts::{
 use r_efi::efi;
 use spin::rwlock::RwLock;
 
-use arm_gic::{
-    Trigger,
-    gicv3::{GicCpuInterface, InterruptGroup},
-};
+use arm_gic::{InterruptGroup, Trigger, gicv3::GicCpuInterface};
 use patina::{
     BinaryGuid,
     boot_services::{BootServices, StandardBootServices},


### PR DESCRIPTION
## Description

Series of commits to get dependencies up-to-date. Does not include `uart_16550` crate since that is being handled separately in #1560.

---

**Normalize workspace dependency version specifier syntax**

Right now, Cargo.toml has a mix of version specifier styles (bare,
caret, tilde). This commit standardizes on the bare form for all
dependencies for consistency and readability.

- Drop redundant `^` prefixes (e.g. `^0.9` to `0.9`)
- Flatten `goblin = "~0.10.2"` to `"0.10.2"`. For 0.x with a minor and
  patch version, tilde and caret resolve to the same range
  (>=0.10.2, <0.11.0).
- Standardize on double quotes.

`alloc-no-stdlib does change from "~2.0"` (>=2.0.0, <2.1.0) to
`2.0` (>=2.0.0, <3.0.0). This is a case where widening the version
range is intentional.

---

**Cargo.toml: Bump semver-compatible workspace dependencies to latest**

Updates the following workspace dependencies to their latest semver
compatible versions. These are non-breaking updates that should not
require integration changes:

- clap 4.5.36 -> 4.6.1
- crc32fast 1.4 -> 1.5
- gdbstub 0.7.3 -> 0.7.10
- goblin 0.10.2 -> 0.10.7
- linkme 0.3.29 -> 0.3.36
- patina_lzma_rs 0.3.1 -> 0.3.2
- patina_paging 11.0.2 -> 11.0.4
- time 0.3.47 -> 0.3.49
- uuid 1.8 -> 1.23
- ruint 1.17.1 -> 1.18.0
- serial_test 3.0 -> 3.5

---

**Cargo.toml: Bump safe-mmio to 0.3.0**

The 0.3.0 release changes `UniqueMmioPointer::split` and
`SharedMmioPointer::split` to take self instead of a reference. The
only direct consumer in the workspace is the PL011 UART register code
in the Patina SDK that uses field!/read/write rather than split, so
no integration changes are required.

---

**Cargo.toml: Bump arm-gic to 0.8.1**

The 0.8 release relocates the `InterruptGroup` enum from the `gicv3`
submodule to the `arm_gic` crate root.

This change updates the two import sites in the aarch64 GIC manager
and the DXE core hardware interrupt protocol accordingly.

`arm-gic` 0.8 also updates its `safe-mmio` dependency to 0.3, which
matches the version already used by Patina.

---

**Cargo.toml: Bump bitfield-struct to 0.13**

The only direct consumer appears to be `patina_smbios`, which uses
the `#[bitfield(uN)]` / `#[bits(N)]` attribute syntax that is not
changed in 0.13, so no integration changes are made.

---

**Cargo.toml: Bump brotli-decompressor to 5.0.3**

The Brotli decompression APIs used by `patina_ffs_extractors`
(`BrotliDecompressStream`, `BrotliState`, `BrotliResult`, `HuffmanCode`)
and the custom `alloc_no_stdlib::Allocator` implementation are
not changed in 5.0, so no integration changes are required.

`brotli-decompressor` 5.0.3 continues to depend on `alloc-no-stdlib`
2.x, so no changes are needed to the `alloc-no-stdlib` dependency.

---

**Cargo.toml: Bump spin to 0.12**

The 0.10 and 0.11 releases renamed the `portable_atomic` feature to
`portable-atomic` and renamed `Lazy` to `LazyLock`.

Patina only appears to use `Mutex`, `RwLock`, `rwlock::RwLock`, and
`Once` (plus the unchanged `rwlock` feature flag), none of which are
affected, so no integration changes are required.

---

**Cargo.toml: Bump criterion to 0.8**

criterion 0.6 deprecated `criterion::black_box` in favor of
`std::hint::black_box`. Patina benchmarks do not use
`criterion::black_box`.

The APIs in use (`Criterion`, `BenchmarkId`, `Bencher`, `BatchSize`,
`criterion_group!`, `criterion_main!`) are unchanged, so no
integration changes are required.

---

**Cargo.toml: Bump mockall to 0.14**

mockall 0.14.0 contains only additions and bug fixes plus an MSRV
bump to 1.77.0 (Patina requires 1.89). The macros and helpers in use
(`mock!`, `automock`, `predicate`) are unchanged, so no integration
changes are required.

---

**cpu: Replace lazy_static with spin::LazyLock for the x64 GDT**

Bumping `spin` to 0.12 results in two versions of `spin` in the
dependency tree:

- 0.12 (the workspace's direct dependency and latest)
- 0.9.8, pulled in by `lazy_static`'s `spin_no_std` feature.

This results in duplicate `spin` crates being pulled in.

`lazy_static` was only used in one place, the x64 GDT.

This change replaces the single `lazy_static!` block with
`spin::LazyLock` (already available in `spin` 0.12).

---

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

- `cargo make all`
- QEMU EFI shell boot

## Integration Instructions

- N/A