### PR TITLE
Switch to the stable toolchain (and RUSTC_BOOTSTRAP=1)

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -6,6 +6,15 @@
 
 [env]
 PATINA_CONFIG_VERSION = "1"
+RUSTC_BOOTSTRAP = "1"
+
+# Restrict the unstable features RUSTC_BOOTSTRAP makes available to only those Patina has accepted
+# through the unstable feature process. This applies to host builds (tests, proc-macros).
+# The UEFI targets below repeat the flag because Cargo does not merge rustflags sources.
+[build]
+rustflags = [
+    "-Z", "allow-features=c_variadic,allocator_api,coverage_attribute",
+]
 
 [profile.dev]
 # optimize for size
@@ -61,6 +70,8 @@ rustflags = [
     "-C", "force-frame-pointers",
     # Preserve stack unwind info
     "-C", "force-unwind-tables",
+    # Restrict the unstable features RUSTC_BOOTSTRAP unlocks to the accepted set
+    "-Z", "allow-features=c_variadic,allocator_api,coverage_attribute",
 ]
 
 [target.aarch64-unknown-uefi]
@@ -71,4 +82,6 @@ rustflags = [
     "-C", "force-frame-pointers",
     # Preserve stack unwind info
     "-C", "force-unwind-tables",
+    # Restrict the unstable features RUSTC_BOOTSTRAP unlocks to the accepted set
+    "-Z", "allow-features=c_variadic,allocator_api,coverage_attribute",
 ]

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -353,6 +353,7 @@ doctests link against rlibs built by the same compiler, and points `mdbook test`
 to the mdbook profile `target/mdbook/deps/` directory produced by `build-mdbook-deps`.
 """
 clear = true
+env = { RUSTC_BOOTSTRAP = "1" }
 script_runner = "@duckscript"
 script = '''
 toolchain_file = readfile rust-toolchain.toml

--- a/docs/src/dev/rust_version_update_process.md
+++ b/docs/src/dev/rust_version_update_process.md
@@ -2,8 +2,13 @@
 
 ```admonish tip title="TL;DR"
 - **Cadence:** Update at least once per quarter. Do not jump to a new stable release the day it ships.
-- **Toolchain are specified in:** `rust-toolchain.toml` (nightly channel) and the `rust-version` field in each crate's `Cargo.toml`.
-- **Nightly selection:** Use the "Branched from master" date for the target stable release from [releases.rs](https://releases.rs/).
+- **Toolchain are specified in:** `rust-toolchain.toml` (stable channel) and the `rust-version` field in each crate's
+  `Cargo.toml`.
+- **Stable selection:** Pin the explicit stable release version (for example, `channel = "1.95.0"`) in
+  `rust-toolchain.toml`.
+- **Unstable features:** The pinned stable toolchain builds the unstable feature gates Patina uses via
+  `RUSTC_BOOTSTRAP=1`, set in the `[env]` table of `.cargo/config.toml`. See
+  [Use of Unstable Rust Features in Patina](unstable.md).
 - **MSRV verification:** The `MSRV Check` workflow builds the workspace against the toolchain in the `[msrv]` table of
   `rust-toolchain.toml`. Keep that table in sync with the `rust-version` field.
 - **Review:** Open the PR against `main`, add the `OpenDevicePartnership/patina-contributors` team, and leave it open for at least three full business days.
@@ -47,38 +52,32 @@ The minimum supported Rust version is also verified automatically by the `MSRV C
 (`.github/workflows/msrv-check.yml`). This workflow builds and tests the workspace against the toolchain declared in the
 `[msrv]` table of `rust-toolchain.toml` (rather than the primary `[toolchain]` channel used for day-to-day development).
 
-The `[msrv]` table pins the nightly toolchain that corresponds to the `rust-version` declared in the crates' `Cargo.toml`
-files, using the "Branched from master" date for that stable release:
+The `[msrv]` table pins the stable release that corresponds to the `rust-version` declared in the crates' `Cargo.toml`
+files:
 
 ```toml
 [msrv]
-channel = "nightly-2025-06-20"   # branched-from date for rust-version = "1.89"
+channel = "1.89.0"   # matches rust-version = "1.89"
 ```
 
 The workflow runs on a daily schedule and on any pull request that modifies `rust-toolchain.toml`. This catches cases
 where a change unintentionally relies on functionality newer than the declared minimum. When you raise the minimum
-supported Rust version, update the `[msrv]` table's `channel` to the nightly that matches the new `rust-version`.
+supported Rust version, update the `[msrv]` table's `channel` to the stable release that matches the new `rust-version`.
 
-## Choosing a Nightly Version
+## Choosing a Stable Version
 
-Patina currently builds against nightly Rust since the project depends on a small number of unstable features. Unless
-there is a compelling reason to update the nightly version, it is recommended to continue using the same nightly version
-until the next stable release. The project typically takes the nightly version listed as the "Branched from master" date
-for the release on [releases.rs](https://releases.rs/). For example, the [1.97.0](https://releases.rs/docs/1.97.0/)
-release has a "branched from master on" date of "22 May, 2026".
+Patina builds against a pinned stable Rust release. The small number of unstable features the project still depends on
+are compiled by setting `RUSTC_BOOTSTRAP=1` in the `[env]` table of `.cargo/config.toml`, which lets the stable
+toolchain accept `#![feature(...)]` gates. See [Use of Unstable Rust Features in Patina](unstable.md) for the
+feature policy and the `-Z allow-features` list that restricts which gates are permitted.
 
-````admonish tip
-If you need to find the commit that the stable release was branched from, you can use `git` to find the commit hash
-working within the <https://github.com/rust-lang/rust> repository. For example, `git merge-base main 1.95.0` returns
-`67aec36df76a7b67b71a8ee47684467e16f1847e`. `git show 67aec36df76a7b67b71a8ee47684467e16f1847e` returns:
+Pin the explicit stable release in `rust-toolchain.toml`:
 
-```text
-commit 67aec36df76a7b67b71a8ee47684467e16f1847e
-Merge: 3a70d0349fa 70da8044517
-Author: bors <bors@rust-lang.org>
-Date:   Fri Feb 27 22:04:20 2026 +0000
+```toml
+[toolchain]
+channel = "1.95.0"
 ```
 
-[releases.rs - 1.95.0](https://releases.rs/docs/1.95.0/) also lists the "Branched from master on" date as
-"27 Feb, 2026".
-````
+Use an explicit version rather than the floating `stable` channel so builds stay reproducible and each toolchain move is
+an intentional, reviewable change. Available stable releases are listed on [releases.rs](https://releases.rs/)
+and [the Rust release schedule](https://forge.rust-lang.org/).

--- a/docs/src/dev/unstable.md
+++ b/docs/src/dev/unstable.md
@@ -13,6 +13,20 @@ Patina.
 All active rustc feature usage is tracked with the [`state:rustc-feature-gate`](https://github.com/OpenDevicePartnership/patina/issues?q=is%3Aissue%20state%3Aopen%20label%3Arustc-feature-gate)
 label.
 
+## How Patina Enables Unstable Features
+
+Patina builds against a pinned stable Rust toolchain rather than nightly (see
+[Rust and Toolchain Version Update Process](rust_version_update_process.md)). A stable `rustc` normally rejects
+`#![feature(...)]` gates, so the build sets `RUSTC_BOOTSTRAP=1` so they are accepted by the stable toolchain.
+
+To constrain the set of unstable features allowed, the build also passes `-Z allow-features=<list>` through `rustflags`
+(in `.cargo/config.toml`).
+
+```admonish important
+When the feature process below adds or removes a feature, update the `-Z allow-features` list in every `rustflags` block
+of `.cargo/config.toml`. A feature that is gated with `#![feature(...)]` but missing from this list will fail to build.
+```
+
 ## When Unstable Rust Features May Be Used
 
 Common scenarios for using unstable features:
@@ -87,9 +101,10 @@ either be accepted or denied and then merged.
 ### Create and Merge Implementation
 
 If the RFC is merged, it is now your responsibility to implement it's usage and create a pull-request for review. The
-pull-request should reference that this is the implementation for your accepted RFC. Once merged, **you must continue**
-**to monitor** the stability of the feature. Notably, if any changes to the feature's API occur, you will be responsible
-for adjusting the usage of the feature in the codebase.
+pull-request should reference that this is the implementation for your accepted RFC. Add the feature name to the
+`-Z allow-features` list in every `rustflags` block of `.cargo/config.toml`. Once merged, **you must continue to monitor**
+the stability of the feature. Notably, if any changes to the feature's API occur, you will be responsible for adjusting
+the usage of the feature in the codebase.
 
 ### Stabilization
 
@@ -106,4 +121,5 @@ declaration of the minimum supported rust version.
 The other possibility is that feature was removed from rustc, or an alternative is available that better meets the needs
 of the project. In this scenario, the project must update all usage of the feature to an alternative.
 
-Finally, once all is said and done, and the `#![feature(...)]` has been removed, the tracking issue can be closed.
+Finally, once all is said and done, and the `#![feature(...)]` has been removed, remove the feature name from the
+`-Z allow-features` list in `.cargo/config.toml` and the tracking issue can be closed.

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -5,7 +5,7 @@
 # - File Sync Settings: https://github.com/OpenDevicePartnership/patina-devops/blob/main/.sync/Files.yml
 
 [toolchain]
-channel = "nightly-2026-04-11" # Last nightly build of 1.96.0-nightly
+channel = "1.95.0"
 targets = ["x86_64-unknown-uefi", "aarch64-unknown-uefi"]
 components = ["rust-src", "clippy", "rustfmt", "rust-docs"]
 
@@ -23,4 +23,4 @@ mdbook-linkcheck = "0.7.7"
 mdbook-mermaid = "0.16.2"
 
 [msrv]
-channel = "nightly-2025-06-20"   # branched-from date for rust-version = "1.89"
+channel = "1.89.0"


### PR DESCRIPTION
## Description

Per RFC 0030, switch to the stable toolchain and set RUSTC_BOOTSTRAP=1 to allow the stable toolchain to accept the unstable feature gates Patina still depends on.

Sets `allow-features` to the list of unstable features Patina uses.

Update associated documentation to reflect the change.

---

Plan is to get a single change into this repo (this PR) that includes the exact changes from patina-devops + doc updates then the patina-devops changes will not make any subsequent updates to the files.

- patina-devops PR: https://github.com/OpenDevicePartnership/patina-devops/pull/169

---

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [x] Includes documentation?

## How This Was Tested

- `cargo make all`

## Integration Instructions

- See [RFC 0030 - Build on Stable Rust with RUSTC_BOOTSTRAP](https://github.com/OpenDevicePartnership/patina/blob/main/docs/src/rfc/text/0030-rustc-bootstrap.md) and the documentation updates in this change.