### PR TITLE
sdk: Prevent re-entrant lock acquisition in add_fbpt_record()

### DIFF
--- a/cspell.yml
+++ b/cspell.yml
@@ -86,6 +86,7 @@ words:
   - eficall
   - efierror
   - eflags
+  - entrantly
   - epage
   - eprom
   - expressx

--- a/sdk/patina/src/performance/measurement.rs
+++ b/sdk/patina/src/performance/measurement.rs
@@ -26,6 +26,7 @@ use crate::{
         error::Error,
         globals::{get_load_image_count, get_static_state, increment_load_image_count},
         record::{
+            PerformanceRecord,
             extended::{
                 DualGuidStringEventRecord, DynamicStringEventRecord, GuidEventRecord, GuidQwordEventRecord,
                 GuidQwordStringEventRecord,
@@ -211,6 +212,27 @@ pub fn create_performance_measurement(
     }
 }
 
+/// Adds a record to the FBPT, returning an error if the table lock cannot be acquired.
+///
+/// The FBPT [`TplMutex`] must never be acquired re-entrantly. A re-entrant performance measurement
+/// may occur when dropping a measurement's lock guard restores the TPL and dispatches a pending
+/// event notification whose callback creates another measurement before the guard finishes releasing
+/// the lock. To avoid panicking, this attempts lock acquisition and, on contention, drops the record and returns
+/// [`EfiError::InvalidParameter`] so the caller can observe that the record was not added. This is similar
+/// in behavior and return status to the edk2 implementation of [`create_performance_measurement`].
+fn add_fbpt_record<B, F, T>(fbpt: &TplMutex<F, B>, record: T) -> Result<(), Error>
+where
+    B: BootServices,
+    F: FirmwareBasicBootPerfTable,
+    T: PerformanceRecord,
+{
+    match fbpt.try_lock() {
+        Ok(mut table) => table.add_record(record),
+        // Re-entrant measurement: See function docs.
+        Err(()) => Err(EfiError::InvalidParameter.into()),
+    }
+}
+
 /// Create a performance measurement and add it to the FBPT.
 #[allow(clippy::too_many_arguments)]
 fn _create_performance_measurement<B, F>(
@@ -254,7 +276,7 @@ where
             return Err(EfiError::InvalidParameter.into());
         };
         let module_name = string.unwrap_or("unknown name");
-        fbpt.lock().add_record(DynamicStringEventRecord::new(perf_id, 0, timestamp, guid, module_name))?;
+        add_fbpt_record(fbpt, DynamicStringEventRecord::new(perf_id, 0, timestamp, guid, module_name))?;
         return Ok(());
     };
 
@@ -266,7 +288,7 @@ where
                 return Err(EfiError::InvalidParameter.into());
             };
             let record = GuidEventRecord::new(perf_id, 0, timestamp, guid);
-            fbpt.lock().add_record(record)?;
+            add_fbpt_record(fbpt, record)?;
         }
         id @ KnownPerfId::ModuleLoadImageStart | id @ KnownPerfId::ModuleLoadImageEnd => {
             if id == KnownPerfId::ModuleLoadImageStart {
@@ -278,7 +300,7 @@ where
                 return Err(EfiError::InvalidParameter.into());
             };
             let record = GuidQwordEventRecord::new(perf_id, 0, timestamp, guid, get_load_image_count() as u64);
-            fbpt.lock().add_record(record)?;
+            add_fbpt_record(fbpt, record)?;
         }
         KnownPerfId::ModuleDbStart
         | KnownPerfId::ModuleDbSupportStart
@@ -291,7 +313,7 @@ where
                 return Err(EfiError::InvalidParameter.into());
             };
             let record = GuidQwordEventRecord::new(perf_id, 0, timestamp, guid, address as u64);
-            fbpt.lock().add_record(record)?;
+            add_fbpt_record(fbpt, record)?;
         }
         KnownPerfId::ModuleDbEnd => {
             let module_handle = caller_identifier.as_handle().ok_or(EfiError::InvalidParameter)?;
@@ -301,7 +323,7 @@ where
             };
             let module_name = "";
             let record = GuidQwordStringEventRecord::new(perf_id, 0, timestamp, guid, address as u64, module_name);
-            fbpt.lock().add_record(record)?;
+            add_fbpt_record(fbpt, record)?;
         }
         KnownPerfId::PerfEventSignalStart
         | KnownPerfId::PerfEventSignalEnd
@@ -319,7 +341,7 @@ where
                 (*guid).into(),
                 function_string,
             );
-            fbpt.lock().add_record(record)?;
+            add_fbpt_record(fbpt, record)?;
         }
 
         KnownPerfId::PerfFunctionStart
@@ -332,7 +354,7 @@ where
             let module_guid = caller_identifier.as_guid().ok_or(EfiError::InvalidParameter)?;
             let string = string.unwrap_or("unknown name");
             let record = DynamicStringEventRecord::new(perf_id, 0, timestamp, (*module_guid).into(), string);
-            fbpt.lock().add_record(record)?;
+            add_fbpt_record(fbpt, record)?;
         }
     }
     Ok(())


### PR DESCRIPTION
## Description

Today, the FBPT `TplMutex` can be acquired re-entrantly, which can lead to a panic with "Re-entrant lock" when dropping a performance measurement's lock guard restores the TPL and dispatches a pending event notification whose callback creates another measurement before the guard finishes releasing the lock.

This change modifies calls to acquire the FBPT `TplMutex` to attempt the lock and, on contention, drop the record. Because the [edk2 implementation of `create_performance_measurement()`](https://github.com/tianocore/edk2/blob/c70de6b4ed9c4525781ba5ba0fee94c237712e54/MdeModulePkg/Library/DxeCorePerformanceLib/DxeCorePerformanceLib.c#L1616-L1624) also returns `EfiError::InvalidParameter` when the record is not added, this change does that as well so this scenario will be handled similarly in any pre-existing caller status code handling logic.

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

- `cargo make all`
- QEMU ArmVirt & Q35 boot
- Intel physical platform boot (w/ perf enabled)

## Integration Instructions

- N/A