### PR TITLE
[REBASE & FF] Upgrade to r-efi v7

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ linked_list_allocator = { version = "0.10" }
 linkme = { version = "0.3.36" }
 log = { version = "0.4", default-features = false }
 memoffset = {version = "0.9.1" }
+mu_rust_helpers = { version = "4.1" }
 num-traits = { version = "0.2", default-features = false }
 patina = { version = "22.0.2", path = "sdk/patina" }
 patina_debugger = { version = "22.0.2", path = "core/patina_debugger" }
@@ -48,7 +49,7 @@ patina_stacktrace = { version = "22.0.2", path = "core/patina_stacktrace" }
 patina_test = { version = "22.0.2", path = "components/patina_test" }
 proc-macro2 = { version = "1" }
 quote = { version = "1" }
-r-efi = { version = "6.0.0", default-features = false }
+r-efi = { version = "7", default-features = false }
 scroll = { version = "0.13", default-features = false, features = ["derive"]}
 spin = { version = "0.12" }
 syn = { version = "2" }

--- a/components/patina_adv_logger/src/component.rs
+++ b/components/patina_adv_logger/src/component.rs
@@ -98,7 +98,7 @@ where
         let protocol = Box::leak(Box::new(protocol));
         match bs.install_protocol_interface(None, &mut protocol.protocol) {
             Err(status) => {
-                log::error!("Failed to install Advanced Logger protocol! Status = {status:#x?}");
+                log::error!("Failed to install Advanced Logger protocol! Status = {status}");
                 Err(EfiError::ProtocolError)
             }
             Ok(_) => {

--- a/components/patina_mm/src/component/communicator/comm_buffer_update.rs
+++ b/components/patina_mm/src/component/communicator/comm_buffer_update.rs
@@ -180,7 +180,7 @@ extern "efiapi" fn protocol_notify_callback(_event: r_efi::efi::Event, context: 
     } {
         Ok(ptr) => ptr,
         Err(status) => {
-            log::error!(target: "mm_comm", "Failed to locate protocol: status={:?}", status);
+            log::error!(target: "mm_comm", "Failed to locate protocol: status={}", status);
             return;
         }
     };

--- a/components/patina_mm/src/component/sw_mmi_manager.rs
+++ b/components/patina_mm/src/component/sw_mmi_manager.rs
@@ -78,7 +78,7 @@ impl SwMmiManager {
         if let Some(ctrl) = platform_mm_control {
             log::debug!(target: "sw_mmi", "Platform MM Control is available. Calling platform-specific init...");
             ctrl.init().inspect_err(|&err| {
-                log::error!(target: "sw_mmi", "Platform MM Control initialization failed: {:?}", err);
+                log::error!(target: "sw_mmi", "Platform MM Control initialization failed: {}", err);
             })?;
             log::trace!(target: "sw_mmi", "Platform MM Control initialization completed successfully");
         } else {

--- a/components/patina_samples/src/smbios_platform.rs
+++ b/components/patina_samples/src/smbios_platform.rs
@@ -101,31 +101,31 @@ impl SmbiosExampleComponent {
 
         // Type 0: Platform firmware/BIOS information
         if let Err(e) = Self::add_bios_information(&smbios) {
-            log::error!("Failed to add BIOS information: {:?}", e);
+            log::error!("Failed to add BIOS information: {}", e);
             return Err(e);
         }
 
         // Type 1: System information
         if let Err(e) = Self::add_system_information(&smbios) {
-            log::error!("Failed to add system information: {:?}", e);
+            log::error!("Failed to add system information: {}", e);
             return Err(e);
         }
 
         // Type 2: Baseboard/motherboard information
         if let Err(e) = Self::add_baseboard_information(&smbios) {
-            log::error!("Failed to add baseboard information: {:?}", e);
+            log::error!("Failed to add baseboard information: {}", e);
             return Err(e);
         }
 
         // Type 3: System chassis/enclosure information
         if let Err(e) = Self::add_system_enclosure(&smbios) {
-            log::error!("Failed to add system enclosure: {:?}", e);
+            log::error!("Failed to add system enclosure: {}", e);
             return Err(e);
         }
 
         // Type 0x80: Platform-specific vendor record
         if let Err(e) = Self::add_vendor_oem_record(&smbios) {
-            log::error!("Failed to add vendor OEM record: {:?}", e);
+            log::error!("Failed to add vendor OEM record: {}", e);
             return Err(e);
         }
 

--- a/components/patina_smbios/src/manager.rs
+++ b/components/patina_smbios/src/manager.rs
@@ -80,7 +80,7 @@ pub fn install_smbios_protocol(
             unsafe {
                 drop(Box::from_raw(interface));
             }
-            log::error!("Failed to install SMBIOS protocol: {:?}", status);
+            log::error!("Failed to install SMBIOS protocol: {}", status);
             Err(SmbiosError::AllocationFailed)
         }
     }

--- a/patina_dxe_core/src/allocator.rs
+++ b/patina_dxe_core/src/allocator.rs
@@ -1216,7 +1216,7 @@ fn process_hob_allocations(hob_list: &HobList) {
                     None)
                     .inspect_err(|err|{
                         log::error!(
-                            "Failed to allocate memory space for firmware volume HOB at {base_address:#x?} of length {length:#x?}. Error: {err:#x?}",
+                            "Failed to allocate memory space for firmware volume HOB at {base_address:#x?} of length {length:#x?}. Error: {err}",
                         );
                     });
             }

--- a/patina_dxe_core/src/component_dispatcher.rs
+++ b/patina_dxe_core/src/component_dispatcher.rs
@@ -226,7 +226,7 @@ impl ComponentDispatcher {
                 Ok(true) => true,
                 Ok(false) => false,
                 Err(err) => {
-                    log_debug_assert!("Dispatched: Id = [{name:?}] Status = [Failed] Error = [{err:?}]");
+                    log_debug_assert!("Dispatched: Id = [{name:?}] Status = [Failed] Error = [{err}]");
                     true // Component dispatched, even if it did fail, so remove from self.components to avoid re-dispatch.
                 }
             }

--- a/patina_dxe_core/src/config_tables/memory_attributes_table.rs
+++ b/patina_dxe_core/src/config_tables/memory_attributes_table.rs
@@ -71,7 +71,7 @@ impl Debug for MemoryAttributesTable {
         writelncrlf!(f, "  version: {:#X}", mat.version)?;
         writelncrlf!(f, "  number_of_entries: {:#X}", mat.number_of_entries)?;
         writelncrlf!(f, "  descriptor_size: {:#X}", mat.descriptor_size)?;
-        writelncrlf!(f, "  reserved: {:#X}", mat.reserved)?;
+        writelncrlf!(f, "  flags: {:#X}", mat.flags)?;
         writelncrlf!(f, "  entries: [")?;
 
         writelncrlf!(f, "{:?}", MemoryDescriptorSlice(entries))?;
@@ -120,7 +120,7 @@ pub fn core_install_memory_attributes_table() {
                             version: 0,
                             number_of_entries: 0,
                             descriptor_size: 0,
-                            reserved: 0,
+                            flags: 0,
                             entry: [],
                         };
                         let mut st_guard = systemtables::SYSTEM_TABLE.lock();
@@ -213,7 +213,7 @@ pub fn core_install_memory_attributes_table() {
                 mat.version = efi::MEMORY_ATTRIBUTES_TABLE_VERSION;
                 mat.number_of_entries = mat_desc_list.len() as u32;
                 mat.descriptor_size = size_of::<efi::MemoryDescriptor>() as u32;
-                mat.reserved = 0;
+                mat.flags = 0;
 
                 let copy_ptr = core::ptr::from_ref(&mat.entry) as *mut u8;
 

--- a/patina_dxe_core/src/config_tables/memory_attributes_table.rs
+++ b/patina_dxe_core/src/config_tables/memory_attributes_table.rs
@@ -91,7 +91,7 @@ pub fn init_memory_attributes_table_support() {
         None,
         Some(efi::EVENT_GROUP_READY_TO_BOOT),
     ) {
-        log::error!("Failed to register an event at Ready to Boot to create the MAT! Status {status:#X?}");
+        log::error!("Failed to register an event at Ready to Boot to create the MAT! Status {status}");
     }
 }
 
@@ -101,7 +101,7 @@ extern "efiapi" fn core_install_memory_attributes_table_event_wrapper(event: efi
     core_install_memory_attributes_table();
 
     if let Err(status) = EVENT_DB.close_event(event) {
-        log::error!("Failed to close MAT ready to boot event with status {status:#X?}. This should be okay.");
+        log::error!("Failed to close MAT ready to boot event with status {status}. This should be okay.");
     }
 }
 
@@ -129,15 +129,13 @@ pub fn core_install_memory_attributes_table() {
                         if let Err(status) =
                             core_install_configuration_table(efi::MEMORY_ATTRIBUTES_TABLE_GUID, empty_ptr, st)
                         {
-                            log::error!(
-                                "Failed to create a null MAT table with status {status:#X?}, cannot create MAT"
-                            );
+                            log::error!("Failed to create a null MAT table with status {status}, cannot create MAT");
                             return;
                         }
                     }
                 }
                 Err(err) => {
-                    log::error!("Failed to allocate memory for a null MAT! Status {err:#X?}");
+                    log::error!("Failed to allocate memory for a null MAT! Status {err}");
                     return;
                 }
             }
@@ -194,7 +192,7 @@ pub fn core_install_memory_attributes_table() {
         mat_desc_list.len() * size_of::<efi::MemoryDescriptor>() + size_of::<efi::MemoryAttributesTable>();
     match core_allocate_pool(efi::BOOT_SERVICES_DATA, buffer_size) {
         Err(err) => {
-            log::error!("Failed to allocate memory for the MAT! Status {err:#X?}");
+            log::error!("Failed to allocate memory for the MAT! Status {err}");
             return;
         }
         Ok(void_ptr) => {
@@ -228,16 +226,16 @@ pub fn core_install_memory_attributes_table() {
 
                 match core_install_configuration_table(efi::MEMORY_ATTRIBUTES_TABLE_GUID, void_ptr, st) {
                     Err(status) => {
-                        log::error!("Failed to install MAT table! Status {status:#X?}");
+                        log::error!("Failed to install MAT table! Status {status}");
                         if let Err(err) = core_free_pool(void_ptr) {
-                            log::error!("Error freeing newly allocated MAT pointer: {err:#X?}");
+                            log::error!("Error freeing newly allocated MAT pointer: {err}");
                         }
                         return;
                     }
                     Ok(Some(current_ptr)) => {
                         // free the old MAT table if we have one
                         if let Err(err) = core_free_pool(current_ptr.as_ptr()) {
-                            log::error!("Error freeing previous MAT pointer: {err:#X?}");
+                            log::error!("Error freeing previous MAT pointer: {err}");
                         }
                     }
                     Ok(None) => (),

--- a/patina_dxe_core/src/cpu.rs
+++ b/patina_dxe_core/src/cpu.rs
@@ -117,12 +117,12 @@ pub trait CpuInfo {
 pub fn initialize_cpu_subsystem() -> crate::error::Result<(EfiCpu, Interrupts)> {
     let mut cpu = EfiCpu::default();
     cpu.initialize().inspect_err(|err| {
-        log::error!("Failed to initialize CPU subsystem: {:?}", err);
+        log::error!("Failed to initialize CPU subsystem: {}", err);
     })?;
 
     let mut interrupt_manager = Interrupts::new();
     interrupt_manager.initialize().inspect_err(|err| {
-        log::error!("Failed to initialize Interrupt Manager: {:?}", err);
+        log::error!("Failed to initialize Interrupt Manager: {}", err);
     })?;
 
     Ok((cpu, interrupt_manager))

--- a/patina_dxe_core/src/event_db.rs
+++ b/patina_dxe_core/src/event_db.rs
@@ -539,7 +539,7 @@ impl EventDb {
                     current_event.trigger_time = None;
                 }
                 if let Err(e) = self.signal_event(event as *mut c_void) {
-                    log::error!("Error {e:?} signaling event {event:?}.");
+                    log::error!("Error {e} signaling event {event:?}.");
                 }
             }
         }
@@ -605,7 +605,7 @@ impl Drop for EventGuard<'_> {
                 match pending {
                     PendingSignals::Event(event) => {
                         if let Err(e) = self.signal_event(event) {
-                            log::error!("Error {e:?} signaling event {event:?} from pending.");
+                            log::error!("Error {e} signaling event {event:?} from pending.");
                         }
                     }
                     PendingSignals::Group(group) => {

--- a/patina_dxe_core/src/events.rs
+++ b/patina_dxe_core/src/events.rs
@@ -357,10 +357,10 @@ extern "efiapi" fn timer_available_callback(event: efi::Event, _context: *mut c_
             let timer_arch = unsafe { &*(timer_arch_ptr) };
             (timer_arch.register_handler)(timer_arch_ptr, timer_tick);
             if let Err(status_err) = EVENT_DB.close_event(event) {
-                log::warn!("Could not close event for timer_available_callback due to error {status_err:?}");
+                log::warn!("Could not close event for timer_available_callback due to error {status_err}");
             }
         }
-        Err(err) => panic!("Unable to locate timer arch: {err:?}"),
+        Err(err) => panic!("Unable to locate timer arch: {err}"),
     }
 }
 

--- a/patina_dxe_core/src/gcd/spin_locked_gcd.rs
+++ b/patina_dxe_core/src/gcd/spin_locked_gcd.rs
@@ -279,7 +279,7 @@ impl PageAllocator for PagingAllocator<'_> {
                         Ok(root_page) => Ok(root_page as u64),
                         Err(e) => {
                             // okay we are good and dead now
-                            panic!("Failed to allocate root page for the page table page pool: {e:?}");
+                            panic!("Failed to allocate root page for the page table page pool: {e}");
                         }
                     }
                 }
@@ -308,7 +308,7 @@ impl PageAllocator for PagingAllocator<'_> {
                             self.page_pool.pop().ok_or(PtError::OutOfResources)
                         }
                         Err(e) => {
-                            panic!("Failed to allocate pages for the page table page pool {e:?}");
+                            panic!("Failed to allocate pages for the page table page pool {e}");
                         }
                     }
                 }
@@ -2482,7 +2482,7 @@ impl SpinLockedGcd {
         {
             // if we fail to set these attributes we can continue to boot, but we will not be able to detect null
             // pointer dereferences.
-            log::error!("Failed to unmap page 0, which is reserved for null pointer detection. Error: {err:?}");
+            log::error!("Failed to unmap page 0, which is reserved for null pointer detection. Error: {err}");
             debug_assert!(false);
         }
 

--- a/patina_dxe_core/src/lib.rs
+++ b/patina_dxe_core/src/lib.rs
@@ -377,7 +377,7 @@ impl<P: PlatformInfo> Core<P> {
         let relocated_hob_list = self.init_memory(physical_hob_list);
 
         if let Err(err) = self.start_dispatcher(relocated_hob_list) {
-            log::error!("DXE Core failed to start: {err:?}");
+            log::error!("DXE Core failed to start: {err}");
         }
 
         call_bds();
@@ -494,10 +494,7 @@ impl<P: PlatformInfo> Core<P> {
 
             // UEFI driver dispatch
             let dispatched = dispatched
-                || self
-                    .pi_dispatcher
-                    .dispatch()
-                    .inspect_err(|err| log::error!("UEFI Driver Dispatch error: {err:?}"))?;
+                || self.pi_dispatcher.dispatch().inspect_err(|err| log::error!("UEFI Driver Dispatch error: {err}"))?;
 
             if !dispatched {
                 break;
@@ -652,7 +649,7 @@ fn call_bds() -> ! {
                 log::error!("status_code protocol pointer is NULL")
             }
         }
-        Err(err) => log::error!("Unable to locate status code runtime protocol: {err:?}"),
+        Err(err) => log::error!("Unable to locate status code runtime protocol: {err}"),
     }
 
     match protocols::PROTOCOL_DB.locate_protocol(bds::PROTOCOL_GUID.into_inner()) {
@@ -669,7 +666,7 @@ fn call_bds() -> ! {
                 log::error!("bds protocol pointer is NULL")
             }
         }
-        Err(err) => log::error!("Unable to locate BDS arch protocol: {err:?}"),
+        Err(err) => log::error!("Unable to locate BDS arch protocol: {err}"),
     };
 
     unreachable!("BDS arch protocol should be found and should never return.");

--- a/patina_dxe_core/src/memory_attributes_protocol.rs
+++ b/patina_dxe_core/src/memory_attributes_protocol.rs
@@ -271,7 +271,7 @@ pub(crate) fn install_memory_attributes_protocol() {
             }
         }
         Err(e) => {
-            log::error!("Failed to install MEMORY_ATTRIBUTES_PROTOCOL_GUID: {e:?}");
+            log::error!("Failed to install MEMORY_ATTRIBUTES_PROTOCOL_GUID: {e}");
         }
     }
 }
