### PR TITLE
Report Dependency Expressions with Indices [Rebase & FF]

### DIFF
--- a/core/patina_internal_depex/src/lib.rs
+++ b/core/patina_internal_depex/src/lib.rs
@@ -13,7 +13,11 @@
 
 extern crate alloc;
 
-use alloc::vec::Vec;
+use alloc::{
+    format,
+    string::{String, ToString},
+    vec::Vec,
+};
 use core::mem;
 use r_efi::efi;
 use uuid::Uuid;
@@ -282,9 +286,56 @@ impl Depex {
         false
     }
 
-    /// Returns an iterator over internal opcodes.
-    pub fn iter(&self) -> impl Iterator<Item = &Opcode> {
-        self.expression.iter()
+    /// Returns an iterator over the protocols pushed by this expression, paired with whether each
+    /// was found to be present at the most recent evaluation, in expression order.
+    ///
+    /// The position of each item corresponds to the references used by [`Depex::infix_expression`].
+    pub fn pushes(&self) -> impl Iterator<Item = (&Uuid, bool)> {
+        self.expression.iter().filter_map(|opcode| match opcode {
+            Opcode::Push(guid, present) => Some((guid, *present)),
+            _ => None,
+        })
+    }
+
+    /// Renders the dependency expression in fully parenthesized infix form.
+    ///
+    /// Each pushed protocol is referenced by its position in [`Depex::pushes`]. It can be paired
+    /// with [`Depex::pushes`] to map the numbers back to GUIDs.
+    pub fn infix_expression(&self) -> String {
+        let mut stack: Vec<String> = Vec::new();
+        let mut prefix = String::new();
+        let mut push_index = 0usize;
+        for opcode in &self.expression {
+            match opcode {
+                Opcode::Push(_, _) => {
+                    push_index += 1;
+                    stack.push(push_index.to_string());
+                }
+                Opcode::And => {
+                    let rhs = stack.pop().unwrap_or_default();
+                    let lhs = stack.pop().unwrap_or_default();
+                    stack.push(format!("({lhs} AND {rhs})"));
+                }
+                Opcode::Or => {
+                    let rhs = stack.pop().unwrap_or_default();
+                    let lhs = stack.pop().unwrap_or_default();
+                    stack.push(format!("({lhs} OR {rhs})"));
+                }
+                Opcode::Not => {
+                    let operand = stack.pop().unwrap_or_default();
+                    stack.push(format!("(NOT {operand})"));
+                }
+                Opcode::True => stack.push(String::from("TRUE")),
+                Opcode::False => stack.push(String::from("FALSE")),
+                Opcode::Before(guid) => stack.push(format!("BEFORE {guid:?}")),
+                Opcode::After(guid) => stack.push(format!("AFTER {guid:?}")),
+                Opcode::Sor => prefix = String::from("SOR "),
+                Opcode::Unknown => stack.push(String::from("UNKNOWN")),
+                Opcode::Malformed { opcode, len } => stack.push(format!("MALFORMED(0x{opcode:02x}, len {len})")),
+                Opcode::End => break,
+            }
+        }
+        format!("{prefix}{}", stack.pop().unwrap_or_default())
     }
 
     /// If the depex expression is an associated dependency, it returns the associated dependency.
@@ -728,5 +779,109 @@ mod tests {
         let opcodes = [Opcode::Malformed { opcode: 0x00, len: 0 }];
         let mut depex = Depex::from(opcodes.as_slice());
         depex.eval(&[]);
+    }
+
+    #[test]
+    fn pushes_should_yield_protocols_in_order_with_presence() {
+        let guid_a = Uuid::from_str("1e5668e2-8481-11d4-bcf1-0080c73c8881").unwrap();
+        let guid_b = Uuid::from_str("6441f818-6362-eb44-5700-7dba31dd2453").unwrap();
+        let expression: &[Opcode] =
+            &[Opcode::Push(guid_a, true), Opcode::Push(guid_b, false), Opcode::And, Opcode::End];
+        let depex = Depex::from(expression);
+
+        let pushes: Vec<(Uuid, bool)> = depex.pushes().map(|(guid, present)| (*guid, present)).collect();
+        assert_eq!(pushes, vec![(guid_a, true), (guid_b, false)]);
+    }
+
+    #[test]
+    fn infix_expression_should_render_numbered_and_and_or() {
+        let guid = Uuid::from_str("1e5668e2-8481-11d4-bcf1-0080c73c8881").unwrap();
+        // 1 2 AND 3 4 AND OR
+        let expression: &[Opcode] = &[
+            Opcode::Push(guid, false),
+            Opcode::Push(guid, false),
+            Opcode::And,
+            Opcode::Push(guid, false),
+            Opcode::Push(guid, false),
+            Opcode::And,
+            Opcode::Or,
+            Opcode::End,
+        ];
+        let depex = Depex::from(expression);
+        assert_eq!(depex.infix_expression(), "((1 AND 2) OR (3 AND 4))");
+    }
+
+    #[test]
+    fn infix_expression_should_render_not_true_false() {
+        let expression: &[Opcode] = &[Opcode::True, Opcode::Not, Opcode::End];
+        let depex = Depex::from(expression);
+        assert_eq!(depex.infix_expression(), "(NOT TRUE)");
+
+        let expression: &[Opcode] = &[Opcode::False, Opcode::End];
+        let depex = Depex::from(expression);
+        assert_eq!(depex.infix_expression(), "FALSE");
+    }
+
+    #[test]
+    fn infix_expression_should_be_empty_for_empty_expression() {
+        let expression: &[Opcode] = &[];
+        let depex = Depex::from(expression);
+        assert_eq!(depex.infix_expression(), "");
+    }
+
+    #[test]
+    fn infix_expression_should_render_before_and_after() {
+        let guid = Uuid::from_str("76b6bdfa-2acd-4462-9e3f-cb58c969d937").unwrap();
+
+        let expression: &[Opcode] = &[Opcode::Before(guid), Opcode::End];
+        let depex = Depex::from(expression);
+        assert_eq!(depex.infix_expression(), format!("BEFORE {guid:?}"));
+
+        let expression: &[Opcode] = &[Opcode::After(guid), Opcode::End];
+        let depex = Depex::from(expression);
+        assert_eq!(depex.infix_expression(), format!("AFTER {guid:?}"));
+    }
+
+    #[test]
+    fn infix_expression_should_render_sor_as_prefix() {
+        let expression: &[Opcode] = &[Opcode::Sor, Opcode::True, Opcode::End];
+        let depex = Depex::from(expression);
+        assert_eq!(depex.infix_expression(), "SOR TRUE");
+    }
+
+    #[test]
+    fn infix_expression_should_render_unknown_and_malformed() {
+        let expression: &[Opcode] = &[Opcode::Unknown, Opcode::End];
+        let depex = Depex::from(expression);
+        assert_eq!(depex.infix_expression(), "UNKNOWN");
+
+        let expression: &[Opcode] = &[Opcode::Malformed { opcode: 0x02, len: 3 }, Opcode::End];
+        let depex = Depex::from(expression);
+        assert_eq!(depex.infix_expression(), "MALFORMED(0x02, len 3)");
+    }
+
+    #[test]
+    fn infix_expression_should_render_complex_before_after_and_or() {
+        let guid_a = Uuid::from_str("1e5668e2-8481-11d4-bcf1-0080c73c8881").unwrap();
+        let guid_b = Uuid::from_str("6441f818-6362-eb44-5700-7dba31dd2453").unwrap();
+        let guid_before = Uuid::from_str("76b6bdfa-2acd-4462-9e3f-cb58c969d937").unwrap();
+        let guid_after = Uuid::from_str("0379be4e-d706-437d-b037-edb82fb772a4").unwrap();
+
+        // Postfix: A B AND  BEFORE  AFTER  OR  AND
+        let expression: &[Opcode] = &[
+            Opcode::Push(guid_a, false),
+            Opcode::Push(guid_b, false),
+            Opcode::And,
+            Opcode::Before(guid_before),
+            Opcode::After(guid_after),
+            Opcode::Or,
+            Opcode::And,
+            Opcode::End,
+        ];
+        let depex = Depex::from(expression);
+        assert_eq!(
+            depex.infix_expression(),
+            format!("((1 AND 2) AND (BEFORE {guid_before:?} OR AFTER {guid_after:?}))")
+        );
     }
 }

