### PR TITLE
Makefile.toml: Add `install-tools` task

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -19,6 +19,87 @@ RUSTC_PROFILE = "dev"
 [env.release]
 RUSTC_PROFILE = "release"
 
+[tasks.install-tools]
+description = """Installs the project tools pinned in the `[tools]` section of
+`rust-toolchain.toml` at their specified versions. Each tool is installed with
+`cargo binstall`, falling back to `cargo install` when a prebuilt binary is not
+available. CI also installs and tests the tools in this section.
+
+`cargo-binstall` (https://github.com/cargo-bins/cargo-binstall) is installed
+automatically with `cargo install` when it is not already present.
+
+Example:
+    `cargo make install-tools`
+"""
+clear = true
+install_crate = false
+script_runner = "@duckscript"
+script = '''
+# cargo-binstall is used to install tools.
+binstall_path = which cargo-binstall
+if is_empty ${binstall_path}
+    echo "==> cargo-binstall not found. Installing it with cargo install..."
+    exec --fail-on-error cargo install cargo-binstall
+end
+
+toolchain_file = readfile rust-toolchain.toml
+lines = split ${toolchain_file} "\n"
+
+# Track whether the current line is inside the `[tools]` section. Parsing runs
+# from the `[tools]` header until the next section header.
+in_tools = set false
+for line in ${lines}
+    trimmed = trim ${line}
+    is_section = starts_with ${trimmed} "["
+    if ${is_section}
+        if eq ${trimmed} "[tools]"
+            in_tools = set true
+        else
+            in_tools = set false
+        end
+    elseif ${in_tools}
+        is_comment = starts_with ${trimmed} "#"
+        is_blank = is_empty ${trimmed}
+        has_assignment = contains ${trimmed} "="
+        # Only process `name = "version"` lines.
+        if not ${is_blank}
+            if not ${is_comment}
+                if ${has_assignment}
+                    kv = split ${trimmed} "="
+                    name = array_get ${kv} 0
+                    name = trim ${name}
+
+                    version = array_get ${kv} 1
+                    version_parts = split ${version} "\""
+                    version = array_get ${version_parts} 1
+
+                    result = exec cargo binstall -y ${name} --version ${version}
+                    output = set "${result.stdout}${result.stderr}"
+                    if not eq ${result.code} "0"
+                        echo "  building ${name} ${version} from source (no prebuilt binary)..."
+                        result = exec cargo install ${name} --version ${version}
+                        output = set "${result.stdout}${result.stderr}"
+                    end
+
+                    if not eq ${result.code} "0"
+                        echo "  FAILED       ${name} ${version}"
+                        echo ${output}
+                        exit 1
+                    end
+
+                    already = contains ${output} "already installed"
+                    if ${already}
+                        echo "  up-to-date   ${name} ${version}"
+                    else
+                        echo "  installed    ${name} ${version}"
+                    end
+                end
+            end
+        end
+    end
+end
+'''
+
 [tasks.individual-package-targets]
 script_runner = "@duckscript"
 script = '''

--- a/docs/src/background/rust_tools.md
+++ b/docs/src/background/rust_tools.md
@@ -95,6 +95,28 @@ cargo binstall cargo-llvm-cov
 
 It is recommended to use `cargo-binstall` when possible to minimize setup time.
 
+**Automated Installation of Project Tools**:
+
+Patina maintains a pinned set of tool versions in the `[tools]` section of `rust-toolchain.toml`:
+
+```toml
+[tools]
+cargo-deny = "^0.18"
+cargo-llvm-cov = "0.6.18"
+cargo-make = "0.37.21"
+# ...
+```
+
+Run the `install-tools` task to install every tool at its specified version so a local environment matches CI:
+
+```bash
+cargo make install-tools
+```
+
+The task reads the `[tools]` section and installs each entry with `cargo binstall`, falling back to `cargo install`
+when a pre-built binary is unavailable. If `cargo-binstall` is not already present, the task installs it first. Because
+the versions come from `rust-toolchain.toml`, this is the recommended way to keep local tooling in sync with CI.
+
 ### Tool Discovery and Version Management
 
 `cargo-binstall` streamlines discovery and version control for external tooling by downloading pre-built binaries when


### PR DESCRIPTION
## Description

Resolves #1613

Patina maintains a list of project tools in the `[tools]` section of `rust-toolchain.toml`. While CI directly installs these tools, local developers have to do so manually. That was raised as a pain point as noted in the referenced GitHub issue.

This commit adds a new `install-tools` task to the Makefile that will automatically install all tools listed in the `[tools]` section of `rust-toolchain.toml`. The task first verifies that `cargo-binstall` is installed, and if not, it installs it. Then it parses the `[tools]` section of `rust-toolchain.toml` and installs each tool using `cargo binstall`.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [x] Includes documentation?

## How This Was Tested

- Run `cargo make install-tools` with some intentional tool issues: a tool missing (`cargo-vet`) and a tool on the wrong version (`cargo-mdbook`).

  <img width="641" height="323" alt="image" src="https://github.com/user-attachments/assets/df20f9e2-2850-4b0d-b369-df93620b7392" />

- Run `cargo make install-tools` with everything installed on the correct versions:

  <img width="617" height="323" alt="image" src="https://github.com/user-attachments/assets/6ba9a3b0-77a1-4371-b1ba-8b4f25073fb2" />

## Integration Instructions

- N/A - Local workspace task