### PR TITLE
[REBASE & FF] Check EL Before Setting HCR_EL2

### DIFF
--- a/core/patina_internal_cpu/src/interrupts/aarch64/gic_manager.rs
+++ b/core/patina_internal_cpu/src/interrupts/aarch64/gic_manager.rs
@@ -5,7 +5,10 @@ use arm_gic::{
 use core::ptr::NonNull;
 use patina::error::EfiError;
 
-use patina::{read_sysreg, write_sysreg};
+use patina::{
+    arch::aarch64::{AArch64El, get_current_el},
+    read_sysreg, write_sysreg,
+};
 
 // This masks out bits in MPIDR_EL1 that are not part of the affinity fields used to identify a core.
 // See definition of MPIDR_EL1 in the ARM Architecture Reference Manual for details.
@@ -19,18 +22,12 @@ pub enum GicVersion {
     ArmGicV3 = 3,
 }
 
-// Determine the current exception level
-pub fn get_current_el() -> u64 {
-    read_sysreg!(CurrentEL)
-}
-
 #[allow(dead_code)]
 fn get_control_system_reg_enable() -> u64 {
     let current_el = get_current_el();
     match current_el {
-        0x08 => read_sysreg!(ICC_SRE_EL2),
-        0x04 => read_sysreg!(ICC_SRE_EL1),
-        _ => panic!("Invalid current EL {}", current_el),
+        AArch64El::EL2 => read_sysreg!(ICC_SRE_EL2),
+        AArch64El::EL1 => read_sysreg!(ICC_SRE_EL1),
     }
 }
 
@@ -38,13 +35,12 @@ fn get_control_system_reg_enable() -> u64 {
 fn set_control_system_reg_enable(icc_sre: u64) -> u64 {
     let current_el = get_current_el();
     match current_el {
-        0x08 => {
+        AArch64El::EL2 => {
             write_sysreg!(reg ICC_SRE_EL2, icc_sre);
         }
-        0x04 => {
+        AArch64El::EL1 => {
             write_sysreg!(reg ICC_SRE_EL1, icc_sre);
         }
-        _ => panic!("Invalid current EL {}", current_el),
     }
 
     get_control_system_reg_enable()

--- a/core/patina_internal_cpu/src/interrupts/aarch64/interrupt_manager.rs
+++ b/core/patina_internal_cpu/src/interrupts/aarch64/interrupt_manager.rs
@@ -22,8 +22,7 @@ use crate::interrupts::{
 cfg_if::cfg_if! {
     if #[cfg(not(test))] {
         use core::arch::global_asm;
-        use patina::{read_sysreg, write_sysreg};
-        use crate::interrupts::aarch64::gic_manager::get_current_el;
+        use patina::{read_sysreg, write_sysreg, arch::aarch64::{AArch64El, get_current_el}};
 
         global_asm!(include_str!("exception_handler.asm"));
 
@@ -131,9 +130,8 @@ fn initialize_exception() -> Result<(), EfiError> {
         let vec_base = unsafe { &exception_handlers_start as *const _ as u64 };
         let current_el = get_current_el();
         match current_el {
-            0xC => write_sysreg!(reg vbar_el1, vec_base, "isb sy"),
-            0x08 => write_sysreg!(reg vbar_el2, vec_base, "isb sy"),
-            _ => panic!("Invalid current EL {}", current_el),
+            AArch64El::EL2 => write_sysreg!(reg vbar_el2, vec_base, "isb sy"),
+            AArch64El::EL1 => write_sysreg!(reg vbar_el1, vec_base, "isb sy"),
         };
     }
 

--- a/core/patina_internal_cpu/src/interrupts/aarch64/interrupt_manager.rs
+++ b/core/patina_internal_cpu/src/interrupts/aarch64/interrupt_manager.rs
@@ -118,17 +118,16 @@ fn initialize_exception() -> Result<(), EfiError> {
         sp_el0_reg &= !0x0F;
         write_sysreg!(reg sp_el0, sp_el0_reg);
 
-        let mut hcr = read_sysreg!(hcr_el2);
-        hcr |= 1 << 27; // Enable TGE
-        write_sysreg!(reg hcr_el2, hcr);
-    }
+        let current_el = get_current_el();
+        if current_el == AArch64El::EL2 {
+            let mut hcr = read_sysreg!(hcr_el2);
+            hcr |= 1 << 27; // Enable TGE
+            write_sysreg!(reg hcr_el2, hcr);
+        }
 
-    // Program VBar
-    #[cfg(not(test))]
-    {
+        // Program VBar
         // SAFETY: We are using the address of the exception handlers as the vector base address.
         let vec_base = unsafe { &exception_handlers_start as *const _ as u64 };
-        let current_el = get_current_el();
         match current_el {
             AArch64El::EL2 => write_sysreg!(reg vbar_el2, vec_base, "isb sy"),
             AArch64El::EL1 => write_sysreg!(reg vbar_el1, vec_base, "isb sy"),

--- a/sdk/patina/src/arch/aarch64.rs
+++ b/sdk/patina/src/arch/aarch64.rs
@@ -146,3 +146,21 @@ impl super::Interrupts for AArch64 {
         daif & 0x80 == 0
     }
 }
+
+/// Supported AARCH64 Exception Levels
+#[derive(Debug, PartialEq, Eq)]
+pub enum AArch64El {
+    EL1,
+    EL2,
+}
+
+// Determine the current exception level
+pub fn get_current_el() -> AArch64El {
+    match read_sysreg!(CurrentEL) & 0xC {
+        0xC => panic!("EL3 is not supported"),
+        0x8 => AArch64El::EL2,
+        0x4 => AArch64El::EL1,
+        0x0 => panic!("EL0 is not supported"),
+        _ => unreachable!(),
+    }
+}


### PR DESCRIPTION
## Description

This PR contains two commits:

 SDK: Move get_current_el() to SDK and Introduce EL Enum
--
get_current_el() is a common AARCH64 function. It is currently being shared in patina_internal_cpu, but is broadly applicable.

This moves it to the SDK and introduces an EL enum for it to return instead of each caller needing to know the register values.

aarch64 intr: Only Set TGE if Running in EL2
--
When initializing exceptions, TGE is always set in HCR_EL2. However, this will hang the system when running at EL1.

Trapping general exceptions is not required at EL1, we are only getting the EL1 exceptions. As such, this commit just changes the code to check the current EL and only set the bit if we are running at EL2.

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Tested on a platform that runs at EL1. Before this change, it hangs, after this, it boots past this point.

## Integration Instructions

N/A.