@@ -295,7 +295,7 @@ pub(crate) fn uninstall_memory_attributes_protocol() {
                         log::info!("uninstalled MEMORY_ATTRIBUTES_PROTOCOL_GUID");
                     }
                     Err(e) => {
-                        log::error!("Failed to uninstall MEMORY_ATTRIBUTES_PROTOCOL_GUID: {e:?}");
+                        log::error!("Failed to uninstall MEMORY_ATTRIBUTES_PROTOCOL_GUID: {e}");
                     }
                 }
             }

--- a/patina_dxe_core/src/misc_boot_services.rs
+++ b/patina_dxe_core/src/misc_boot_services.rs
@@ -153,10 +153,10 @@ extern "efiapi" fn metronome_arch_available(event: efi::Event, _context: *mut c_
             // associated with the metronome arch guid.
             unsafe { METRONOME_ARCH_PTR.init(metronome_arch_ptr) };
             if let Err(status_err) = EVENT_DB.close_event(event) {
-                log::warn!("Could not close event for metronome_arch_available due to error {status_err:?}");
+                log::warn!("Could not close event for metronome_arch_available due to error {status_err}");
             }
         }
-        Err(err) => panic!("Unable to retrieve metronome arch: {err:?}"),
+        Err(err) => panic!("Unable to retrieve metronome arch: {err}"),
     }
 }
 // Requires excessive Mocking for the OK case.
