### PR TITLE
patina_ffs_extractors: Use Decompressed Size Bound Globally

### DIFF
--- a/sdk/patina_ffs_extractors/src/brotli.rs
+++ b/sdk/patina_ffs_extractors/src/brotli.rs
@@ -15,6 +15,8 @@ use patina_ffs::{
     section::{Section, SectionExtractor, SectionHeader},
 };
 
+use crate::DECOMPRESSION_MAX_MEMORY_LIMIT;
+
 //Rebox and HeapAllocator exist to satisfy BrotliDecompress custom allocation requirements.
 //They essentially wrap Box for heap allocations.
 struct Rebox<T>(Box<[T]>);
@@ -74,6 +76,10 @@ impl SectionExtractor for BrotliSectionExtractor {
                     .try_into()
                     .map_err(|_| FirmwareFileSystemError::DataCorrupt)?,
             );
+            if out_size > DECOMPRESSION_MAX_MEMORY_LIMIT as u64 {
+                return Err(FirmwareFileSystemError::DataCorrupt);
+            }
+
             let _scratch_size = u64::from_le_bytes(
                 data.get(8..16)
                     .ok_or(FirmwareFileSystemError::DataCorrupt)?
@@ -129,5 +135,16 @@ mod tests {
         assert!(result.is_ok());
         let result = result.unwrap();
         assert_eq!(result, b"Hello, World!");
+    }
+
+    #[test]
+    fn test_brotli_extractor_out_size_exceeds_limit() {
+        // Declare an uncompressed size larger than the 512MB decompression limit; the
+        // extractor must reject it before attempting to allocate the output buffer.
+        let out_size = DECOMPRESSION_MAX_MEMORY_LIMIT as u64 + 1;
+        let section = create_brotli_section(&[0u8; 4], out_size);
+        let extractor = BrotliSectionExtractor;
+        let result = extractor.extract(&section);
+        assert!(matches!(result, Err(FirmwareFileSystemError::DataCorrupt)));
     }
 }

--- a/sdk/patina_ffs_extractors/src/lib.rs
+++ b/sdk/patina_ffs_extractors/src/lib.rs
@@ -44,6 +44,10 @@ pub use composite::CompositeSectionExtractor;
 mod null;
 pub use null::NullSectionExtractor;
 
+#[cfg(any(feature = "brotli", feature = "lzma"))]
+/// Maximum memory limit for compressed section decompression. This is set to 512MB as a reasonable upper limit.
+const DECOMPRESSION_MAX_MEMORY_LIMIT: u32 = patina::base::SIZE_512MB as u32;
+
 #[cfg(test)]
 #[coverage(off)]
 mod tests {

--- a/sdk/patina_ffs_extractors/src/lzma.rs
+++ b/sdk/patina_ffs_extractors/src/lzma.rs
@@ -15,12 +15,11 @@ use patina_ffs::{
     section::{Section, SectionExtractor, SectionHeader},
 };
 
+use crate::DECOMPRESSION_MAX_MEMORY_LIMIT;
+
 /// Sentinel uncompressed-size value in the `.lzma` (FORMAT_ALONE) header that indicates
 /// the uncompressed size is unknown.
 const LZMA_UNKNOWN_UNPACKED_SIZE_MAGIC_VALUE: u64 = 0xFFFF_FFFF_FFFF_FFFF;
-
-/// Maximum memory limit for LZMA decompression. This is set to 512MB as a reasonable upper limit.
-const LZMA_MAX_MEMORY_LIMIT: u32 = patina::base::SIZE_512MB as u32;
 
 /// Provides decompression for LZMA GUIDed sections.
 #[derive(Default, Clone, Copy)]
@@ -48,13 +47,16 @@ impl SectionExtractor for LzmaSectionExtractor {
             let mut decompressed = if unpacked_size == LZMA_UNKNOWN_UNPACKED_SIZE_MAGIC_VALUE {
                 Vec::<u8>::new()
             } else {
+                if unpacked_size > DECOMPRESSION_MAX_MEMORY_LIMIT as u64 {
+                    return Err(FirmwareFileSystemError::DataCorrupt);
+                }
                 Vec::<u8>::with_capacity(unpacked_size as usize)
             };
 
             // The section payload is a `.lzma` (FORMAT_ALONE) stream: a 13-byte header
             // (properties byte, dictionary size, uncompressed size) followed by the
             // range-coded payload. `LzmaReader::new_mem_limit` parses that header.
-            let mut reader = LzmaReader::new_mem_limit(data, LZMA_MAX_MEMORY_LIMIT, None)
+            let mut reader = LzmaReader::new_mem_limit(data, DECOMPRESSION_MAX_MEMORY_LIMIT, None)
                 .map_err(|_| FirmwareFileSystemError::DataCorrupt)?;
 
             let mut chunk = [0u8; 4096];
@@ -114,6 +116,22 @@ mod tests {
 
         // Result depends on whether the compressed data is valid
         assert!(result.is_ok() || matches!(result, Err(FirmwareFileSystemError::DataCorrupt)));
+    }
+
+    #[test]
+    fn test_lzma_extractor_unpacked_size_exceeds_limit() {
+        // Declare an unpacked size larger than the 512MB decompression limit (but not the
+        // "unknown size" sentinel); the extractor must reject it before decompressing.
+        let unpacked_size = DECOMPRESSION_MAX_MEMORY_LIMIT as u64 + 1;
+        let mut lzma_data = vec![0x5D, 0x00, 0x00, 0x80, 0x00]; // LZMA properties
+        lzma_data.extend_from_slice(&unpacked_size.to_le_bytes()); // Oversized unpacked size
+        lzma_data.extend_from_slice(&[0x00, 0x00, 0x00, 0x00, 0x00]); // Placeholder payload
+
+        let section = create_lzma_section(&lzma_data);
+        let extractor = LzmaSectionExtractor;
+        let result = extractor.extract(&section);
+
+        assert!(matches!(result, Err(FirmwareFileSystemError::DataCorrupt)));
     }
 
     #[test]


### PR DESCRIPTION
## Description

The LZMA code bounds decompressed section size to 512MB to ensure a corrupted FV does not trigger unbounded memory allocation.

This commit moves that to the global level and also applies it for Brotli compressed sections.

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

N/A.

## Integration Instructions

Platforms are not expected to have any compressed sections that uncompress to > 512 MB. If so, the limit can be expanded.
