### PR TITLE
Cargo.toml: Use ruint 1.17.x for MSRV compatibility

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,7 +64,9 @@ criterion = { version = "0.8" }
 env_logger = "0.11"
 mockall = { version = "0.14.0" }
 rand = { version = "0.10" }
-ruint = { version = "1.18.0" }
+# ruint ~1.17 is used right now because 1.18.0 has a MSRV of Rust 1.90.
+# This can be updated when the Patina MSRV is updated to 1.90+.
+ruint = { version = "~1.17" }
 serial_test = { version = "3.5" }
 winapi = { version = "0.3" }
 serde = { version = "1.0", default-features = false, features = ["derive"] }


### PR DESCRIPTION
## Description

Resolves #1569

Patina's MSRV is currently Rust 1.89. ruint 1.18.0 has a MSRV of Rust 1.90. This sets the ruint dependency to version 1.17.x until the Patina MSRV is updated to Rust 1.90 or higher.

This is only used in tests and was not a compelling enough reason on its own to update the MSRV, so this just rolls the version back for now.

---

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

- Switch to the MSRV toolchain and run `cargo make all`
- [MSRV workflow results (27727734091)](https://github.com/OpenDevicePartnership/patina/actions/runs/27727734091)

## Integration Instructions

- N/A