### PR TITLE
[REBASE & FF] Always Allocate FV Regions

### DIFF
--- a/patina_dxe_core/src/allocator.rs
+++ b/patina_dxe_core/src/allocator.rs
@@ -38,7 +38,7 @@ use crate::{
 };
 pub use fixed_size_block_allocator::SpinLockedFixedSizeBlockAllocator;
 use patina::pi::{
-    dxe_services::{self, GcdMemoryType},
+    dxe_services::GcdMemoryType,
     hob::{self, EFiMemoryTypeInformation, Hob, HobList, MEMORY_TYPE_INFO_HOB_GUID},
 };
 use r_efi::{efi, system::TPL_HIGH_LEVEL};
@@ -1094,7 +1094,8 @@ fn process_hob_allocations(hob_list: &HobList) {
                 }
 
                 let address = desc.memory_base_address;
-                match GCD.get_existent_memory_descriptor_for_address(address) {
+                match GCD.get_memory_descriptor_for_address(address, |d, _| d.memory_type != GcdMemoryType::NonExistent)
+                {
                     // we found the region in the GCD, so we can allocate it
                     Ok(gcd_desc) => {
                         if gcd_desc.base_address == desc.memory_base_address
@@ -1229,7 +1230,7 @@ fn process_hob_allocations(hob_list: &HobList) {
     // EFI_MEMORY_MAP reports as EfiConventionalMemory), which will cause a failure that is unnecessary. We do this
     // after HOB processing because we want to ensure that the GCD is fully populated with the memory map
     // before we allocate page 0, as it may not live in system memory, in which case we cannot allocate it.
-    match GCD.get_existent_memory_descriptor_for_address(0) {
+    match GCD.get_memory_descriptor_for_address(0, |d, _| d.memory_type != GcdMemoryType::NonExistent) {
         Ok(desc) if desc.memory_type == GcdMemoryType::SystemMemory => {
             let address: efi::PhysicalAddress = 0;
 
@@ -1639,7 +1640,10 @@ mod tests {
     };
 
     use super::*;
-    use patina::pi::hob::{GUID_EXTENSION, GuidHob, Hob, header};
+    use patina::pi::{
+        dxe_services,
+        hob::{GUID_EXTENSION, GuidHob, Hob, header},
+    };
     use r_efi::efi;
 
     enum GcdInit {
@@ -2108,7 +2112,9 @@ mod tests {
             ]
             .iter()
             {
-                let allocator = allocators.get_allocator(*memory_type).unwrap();
+                let allocator = allocators
+                    .get_allocator(*memory_type)
+                    .unwrap_or_else(|| panic!("no allocator for type {:#x}", memory_type));
 
                 let granularity = match *memory_type {
                     efi::RESERVED_MEMORY_TYPE
@@ -2132,14 +2138,18 @@ mod tests {
             }
 
             // confirm the MMIO memory allocation occurred in the GCD
-            let mmio_desc = GCD.get_existent_memory_descriptor_for_address(0x10000000).unwrap();
+            let mmio_desc = GCD
+                .get_memory_descriptor_for_address(0x10000000, |d, _| d.memory_type != GcdMemoryType::NonExistent)
+                .unwrap();
             assert_eq!(mmio_desc.memory_type, dxe_services::GcdMemoryType::MemoryMappedIo);
             assert_eq!(mmio_desc.base_address, 0x10000000);
             assert_eq!(mmio_desc.length, 0x2000);
             assert_eq!(mmio_desc.image_handle, protocol_db::DXE_CORE_HANDLE);
 
             // confirm the rest of the MMIO region is not allocated
-            let mmio_desc = GCD.get_existent_memory_descriptor_for_address(0x10002000).unwrap();
+            let mmio_desc = GCD
+                .get_memory_descriptor_for_address(0x10002000, |d, _| d.memory_type != GcdMemoryType::NonExistent)
+                .unwrap();
             assert_eq!(mmio_desc.memory_type, dxe_services::GcdMemoryType::MemoryMappedIo);
             assert_eq!(mmio_desc.base_address, 0x10002000);
             assert_eq!(mmio_desc.length, 0x1000000 - 0x2000);

--- a/patina_dxe_core/src/allocator.rs
+++ b/patina_dxe_core/src/allocator.rs
@@ -1192,25 +1192,20 @@ fn process_hob_allocations(hob_list: &HobList) {
             }) => {
                 log::trace!("[{}] Processing Firmware Volume HOB:\n{:#x?}\n\n", function!(), hob);
 
-                //The EDK2 C reference core maps FVs to MMIO space, but many implementations don't declare the
-                //corresponding resource descriptor. Check the current region in the GCD to see whether a resource
-                //descriptor of the appropriate type has been reported. If not, print a warning and skip attempting
-                //to reserve it in the GCD.
-                if let Ok(existing_desc) = GCD.get_existent_memory_descriptor_for_address(*base_address)
-                    && (existing_desc.memory_type != dxe_services::GcdMemoryType::MemoryMappedIo
-                        || existing_desc.image_handle != INVALID_HANDLE)
-                {
-                    log::info!(
-                        "Skipping FV HOB at {base_address:#x?} of length {length:#x?}. Containing region is not MMIO."
-                    );
-                    continue;
-                }
+                // EDK II assumes all FVs are MMIO, however many platforms do not report the
+                // backing address space as an MMIO resource, causing the allocation to silently fail.
+                // Instead of assuming MMIO here, retrieve the backing memory type from the GCD if it
+                // exists and allocate the FV region using that type. Note: there are often multiple
+                // FV HOBs for the same FV. This will only allocate for the first HOB since
+                // get_memory_descriptor_for_address() is filtering for free descriptors.
 
                 //The 4K granularity rule does not apply to FV hobs, so allocate_pages cannot be used.
                 //This means they must be direct-allocated in the GCD, and no stats will be tracked for them.
-                let _ = GCD.allocate_memory_space(
+                match GCD.get_memory_descriptor_for_address(*base_address, |_, allocated| !allocated) {
+                    Ok(desc) => {
+                        let _ = GCD.allocate_memory_space(
                     AllocationStrategy::Address(*base_address as usize),
-                    dxe_services::GcdMemoryType::MemoryMappedIo,
+                    desc.memory_type,
                     0,
                     *length as usize,
                     protocol_db::DXE_CORE_HANDLE,
@@ -1220,6 +1215,9 @@ fn process_hob_allocations(hob_list: &HobList) {
                             "Failed to allocate memory space for firmware volume HOB at {base_address:#x?} of length {length:#x?}. Error: {err}",
                         );
                     });
+                    }
+                    Err(_) => continue,
+                }
             }
             _ => continue,
         };
@@ -2062,6 +2060,61 @@ mod tests {
             // This should fail to set attributes on the stack because the address
             // is not in the GCD, but should continue processing without panicking
             process_hob_allocations(&hob_list);
+        })
+    }
+
+    #[test]
+    fn process_hob_allocations_should_allocate_fv_in_system_memory() {
+        // A firmware volume HOB whose region resides in free system memory (rather than MMIO) must still
+        // be allocated so that regular allocations cannot corrupt the FV.
+        with_locked_state(GcdInit::WithHobList(0x1000000), |_physical_hob_list| {
+            // Carve out a page-aligned region of free system memory from the GCD, then free it back so it
+            // becomes free (unallocated) system memory. This is where the FV HOB will point.
+            let fv_len = 0x10000usize; // 64 KiB
+            let fv_base = GCD
+                .allocate_memory_space(
+                    DEFAULT_ALLOCATION_STRATEGY,
+                    GcdMemoryType::SystemMemory,
+                    patina::base::UEFI_PAGE_SHIFT,
+                    fv_len,
+                    protocol_db::DXE_CORE_HANDLE,
+                    None,
+                )
+                .expect("Failed to reserve system memory for the FV region");
+            GCD.free_memory_space(fv_base, fv_len).expect("Failed to free the FV region back to the GCD");
+
+            // Confirm the region is free system memory before processing the FV HOB.
+            let desc = GCD
+                .get_memory_descriptor_for_address(fv_base as u64, |d, allocated| {
+                    !allocated && d.memory_type == GcdMemoryType::SystemMemory
+                })
+                .unwrap();
+            assert_eq!(desc.memory_type, dxe_services::GcdMemoryType::SystemMemory);
+            assert_eq!(desc.image_handle, INVALID_HANDLE);
+
+            // Build a HOB list containing only the FV HOB pointing at the free system memory region.
+            let fv_hob = patina::pi::hob::FirmwareVolume {
+                header: patina::pi::hob::header::Hob {
+                    r#type: hob::FV,
+                    length: core::mem::size_of::<patina::pi::hob::FirmwareVolume>() as u16,
+                    reserved: 0,
+                },
+                base_address: fv_base as u64,
+                length: fv_len as u64,
+            };
+            let mut hob_list = HobList::default();
+            hob_list.push(Hob::FirmwareVolume(&fv_hob));
+
+            process_hob_allocations(&hob_list);
+
+            // The FV region should now be allocated to the DXE Core, still typed as system memory.
+            let desc = GCD
+                .get_memory_descriptor_for_address(fv_base as u64, |d, _| d.memory_type != GcdMemoryType::NonExistent)
+                .unwrap();
+            assert_eq!(desc.memory_type, dxe_services::GcdMemoryType::SystemMemory);
+            assert_eq!(desc.base_address, fv_base as u64);
+            assert_eq!(desc.length, fv_len as u64);
+            assert_eq!(desc.image_handle, protocol_db::DXE_CORE_HANDLE);
         })
     }
 

--- a/patina_dxe_core/src/allocator/fixed_size_block_allocator.rs
+++ b/patina_dxe_core/src/allocator/fixed_size_block_allocator.rs
@@ -560,12 +560,14 @@ impl SpinLockedFixedSizeBlockAllocator {
             return Err(EfiError::InvalidParameter);
         }
 
-        let descriptor =
-            self.gcd.get_existent_memory_descriptor_for_address(address as efi::PhysicalAddress).map_err(|err| {
-                match err {
-                    EfiError::NotFound => err,
-                    _ => EfiError::InvalidParameter,
-                }
+        let descriptor = self
+            .gcd
+            .get_memory_descriptor_for_address(address as efi::PhysicalAddress, |d, _| {
+                d.memory_type != GcdMemoryType::NonExistent
+            })
+            .map_err(|err| match err {
+                EfiError::NotFound => err,
+                _ => EfiError::InvalidParameter,
             })?;
 
         if descriptor.image_handle != self.handle {

--- a/patina_dxe_core/src/core_patina_tests/audit_tests.rs
+++ b/patina_dxe_core/src/core_patina_tests/audit_tests.rs
@@ -25,7 +25,10 @@ use r_efi::efi;
 fn gcd_free_memory_merged_test() -> patina_test::error::Result {
     let mut last_desc: Option<patina::pi::dxe_services::MemorySpaceDescriptor> = None;
     let mut descs = Vec::with_capacity(GCD.memory_descriptor_count() * 2);
-    GCD.get_memory_descriptors(&mut descs, crate::gcd::DescriptorFilter::Free).map_err(|_| "Can't get descriptors")?;
+    GCD.get_memory_descriptors(&mut descs, |d, allocated| {
+        !allocated && d.memory_type == patina::pi::dxe_services::GcdMemoryType::SystemMemory
+    })
+    .map_err(|_| "Can't get descriptors")?;
     for desc in descs {
         // check if the last descriptor and the current descriptor are both free memory descriptors and not part of
         // a memory bin (image_handle != null)

--- a/patina_dxe_core/src/dxe_services.rs
+++ b/patina_dxe_core/src/dxe_services.rs
@@ -128,7 +128,7 @@ extern "efiapi" fn get_memory_space_descriptor(
 pub fn core_get_memory_space_descriptor(
     base_address: efi::PhysicalAddress,
 ) -> Result<dxe_services::MemorySpaceDescriptor, EfiError> {
-    GCD.get_memory_descriptor_for_address(base_address)
+    GCD.get_memory_descriptor_for_address(base_address, |_, _| true)
 }
 
 extern "efiapi" fn set_memory_space_attributes(
@@ -195,7 +195,7 @@ extern "efiapi" fn get_memory_space_map(
     //that extra descriptors come into being after creation but before usage.
     let mut descriptors: Vec<dxe_services::MemorySpaceDescriptor> =
         Vec::with_capacity(GCD.memory_descriptor_count() + 10);
-    let result = GCD.get_memory_descriptors(&mut descriptors, crate::gcd::DescriptorFilter::All);
+    let result = GCD.get_memory_descriptors(&mut descriptors, |_, _| true);
 
     if let Err(err) = result {
         return efi::Status::from(err);
@@ -1457,8 +1457,7 @@ mod tests {
 
             let expected_count = GCD.memory_descriptor_count();
             let mut expected: Vec<dxe_services::MemorySpaceDescriptor> = Vec::with_capacity(expected_count + 10);
-            GCD.get_memory_descriptors(&mut expected, crate::gcd::DescriptorFilter::All)
-                .expect("get_memory_descriptors failed");
+            GCD.get_memory_descriptors(&mut expected, |_, _| true).expect("get_memory_descriptors failed");
             assert!(!expected.is_empty());
 
             let mut out_count: usize = 0;
@@ -1493,8 +1492,7 @@ mod tests {
             // Fetch expected
             let expected_count = GCD.memory_descriptor_count();
             let mut expected: Vec<dxe_services::MemorySpaceDescriptor> = Vec::with_capacity(expected_count + 10);
-            GCD.get_memory_descriptors(&mut expected, crate::gcd::DescriptorFilter::All)
-                .expect("get_memory_descriptors failed");
+            GCD.get_memory_descriptors(&mut expected, |_, _| true).expect("get_memory_descriptors failed");
             assert!(expected.len() >= 3);
 
             // Call API

--- a/patina_dxe_core/src/gcd.rs
+++ b/patina_dxe_core/src/gcd.rs
@@ -303,7 +303,7 @@ impl MemoryProtectionPolicy {
         // always map page 0 if it exists in this system, as grub will attempt to read it for legacy boot structures
         // map it WB by default, because 0 is being used as the null page, it may not have gotten cache attributes
         // populated
-        match gcd.get_existent_memory_descriptor_for_address(0) {
+        match gcd.get_memory_descriptor_for_address(0, |d, _| d.memory_type != GcdMemoryType::NonExistent) {
             Ok(descriptor) if descriptor.memory_type == GcdMemoryType::SystemMemory => {
                 // set_memory_space_attributes will set both the GCD and paging attributes
                 if let Err(e) = gcd.set_memory_space_attributes(
@@ -321,7 +321,9 @@ impl MemoryProtectionPolicy {
         let mut address = UEFI_PAGE_SIZE; // start at 0x1000, as we already mapped page 0
         while address < LEGACY_BIOS_WB_ADDRESS {
             let mut size = UEFI_PAGE_SIZE;
-            if let Ok(descriptor) = gcd.get_existent_memory_descriptor_for_address(address as efi::PhysicalAddress) {
+            if let Ok(descriptor) = gcd.get_memory_descriptor_for_address(address as efi::PhysicalAddress, |d, _| {
+                d.memory_type != GcdMemoryType::NonExistent
+            }) {
                 // if the legacy region is not system memory, we should not map it
                 if descriptor.memory_type == GcdMemoryType::SystemMemory {
                     size = match address + descriptor.length as usize {
@@ -359,7 +361,7 @@ impl MemoryProtectionPolicy {
             let mut addr = range.start;
             while addr < range.end {
                 let mut len = UEFI_PAGE_SIZE as u64;
-                match gcd.get_existent_memory_descriptor_for_address(addr) {
+                match gcd.get_memory_descriptor_for_address(addr, |d, _| d.memory_type != GcdMemoryType::NonExistent) {
                     Ok(descriptor) => {
                         let attributes = descriptor.attributes & !efi::MEMORY_XP;
                         len = match descriptor.base_address + descriptor.length {
@@ -403,7 +405,9 @@ impl MemoryProtectionPolicy {
 
         // for this image map all mem RWX preserving cache attributes if we find them
         let stripped_attrs = gcd
-            .get_existent_memory_descriptor_for_address(image_base_page as u64)
+            .get_memory_descriptor_for_address(image_base_page as u64, |d, _| {
+                d.memory_type != GcdMemoryType::NonExistent
+            })
             .map(|desc| desc.attributes & efi::CACHE_ATTRIBUTE_MASK)
             .unwrap_or(patina::base::DEFAULT_CACHE_ATTR);
         if gcd
@@ -1074,7 +1078,9 @@ mod tests {
                 let mut addr = range.start;
                 while addr < range.end {
                     let mut len = 0x1000;
-                    if let Ok(desc) = GCD.get_existent_memory_descriptor_for_address(addr) {
+                    if let Ok(desc) =
+                        GCD.get_memory_descriptor_for_address(addr, |d, _| d.memory_type != GcdMemoryType::NonExistent)
+                    {
                         assert_eq!(desc.attributes & efi::MEMORY_XP, efi::MEMORY_XP);
                         len = desc.length;
                     }
@@ -1088,7 +1094,9 @@ mod tests {
             let image_num_pages = 4;
             let filename = "legacy_app.efi";
 
-            let desc = GCD.get_existent_memory_descriptor_for_address(image_base_page).unwrap();
+            let desc = GCD
+                .get_memory_descriptor_for_address(image_base_page, |d, _| d.memory_type != GcdMemoryType::NonExistent)
+                .unwrap();
             assert_eq!(desc.attributes & efi::MEMORY_XP, efi::MEMORY_XP);
 
             // 2. Activate compatibility mode
@@ -1104,11 +1112,13 @@ mod tests {
             assert_eq!(policy.memory_allocation_default_attributes.get(), 0);
 
             // 4. Page 0 should be mapped
-            let desc = GCD.get_existent_memory_descriptor_for_address(0).unwrap();
+            let desc =
+                GCD.get_memory_descriptor_for_address(0, |d, _| d.memory_type != GcdMemoryType::NonExistent).unwrap();
             assert_eq!(desc.attributes & efi::CACHE_ATTRIBUTE_MASK, efi::MEMORY_WB);
 
             // 5. Legacy BIOS region (0xA0000) should be mapped if system memory
-            let legacy_desc = GCD.get_existent_memory_descriptor_for_address(0xA0000);
+            let legacy_desc =
+                GCD.get_memory_descriptor_for_address(0xA0000, |d, _| d.memory_type != GcdMemoryType::NonExistent);
             if let Ok(desc) = legacy_desc
                 && desc.memory_type == GcdMemoryType::SystemMemory
             {
@@ -1123,7 +1133,9 @@ mod tests {
                 let mut addr = range.start;
                 while addr < range.end {
                     let mut len = 0x1000;
-                    if let Ok(desc) = GCD.get_existent_memory_descriptor_for_address(addr) {
+                    if let Ok(desc) =
+                        GCD.get_memory_descriptor_for_address(addr, |d, _| d.memory_type != GcdMemoryType::NonExistent)
+                    {
                         assert_eq!(desc.attributes & efi::MEMORY_XP, 0);
                         len = desc.length;
                     }
@@ -1132,7 +1144,9 @@ mod tests {
             }
 
             // 7. The image region should be mapped RWX (XP cleared)
-            let desc = GCD.get_existent_memory_descriptor_for_address(image_base_page).unwrap();
+            let desc = GCD
+                .get_memory_descriptor_for_address(image_base_page, |d, _| d.memory_type != GcdMemoryType::NonExistent)
+                .unwrap();
             assert_eq!(desc.attributes & efi::MEMORY_XP, 0);
         });
     }

--- a/patina_dxe_core/src/gcd.rs
+++ b/patina_dxe_core/src/gcd.rs
@@ -10,8 +10,6 @@ mod io_block;
 mod memory_block;
 mod spin_locked_gcd;
 
-pub use spin_locked_gcd::DescriptorFilter;
-
 use goblin::pe::section_table;
 
 use alloc::boxed::Box;
@@ -780,7 +778,7 @@ mod tests {
         assert!(free_memory_start >= mem_base && free_memory_start < mem_base + MEM_SIZE);
         assert!(free_memory_size <= 0x100000);
         let mut descriptors: Vec<MemorySpaceDescriptor> = Vec::with_capacity(GCD.memory_descriptor_count() + 10);
-        GCD.get_memory_descriptors(&mut descriptors, DescriptorFilter::All).expect("get_memory_descriptors failed.");
+        GCD.get_memory_descriptors(&mut descriptors, |_, _| true).expect("get_memory_descriptors failed.");
         assert!(
             descriptors
                 .iter()
@@ -791,7 +789,7 @@ mod tests {
     fn add_resource_descriptors_should_add_resource_descriptors(hob_list: &HobList, mem_base: u64) {
         add_hob_resource_descriptors_to_gcd(hob_list);
         let mut descriptors: Vec<MemorySpaceDescriptor> = Vec::with_capacity(GCD.memory_descriptor_count() + 10);
-        GCD.get_memory_descriptors(&mut descriptors, DescriptorFilter::All).expect("get_memory_descriptors failed.");
+        GCD.get_memory_descriptors(&mut descriptors, |_, _| true).expect("get_memory_descriptors failed.");
         descriptors
             .iter()
             .find(|x| x.base_address == mem_base + 0xE0000 && x.memory_type == GcdMemoryType::SystemMemory)

--- a/patina_dxe_core/src/gcd/spin_locked_gcd.rs
+++ b/patina_dxe_core/src/gcd/spin_locked_gcd.rs
@@ -1236,11 +1236,11 @@ impl GCD {
         // Validate page alignment and size
         let number_of_pages = ((descriptor.length as usize + UEFI_PAGE_MASK) / UEFI_PAGE_SIZE) as u64;
         if number_of_pages == 0 {
-            debug_assert!(false, "GCD returned a memory descriptor smaller than a page.");
+            log::warn!("GCD returned a memory descriptor smaller than a page.");
             return None; // skip entries for things smaller than a page
         }
         if !descriptor.base_address.is_multiple_of(UEFI_PAGE_SIZE as u64) {
-            debug_assert!(false, "GCD returned a non-page-aligned memory descriptor.");
+            log::warn!("GCD returned a non-page-aligned memory descriptor.");
             return None; // skip entries not page aligned
         }
 

--- a/patina_dxe_core/src/gcd/spin_locked_gcd.rs
+++ b/patina_dxe_core/src/gcd/spin_locked_gcd.rs
@@ -94,19 +94,6 @@ pub enum AllocateType {
     Address(usize),
 }
 
-/// Filter for selecting which memory descriptors to retrieve.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum DescriptorFilter {
-    /// Return all memory descriptors (both allocated and unallocated).
-    All,
-    /// Return only allocated memory descriptors.
-    Allocated,
-    /// Return only free (unallocated) system memory descriptors.
-    Free,
-    /// Return only MMIO and Reserved memory descriptors.
-    MmioAndReserved,
-}
-
 #[derive(Clone, Copy)]
 struct GcdAttributeConversionEntry {
     attribute: u32,
@@ -997,7 +984,8 @@ impl GCD {
     ///
     /// # Arguments
     /// * `buffer` - A mutable reference to a vector to hold the descriptors.
-    /// * `filter` - The filter to apply when selecting descriptors.
+    /// * `filter` - A closure invoked with each descriptor and a boolean indicating whether the
+    ///   descriptor's block is allocated. Returns `true` if the descriptor should be included.
     ///
     /// # Returns
     /// * `Ok(())` if successful.
@@ -1006,38 +994,25 @@ impl GCD {
     pub fn get_memory_descriptors(
         &self,
         buffer: &mut Vec<dxe_services::MemorySpaceDescriptor>,
-        filter: DescriptorFilter,
+        filter: fn(&dxe_services::MemorySpaceDescriptor, bool) -> bool,
     ) -> Result<(), EfiError> {
         ensure!(self.maximum_address != 0, EfiError::NotReady);
         ensure!(buffer.capacity() >= self.memory_descriptor_count(), EfiError::InvalidParameter);
         ensure!(buffer.is_empty(), EfiError::InvalidParameter);
 
-        log::trace!(target: "allocations", "[{}] Enter with filter {:?}\n", function!(), filter);
+        log::trace!(target: "allocations", "[{}] Enter\n", function!());
 
         let blocks = &self.memory_blocks;
 
         let mut current = blocks.first_idx();
         while let Some(idx) = current {
             let mb = blocks.get_with_idx(idx).expect("idx is valid from next_idx");
-            match (filter, mb) {
-                (DescriptorFilter::All, MemoryBlock::Allocated(descriptor) | MemoryBlock::Unallocated(descriptor)) => {
-                    buffer.push(*descriptor);
-                }
-                (DescriptorFilter::Allocated, MemoryBlock::Allocated(descriptor)) => {
-                    buffer.push(*descriptor);
-                }
-                (DescriptorFilter::Free, MemoryBlock::Unallocated(descriptor))
-                    if descriptor.memory_type == dxe_services::GcdMemoryType::SystemMemory =>
-                {
-                    buffer.push(*descriptor);
-                }
-                (DescriptorFilter::MmioAndReserved, MemoryBlock::Unallocated(descriptor))
-                    if descriptor.memory_type == dxe_services::GcdMemoryType::MemoryMappedIo
-                        || descriptor.memory_type == dxe_services::GcdMemoryType::Reserved =>
-                {
-                    buffer.push(*descriptor);
-                }
-                _ => {}
+            let (descriptor, allocated) = match mb {
+                MemoryBlock::Allocated(descriptor) => (descriptor, true),
+                MemoryBlock::Unallocated(descriptor) => (descriptor, false),
+            };
+            if filter(descriptor, allocated) {
+                buffer.push(*descriptor);
             }
             current = blocks.next_idx(idx);
         }
@@ -1045,9 +1020,15 @@ impl GCD {
     }
 
     /// This service returns the descriptor for the given physical address.
+    ///
+    /// # Arguments
+    /// * `address` - The physical address to look up.
+    /// * `filter` - A closure invoked with the descriptor and a boolean indicating whether the
+    ///   descriptor's block is allocated. Returns `true` if the descriptor should be included.
     pub fn get_memory_descriptor_for_address(
         &mut self,
         address: efi::PhysicalAddress,
+        mut filter: impl FnMut(&dxe_services::MemorySpaceDescriptor, bool) -> bool,
     ) -> Result<dxe_services::MemorySpaceDescriptor, EfiError> {
         ensure!(self.maximum_address != 0, EfiError::NotReady);
 
@@ -1056,9 +1037,11 @@ impl GCD {
         log::trace!(target: "gcd_measure", "search");
         let idx = memory_blocks.get_closest_idx(&(address)).ok_or(EfiError::NotFound)?;
         let mb = memory_blocks.get_with_idx(idx).expect("idx is valid from get_closest_idx");
-        match mb {
-            MemoryBlock::Allocated(descriptor) | MemoryBlock::Unallocated(descriptor) => Ok(*descriptor),
-        }
+        let (descriptor, allocated) = match mb {
+            MemoryBlock::Allocated(descriptor) => (descriptor, true),
+            MemoryBlock::Unallocated(descriptor) => (descriptor, false),
+        };
+        if filter(descriptor, allocated) { Ok(*descriptor) } else { Err(EfiError::NotFound) }
     }
 
     fn split_state_transition_at_idx(
@@ -2257,7 +2240,12 @@ impl SpinLockedGcd {
             Vec::with_capacity(self.memory_descriptor_count() + 10);
         self.memory
             .lock()
-            .get_memory_descriptors(mmio_res_descs.as_mut(), DescriptorFilter::MmioAndReserved)
+            .get_memory_descriptors(mmio_res_descs.as_mut(), |d, _| {
+                matches!(
+                    d.memory_type,
+                    dxe_services::GcdMemoryType::MemoryMappedIo | dxe_services::GcdMemoryType::Reserved
+                )
+            })
             .expect("Failed to get MMIO descriptors!");
 
         // Before we install this page table, we need to ensure that DXE Core is mapped correctly here as well as any
@@ -2269,7 +2257,15 @@ impl SpinLockedGcd {
             Vec::with_capacity(self.memory_descriptor_count() + 10);
         self.memory
             .lock()
-            .get_memory_descriptors(&mut descriptors, DescriptorFilter::Allocated)
+            .get_memory_descriptors(&mut descriptors, |d, allocated| {
+                if d.memory_type == dxe_services::GcdMemoryType::MemoryMappedIo
+                    || d.memory_type == dxe_services::GcdMemoryType::Reserved
+                {
+                    // we've already handled MMIO and reserved memory, so skip these
+                    return false;
+                }
+                allocated
+            })
             .expect("Failed to get allocated memory descriptors!");
 
         // now map the memory regions, keeping any cache attributes set in the GCD descriptors
@@ -2320,9 +2316,9 @@ impl SpinLockedGcd {
 
         let dxe_core_desc =
             match self.get_existent_memory_descriptor_for_address(dxe_core_hob.alloc_descriptor.memory_base_address) {
-                Ok(desc) => desc,
-                Err(e) => panic!("DXE Core not mapped in GCD {e:?}"),
-            };
+            Ok(desc) => desc,
+            Err(e) => panic!("DXE Core not mapped in GCD {e:?}"),
+        };
 
         // map the entire image as RW, as the PE headers don't live in the sections
         self.set_memory_space_attributes(
@@ -2840,11 +2836,12 @@ impl SpinLockedGcd {
     ///
     /// # Arguments
     /// * `buffer` - A mutable reference to a vector to hold the descriptors.
-    /// * `filter` - The filter to apply when selecting descriptors.
+    /// * `filter` - A closure invoked with each descriptor and a boolean indicating whether the
+    ///   descriptor's block is allocated. Returns `true` if the descriptor should be included.
     pub fn get_memory_descriptors(
         &self,
         buffer: &mut Vec<dxe_services::MemorySpaceDescriptor>,
-        filter: DescriptorFilter,
+        filter: fn(&dxe_services::MemorySpaceDescriptor, bool) -> bool,
     ) -> Result<(), EfiError> {
         self.memory.lock().get_memory_descriptors(buffer, filter)
     }
@@ -2853,8 +2850,9 @@ impl SpinLockedGcd {
     pub fn get_memory_descriptor_for_address(
         &self,
         address: efi::PhysicalAddress,
+        filter: fn(&dxe_services::MemorySpaceDescriptor, bool) -> bool,
     ) -> Result<dxe_services::MemorySpaceDescriptor, EfiError> {
-        self.memory.lock().get_memory_descriptor_for_address(address)
+        self.memory.lock().get_memory_descriptor_for_address(address, filter)
     }
 
     // Returns the descriptor for the given address if that memory range is not NonExistent
@@ -2862,7 +2860,7 @@ impl SpinLockedGcd {
         &self,
         address: efi::PhysicalAddress,
     ) -> Result<dxe_services::MemorySpaceDescriptor, EfiError> {
-        match self.memory.lock().get_memory_descriptor_for_address(address) {
+        match self.memory.lock().get_memory_descriptor_for_address(address, |_, _| true) {
             Ok(desc) if desc.memory_type != GcdMemoryType::NonExistent => Ok(desc),
             Ok(_) => Err(EfiError::NotFound),
             Err(e) => Err(e),
@@ -3013,10 +3011,11 @@ impl<'a> Iterator for DescRangeIterator<'a> {
             return None;
         }
 
-        let descriptor = match self.gcd.get_memory_descriptor_for_address(self.current_base as efi::PhysicalAddress) {
-            Ok(desc) => desc,
-            Err(e) => return Some(Err(e)),
-        };
+        let descriptor =
+            match self.gcd.get_memory_descriptor_for_address(self.current_base as efi::PhysicalAddress, |_, _| true) {
+                Ok(desc) => desc,
+                Err(e) => return Some(Err(e)),
+            };
 
         let descriptor_end = descriptor.base_address + descriptor.length;
         let next_base = u64::min(descriptor_end, self.range_end);
@@ -3058,6 +3057,7 @@ mod tests {
 
     use super::*;
     use alloc::vec::Vec;
+    use patina::pi::dxe_services::GcdMemoryType;
     use r_efi::efi;
     use std::{alloc::GlobalAlloc, cell::RefCell, rc::Rc};
 
@@ -5303,7 +5303,7 @@ mod tests {
             .unwrap();
 
             let mut buffer = Vec::with_capacity(gcd.memory_descriptor_count());
-            gcd.get_memory_descriptors(&mut buffer, DescriptorFilter::Allocated).unwrap();
+            gcd.get_memory_descriptors(&mut buffer, |_, allocated| allocated).unwrap();
             assert_eq!(buffer.len(), 3); // one extra allocated space for memory_block region
             assert!(
                 buffer
@@ -5337,7 +5337,13 @@ mod tests {
             }
 
             let mut buffer = Vec::with_capacity(gcd.memory_descriptor_count());
-            gcd.get_memory_descriptors(&mut buffer, DescriptorFilter::MmioAndReserved).unwrap();
+            gcd.get_memory_descriptors(&mut buffer, |d, _| {
+                matches!(
+                    d.memory_type,
+                    dxe_services::GcdMemoryType::MemoryMappedIo | dxe_services::GcdMemoryType::Reserved
+                )
+            })
+            .unwrap();
             assert!(buffer.len() == 2);
             assert!(buffer.iter().any(|desc| desc.memory_type == dxe_services::GcdMemoryType::MemoryMappedIo
                 && desc.base_address == 0x2000
@@ -5345,6 +5351,192 @@ mod tests {
             assert!(buffer.iter().any(|desc| desc.memory_type == dxe_services::GcdMemoryType::Reserved
                 && desc.base_address == 0x3000
                 && desc.length == 0x10000));
+        });
+    }
+
+    #[test]
+    fn test_get_memory_descriptors_all_filter() {
+        with_locked_state(|| {
+            let (mut gcd, _address) = create_gcd();
+            // SAFETY: Test-controlled addresses and sizes are used with the GCD initialized by create_gcd.
+            unsafe {
+                gcd.add_memory_space(dxe_services::GcdMemoryType::MemoryMappedIo, 0x2000, 0x1000, 0).unwrap();
+                gcd.add_memory_space(dxe_services::GcdMemoryType::Reserved, 0x3000, 0x1000, 0).unwrap();
+                gcd.add_memory_space(dxe_services::GcdMemoryType::SystemMemory, 0x14000, 0x6000, 0).unwrap();
+            }
+
+            let mut buffer = Vec::with_capacity(gcd.memory_descriptor_count());
+            gcd.get_memory_descriptors(&mut buffer, |_, _| true).unwrap();
+
+            // The `All` filter returns every block, including NonExistent regions.
+            assert_eq!(buffer.len(), gcd.memory_descriptor_count());
+            assert!(
+                buffer.iter().any(|desc| desc.memory_type == dxe_services::GcdMemoryType::MemoryMappedIo
+                    && desc.base_address == 0x2000)
+            );
+            assert!(
+                buffer.iter().any(
+                    |desc| desc.memory_type == dxe_services::GcdMemoryType::Reserved && desc.base_address == 0x3000
+                )
+            );
+            assert!(
+                buffer.iter().any(|desc| desc.memory_type == dxe_services::GcdMemoryType::SystemMemory
+                    && desc.base_address == 0x14000)
+            );
+            assert!(buffer.iter().any(|desc| desc.memory_type == dxe_services::GcdMemoryType::NonExistent));
+        });
+    }
+
+    #[test]
+    fn test_get_memory_descriptors_free_filter() {
+        with_locked_state(|| {
+            let (mut gcd, _address) = create_gcd();
+            // SAFETY: Test-controlled addresses and sizes are used with the GCD initialized by create_gcd.
+            unsafe {
+                gcd.add_memory_space(dxe_services::GcdMemoryType::MemoryMappedIo, 0x2000, 0x1000, 0).unwrap();
+                gcd.add_memory_space(dxe_services::GcdMemoryType::Reserved, 0x3000, 0x1000, 0).unwrap();
+                gcd.add_memory_space(dxe_services::GcdMemoryType::SystemMemory, 0x14000, 0x6000, 0).unwrap();
+            }
+            // Allocate part of the system memory so that an allocated block is present to exclude.
+            gcd.allocate_memory_space(
+                AllocateType::Address(0x14000),
+                dxe_services::GcdMemoryType::SystemMemory,
+                UEFI_PAGE_SHIFT,
+                0x1000,
+                1 as _,
+                None,
+            )
+            .unwrap();
+
+            let mut buffer = Vec::with_capacity(gcd.memory_descriptor_count());
+            gcd.get_memory_descriptors(&mut buffer, |d, allocated| {
+                !allocated && d.memory_type == dxe_services::GcdMemoryType::SystemMemory
+            })
+            .unwrap();
+
+            // Only unallocated system memory is returned.
+            assert!(!buffer.is_empty());
+            assert!(buffer.iter().all(|desc| desc.memory_type == dxe_services::GcdMemoryType::SystemMemory));
+            assert!(buffer.iter().all(|desc| desc.image_handle == INVALID_HANDLE));
+            // The remaining free portion of the added system memory is present, the allocated portion is not.
+            assert!(buffer.iter().any(|desc| desc.base_address == 0x15000 && desc.length == 0x5000));
+            assert!(!buffer.iter().any(|desc| desc.base_address == 0x14000));
+            // MMIO and Reserved are excluded.
+            assert!(!buffer.iter().any(|desc| desc.base_address == 0x2000 || desc.base_address == 0x3000));
+        });
+    }
+
+    #[test]
+    fn test_get_memory_descriptors_existent_filter() {
+        with_locked_state(|| {
+            let (mut gcd, _address) = create_gcd();
+            // SAFETY: Test-controlled addresses and sizes are used with the GCD initialized by create_gcd.
+            unsafe {
+                gcd.add_memory_space(dxe_services::GcdMemoryType::MemoryMappedIo, 0x2000, 0x1000, 0).unwrap();
+                gcd.add_memory_space(dxe_services::GcdMemoryType::Reserved, 0x3000, 0x1000, 0).unwrap();
+                gcd.add_memory_space(dxe_services::GcdMemoryType::SystemMemory, 0x14000, 0x6000, 0).unwrap();
+            }
+
+            let mut buffer = Vec::with_capacity(gcd.memory_descriptor_count());
+            gcd.get_memory_descriptors(&mut buffer, |d, _| d.memory_type != dxe_services::GcdMemoryType::NonExistent)
+                .unwrap();
+
+            // Every existent (non-NonExistent) block is returned, regardless of allocation state or type.
+            assert!(buffer.iter().all(|desc| desc.memory_type != dxe_services::GcdMemoryType::NonExistent));
+            assert!(
+                buffer.iter().any(|desc| desc.memory_type == dxe_services::GcdMemoryType::MemoryMappedIo
+                    && desc.base_address == 0x2000)
+            );
+            assert!(
+                buffer.iter().any(
+                    |desc| desc.memory_type == dxe_services::GcdMemoryType::Reserved && desc.base_address == 0x3000
+                )
+            );
+            assert!(
+                buffer.iter().any(|desc| desc.memory_type == dxe_services::GcdMemoryType::SystemMemory
+                    && desc.base_address == 0x14000)
+            );
+        });
+    }
+
+    #[test]
+    fn test_get_memory_descriptors_free_any_type_filter() {
+        with_locked_state(|| {
+            let (mut gcd, _address) = create_gcd();
+            // SAFETY: Test-controlled addresses and sizes are used with the GCD initialized by create_gcd.
+            unsafe {
+                gcd.add_memory_space(dxe_services::GcdMemoryType::MemoryMappedIo, 0x2000, 0x1000, 0).unwrap();
+                gcd.add_memory_space(dxe_services::GcdMemoryType::Reserved, 0x3000, 0x1000, 0).unwrap();
+                gcd.add_memory_space(dxe_services::GcdMemoryType::SystemMemory, 0x14000, 0x6000, 0).unwrap();
+            }
+            // Allocate part of the system memory so that an allocated block is present to exclude.
+            gcd.allocate_memory_space(
+                AllocateType::Address(0x14000),
+                dxe_services::GcdMemoryType::SystemMemory,
+                UEFI_PAGE_SHIFT,
+                0x1000,
+                1 as _,
+                None,
+            )
+            .unwrap();
+
+            let mut buffer = Vec::with_capacity(gcd.memory_descriptor_count());
+            gcd.get_memory_descriptors(&mut buffer, |_, allocated| !allocated).unwrap();
+
+            // Unallocated blocks of any type are returned; unlike `Free`, MMIO and Reserved are included.
+            assert!(buffer.iter().all(|desc| desc.image_handle == INVALID_HANDLE));
+            assert!(
+                buffer.iter().any(|desc| desc.memory_type == dxe_services::GcdMemoryType::MemoryMappedIo
+                    && desc.base_address == 0x2000)
+            );
+            assert!(
+                buffer.iter().any(
+                    |desc| desc.memory_type == dxe_services::GcdMemoryType::Reserved && desc.base_address == 0x3000
+                )
+            );
+            assert!(buffer.iter().any(|desc| desc.base_address == 0x15000 && desc.length == 0x5000));
+            // The allocated portion is excluded.
+            assert!(!buffer.iter().any(|desc| desc.base_address == 0x14000 && desc.length == 0x1000));
+        });
+    }
+
+    #[test]
+    fn test_get_memory_descriptors_mmio_and_reserved_includes_allocated() {
+        with_locked_state(|| {
+            let (mut gcd, _address) = create_gcd();
+            // SAFETY: Test-controlled addresses and sizes are used with the GCD initialized by create_gcd.
+            unsafe {
+                gcd.add_memory_space(dxe_services::GcdMemoryType::MemoryMappedIo, 0x2000, 0x2000, 0).unwrap();
+            }
+            // Allocate part of the MMIO region so both an allocated and unallocated MMIO block exist.
+            gcd.allocate_memory_space(
+                AllocateType::Address(0x2000),
+                dxe_services::GcdMemoryType::MemoryMappedIo,
+                UEFI_PAGE_SHIFT,
+                0x1000,
+                1 as _,
+                None,
+            )
+            .unwrap();
+
+            let mut buffer = Vec::with_capacity(gcd.memory_descriptor_count());
+            gcd.get_memory_descriptors(&mut buffer, |d, _| {
+                matches!(
+                    d.memory_type,
+                    dxe_services::GcdMemoryType::MemoryMappedIo | dxe_services::GcdMemoryType::Reserved
+                )
+            })
+            .unwrap();
+
+            // The `MmioAndReserved` filter returns both allocated and unallocated MMIO/Reserved blocks.
+            assert!(buffer.iter().any(|desc| desc.memory_type == dxe_services::GcdMemoryType::MemoryMappedIo
+                && desc.base_address == 0x2000
+                && desc.length == 0x1000
+                && desc.image_handle == 1 as _));
+            assert!(buffer.iter().any(|desc| desc.memory_type == dxe_services::GcdMemoryType::MemoryMappedIo
+                && desc.base_address == 0x3000
+                && desc.length == 0x1000
+                && desc.image_handle == INVALID_HANDLE));
         });
     }
 
@@ -5500,13 +5692,15 @@ mod tests {
             assert!(stack_hob.memory_length != 0);
 
             // Check Guard Page.
-            let mut stack_desc = GCD.get_memory_descriptor_for_address(stack_hob.memory_base_address).unwrap();
+            let mut stack_desc =
+                GCD.get_memory_descriptor_for_address(stack_hob.memory_base_address, |_, _| true).unwrap();
             assert_eq!(stack_desc.memory_type, dxe_services::GcdMemoryType::SystemMemory);
             assert_eq!((stack_desc.attributes & efi::MEMORY_RP), efi::MEMORY_RP);
 
             // Check rest of the stack.
-            stack_desc =
-                GCD.get_memory_descriptor_for_address(stack_hob.memory_base_address + UEFI_PAGE_SIZE as u64).unwrap();
+            stack_desc = GCD
+                .get_memory_descriptor_for_address(stack_hob.memory_base_address + UEFI_PAGE_SIZE as u64, |_, _| true)
+                .unwrap();
             assert_eq!((stack_desc.attributes & efi::MEMORY_XP), efi::MEMORY_XP);
             assert_eq!(stack_desc.memory_type, dxe_services::GcdMemoryType::SystemMemory);
         });
@@ -6680,6 +6874,197 @@ mod tests {
 
             // Test: Address way outside any added memory space
             let result = GCD.get_existent_memory_descriptor_for_address(0xFFFF0000);
+            assert_eq!(result, Err(EfiError::NotFound));
+        });
+    }
+
+    #[test]
+    fn test_get_memory_descriptor_for_address_all_filter() {
+        with_locked_state(|| {
+            let (mut gcd, _address) = create_gcd();
+            // SAFETY: Test-controlled addresses and sizes are used with the GCD initialized by create_gcd.
+            unsafe {
+                gcd.add_memory_space(dxe_services::GcdMemoryType::SystemMemory, 0x1000, 0x2000, 0).unwrap();
+            }
+
+            // An existent address returns its descriptor.
+            let desc = gcd.get_memory_descriptor_for_address(0x1000, |_, _| true).unwrap();
+            assert_eq!(desc.base_address, 0x1000);
+            assert_eq!(desc.memory_type, dxe_services::GcdMemoryType::SystemMemory);
+
+            // The `All` filter also returns NonExistent regions rather than failing.
+            let desc = gcd.get_memory_descriptor_for_address(0x500, |_, _| true).unwrap();
+            assert_eq!(desc.memory_type, dxe_services::GcdMemoryType::NonExistent);
+        });
+    }
+
+    #[test]
+    fn test_get_memory_descriptor_for_address_allocated_filter() {
+        with_locked_state(|| {
+            let (mut gcd, _address) = create_gcd();
+            // SAFETY: Test-controlled addresses and sizes are used with the GCD initialized by create_gcd.
+            unsafe {
+                gcd.add_memory_space(dxe_services::GcdMemoryType::SystemMemory, 0x1000, 0x2000, 0).unwrap();
+            }
+            gcd.allocate_memory_space(
+                AllocateType::Address(0x1000),
+                dxe_services::GcdMemoryType::SystemMemory,
+                UEFI_PAGE_SHIFT,
+                0x1000,
+                1 as _,
+                None,
+            )
+            .unwrap();
+
+            // The allocated block is returned.
+            let desc = gcd.get_memory_descriptor_for_address(0x1000, |_, allocated| allocated).unwrap();
+            assert_eq!(desc.base_address, 0x1000);
+            assert_eq!(desc.length, 0x1000);
+            assert_eq!(desc.image_handle, 1 as _);
+
+            // The remaining unallocated portion is not matched by the `Allocated` filter.
+            let result = gcd.get_memory_descriptor_for_address(0x2000, |_, allocated| allocated);
+            assert_eq!(result, Err(EfiError::NotFound));
+        });
+    }
+
+    #[test]
+    fn test_get_memory_descriptor_for_address_free_filter() {
+        with_locked_state(|| {
+            let (mut gcd, _address) = create_gcd();
+            // SAFETY: Test-controlled addresses and sizes are used with the GCD initialized by create_gcd.
+            unsafe {
+                gcd.add_memory_space(dxe_services::GcdMemoryType::SystemMemory, 0x1000, 0x2000, 0).unwrap();
+                gcd.add_memory_space(dxe_services::GcdMemoryType::MemoryMappedIo, 0x5000, 0x1000, 0).unwrap();
+            }
+            gcd.allocate_memory_space(
+                AllocateType::Address(0x1000),
+                dxe_services::GcdMemoryType::SystemMemory,
+                UEFI_PAGE_SHIFT,
+                0x1000,
+                1 as _,
+                None,
+            )
+            .unwrap();
+
+            // Free system memory is returned.
+            let desc = gcd
+                .get_memory_descriptor_for_address(0x2000, |d, allocated| {
+                    !allocated && d.memory_type == dxe_services::GcdMemoryType::SystemMemory
+                })
+                .unwrap();
+            assert_eq!(desc.base_address, 0x2000);
+            assert_eq!(desc.memory_type, dxe_services::GcdMemoryType::SystemMemory);
+            assert_eq!(desc.image_handle, INVALID_HANDLE);
+
+            // Allocated system memory is not free.
+            let result = gcd.get_memory_descriptor_for_address(0x1000, |d, allocated| {
+                !allocated && d.memory_type == dxe_services::GcdMemoryType::SystemMemory
+            });
+            assert_eq!(result, Err(EfiError::NotFound));
+
+            // Unallocated MMIO is not system memory, so it is not matched by the `Free` filter.
+            let result = gcd.get_memory_descriptor_for_address(0x5000, |d, allocated| {
+                !allocated && d.memory_type == dxe_services::GcdMemoryType::SystemMemory
+            });
+            assert_eq!(result, Err(EfiError::NotFound));
+        });
+    }
+
+    #[test]
+    fn test_get_memory_descriptor_for_address_mmio_and_reserved_filter() {
+        with_locked_state(|| {
+            let (mut gcd, _address) = create_gcd();
+            // SAFETY: Test-controlled addresses and sizes are used with the GCD initialized by create_gcd.
+            unsafe {
+                gcd.add_memory_space(dxe_services::GcdMemoryType::SystemMemory, 0x1000, 0x2000, 0).unwrap();
+                gcd.add_memory_space(dxe_services::GcdMemoryType::MemoryMappedIo, 0x5000, 0x2000, 0).unwrap();
+                gcd.add_memory_space(dxe_services::GcdMemoryType::Reserved, 0x8000, 0x1000, 0).unwrap();
+            }
+
+            // Unallocated MMIO and Reserved are returned.
+            let desc = gcd
+                .get_memory_descriptor_for_address(0x5000, |d, allocated| {
+                    !allocated
+                        && matches!(
+                            d.memory_type,
+                            dxe_services::GcdMemoryType::MemoryMappedIo | dxe_services::GcdMemoryType::Reserved
+                        )
+                })
+                .unwrap();
+            assert_eq!(desc.memory_type, dxe_services::GcdMemoryType::MemoryMappedIo);
+            let desc = gcd
+                .get_memory_descriptor_for_address(0x8000, |d, allocated| {
+                    !allocated
+                        && matches!(
+                            d.memory_type,
+                            dxe_services::GcdMemoryType::MemoryMappedIo | dxe_services::GcdMemoryType::Reserved
+                        )
+                })
+                .unwrap();
+            assert_eq!(desc.memory_type, dxe_services::GcdMemoryType::Reserved);
+
+            // System memory is not matched.
+            let result = gcd.get_memory_descriptor_for_address(0x1000, |d, allocated| {
+                !allocated
+                    && matches!(
+                        d.memory_type,
+                        dxe_services::GcdMemoryType::MemoryMappedIo | dxe_services::GcdMemoryType::Reserved
+                    )
+            });
+            assert_eq!(result, Err(EfiError::NotFound));
+
+            // Allocated MMIO is not matched (this filter only returns unallocated MMIO/Reserved for a single address).
+            gcd.allocate_memory_space(
+                AllocateType::Address(0x5000),
+                dxe_services::GcdMemoryType::MemoryMappedIo,
+                UEFI_PAGE_SHIFT,
+                0x1000,
+                1 as _,
+                None,
+            )
+            .unwrap();
+            let result = gcd.get_memory_descriptor_for_address(0x5000, |d, allocated| {
+                !allocated
+                    && matches!(
+                        d.memory_type,
+                        dxe_services::GcdMemoryType::MemoryMappedIo | dxe_services::GcdMemoryType::Reserved
+                    )
+            });
+            assert_eq!(result, Err(EfiError::NotFound));
+        });
+    }
+
+    #[test]
+    fn test_get_memory_descriptor_for_address_free_any_type_filter() {
+        with_locked_state(|| {
+            let (mut gcd, _address) = create_gcd();
+            // SAFETY: Test-controlled addresses and sizes are used with the GCD initialized by create_gcd.
+            unsafe {
+                gcd.add_memory_space(dxe_services::GcdMemoryType::SystemMemory, 0x1000, 0x2000, 0).unwrap();
+                gcd.add_memory_space(dxe_services::GcdMemoryType::MemoryMappedIo, 0x5000, 0x1000, 0).unwrap();
+            }
+
+            // Unlike `Free`, unallocated MMIO is matched by `FreeAnyType`.
+            let desc = gcd.get_memory_descriptor_for_address(0x5000, |_, allocated| !allocated).unwrap();
+            assert_eq!(desc.memory_type, dxe_services::GcdMemoryType::MemoryMappedIo);
+            assert_eq!(desc.image_handle, INVALID_HANDLE);
+
+            // Unallocated system memory is also matched.
+            let desc = gcd.get_memory_descriptor_for_address(0x1000, |_, allocated| !allocated).unwrap();
+            assert_eq!(desc.memory_type, dxe_services::GcdMemoryType::SystemMemory);
+
+            // Allocated regions are not matched.
+            gcd.allocate_memory_space(
+                AllocateType::Address(0x5000),
+                dxe_services::GcdMemoryType::MemoryMappedIo,
+                UEFI_PAGE_SHIFT,
+                0x1000,
+                1 as _,
+                None,
+            )
+            .unwrap();
+            let result = gcd.get_memory_descriptor_for_address(0x5000, |_, allocated| !allocated);
             assert_eq!(result, Err(EfiError::NotFound));
         });
     }

--- a/patina_dxe_core/src/gcd/spin_locked_gcd.rs
+++ b/patina_dxe_core/src/gcd/spin_locked_gcd.rs
@@ -16,7 +16,7 @@ use patina::{
     function,
     guids::{self, CACHE_ATTRIBUTE_CHANGE_EVENT_GROUP},
     pi::{
-        dxe_services::{self, GcdMemoryType, MemorySpaceDescriptor},
+        dxe_services::{self, MemorySpaceDescriptor},
         hob,
     },
     uefi_pages_to_size, uefi_size_to_pages, writelncrlf,
@@ -2314,8 +2314,10 @@ impl SpinLockedGcd {
             .expect("Failed to parse PE info for DXE Core")
         };
 
-        let dxe_core_desc =
-            match self.get_existent_memory_descriptor_for_address(dxe_core_hob.alloc_descriptor.memory_base_address) {
+        let dxe_core_desc = match self
+            .get_memory_descriptor_for_address(dxe_core_hob.alloc_descriptor.memory_base_address, |d, _| {
+                d.memory_type != dxe_services::GcdMemoryType::NonExistent
+            }) {
             Ok(desc) => desc,
             Err(e) => panic!("DXE Core not mapped in GCD {e:?}"),
         };
@@ -2423,7 +2425,9 @@ impl SpinLockedGcd {
                 "Invalid Stack Configuration: Stack base address {stack_address:#X} for len {stack_length:#X}"
             );
 
-            if let Ok(gcd_desc) = self.get_existent_memory_descriptor_for_address(stack_address) {
+            if let Ok(gcd_desc) = self.get_memory_descriptor_for_address(stack_address, |d, _| {
+                d.memory_type != dxe_services::GcdMemoryType::NonExistent
+            }) {
                 // Set Stack region to execute protect. We use the allocated memory protection policy here because
                 // that matches our standard policy
                 let attributes =
@@ -2469,7 +2473,8 @@ impl SpinLockedGcd {
 
         // make sure we didn't map page 0 if it was reserved or MMIO, we are using this for null pointer detection
         // only do this if page 0 actually exists
-        if let Ok(descriptor) = self.get_existent_memory_descriptor_for_address(0)
+        if let Ok(descriptor) =
+            self.get_memory_descriptor_for_address(0, |d, _| d.memory_type != dxe_services::GcdMemoryType::NonExistent)
             && let Err(err) = self.set_memory_space_attributes(
                 0,
                 UEFI_PAGE_SIZE,
@@ -2566,11 +2571,13 @@ impl SpinLockedGcd {
             // here, we rely on the image loader to update the attributes as appropriate for the code sections. The
             // same holds true for other required attributes.
             if let Ok(base_address) = result.as_ref() {
-                let mut attributes =
-                    match self.get_existent_memory_descriptor_for_address(*base_address as efi::PhysicalAddress) {
-                        Ok(descriptor) => descriptor.attributes,
-                        Err(_) => DEFAULT_CACHE_ATTR,
-                    };
+                let mut attributes = match self
+                    .get_memory_descriptor_for_address(*base_address as efi::PhysicalAddress, |d, _| {
+                        d.memory_type != dxe_services::GcdMemoryType::NonExistent
+                    }) {
+                    Ok(descriptor) => descriptor.attributes,
+                    Err(_) => DEFAULT_CACHE_ATTR,
+                };
                 // it is safe to call set_memory_space_attributes without calling set_memory_space_capabilities here
                 // because we set efi::MEMORY_XP as a capability on all memory ranges we add to the GCD. A driver could
                 // call set_memory_space_capabilities to remove the XP capability, but that is something that should
@@ -2853,18 +2860,6 @@ impl SpinLockedGcd {
         filter: fn(&dxe_services::MemorySpaceDescriptor, bool) -> bool,
     ) -> Result<dxe_services::MemorySpaceDescriptor, EfiError> {
         self.memory.lock().get_memory_descriptor_for_address(address, filter)
-    }
-
-    // Returns the descriptor for the given address if that memory range is not NonExistent
-    pub fn get_existent_memory_descriptor_for_address(
-        &self,
-        address: efi::PhysicalAddress,
-    ) -> Result<dxe_services::MemorySpaceDescriptor, EfiError> {
-        match self.memory.lock().get_memory_descriptor_for_address(address, |_, _| true) {
-            Ok(desc) if desc.memory_type != GcdMemoryType::NonExistent => Ok(desc),
-            Ok(_) => Err(EfiError::NotFound),
-            Err(e) => Err(e),
-        }
     }
 
     /// returns the current count of blocks in the list.
@@ -6835,7 +6830,9 @@ mod tests {
             }
 
             // Test: Address at the start of a SystemMemory block
-            let result = GCD.get_existent_memory_descriptor_for_address(0x1000);
+            let result = GCD.get_memory_descriptor_for_address(0x1000, |d, _| {
+                d.memory_type != dxe_services::GcdMemoryType::NonExistent
+            });
             assert!(result.is_ok());
             let desc = result.unwrap();
             assert_eq!(desc.base_address, 0x1000);
@@ -6843,14 +6840,18 @@ mod tests {
             assert_eq!(desc.memory_type, dxe_services::GcdMemoryType::SystemMemory);
 
             // Test: Address in the middle of a SystemMemory block
-            let result = GCD.get_existent_memory_descriptor_for_address(0x2000);
+            let result = GCD.get_memory_descriptor_for_address(0x2000, |d, _| {
+                d.memory_type != dxe_services::GcdMemoryType::NonExistent
+            });
             assert!(result.is_ok());
             let desc = result.unwrap();
             assert_eq!(desc.base_address, 0x1000);
             assert_eq!(desc.memory_type, dxe_services::GcdMemoryType::SystemMemory);
 
             // Test: Address at the start of MMIO block
-            let result = GCD.get_existent_memory_descriptor_for_address(0x5000);
+            let result = GCD.get_memory_descriptor_for_address(0x5000, |d, _| {
+                d.memory_type != dxe_services::GcdMemoryType::NonExistent
+            });
             assert!(result.is_ok());
             let desc = result.unwrap();
             assert_eq!(desc.base_address, 0x5000);
@@ -6858,22 +6859,30 @@ mod tests {
             assert_eq!(desc.memory_type, dxe_services::GcdMemoryType::MemoryMappedIo);
 
             // Test: Address at the start of Reserved block
-            let result = GCD.get_existent_memory_descriptor_for_address(0x8000);
+            let result = GCD.get_memory_descriptor_for_address(0x8000, |d, _| {
+                d.memory_type != dxe_services::GcdMemoryType::NonExistent
+            });
             assert!(result.is_ok());
             let desc = result.unwrap();
             assert_eq!(desc.base_address, 0x8000);
             assert_eq!(desc.memory_type, dxe_services::GcdMemoryType::Reserved);
 
             // Test: Address in a NonExistent region (between added blocks)
-            let result = GCD.get_existent_memory_descriptor_for_address(0x4000);
+            let result = GCD.get_memory_descriptor_for_address(0x4000, |d, _| {
+                d.memory_type != dxe_services::GcdMemoryType::NonExistent
+            });
             assert_eq!(result, Err(EfiError::NotFound));
 
             // Test: Address before any added memory space (in NonExistent region)
-            let result = GCD.get_existent_memory_descriptor_for_address(0x500);
+            let result = GCD.get_memory_descriptor_for_address(0x500, |d, _| {
+                d.memory_type != dxe_services::GcdMemoryType::NonExistent
+            });
             assert_eq!(result, Err(EfiError::NotFound));
 
             // Test: Address way outside any added memory space
-            let result = GCD.get_existent_memory_descriptor_for_address(0xFFFF0000);
+            let result = GCD.get_memory_descriptor_for_address(0xFFFF0000, |d, _| {
+                d.memory_type != dxe_services::GcdMemoryType::NonExistent
+            });
             assert_eq!(result, Err(EfiError::NotFound));
         });
     }

--- a/patina_dxe_core/src/gcd/spin_locked_gcd.rs
+++ b/patina_dxe_core/src/gcd/spin_locked_gcd.rs
@@ -16,7 +16,7 @@ use patina::{
     function,
     guids::{self, CACHE_ATTRIBUTE_CHANGE_EVENT_GROUP},
     pi::{
-        dxe_services::{self, MemorySpaceDescriptor},
+        dxe_services::{self, GcdMemoryType, MemorySpaceDescriptor},
         hob,
     },
     uefi_pages_to_size, uefi_size_to_pages, writelncrlf,
@@ -1224,6 +1224,70 @@ impl GCD {
         }
     }
 
+    /// Determines if this memory descriptor should be included in the EFI memory map.
+    ///
+    /// Only descriptors that meet UEFI requirements and represent allocatable or special memory
+    /// types are included in the EFI memory map.
+    ///
+    /// # Returns
+    /// * `Some(memory_type)` if the descriptor should be included in the EFI memory map
+    /// * `None` if the descriptor should be excluded
+    fn is_efi_memory_map_descriptor(descriptor: &MemorySpaceDescriptor) -> Option<efi::MemoryType> {
+        // Validate page alignment and size
+        let number_of_pages = ((descriptor.length as usize + UEFI_PAGE_MASK) / UEFI_PAGE_SIZE) as u64;
+        if number_of_pages == 0 {
+            debug_assert!(false, "GCD returned a memory descriptor smaller than a page.");
+            return None; // skip entries for things smaller than a page
+        }
+        if !descriptor.base_address.is_multiple_of(UEFI_PAGE_SIZE as u64) {
+            debug_assert!(false, "GCD returned a non-page-aligned memory descriptor.");
+            return None; // skip entries not page aligned
+        }
+
+        // first check if an allocator owns this memory, if so, we can use the allocator's memory type for
+        // the EFI memory map
+        if let Some(memory_type) = memory_type_for_handle(descriptor.image_handle) {
+            return Some(memory_type);
+        }
+
+        match descriptor.memory_type {
+            GcdMemoryType::SystemMemory => {
+                if descriptor.image_handle.is_null() {
+                    // Free memory not tracked by any allocator or directly allocated in the GCD
+                    Some(efi::CONVENTIONAL_MEMORY)
+                } else if descriptor.attributes & efi::MEMORY_RUNTIME == efi::MEMORY_RUNTIME {
+                    // Directly allocated in the GCD and has the runtime attribute set. Mark it as reserved so it is
+                    // preserved into runtime but doesn't have expectations about being in the MAT
+                    Some(efi::RESERVED_MEMORY_TYPE)
+                } else {
+                    // Directly allocated in the GCD and does not have the runtime attribute set. Mark it as boot
+                    // services data so it is reflected correctly but doesn't get preserved to runtime
+                    Some(efi::BOOT_SERVICES_DATA)
+                }
+            }
+
+            // Note: there could also be MMIO tracked by the allocators which would not hit this case.
+            GcdMemoryType::MemoryMappedIo => {
+                // we should only be returning runtime MMIO here
+                if descriptor.attributes & efi::MEMORY_RUNTIME == 0 { None } else { Some(efi::MEMORY_MAPPED_IO) }
+            }
+
+            // Persistent. Note: this type is not allocatable, but might be created by agents other than the core directly
+            // in the GCD.
+            GcdMemoryType::Persistent => Some(efi::PERSISTENT_MEMORY),
+
+            // Unaccepted. Note: this type is not allocatable, but might be created by agents other than the core directly
+            // in the GCD.
+            GcdMemoryType::Unaccepted => Some(efi::UNACCEPTED_MEMORY_TYPE),
+
+            // Reserved.
+            GcdMemoryType::Reserved => Some(efi::RESERVED_MEMORY_TYPE),
+
+            // Other memory types are ignored for purposes of the memory map
+            _ => None,
+        }
+    }
+
     /// Counts the number of EFI memory map descriptors needed.
     ///
     /// Returns
@@ -1239,10 +1303,7 @@ impl GCD {
                 MemoryBlock::Allocated(descriptor) | MemoryBlock::Unallocated(descriptor) => descriptor,
             };
 
-            if memory_type_for_handle(descriptor.image_handle)
-                .or_else(|| descriptor.is_efi_memory_map_descriptor())
-                .is_some()
-            {
+            if Self::is_efi_memory_map_descriptor(descriptor).is_some() {
                 count += 1;
             }
             current = blocks.next_idx(idx);
@@ -1284,9 +1345,7 @@ impl GCD {
                 MemoryBlock::Allocated(descriptor) | MemoryBlock::Unallocated(descriptor) => descriptor,
             };
 
-            if let Some(memory_type) =
-                memory_type_for_handle(descriptor.image_handle).or_else(|| descriptor.is_efi_memory_map_descriptor())
-            {
+            if let Some(memory_type) = Self::is_efi_memory_map_descriptor(descriptor) {
                 let number_of_pages = uefi_size_to_pages!(descriptor.length as usize) as u64;
                 let attributes = Self::adjust_efi_memory_map_descriptor(descriptor, memory_type, active_attributes);
 
@@ -6606,6 +6665,185 @@ mod tests {
                 );
                 assert_eq!(result_capabilities, expected, "Failed for capabilities={:#x}", capabilities);
             }
+        });
+    }
+
+    #[test]
+    fn test_is_efi_memory_map_descriptor_system_memory_free() {
+        with_locked_state(|| {
+            // Free system memory not tracked by any allocator (null handle) is reported as conventional memory.
+            let descriptor = dxe_services::MemorySpaceDescriptor {
+                memory_type: GcdMemoryType::SystemMemory,
+                base_address: 0x1000,
+                length: UEFI_PAGE_SIZE as u64,
+                capabilities: efi::MEMORY_WB,
+                attributes: efi::MEMORY_WB,
+                image_handle: core::ptr::null_mut(),
+                device_handle: core::ptr::null_mut(),
+            };
+
+            assert_eq!(GCD::is_efi_memory_map_descriptor(&descriptor), Some(efi::CONVENTIONAL_MEMORY));
+        });
+    }
+
+    #[test]
+    fn test_is_efi_memory_map_descriptor_system_memory_gcd_allocated_boot_services() {
+        with_locked_state(|| {
+            // System memory directly allocated in the GCD (non-null, non-allocator handle) without the runtime
+            // attribute is reported as boot services data.
+            let descriptor = dxe_services::MemorySpaceDescriptor {
+                memory_type: GcdMemoryType::SystemMemory,
+                base_address: 0x1000,
+                length: UEFI_PAGE_SIZE as u64,
+                capabilities: efi::MEMORY_WB,
+                attributes: efi::MEMORY_WB,
+                image_handle: crate::protocol_db::DXE_CORE_HANDLE,
+                device_handle: core::ptr::null_mut(),
+            };
+
+            assert_eq!(GCD::is_efi_memory_map_descriptor(&descriptor), Some(efi::BOOT_SERVICES_DATA));
+        });
+    }
+
+    #[test]
+    fn test_is_efi_memory_map_descriptor_system_memory_gcd_allocated_runtime() {
+        with_locked_state(|| {
+            // System memory directly allocated in the GCD (non-null, non-allocator handle) with the runtime attribute
+            // is reported as reserved so it is preserved into runtime without being expected in the MAT.
+            let descriptor = dxe_services::MemorySpaceDescriptor {
+                memory_type: GcdMemoryType::SystemMemory,
+                base_address: 0x1000,
+                length: UEFI_PAGE_SIZE as u64,
+                capabilities: efi::MEMORY_WB | efi::MEMORY_RUNTIME,
+                attributes: efi::MEMORY_WB | efi::MEMORY_RUNTIME,
+                image_handle: crate::protocol_db::DXE_CORE_HANDLE,
+                device_handle: core::ptr::null_mut(),
+            };
+
+            assert_eq!(GCD::is_efi_memory_map_descriptor(&descriptor), Some(efi::RESERVED_MEMORY_TYPE));
+        });
+    }
+
+    #[test]
+    fn test_is_efi_memory_map_descriptor_mmio_non_runtime() {
+        with_locked_state(|| {
+            // Non-runtime MMIO is excluded from the EFI memory map.
+            let descriptor = dxe_services::MemorySpaceDescriptor {
+                memory_type: GcdMemoryType::MemoryMappedIo,
+                base_address: 0xF0000000,
+                length: UEFI_PAGE_SIZE as u64,
+                capabilities: efi::MEMORY_UC,
+                attributes: efi::MEMORY_UC,
+                image_handle: core::ptr::null_mut(),
+                device_handle: core::ptr::null_mut(),
+            };
+
+            assert_eq!(GCD::is_efi_memory_map_descriptor(&descriptor), None);
+        });
+    }
+
+    #[test]
+    fn test_is_efi_memory_map_descriptor_mmio_runtime() {
+        with_locked_state(|| {
+            // Runtime MMIO is included in the EFI memory map.
+            let descriptor = dxe_services::MemorySpaceDescriptor {
+                memory_type: GcdMemoryType::MemoryMappedIo,
+                base_address: 0xF0000000,
+                length: UEFI_PAGE_SIZE as u64,
+                capabilities: efi::MEMORY_UC | efi::MEMORY_RUNTIME,
+                attributes: efi::MEMORY_UC | efi::MEMORY_RUNTIME,
+                image_handle: core::ptr::null_mut(),
+                device_handle: core::ptr::null_mut(),
+            };
+
+            assert_eq!(GCD::is_efi_memory_map_descriptor(&descriptor), Some(efi::MEMORY_MAPPED_IO));
+        });
+    }
+
+    #[test]
+    fn test_is_efi_memory_map_descriptor_persistent() {
+        with_locked_state(|| {
+            let descriptor = dxe_services::MemorySpaceDescriptor {
+                memory_type: GcdMemoryType::Persistent,
+                base_address: 0x1000,
+                length: UEFI_PAGE_SIZE as u64,
+                capabilities: efi::MEMORY_WB | efi::MEMORY_NV,
+                attributes: efi::MEMORY_WB | efi::MEMORY_NV,
+                image_handle: core::ptr::null_mut(),
+                device_handle: core::ptr::null_mut(),
+            };
+
+            assert_eq!(GCD::is_efi_memory_map_descriptor(&descriptor), Some(efi::PERSISTENT_MEMORY));
+        });
+    }
+
+    #[test]
+    fn test_is_efi_memory_map_descriptor_unaccepted() {
+        with_locked_state(|| {
+            let descriptor = dxe_services::MemorySpaceDescriptor {
+                memory_type: GcdMemoryType::Unaccepted,
+                base_address: 0x1000,
+                length: UEFI_PAGE_SIZE as u64,
+                capabilities: efi::MEMORY_WB,
+                attributes: efi::MEMORY_WB,
+                image_handle: core::ptr::null_mut(),
+                device_handle: core::ptr::null_mut(),
+            };
+
+            assert_eq!(GCD::is_efi_memory_map_descriptor(&descriptor), Some(efi::UNACCEPTED_MEMORY_TYPE));
+        });
+    }
+
+    #[test]
+    fn test_is_efi_memory_map_descriptor_reserved() {
+        with_locked_state(|| {
+            let descriptor = dxe_services::MemorySpaceDescriptor {
+                memory_type: GcdMemoryType::Reserved,
+                base_address: 0x1000,
+                length: UEFI_PAGE_SIZE as u64,
+                capabilities: efi::MEMORY_UC,
+                attributes: efi::MEMORY_UC,
+                image_handle: core::ptr::null_mut(),
+                device_handle: core::ptr::null_mut(),
+            };
+
+            assert_eq!(GCD::is_efi_memory_map_descriptor(&descriptor), Some(efi::RESERVED_MEMORY_TYPE));
+        });
+    }
+
+    #[test]
+    fn test_is_efi_memory_map_descriptor_nonexistent_excluded() {
+        with_locked_state(|| {
+            // NonExistent memory is not represented in the EFI memory map.
+            let descriptor = dxe_services::MemorySpaceDescriptor {
+                memory_type: GcdMemoryType::NonExistent,
+                base_address: 0x1000,
+                length: UEFI_PAGE_SIZE as u64,
+                capabilities: 0,
+                attributes: 0,
+                image_handle: core::ptr::null_mut(),
+                device_handle: core::ptr::null_mut(),
+            };
+
+            assert_eq!(GCD::is_efi_memory_map_descriptor(&descriptor), None);
+        });
+    }
+
+    #[test]
+    fn test_is_efi_memory_map_descriptor_multi_page_length() {
+        with_locked_state(|| {
+            // A descriptor spanning multiple pages is still classified by its memory type.
+            let descriptor = dxe_services::MemorySpaceDescriptor {
+                memory_type: GcdMemoryType::SystemMemory,
+                base_address: 0x2000,
+                length: (UEFI_PAGE_SIZE * 4) as u64,
+                capabilities: efi::MEMORY_WB,
+                attributes: efi::MEMORY_WB,
+                image_handle: core::ptr::null_mut(),
+                device_handle: core::ptr::null_mut(),
+            };
+
+            assert_eq!(GCD::is_efi_memory_map_descriptor(&descriptor), Some(efi::CONVENTIONAL_MEMORY));
         });
     }
 

--- a/sdk/patina/src/pi/dxe_services.rs
+++ b/sdk/patina/src/pi/dxe_services.rs
@@ -320,60 +320,6 @@ impl MemorySpaceDescriptor {
 
         overlap_start..overlap_end
     }
-
-    /// Determines if this memory descriptor should be included in the EFI memory map.
-    ///
-    /// Only descriptors that meet UEFI requirements and represent allocatable or special memory
-    /// types are included in the EFI memory map.
-    ///
-    /// # Returns
-    /// * `Some(memory_type)` if the descriptor should be included in the EFI memory map
-    /// * `None` if the descriptor should be excluded
-    pub fn is_efi_memory_map_descriptor(&self) -> Option<r_efi::efi::MemoryType> {
-        use crate::base::{UEFI_PAGE_MASK, UEFI_PAGE_SIZE};
-
-        // Validate page alignment and size
-        let number_of_pages = ((self.length as usize + UEFI_PAGE_MASK) / UEFI_PAGE_SIZE) as u64;
-        if number_of_pages == 0 {
-            debug_assert!(false, "GCD returned a memory descriptor smaller than a page.");
-            return None; // skip entries for things smaller than a page
-        }
-        if !self.base_address.is_multiple_of(UEFI_PAGE_SIZE as u64) {
-            debug_assert!(false, "GCD returned a non-page-aligned memory descriptor.");
-            return None; // skip entries not page aligned
-        }
-
-        // Note: For allocator-tracked memory types, this should be called by the DXE core
-        // after checking memory_type_for_handle(self.image_handle)
-        match self.memory_type {
-            // Free memory not tracked by any allocator.
-            GcdMemoryType::SystemMemory => Some(r_efi::efi::CONVENTIONAL_MEMORY),
-
-            // Note: there could also be MMIO tracked by the allocators which would not hit this case.
-            GcdMemoryType::MemoryMappedIo => {
-                // we should only be returning runtime MMIO here
-                if self.attributes & r_efi::efi::MEMORY_RUNTIME == 0 {
-                    None
-                } else {
-                    Some(r_efi::efi::MEMORY_MAPPED_IO)
-                }
-            }
-
-            // Persistent. Note: this type is not allocatable, but might be created by agents other than the core directly
-            // in the GCD.
-            GcdMemoryType::Persistent => Some(r_efi::efi::PERSISTENT_MEMORY),
-
-            // Unaccepted. Note: this type is not allocatable, but might be created by agents other than the core directly
-            // in the GCD.
-            GcdMemoryType::Unaccepted => Some(r_efi::efi::UNACCEPTED_MEMORY_TYPE),
-
-            // Reserved.
-            GcdMemoryType::Reserved => Some(r_efi::efi::RESERVED_MEMORY_TYPE),
-
-            // Other memory types are ignored for purposes of the memory map
-            _ => None,
-        }
-    }
 }
 
 #[repr(C)]


### PR DESCRIPTION
## Description

This PR contains five commits, two of which are set up/clean up for the third commit which is a bug fix. The final two commits are bugs noticed doing this work.

dxe: GCD: Get Descriptors With Closure, Not Filter
--
Currently, get_memory_descriptor_for_address will return any descriptor for an address. get_memory_descriptors accepts a filter to determine which descs to return.

This commit updates both fns to accept a closure so that custom logic can be applied to determine when a desc should
be returned. This removes increasingly complicated and use case specific descriptor filters in favor of a more flexible mechanism.

dxe: GCD: Consolidate get_existent_memory_descriptor_for_address
--
Now that get_memory_descriptor_for_address accepts a closure, convert users of get_existent_memory_descriptor_for_address and drop the function.

dxe: GCD: Always Allocate FV Regions
--
Currently, the DXE Core initialization only attempts to allocate FV regions if they are marked as MMIO in the GCD. However, many platforms mark these regions as system memory (particularly for FVs that were decompressed into memory).

These regions are not allocated and so are free to allocate by regular allocations. This causes corruption in the FV and failure to parse it.

This commit changes the behavior from the EDK II behavior to always allocate FV regions if they are not already allocated (some platforms produce memory allocation HOBs for the FV region; also three FVs are produced for each extracted FV, so we only allocate it once).

This ensures that the FVs do not get corrupted.

dxe: GCD: Account For Direct Allocated GCD Memory in EFI_MEMORY_MAP
--
is_efi_memory_map_descriptor() currently assumes all system memory is efi::ConventionalMemory because it assumes that the allocators have been checked for this descriptor before it runs.

However, this misses direct allocated GCD memory (calling through DXE services).

This commit does three things:
- Move is_efi_memory_map_descriptor() from the SDK to the core so that it can directly call memory_type_for_handle() and be a complete function. Given any memory descriptor it will correctly report what the EFI_MEMORY_MAP type will be, instead of relying on memory_type_handle() being called first. It is not a useful function in the SDK, only intended for core use. It cannot be used by SDK consumers because it relies on a core internal function.
- Update the system memory logic in that function to check whether it is allocated and if the runtime flag is set.
- Add tests.

This was noticed because the FVs are directly allocated in the GCD.

dxe: GCD: Don't Assert on Non-Page Aligned GCD Allocations
--
This updates the EFI_MEMORY_MAP building logic to not assert on non-page aligned GCD allocations. FVs are expected to not be page aligned, but must be allocated to avoid being corrupted by other allocations.

This is a temporary workaround to log and drop the allocations. A longer term solution is tracked in https://github.com/OpenDevicePartnership/patina/issues/1614.

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Tested on a platform that had an FV starting at 0x1000. When the page table was allocated bottom up, the root landed at 0x1000. This overwrote the FV signature, causing Patina to fail to parse the FV and therefore could not dispatch any drivers. Obviously, it is incredibly dangerous to have the page table conflict with any other memory as well, though the FV should be read only.

After this change, the FV is marked as allocated and the page table lands on a different page and the system is able to read the FV and dispatch drivers.

Also booted to Windows on a physical Intel platform to confirm no regression.

## Integration Instructions

N/A.
