### PR TITLE
patina_internal_cpu: Prevent sign extension of symbol addresses in x64 interrupt handlers

### DIFF
--- a/core/patina_internal_cpu/src/interrupts/x64/interrupt_handler.asm
+++ b/core/patina_internal_cpu/src/interrupts/x64/interrupt_handler.asm
@@ -22,7 +22,7 @@ AsmIdtVectorBegin:
         sub     rsp, 8
         mov     qword ptr [rsp], vector
         push    rax
-        mov     rax, offset common_interrupt_entry
+        lea     rax, [rip + common_interrupt_entry]
         jmp     rax
         .set vector, vector+1
     .endr
@@ -293,8 +293,8 @@ stack_normalized:
 # This routine only uses volatile registers for the EFI calling convention.
 #
 AsmGetVectorAddress:
-    lea     r10, AsmIdtVectorBegin
-    lea     rax, AsmIdtVectorEnd
+    lea     r10, [rip + AsmIdtVectorBegin]
+    lea     rax, [rip + AsmIdtVectorEnd]
     sub     rax, r10
     shr     rax, 8 # >> 8 == / 256
 


### PR DESCRIPTION
## Description

In GAS assembly syntax, lea <global-variable> will create a 32bit absolute address and place it into the register. If the register is a 64 bit register, the value will be signed extended. 

This is a problem if the patina image is loaded above address 0x8000_0000. The 32bit address will be sign extended.

This was found on a physical platform where patina was loaded into system memory at 0xA000_0000. 

Switch to using RIP relative form syntax. 

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested
On a platform where PEI allocated dxe_core at a higher address, exceptions would occur, but the exception handlers were never reached. After changing assembly syntax, exception handlers were reached. 

## Integration Instructions
No integration necessary.