--- a/core/patina_internal_depex/src/lib.rs
+++ b/core/patina_internal_depex/src/lib.rs
@@ -159,11 +159,11 @@ impl Depex {
     /// Evaluates a DEPEX expression.
     pub fn eval(&mut self, protocols: &[efi::Guid]) -> bool {
         let mut stack = Vec::with_capacity(DEPEX_STACK_SIZE_INCREMENT);
-        log::debug!("Depex:");
+        log::trace!("Depex:");
         for (index, opcode) in self.expression.iter_mut().enumerate() {
             match opcode {
                 Opcode::Before(_) | Opcode::After(_) => {
-                    log::debug!("  {opcode:#x?}");
+                    log::trace!("  {opcode:#x?}");
                     if index != 0 {
                         debug_assert!(false, "Invalid BEFORE or AFTER not at start of depex {:#x?}", self.expression);
                         return false;
@@ -189,7 +189,7 @@ impl Depex {
                     return false;
                 }
                 Opcode::Sor => {
-                    log::debug!("  {opcode:#x?}");
+                    log::trace!("  {opcode:#x?}");
                     if index != 0 {
                         debug_assert!(false, "Invalid SOR not at start of depex.");
                         return false;
@@ -209,7 +209,7 @@ impl Depex {
                         }
                         stack.push(false);
                     }
-                    log::debug!(
+                    log::trace!(
                         "  {opcode:x?} => {:?}, stack ->{:?}",
                         stack.last(),
                         stack.iter().rev().collect::<Vec<_>>()
@@ -219,7 +219,7 @@ impl Depex {
                     let operator1 = stack.pop().unwrap_or(false);
                     let operator2 = stack.pop().unwrap_or(false);
                     stack.push(operator1 && operator2);
-                    log::debug!(
+                    log::trace!(
                         "  {opcode:x?}({operator1:?},{operator2:?}) => {:?}, stack ->{:?}",
                         stack.last(),
                         stack.iter().rev().collect::<Vec<_>>()
@@ -229,7 +229,7 @@ impl Depex {
                     let operator1 = stack.pop().unwrap_or(false);
                     let operator2 = stack.pop().unwrap_or(false);
                     stack.push(operator1 || operator2);
-                    log::debug!(
+                    log::trace!(
                         "  {opcode:x?}({operator1:?},{operator2:?}) => {:?}, stack ->{:?}",
                         stack.last(),
                         stack.iter().rev().collect::<Vec<_>>()
@@ -238,7 +238,7 @@ impl Depex {
                 Opcode::Not => {
                     let operator = stack.pop().unwrap_or(false);
                     stack.push(!operator);
-                    log::debug!(
+                    log::trace!(
                         "  {opcode:x?}({operator:?}) => {:?}, stack ->{:?}",
                         stack.last(),
                         stack.iter().rev().collect::<Vec<_>>()
@@ -246,7 +246,7 @@ impl Depex {
                 }
                 Opcode::True => {
                     stack.push(true);
-                    log::debug!(
+                    log::trace!(
                         "  {opcode:x?} => {:?}, stack ->{:?}",
                         stack.last(),
                         stack.iter().rev().collect::<Vec<_>>()
@@ -254,7 +254,7 @@ impl Depex {
                 }
                 Opcode::False => {
                     stack.push(false);
-                    log::debug!(
+                    log::trace!(
                         "  {opcode:x?} => {:?}, stack ->{:?}",
                         stack.last(),
                         stack.iter().rev().collect::<Vec<_>>()
@@ -262,7 +262,7 @@ impl Depex {
                 }
                 Opcode::End => {
                     let operator = stack.pop().unwrap_or(false);
-                    log::debug!(
+                    log::trace!(
                         "  {opcode:x?} => final result: {:?}, final stack ->{:?}",
                         operator,
                         stack.iter().rev().collect::<Vec<_>>()

--- a/patina_dxe_core/src/pi_dispatcher.rs
+++ b/patina_dxe_core/src/pi_dispatcher.rs
@@ -133,17 +133,11 @@ impl<P: PlatformInfo> PiDispatcher<P> {
             );
 
             if let Some(depex) = &driver.depex {
-                for opcode in depex.iter() {
-                    match opcode {
-                        Opcode::Push(guid, present) => {
-                            log::debug!("  {guid:?} : {present}");
-                        }
-                        Opcode::End => {
-                            log::debug!("  {opcode:?}");
-                        }
-                        _ => {}
-                    }
+                // Number and print each pushed protocol GUID and whether it is present.
+                for (index, (guid, present)) in depex.pushes().enumerate() {
+                    log::debug!("  [{}] {guid:?} : {present}", index + 1);
                 }
+                log::debug!("  Expression: {}", depex.infix_expression());
             } else {
                 log::debug!("  No Depex");
             }


### PR DESCRIPTION
## Description

A follow up to https://github.com/OpenDevicePartnership/patina/pull/1552 to improve reporting info and clean up overall dependency expression noise in a debug log.

---

**pi_dispatcher: Render not-dispatched driver depex as infix expression**

The "Drivers Not Dispatched" detail report previously printed a list of pushed protocol GUIDs with their presence flags.

This moves the opcode logic into the patina_internal_depex crate and adds two `Depex` methods to support rendering the depex in infix form which is more natural to read.

- `Depex::pushes` yields each pushed protocol GUID paired with its presence flag, in expression order.
- `Depex::infix_expression` reconstructs the postfix opcode stream into a parenthesized infix string, referencing each protocol by its index-based position in `pushes()`.

The report now numbers each protocol and prints the corresponding expression (e.g. `((1 AND 2) OR (3 AND 4))`), so the expression can be used in conjunction with the numbered list to make it clear which combination of missing protocols blocked dispatch.

---

**patina_internal_depex: Move open parsing log msgs to trace level**

Now that the dispatcher produces a report showing the final results of depex evaluation, the detailed expression parsing logs throughout boot are less useful and moved to trace level in the change.

Note: The line that says a DEPEX is being evaluated for a given driver is left at debug log level since it is one line and "debug-level" analysis of the log at `pi_dispatcher` scope is likely to care if a driver is being re-evaluated at all through different passes in the dispatcher.

  - This line stays at `debug`: `Evaluating depex for candidate: PrintScreenLogger (EA205B85-27E0-44E6-9643-7E808368550F)`

  - The lines marked `TRACE` below are now `trace` level (they were `debug` prior to this change):

    ```
    DEBUG - Evaluating depex for candidate: Udp4Dxe (6D6963AB-906D-4A65-A7CA-BD40E5D6AF2B)
    TRACE - C:\src\patina\core\patina_internal_depex\src\lib.rs:162: Depex:
    TRACE - C:\src\patina\core\patina_internal_depex\src\lib.rs:212:   Push(665e3ff6-46cc-11d4-9a38-0090273fc14d, false) => Some(false), stack ->[false]
    TRACE - C:\src\patina\core\patina_internal_depex\src\lib.rs:212:   Push(26baccb1-6f42-11d4-bce7-0080c73c8881, true) => Some(true), stack ->[true, false]
    TRACE - C:\src\patina\core\patina_internal_depex\src\lib.rs:212:   Push(26baccb2-6f42-11d4-bce7-0080c73c8881, true) => Some(true), stack ->[true, true, false]
    TRACE - C:\src\patina\core\patina_internal_depex\src\lib.rs:212:   Push(1da97072-bddc-4b30-99f1-72a0b56fff2a, false) => Some(false), stack ->[false, true, true, false]
    TRACE - C:\src\patina\core\patina_internal_depex\src\lib.rs:212:   Push(27cfac87-46cc-11d4-9a38-0090273fc14d, false) => Some(false), stack ->[false, false, true, true, false]
    TRACE - C:\src\patina\core\patina_internal_depex\src\lib.rs:212:   Push(27cfac88-46cc-11d4-9a38-0090273fc14d, true) => Some(true), stack ->[true, false, false, true, true, false]
    TRACE - C:\src\patina\core\patina_internal_depex\src\lib.rs:212:   Push(b7dfb4e1-052f-449f-87be-9818fc91b733, true) => Some(true), stack ->[true, true, false, false, true, true, false]
    TRACE - C:\src\patina\core\patina_internal_depex\src\lib.rs:212:   Push(a46423e3-4617-49f1-b9ff-d1bfa9115839, true) => Some(true), stack ->[true, true, true, false, false, true, true, false]
    TRACE - C:\src\patina\core\patina_internal_depex\src\lib.rs:212:   Push(26baccb3-6f42-11d4-bce7-0080c73c8881, true) => Some(true), stack ->[true, true, true, true, false, false, true, true, false]
    TRACE - C:\src\patina\core\patina_internal_depex\src\lib.rs:212:   Push(665e3ff5-46cc-11d4-9a38-0090273fc14d, true) => Some(true), stack ->[true, true, true, true, true, true, true, false, false, true, true, false]
    TRACE - C:\src\patina\core\patina_internal_depex\src\lib.rs:212:   Push(3152bca5-eade-433d-862e-c01cdc291f44, true) => Some(true), stack ->[true, true, true, true, true, true, true, true, false, false, true, true, false]
    TRACE - C:\src\patina\core\patina_internal_depex\src\lib.rs:222:   And(true,true) => Some(true), stack ->[true, true, true, true, true, true, true, false, false, true, true, false]
    TRACE - C:\src\patina\core\patina_internal_depex\src\lib.rs:222:   And(true,true) => Some(true), stack ->[true, true, true, true, true, true, false, false, true, true, false]
    TRACE - C:\src\patina\core\patina_internal_depex\src\lib.rs:222:   And(true,true) => Some(true), stack ->[true, true, true, true, true, false, false, true, true, false]
    TRACE - C:\src\patina\core\patina_internal_depex\src\lib.rs:222:   And(true,true) => Some(true), stack ->[true, true, true, true, false, false, true, true, false]
    TRACE - C:\src\patina\core\patina_internal_depex\src\lib.rs:222:   And(true,true) => Some(true), stack ->[true, true, true, false, false, true, true, false]
    TRACE - C:\src\patina\core\patina_internal_depex\src\lib.rs:222:   And(true,true) => Some(true), stack ->[true, true, false, false, true, true, false]
    TRACE - C:\src\patina\core\patina_internal_depex\src\lib.rs:222:   And(true,true) => Some(true), stack ->[true, false, false, true, true, false]
    TRACE - C:\src\patina\core\patina_internal_depex\src\lib.rs:222:   And(true,false) => Some(false), stack ->[false, false, true, true, false]
    TRACE - C:\src\patina\core\patina_internal_depex\src\lib.rs:222:   And(false,false) => Some(false), stack ->[false, true, true, false]
    TRACE - C:\src\patina\core\patina_internal_depex\src\lib.rs:222:   And(false,true) => Some(false), stack ->[false, true, false]
    TRACE - C:\src\patina\core\patina_internal_depex\src\lib.rs:222:   And(false,true) => Some(false), stack ->[false, false]
    TRACE - C:\src\patina\core\patina_internal_depex\src\lib.rs:222:   And(false,false) => Some(false), stack ->[false]
    TRACE - C:\src\patina\core\patina_internal_depex\src\lib.rs:265:   End => final result: false, final stack ->[]
    ```

---

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [x] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

- `cargo make all`
- Verify `pi_dispatcher` `debug` level prints:
  ```rust
        TargetFilter { target: "pi_dispatcher", log_level: log::LevelFilter::Debug, hw_filter_override: Some(log::LevelFilter::Debug) },
  ```

Example of output:

```
DEBUG - Begin Report of Drivers Not Dispatched:
DEBUG - Driver PrintScreenLogger (EA205B85-27E0-44E6-9643-7E808368550F) found but not dispatched. Protocols present:
DEBUG -   [1] 9042a9de-23dc-4a38-96fb-7aded080516a : false
DEBUG -   [2] dd9e7534-7762-4698-8c14-f58517a625aa : true
DEBUG -   [3] 13a3f0f6-264a-3ef0-f2e0-dec512342f34 : true
DEBUG -   [4] 0379be4e-d706-437d-b037-edb82fb772a4 : true
DEBUG -   Expression: (1 AND (2 AND (3 AND 4)))
DEBUG - Driver DisplayEngine (C09E4CE4-AE29-4340-B941-078871BD89D1) found but not dispatched. Protocols present:
DEBUG -   [1] ef9fc172-a1b2-4693-b327-6d32fc416042 : true
DEBUG -   [2] 587e72d7-cc50-4f79-8209-ca291fc1a10f : true
DEBUG -   [3] a770c357-b693-4e6d-a6cf-d21c728e550b : true
DEBUG -   [4] 9d400d20-6f35-4268-904f-dc04b1877b62 : false
DEBUG -   [5] 13a3f0f6-264a-3ef0-f2e0-dec512342f34 : true
DEBUG -   [6] 0379be4e-d706-437d-b037-edb82fb772a4 : true
DEBUG -   [7] fc111ae5-f073-4348-aa5c-49124bbfed7b : true
DEBUG -   [8] 0fd96974-23aa-4cdc-b9cb-98d17750322a : true
DEBUG -   Expression: (1 AND (2 AND (3 AND (4 AND (5 AND (6 AND (7 AND 8)))))))
DEBUG - End Report of Drivers Not Dispatched.
```

---

Example of a complex expression (with unusual opcodes):

In this case the GUIDs associated with `BEFORE` and `AFTER` stay are not assigned a number since this are not directly pushed.

```rust
  let guid_a = Uuid::from_str("1e5668e2-8481-11d4-bcf1-0080c73c8881").unwrap();
  let guid_b = Uuid::from_str("6441f818-6362-eb44-5700-7dba31dd2453").unwrap();
  let guid_before = Uuid::from_str("76b6bdfa-2acd-4462-9e3f-cb58c969d937").unwrap();
  let guid_after = Uuid::from_str("0379be4e-d706-437d-b037-edb82fb772a4").unwrap();
```

Built as:

```rust
  let expression: &[Opcode] = &[
      Opcode::Push(guid_a, false),
      Opcode::Push(guid_b, false),
      Opcode::And,
      Opcode::Before(guid_before),
      Opcode::After(guid_after),
      Opcode::Or,
      Opcode::And,
      Opcode::End,
  ];
```

Results in:

```
((1 AND 2) AND (BEFORE 76b6bdfa-2acd-4462-9e3f-cb58c969d937 OR AFTER 0379be4e-d706-437d-b037-edb82fb772a4))
```

## Integration Instructions

- N/A. For platform developers, note that format of the "report of drivers not dispatched" messages are different now than in b95fa53.