@@ -173,10 +173,10 @@ extern "efiapi" fn watchdog_arch_available(event: efi::Event, _context: *mut c_v
             // associated with the watchdog arch guid.
             unsafe { WATCHDOG_ARCH_PTR.init(watchdog_arch_ptr) };
             if let Err(status_err) = EVENT_DB.close_event(event) {
-                log::warn!("Could not close event for watchdog_arch_available due to error {status_err:?}");
+                log::warn!("Could not close event for watchdog_arch_available due to error {status_err}");
             }
         }
-        Err(err) => panic!("Unable to retrieve watchdog arch: {err:?}"),
+        Err(err) => panic!("Unable to retrieve watchdog arch: {err}"),
     }
 }
 
@@ -213,7 +213,7 @@ pub extern "efiapi" fn exit_boot_services(_handle: efi::Handle, map_key: usize) 
             let timer_arch = unsafe { &*(timer_arch_ptr) };
             (timer_arch.set_timer_period)(timer_arch_ptr, 0);
         }
-        Err(err) => log::error!("Unable to locate timer arch: {err:?}"),
+        Err(err) => log::error!("Unable to locate timer arch: {err}"),
     };
 
     // Lock the memory space to prevent edits to the memory map after this point.
@@ -224,7 +224,7 @@ pub extern "efiapi" fn exit_boot_services(_handle: efi::Handle, map_key: usize) 
     match terminate_memory_map(map_key) {
         Ok(_) => (),
         Err(err) => {
-            log::error!("Failed to terminate memory map: {err:?}");
+            log::error!("Failed to terminate memory map: {err}");
             GCD.unlock_memory_space();
             EVENT_DB.signal_group(guids::EBS_FAILED.into_inner());
             return err.into();
@@ -249,7 +249,7 @@ pub extern "efiapi" fn exit_boot_services(_handle: efi::Handle, map_key: usize) 
                 core::ptr::null(),
             );
         }
-        Err(err) => log::error!("Unable to locate status code runtime protocol: {err:?}"),
+        Err(err) => log::error!("Unable to locate status code runtime protocol: {err}"),
     };
 
     // Disable CPU interrupts
@@ -273,7 +273,7 @@ pub extern "efiapi" fn exit_boot_services(_handle: efi::Handle, map_key: usize) 
             let rt_arch_protocol = unsafe { &mut *(rt_arch_ptr) };
             rt_arch_protocol.at_runtime.store(true, Ordering::SeqCst);
         }
-        Err(err) => log::error!("Unable to locate runtime architectural protocol: {err:?}"),
+        Err(err) => log::error!("Unable to locate runtime architectural protocol: {err}"),
     };
 
     crate::runtime::finalize_runtime_support();

--- a/patina_dxe_core/src/misc_boot_services.rs
+++ b/patina_dxe_core/src/misc_boot_services.rs
@@ -94,14 +94,14 @@ extern "efiapi" fn stall(microseconds: usize) -> efi::Status {
         while ticks > u32::MAX as u128 {
             let status = (metronome.wait_for_tick)(metronome_ptr, u32::MAX);
             if status.is_error() {
-                log::warn!("metronome.wait_for_tick returned unexpected error {status:#x?}");
+                log::warn!("metronome.wait_for_tick returned unexpected error {status}");
             }
             ticks -= u32::MAX as u128;
         }
         if ticks != 0 {
             let status = (metronome.wait_for_tick)(metronome_ptr, ticks as u32);
             if status.is_error() {
-                log::warn!("metronome.wait_for_tick returned unexpected error {status:#x?}");
+                log::warn!("metronome.wait_for_tick returned unexpected error {status}");
             }
         }
         efi::Status::SUCCESS
@@ -384,7 +384,7 @@ mod tests {
                     log::warn!("CRC32 mismatch: got {data_crc:#x}, expected {expected_crc:#x}");
                 }
             } else {
-                log::warn!("CRC32 calculation failed with status: {status:#x?}");
+                log::warn!("CRC32 calculation failed with status: {status}");
             }
 
             // Test case 2: Zero data size - should return INVALID_PARAMETER
@@ -395,7 +395,7 @@ mod tests {
             if status == efi::Status::INVALID_PARAMETER {
                 log::debug!("Zero data size correctly returned INVALID_PARAMETER");
             } else {
-                log::warn!("Zero data size returned unexpected status: {status:#x?}");
+                log::warn!("Zero data size returned unexpected status: {status}");
             }
 
             // Test case 3: Null data pointer - should return INVALID_PARAMETER
@@ -410,7 +410,7 @@ mod tests {
             if status == efi::Status::INVALID_PARAMETER {
                 log::debug!("Null data pointer correctly returned INVALID_PARAMETER");
             } else {
-                log::warn!("Null data pointer returned unexpected status: {status:#x?}");
+                log::warn!("Null data pointer returned unexpected status: {status}");
             }
 
             // Test case 4: Null output pointer - should return INVALID_PARAMETER
@@ -425,7 +425,7 @@ mod tests {
             if status == efi::Status::INVALID_PARAMETER {
                 log::debug!("Null output pointer correctly returned INVALID_PARAMETER");
             } else {
-                log::warn!("Null output pointer returned unexpected status: {status:#x?}");
+                log::warn!("Null output pointer returned unexpected status: {status}");
             }
         });
     }
@@ -441,7 +441,7 @@ mod tests {
             if status == efi::Status::NOT_READY {
                 log::debug!("Set watchdog timer correctly returned NOT_READY (no watchdog protocol)");
             } else {
-                log::warn!("Set watchdog timer returned unexpected status: {status:#x?}");
+                log::warn!("Set watchdog timer returned unexpected status: {status}");
             }
 
             // Test case 2: Disable watchdog timer with null data - should return NOT_READY
@@ -451,7 +451,7 @@ mod tests {
             if status == efi::Status::NOT_READY {
                 log::debug!("Disable watchdog timer correctly returned NOT_READY");
             } else {
-                log::warn!("Disable watchdog timer returned unexpected status: {status:#x?}");
+                log::warn!("Disable watchdog timer returned unexpected status: {status}");
             }
 
             let data: [efi::Char16; 6] = [b'H' as u16, b'e' as u16, b'l' as u16, b'l' as u16, b'o' as u16, 0];
@@ -464,7 +464,7 @@ mod tests {
             if status == efi::Status::NOT_READY {
                 log::debug!("Set watchdog timer with data correctly returned NOT_READY");
             } else {
-                log::warn!("Set watchdog timer with data returned unexpected status: {status:#x?}");
+                log::warn!("Set watchdog timer with data returned unexpected status: {status}");
             }
 
             // Test case 4: Disable the watchdog timer with non-null data - should return NOT_READY
@@ -474,7 +474,7 @@ mod tests {
             if status == efi::Status::NOT_READY {
                 log::debug!("Disable watchdog timer with data correctly returned NOT_READY");
             } else {
-                log::warn!("Disable watchdog timer with data returned unexpected status: {status:#x?}");
+                log::warn!("Disable watchdog timer with data returned unexpected status: {status}");
             }
 
             //Mock a watchdog protocol
@@ -513,7 +513,7 @@ mod tests {
                 log::debug!("Set watchdog timer correctly returned SUCCESS (watchdog protocol available)");
                 assert!(SET_PERIOD_CALLED.is_completed(), "set_timer_period was not called during set_watchdog_timer.");
             } else {
-                log::warn!("Set watchdog timer returned unexpected status: {status:#x?}");
+                log::warn!("Set watchdog timer returned unexpected status: {status}");
             }
         });
     }
@@ -529,7 +529,7 @@ mod tests {
             if status == efi::Status::NOT_READY {
                 log::debug!("Stall function correctly returned NOT_READY (no metronome protocol)");
             } else {
-                log::warn!("Stall function returned unexpected status: {status:#x?}");
+                log::warn!("Stall function returned unexpected status: {status}");
             }
 
             // Test case 2: Zero microseconds stall - should return NOT_READY
@@ -539,7 +539,7 @@ mod tests {
             if status == efi::Status::NOT_READY {
                 log::debug!("Zero stall correctly returned NOT_READY");
             } else {
-                log::warn!("Zero stall returned unexpected status: {status:#x?}");
+                log::warn!("Zero stall returned unexpected status: {status}");
             }
 
             // Test case 3: Maximum stall duration - should return NOT_READY
@@ -549,7 +549,7 @@ mod tests {
             if status == efi::Status::NOT_READY {
                 log::debug!("Maximum stall correctly returned NOT_READY");
             } else {
-                log::warn!("Maximum stall returned unexpected status: {status:#x?}");
+                log::warn!("Maximum stall returned unexpected status: {status}");
             }
 
             //Mock a metronome protocol
@@ -582,7 +582,7 @@ mod tests {
                 log::debug!("Stall function correctly returned SUCCESS (metronome protocol available)");
                 assert!(WAIT_FOR_TICK_CALLED.is_completed(), "wait_for_tick was not called during stall.");
             } else {
-                log::warn!("Stall function returned unexpected status: {status:#x?}");
+                log::warn!("Stall function returned unexpected status: {status}");
             }
         });
     }

--- a/patina_dxe_core/src/pi_dispatcher.rs
+++ b/patina_dxe_core/src/pi_dispatcher.rs
@@ -343,7 +343,7 @@ impl<P: PlatformInfo> PiDispatcher<P> {
                     }
                     efi::Status::SECURITY_VIOLATION => {
                         log::info!(
-                            "Deferring driver: {} ({:?}) due to security status: {:x?}",
+                            "Deferring driver: {} ({:?}) due to security status: {}",
                             driver.name.as_deref().unwrap_or("Unnamed"),
                             OwnedGuid::from(driver.file_name),
                             efi::Status::SECURITY_VIOLATION
@@ -352,7 +352,7 @@ impl<P: PlatformInfo> PiDispatcher<P> {
                     }
                     unexpected_status => {
                         log::info!(
-                            "Dropping driver: {} ({:?}) due to security status: {:x?}",
+                            "Dropping driver: {} ({:?}) due to security status: {}",
                             driver.name.as_deref().unwrap_or("Unnamed"),
                             OwnedGuid::from(driver.file_name),
                             unexpected_status

--- a/patina_dxe_core/src/pi_dispatcher.rs
+++ b/patina_dxe_core/src/pi_dispatcher.rs
@@ -39,7 +39,6 @@ use patina_internal_depex::{AssociatedDependency, Depex, Opcode};
 use r_efi::efi;
 use spin::RwLock;
 
-use debug_image_info_table::EfiSystemTablePointer;
 use image::ImageStatus;
 use section_decompress::CoreExtractor;
 
@@ -190,7 +189,7 @@ impl<P: PlatformInfo> PiDispatcher<P> {
         // Perform image related initialization for the debugger.
         // This includes installing the debug image info table and the system table pointer structure.
         if core_install_configuration_table(
-            debug_image_info_table::EFI_DEBUG_IMAGE_INFO_TABLE_GUID,
+            efi::DEBUG_IMAGE_INFO_TABLE_GUID,
             self.debug_image_data.read().header() as *const _ as *mut c_void,
             system_table,
         )
@@ -214,14 +213,14 @@ impl<P: PlatformInfo> PiDispatcher<P> {
             return;
         };
 
-        let ptr = address as *mut EfiSystemTablePointer;
+        let ptr = address as *mut efi::SystemTablePointer;
 
         // SAFETY: This is safe because we just allocated this. We have to do a volatile write because we don't use this
         // pointer, an external debugger does
         unsafe {
             core::ptr::write_volatile(
                 ptr,
-                EfiSystemTablePointer {
+                efi::SystemTablePointer {
                     signature: efi::SYSTEM_TABLE_SIGNATURE,
                     efi_system_table_base: system_table_pointer,
                     crc32: 0,
@@ -229,7 +228,7 @@ impl<P: PlatformInfo> PiDispatcher<P> {
             );
 
             let crc32 =
-                crc32fast::hash(alloc::slice::from_raw_parts(ptr as *const u8, size_of::<EfiSystemTablePointer>()));
+                crc32fast::hash(alloc::slice::from_raw_parts(ptr as *const u8, size_of::<efi::SystemTablePointer>()));
 
             core::ptr::write_volatile(&mut (*ptr).crc32, crc32);
         }

--- a/patina_dxe_core/src/pi_dispatcher/debug_image_info_table.rs
+++ b/patina_dxe_core/src/pi_dispatcher/debug_image_info_table.rs
@@ -14,10 +14,6 @@ use core::{
 use r_efi::efi;
 use spin::rwlock::RwLock;
 
-/// GUID for the EFI_DEBUG_IMAGE_INFO_TABLE per section 18.4.3 of UEFI Spec 2.11
-pub(super) const EFI_DEBUG_IMAGE_INFO_TABLE_GUID: efi::Guid =
-    efi::Guid::from_fields(0x49152e77, 0x1ada, 0x4764, 0xb7, 0xa2, &[0x7a, 0xfe, 0xfe, 0xd9, 0x5e, 0x8b]);
-
 /// Default allocation size for the debug image info table.
 const DEFAULT_CAPACITY: usize = 16;
 const _: () = assert!(DEFAULT_CAPACITY > 0);
@@ -52,15 +48,10 @@ pub(super) enum ImageInfoType {
     Normal,
 }
 
-impl ImageInfoType {
-    /// The UEFI constant representing a normal debug image info entry.
-    const EFI_DEBUG_IMAGE_INFO_TYPE_NORMAL: u32 = 0x1;
-}
-
 impl From<ImageInfoType> for u32 {
     fn from(value: ImageInfoType) -> Self {
         match value {
-            ImageInfoType::Normal => ImageInfoType::EFI_DEBUG_IMAGE_INFO_TYPE_NORMAL,
+            ImageInfoType::Normal => efi::DEBUG_IMAGE_INFO_TYPE_NORMAL,
         }
     }
 }
@@ -69,27 +60,39 @@ impl From<ImageInfoType> for u32 {
 ///
 /// ## Invariants
 ///
-/// - `header.table_size` and `capacity` always reflect the actual state of the allocated bytes buffer pointed to by
-///   `header.table`, ensuring no out-of-bounds access can occur.
+/// - `header.table_size` and `capacity` always reflect the actual state of the allocated buffer pointed to by
+///   `header.debug_image_info_table`, ensuring no out-of-bounds access can occur.
 ///
 /// ## Warning
 ///
 /// The above invariants are only upheld on the assumption that this struct is the sole modifier of the underlying
-/// table. This cannot be guaranteed due to the fact that the table pointer ([DebugImageInfoTableHeader]) is exposed
-/// publicly via the UEFI configuration table mechanism. It is expected that this table is read-only when accessed
-/// via this mechanism, but this cannot be enforced.
+/// table. This cannot be guaranteed due to the fact that the table header (`efi::DebugImageInfoTableHeader`) is
+/// exposed publicly via the UEFI configuration table mechanism. It is expected that this table is read-only when
+/// accessed via this mechanism, but this cannot be enforced.
 pub(super) struct DebugImageInfoData {
     /// The header of the debug image info table, which is registered as a UEFI configuration table.
-    header: DebugImageInfoTableHeader,
-    /// The total number of [EfiDebugImageInfo] entries able to be added to the the table before an reallocation is
+    header: efi::DebugImageInfoTableHeader,
+    /// The total number of `efi::DebugImageInfo` entries able to be added to the table before a reallocation is
     /// needed.
     capacity: usize,
 }
 
+// SAFETY: Access to the raw table pointer in the header is gated behind methods that require `&mut self`.
+unsafe impl Send for DebugImageInfoData {}
+// SAFETY: Access to the raw table pointer in the header is gated behind methods that require `&mut self`.
+unsafe impl Sync for DebugImageInfoData {}
+
 impl DebugImageInfoData {
     /// Creates a new, empty Debug Image Info Table.
     const fn new() -> Self {
-        Self { header: DebugImageInfoTableHeader::new(), capacity: 0 }
+        Self {
+            header: efi::DebugImageInfoTableHeader {
+                volatile_update_status: 0,
+                table_size: 0,
+                debug_image_info_table: ptr::null_mut(),
+            },
+            capacity: 0,
+        }
     }
 
     /// Creates a new, empty Debug Image Info Table wrapped in a RwLock.
@@ -98,27 +101,45 @@ impl DebugImageInfoData {
     }
 
     /// Returns a reference to the header of the debug image info table.
-    pub(super) fn header(&self) -> &DebugImageInfoTableHeader {
+    pub(super) fn header(&self) -> &efi::DebugImageInfoTableHeader {
         &self.header
     }
 
     /// Returns an immutable slice of table entries.
     ///
     /// This should be used for read-only access.
-    fn table(&self) -> &[EfiDebugImageInfo] {
-        self.header.table()
+    fn table(&self) -> &[efi::DebugImageInfo] {
+        if self.header.table_size == 0 {
+            return &[];
+        }
+
+        // SAFETY: `debug_image_info_table` is non-null due to the table_size check above, and the invariants of this
+        //   struct ensure it is valid for reads of `table_size` entries within a single allocation.
+        unsafe { core::slice::from_raw_parts(self.header.debug_image_info_table, self.header.table_size as usize) }
     }
 
     /// Returns a mutable pointer to the start of the debug image info table.
     ///
     /// This should be used for read-write access.
-    fn table_mut(&mut self) -> *mut EfiDebugImageInfo {
-        self.header.table_mut()
+    fn table_mut(&mut self) -> *mut efi::DebugImageInfo {
+        self.header.debug_image_info_table
     }
 
     /// Returns the current number of entries in the table.
     fn len(&self) -> usize {
-        self.header.len()
+        self.header.table_size as usize
+    }
+
+    /// Returns the current update status of the table header.
+    fn update_status(&self) -> u32 {
+        // SAFETY: This is a field owned by this struct and is valid for reads.
+        unsafe { ptr::read_volatile(&self.header.volatile_update_status) }
+    }
+
+    /// Sets the update status of the table header.
+    fn set_update_status(&mut self, status: u32) {
+        // SAFETY: This is a field owned by this struct and is valid for writes.
+        unsafe { ptr::write_volatile(&mut self.header.volatile_update_status, status) }
     }
 
     /// Returns the current capacity of the table.
@@ -128,21 +149,16 @@ impl DebugImageInfoData {
 
     /// Sets the update-in-progress flag.
     fn set_update_in_progress(&mut self) {
-        self.header.set_update_status(
-            self.header.update_status() | DebugImageInfoTableHeader::EFI_DEBUG_IMAGE_INFO_UPDATE_IN_PROGRESS,
-        )
+        self.set_update_status(self.update_status() | efi::DEBUG_IMAGE_INFO_UPDATE_IN_PROGRESS)
     }
 
     fn clear_update_in_progress(&mut self) {
-        self.header.set_update_status(
-            self.header.update_status() & !DebugImageInfoTableHeader::EFI_DEBUG_IMAGE_INFO_UPDATE_IN_PROGRESS,
-        );
+        self.set_update_status(self.update_status() & !efi::DEBUG_IMAGE_INFO_UPDATE_IN_PROGRESS);
     }
 
     /// Sets the table-modified flag.
     fn set_modified(&mut self) {
-        let update_status = self.header.update_status();
-        self.header.set_update_status(update_status | DebugImageInfoTableHeader::EFI_DEBUG_IMAGE_INFO_TABLE_MODIFIED)
+        self.set_update_status(self.update_status() | efi::DEBUG_IMAGE_INFO_TABLE_MODIFIED)
     }
 
     /// Allows for safe modification of the table while managing update flags.
@@ -168,11 +184,11 @@ impl DebugImageInfoData {
                 return;
             }
 
-            let entry = EfiDebugImageInfo::new(image_info_type, protocol, handle);
+            let entry = new_debug_image_info(image_info_type, protocol, handle);
 
             // SAFETY: Invariants of this struct ensure this addition is within bounds and is aligned for
-            //   EfiDebugImageInfo.
-            unsafe { s.table_mut().cast::<EfiDebugImageInfo>().add(s.len()).write(entry) }
+            //   efi::DebugImageInfo.
+            unsafe { s.table_mut().add(s.len()).write(entry) }
             s.header.table_size += 1;
         });
     }
@@ -180,8 +196,10 @@ impl DebugImageInfoData {
     /// Removes the first entry matching the specified handle.
     pub(super) fn remove_entry(&mut self, handle: efi::Handle) {
         self.modify(|s| {
-            if let Some(index) = s.find(handle) {
-                let _ = s.swap_remove(index);
+            if let Some(index) = s.find(handle)
+                && let Some(mut entry) = s.swap_remove(index)
+            {
+                drop_debug_image_info(&mut entry);
             }
         });
     }
@@ -189,7 +207,7 @@ impl DebugImageInfoData {
     /// Finds the index of the first entry matching the specified handle.
     fn find(&self, handle: efi::Handle) -> Option<usize> {
         for (index, entry) in self.table().iter().enumerate() {
-            if let Some(entry_handle) = entry.handle()
+            if let Some(entry_handle) = debug_image_info_handle(entry)
                 && entry_handle == handle
             {
                 return Some(index);
@@ -202,14 +220,14 @@ impl DebugImageInfoData {
     /// Removes and returns the entry at the specified index, replacing it with the last entry.
     ///
     /// Returns `None` if the index is out of bounds.
-    fn swap_remove(&mut self, index: usize) -> Option<EfiDebugImageInfo> {
+    fn swap_remove(&mut self, index: usize) -> Option<efi::DebugImageInfo> {
         if index >= self.len() {
             return None;
         }
 
         let data = self.table_mut();
 
-        // SAFETY: Invariants of this struct ensure that index is within bounds and aligned for EfiDebugImageInfo.
+        // SAFETY: Invariants of this struct ensure that index is within bounds and aligned for efi::DebugImageInfo.
         let value = unsafe { core::ptr::read(data.add(index)) };
 
         let last = self.len() - 1;
@@ -227,15 +245,15 @@ impl DebugImageInfoData {
     /// If the current capacity is zero, sets it to a default initial capacity.
     fn grow(&mut self) -> Result<(), GrowError> {
         let (data, new_capacity) = if self.capacity == 0 {
-            let layout = Layout::array::<EfiDebugImageInfo>(DEFAULT_CAPACITY)?;
+            let layout = Layout::array::<efi::DebugImageInfo>(DEFAULT_CAPACITY)?;
 
             // SAFETY: layout is non-zero sized due to DEFAULT_CAPACITY being non-zero
             let data = unsafe { alloc::alloc::alloc_zeroed(layout) };
             (data, DEFAULT_CAPACITY)
         } else {
-            let old_layout = Layout::array::<EfiDebugImageInfo>(self.capacity)?;
+            let old_layout = Layout::array::<efi::DebugImageInfo>(self.capacity)?;
             let new_capacity = self.capacity * 2;
-            let new_layout = Layout::array::<EfiDebugImageInfo>(new_capacity)?;
+            let new_layout = Layout::array::<efi::DebugImageInfo>(new_capacity)?;
             // SAFETY: layout is the same layout that was used to allocate the original buffer due to the invariants
             //   of this struct.
             // SAFETY: new_size is greater than zero due to the if branch above ensuring capacity is non-zero.
@@ -249,27 +267,25 @@ impl DebugImageInfoData {
         }
 
         self.capacity = new_capacity;
-        self.header.table = data as *mut EfiDebugImageInfo;
+        self.header.debug_image_info_table = data as *mut efi::DebugImageInfo;
         Ok(())
     }
 }
 
 impl Drop for DebugImageInfoData {
     fn drop(&mut self) {
-        // Call drop on each entry in the table
+        // Free the heap allocation backing each entry in the table.
+        let len = self.len();
         let data = self.table_mut();
-        for i in 0..self.len() {
-            // SAFETY: Invariants of this struct meet the requirements of drop_in_place. e.g.
-            //   - data[i] is owned by this struct and is valid for both reads and writes.
-            //   - data[i] is properly aligned for EfiDebugImageInfo.
-            //   - data[i] is non-null.
-            //   - data[i] is initialized and thus valid for dropping.
-            unsafe { core::ptr::drop_in_place(data.add(i)) };
+        for i in 0..len {
+            // SAFETY: Invariants of this struct ensure each entry is a valid, owned `efi::DebugImageInfo` allocated
+            //   by this struct.
+            unsafe { drop_debug_image_info(&mut *data.add(i)) };
         }
 
         // Deallocate the data
         if self.capacity > 0 {
-            let layout = Layout::array::<EfiDebugImageInfo>(self.capacity).unwrap();
+            let layout = Layout::array::<efi::DebugImageInfo>(self.capacity).unwrap();
             // SAFETY: Invariants of this struct ensure that `data` was allocated with this layout.
             unsafe {
                 alloc::alloc::dealloc(self.table_mut().cast::<u8>(), layout);
@@ -278,140 +294,35 @@ impl Drop for DebugImageInfoData {
     }
 }
 
-/// The header structure for the UEFI Debug Image Info Table.
-///
-/// ## Invariants
-///
-/// - `table` is either null or points to a valid array of `EfiDebugImageInfo` entries of length `table_size`.
-/// - `table_size` accurately reflects the number of valid entries in `table`.
-#[repr(C)]
-pub(super) struct DebugImageInfoTableHeader {
-    update_status: u32,
-    table_size: u32,
-    table: *mut EfiDebugImageInfo,
-}
-
-impl DebugImageInfoTableHeader {
-    /// Status flag indicating an update is in progress.
-    const EFI_DEBUG_IMAGE_INFO_UPDATE_IN_PROGRESS: u32 = 0x1;
-
-    /// Status flag indicating the table has been modified.
-    const EFI_DEBUG_IMAGE_INFO_TABLE_MODIFIED: u32 = 0x2;
-
-    /// Creates a new, empty Debug Image Info Table Header.
-    const fn new() -> Self {
-        Self { update_status: 0, table_size: 0, table: ptr::null_mut() }
-    }
-
-    /// Returns the current update status.
-    fn update_status(&self) -> u32 {
-        // SAFETY: This is a field owned by this struct and is valid for reads.
-        unsafe { ptr::read_volatile(&self.update_status) }
-    }
-
-    /// Sets the update status.
-    fn set_update_status(&mut self, status: u32) {
-        // SAFETY: This is a field owned by this struct and is valid for writes.
-        unsafe { ptr::write_volatile(&mut self.update_status, status) }
-    }
-
-    /// Returns the current number of entries in the table.
-    fn len(&self) -> usize {
-        self.table_size as usize
-    }
-
-    /// Returns a mutable pointer to the start of the debug image info table.
-    fn table_mut(&mut self) -> *mut EfiDebugImageInfo {
-        // SAFETY: This is a field owned by this struct and is valid for reads.
-        self.table
-    }
-
-    /// Returns a reference to the debug image info table.
-    fn table(&self) -> &[EfiDebugImageInfo] {
-        if self.table_size == 0 {
-            return &[];
-        }
-
-        // SAFETY: self.table is non-null due to the table_size check above.
-        // SAFETY: self.table is valid for reads of length table_size and is within a single allocation due to the
-        //   invariants of this struct
-        unsafe { core::slice::from_raw_parts(self.table, self.table_size as usize) }
+/// Allocates a new normal debug image info entry, returning an `efi::DebugImageInfo` whose `normal_image` pointer
+/// owns a heap-allocated `efi::DebugImageInfoNormal`.
+fn new_debug_image_info(
+    image_info_type: ImageInfoType,
+    protocol: NonNull<efi::protocols::loaded_image::Protocol>,
+    handle: efi::Handle,
+) -> efi::DebugImageInfo {
+    efi::DebugImageInfo {
+        normal_image: alloc::boxed::Box::into_raw(alloc::boxed::Box::new(efi::DebugImageInfoNormal {
+            image_info_type: image_info_type.into(),
+            loaded_image_protocol_instance: protocol.as_ptr(),
+            image_handle: handle,
+        })),
     }
 }
 
-// SAFETY: Access to the mutable pointer is gated behind methods that requires &mut self.
-unsafe impl Send for DebugImageInfoTableHeader {}
-// SAFETY: Access to the mutable pointer is gated behind methods that requires &mut self.
-unsafe impl Sync for DebugImageInfoTableHeader {}
-
-/// Structure for a normal debug image info entry, per section 18.4.3 of UEFI Spec 2.11.
-#[repr(C)]
-struct EfiDebugImageInfoNormal {
-    /// The type of debug image info entry. Will be `EFI_DEBUG_IMAGE_INFO_TYPE_NORMAL` for this structure.
-    image_info_type: u32,
-    /// Pointer to the loaded image protocol instance for the image.
-    loaded_image_protocol_instance: *mut efi::protocols::loaded_image::Protocol,
-    /// The handle of the image.
-    image_handle: efi::Handle,
+/// Returns the image handle associated with a debug image info entry.
+fn debug_image_info_handle(info: &efi::DebugImageInfo) -> Option<efi::Handle> {
+    // SAFETY: Every entry created by this module is a normal entry whose `normal_image` pointer was produced by
+    //   `new_debug_image_info` and remains valid until it is dropped.
+    let normal = unsafe { &*info.normal_image };
+    Some(normal.image_handle)
 }
 
-/// A union representing different types of debug image info entries.
-///
-/// each variant must start with a `u32` field representing the image info type, which is used to
-/// determine the actual type of the entry to access.
-///
-/// At present, only one type is defined: EfiDebugImageInfoNormal.
-#[repr(C)]
-union EfiDebugImageInfo {
-    /// Pointer to the image info type field of all variants.
-    image_info_type: *const u32,
-    /// A normal debug image info entry if the type is `EFI_DEBUG_IMAGE_INFO_TYPE_NORMAL`.
-    normal: *const EfiDebugImageInfoNormal,
-}
-
-impl EfiDebugImageInfo {
-    /// Creates a new EfiDebugImageInfo instance of type normal.
-    ///
-    /// This allocates memory for the internal EfiDebugImageInfoNormal structure.
-    fn new(
-        image_info_type: ImageInfoType,
-        protocol: NonNull<efi::protocols::loaded_image::Protocol>,
-        handle: efi::Handle,
-    ) -> Self {
-        Self {
-            normal: alloc::boxed::Box::into_raw(alloc::boxed::Box::new(EfiDebugImageInfoNormal {
-                image_info_type: image_info_type.into(),
-                loaded_image_protocol_instance: protocol.as_ptr(),
-                image_handle: handle,
-            })),
-        }
-    }
-
-    /// Returns the handle associated with this debug image info entry, if the entry type has one.
-    fn handle(&self) -> Option<efi::Handle> {
-        // SAFETY: The invariants of this struct ensure that this pointer is in-fact a valid pointer to EfiDebugImageInfoNormal.
-        let normal = unsafe { &*self.normal };
-        Some(normal.image_handle)
-    }
-}
-
-impl Drop for EfiDebugImageInfo {
-    fn drop(&mut self) {
-        // SAFETY: The invariants of this struct ensure that this pointer was allocated via this instance of EfiDebugImageInfo.
-        let normal = unsafe { alloc::boxed::Box::from_raw(self.normal as *mut EfiDebugImageInfoNormal) };
-        drop(normal);
-    }
-}
-
-/// Structure for the EFI_SYSTEM_TABLE_POINTER, per section 18.4.2 of UEFI Spec 2.11.
-#[repr(C)]
-pub(super) struct EfiSystemTablePointer {
-    /// The signature of the system table pointer structure. Must be `EFI_SYSTEM_TABLE_SIGNATURE`.
-    pub signature: u64,
-    /// The physical address of the EFI system table.
-    pub efi_system_table_base: efi::PhysicalAddress,
-    /// The CRC32 checksum of the EFI system table pointer structure.
-    pub crc32: u32,
+/// Frees the heap allocation backing a debug image info entry.
+fn drop_debug_image_info(info: &mut efi::DebugImageInfo) {
+    // SAFETY: `normal_image` was produced by `Box::into_raw` in `new_debug_image_info` and has not yet been freed.
+    let normal = unsafe { alloc::boxed::Box::from_raw(info.normal_image) };
+    drop(normal);
 }
 
 #[cfg(test)]
@@ -488,8 +399,8 @@ mod tests {
 
             // Table has been modified
             assert_eq!(
-                table.header.update_status & DebugImageInfoTableHeader::EFI_DEBUG_IMAGE_INFO_TABLE_MODIFIED,
-                DebugImageInfoTableHeader::EFI_DEBUG_IMAGE_INFO_TABLE_MODIFIED
+                table.update_status() & efi::DEBUG_IMAGE_INFO_TABLE_MODIFIED,
+                efi::DEBUG_IMAGE_INFO_TABLE_MODIFIED
             );
             assert_eq!(table.find(0x2000 as efi::Handle), Some(0));
             assert_eq!(table.find(0x2001 as efi::Handle), Some(1));
@@ -584,44 +495,38 @@ mod tests {
         with_locked_state(|| {
             let mut table = DebugImageInfoData::new();
 
-            assert_eq!(table.header.update_status(), 0);
+            assert_eq!(table.update_status(), 0);
 
             table.set_update_in_progress();
             assert_eq!(
-                table.header.update_status() & DebugImageInfoTableHeader::EFI_DEBUG_IMAGE_INFO_UPDATE_IN_PROGRESS,
-                DebugImageInfoTableHeader::EFI_DEBUG_IMAGE_INFO_UPDATE_IN_PROGRESS
+                table.update_status() & efi::DEBUG_IMAGE_INFO_UPDATE_IN_PROGRESS,
+                efi::DEBUG_IMAGE_INFO_UPDATE_IN_PROGRESS
             );
 
             table.clear_update_in_progress();
-            assert_eq!(
-                table.header.update_status() & DebugImageInfoTableHeader::EFI_DEBUG_IMAGE_INFO_UPDATE_IN_PROGRESS,
-                0
-            );
+            assert_eq!(table.update_status() & efi::DEBUG_IMAGE_INFO_UPDATE_IN_PROGRESS, 0);
 
             table.set_modified();
             assert_eq!(
-                table.header.update_status() & DebugImageInfoTableHeader::EFI_DEBUG_IMAGE_INFO_TABLE_MODIFIED,
-                DebugImageInfoTableHeader::EFI_DEBUG_IMAGE_INFO_TABLE_MODIFIED
+                table.update_status() & efi::DEBUG_IMAGE_INFO_TABLE_MODIFIED,
+                efi::DEBUG_IMAGE_INFO_TABLE_MODIFIED
             );
 
             table.set_update_in_progress();
             assert_eq!(
-                table.header.update_status() & DebugImageInfoTableHeader::EFI_DEBUG_IMAGE_INFO_UPDATE_IN_PROGRESS,
-                DebugImageInfoTableHeader::EFI_DEBUG_IMAGE_INFO_UPDATE_IN_PROGRESS
+                table.update_status() & efi::DEBUG_IMAGE_INFO_UPDATE_IN_PROGRESS,
+                efi::DEBUG_IMAGE_INFO_UPDATE_IN_PROGRESS
             );
             assert_eq!(
-                table.header.update_status() & DebugImageInfoTableHeader::EFI_DEBUG_IMAGE_INFO_TABLE_MODIFIED,
-                DebugImageInfoTableHeader::EFI_DEBUG_IMAGE_INFO_TABLE_MODIFIED
+                table.update_status() & efi::DEBUG_IMAGE_INFO_TABLE_MODIFIED,
+                efi::DEBUG_IMAGE_INFO_TABLE_MODIFIED
             );
 
             table.clear_update_in_progress();
+            assert_eq!(table.update_status() & efi::DEBUG_IMAGE_INFO_UPDATE_IN_PROGRESS, 0);
             assert_eq!(
-                table.header.update_status() & DebugImageInfoTableHeader::EFI_DEBUG_IMAGE_INFO_UPDATE_IN_PROGRESS,
-                0
-            );
-            assert_eq!(
-                table.header.update_status() & DebugImageInfoTableHeader::EFI_DEBUG_IMAGE_INFO_TABLE_MODIFIED,
-                DebugImageInfoTableHeader::EFI_DEBUG_IMAGE_INFO_TABLE_MODIFIED
+                table.update_status() & efi::DEBUG_IMAGE_INFO_TABLE_MODIFIED,
+                efi::DEBUG_IMAGE_INFO_TABLE_MODIFIED
             );
         });
     }
@@ -681,7 +586,7 @@ mod tests {
 
             // Force capacity to a value that will overflow in grow().
             //   - new_capacity = capacity * 2
-            //   - Layout::array::<EfiDebugImageInfo>(usize::MAX) will fail with LayoutError (since it is > isize::MAX)
+            //   - Layout::array::<efi::DebugImageInfo>(usize::MAX) will fail with LayoutError (since it is > isize::MAX)
             table.capacity = usize::MAX / 2;
 
             // grow() should fail with InvalidLayout and leave state unchanged.

--- a/patina_dxe_core/src/pi_dispatcher/image.rs
+++ b/patina_dxe_core/src/pi_dispatcher/image.rs
@@ -930,7 +930,7 @@ impl<P: super::PlatformInfo> super::PiDispatcher<P> {
             CoroutineResult::Return(status) => status,
         };
 
-        log::info!("start_image entrypoint exit with status: {status:x?}");
+        log::info!("start_image entrypoint exit with status: {status}");
 
         // because we used exit() to return from the coroutine (as opposed to
         // returning naturally from it), the coroutine is marked as suspended rather

--- a/patina_dxe_core/src/pi_dispatcher/image.rs
+++ b/patina_dxe_core/src/pi_dispatcher/image.rs
@@ -117,7 +117,7 @@ impl ImageStack {
         if let Err(err) =
             dxe_services::core_set_memory_space_attributes(base_address, UEFI_PAGE_SIZE as u64, attributes)
         {
-            log::error!("Failed to set memory space attributes for stack guard page: {err:?}");
+            log::error!("Failed to set memory space attributes for stack guard page: {err}");
             // unfortunately, this needs to be commented out for now, because the tests have gotten too complex
             // and need to be refactored to handle the page table
             // debug_assert!(false);
@@ -368,7 +368,7 @@ impl PrivateImageData {
             self.image_info.as_ref() as *const efi::protocols::loaded_image::Protocol as *mut c_void,
         ) && !matches!(err, EfiError::NotFound | EfiError::InvalidParameter)
         {
-            log::warn!("Failed to uninstall loaded image protocol for handle {handle:?}: {err:?}");
+            log::warn!("Failed to uninstall loaded image protocol for handle {handle:?}: {err}");
             result = Err(err);
         }
 
@@ -378,7 +378,7 @@ impl PrivateImageData {
             self.get_file_path(),
         ) && !matches!(err, EfiError::NotFound | EfiError::InvalidParameter)
         {
-            log::warn!("Failed to uninstall loaded image device path protocol for handle {handle:?}: {err:?}");
+            log::warn!("Failed to uninstall loaded image device path protocol for handle {handle:?}: {err}");
             result = Err(err);
         }
 
@@ -390,7 +390,7 @@ impl PrivateImageData {
             )
             && !matches!(err, EfiError::NotFound | EfiError::InvalidParameter)
         {
-            log::warn!("Failed to uninstall HII package list protocol for handle {handle:?}: {err:?}");
+            log::warn!("Failed to uninstall HII package list protocol for handle {handle:?}: {err}");
             result = Err(err);
         }
 
@@ -398,7 +398,7 @@ impl PrivateImageData {
             && let Err(err) = runtime::remove_runtime_image(handle)
             && err != EfiError::NotFound
         {
-            log::warn!("Failed to remove runtime image for handle {handle:?}: {err:?}");
+            log::warn!("Failed to remove runtime image for handle {handle:?}: {err}");
             result = Err(err);
         }
 
@@ -609,7 +609,7 @@ impl ImageData {
             efi::protocols::loaded_image::PROTOCOL_GUID,
             private_image_data.image_info.as_ref() as *const efi::protocols::loaded_image::Protocol as *mut c_void,
         )
-        .unwrap_or_else(|err| panic!("Failed to install dxe core image handle: {err:?}"));
+        .unwrap_or_else(|err| panic!("Failed to install dxe core image handle: {err}"));
 
         if handle != protocol_db::DXE_CORE_HANDLE {
             panic!(
@@ -627,10 +627,10 @@ impl ImageData {
 
     /// Validates that the provided parent handle is valid and has a loaded image protocol.
     fn validate_parent(parent: efi::Handle) -> Result<(), EfiError> {
-        PROTOCOL_DB.validate_handle(parent).inspect_err(|err| log::error!("Invalid parent handle {err:?}"))?;
+        PROTOCOL_DB.validate_handle(parent).inspect_err(|err| log::error!("Invalid parent handle {err}"))?;
 
         PROTOCOL_DB.get_interface_for_handle(parent, efi::protocols::loaded_image::PROTOCOL_GUID).map_err(|err| {
-            log::error!("Failed to get loaded image interface on the parent handle: {err:?}");
+            log::error!("Failed to get loaded image interface on the parent handle: {err}");
             EfiError::InvalidParameter
         })?;
         Ok(())
@@ -1243,7 +1243,7 @@ impl<P: super::PlatformInfo> super::PiDispatcher<P> {
         }
 
         if let Err(status) = EVENT_DB.close_event(event) {
-            log::error!("Failed to close image EBS event with status {status:#X?}. This should be okay.");
+            log::error!("Failed to close image EBS event with status {status}. This should be okay.");
         }
     }
 }

--- a/sdk/patina/src/error.rs
+++ b/sdk/patina/src/error.rs
@@ -181,3 +181,34 @@ impl From<efi::Status> for EfiError {
         EfiError::status_to_result(status).unwrap_err()
     }
 }
+
+impl core::fmt::Display for EfiError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        // Delegate to the `efi::Status` `Display` impl so the textual descriptions
+        // stay in sync with the UEFI status code definitions.
+        efi::Status::from(*self).fmt(f)
+    }
+}
+
+impl core::error::Error for EfiError {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    extern crate alloc;
+    use alloc::format;
+
+    #[test]
+    fn test_display_known_variant_matches_status() {
+        assert_eq!(format!("{}", EfiError::InvalidParameter), format!("{}", efi::Status::INVALID_PARAMETER));
+        assert_eq!(format!("{}", EfiError::InvalidParameter), "Invalid Parameter");
+    }
+
+    #[test]
+    fn test_display_unknown_variant_matches_status() {
+        // An unknown status delegates to the `efi::Status` `Display` impl.
+        let status = efi::Status::from_usize(0x1234);
+        let unknown = EfiError::Unknown(status);
+        assert_eq!(format!("{}", unknown), format!("{}", status));
+    }
+}

--- a/sdk/patina/src/performance/error.rs
+++ b/sdk/patina/src/performance/error.rs
@@ -60,7 +60,7 @@ impl Display for Error {
         match self {
             Error::OutOfResources => write!(f, "FBPT buffer full, can't add more performance records."),
             Error::BufferTooSmall => write!(f, "Buffer to small to allocate FBPT table"),
-            Error::Efi(efi_error) => write!(f, "{efi_error:?}"),
+            Error::Efi(efi_error) => write!(f, "{efi_error}"),
             Error::Serialization => write!(f, "Failed to serialize performance data"),
             Error::RecordTooLarge { size } => write!(f, "Performance record size {size} exceeds u8::MAX"),
             Error::DebugAssert { msg, file, line } => write!(f, "Assertion at {file}:{line}: {msg}"),
@@ -92,7 +92,7 @@ mod tests {
     fn test_efi_error_display() {
         let error = Error::Efi(EfiError::InvalidParameter);
         let display = format!("{}", error);
-        assert!(display.contains("InvalidParameter"));
+        assert_eq!(display, "Invalid Parameter");
     }
 
     #[test]


### PR DESCRIPTION
## Description

Update to r-efi v7
--
This upgrades Patina to use r-efi v7. mu_rust_helpers is also updated as a new version is required there to pull in r-efi v7 and not have multiple versions pulled.

The breaking change in v7 is upgrading to MAT v2, so that is done.

Use efi::Status Display
--
r-efi v7 added a Display impl for efi::Status. This is much nicer to read in logs as it prints the pretty name, not a hex value. Update to using it across the tree.

Closes #1302 .

 Global: Add impl Display for EfiError
--
Now that r-efi's Status has impl Display, add impl Display for EfiError and simply use the r-efi Status Display impl.

This commit then changes all usage to use Display instead of Debug to get the more useful Status name instead of hex value.

debug_image_info_table: Use r-efi Defintion
--
r-efi v7 brought in the upstreamed definition of the debug image info table, use that instead of Patina's version.

Closes #490 

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Booting Q35 and QemuArmVirt. Connecting to the debugger at shell time, ensuring all modules could be loaded.

## Integration Instructions

Platforms should upgrade to r-efi v7 and mu_rust_helpers v4.1.0 to avoid pulling in multiple r-efi versions.

Platforms may see the following mismatch due to r-efi v6 and v7 mismatch:

```bash
error[E0308]: mismatched types
    --> TelemetryHelperLib\src\lib.rs:134:43
     |
 134 |         library_id: *library_id.unwrap_or(&guid::ZERO),
     |                                 --------- ^^^^^^^^^^^ expected `r_efi::base::Guid`, found a different `r_efi::base::Guid`
     |                                 |
     |                                 arguments to this method are incorrect
     |
note: two different versions of crate `r_efi` are being used; two types coming from two different versions of the same crate are different types even if they look the same
```