### PR TITLE
sdk: Prevent underflow and reverse range slicing in FFS section parsing

### DIFF
--- a/sdk/patina_ffs/src/section.rs
+++ b/sdk/patina_ffs/src/section.rs
@@ -330,7 +330,9 @@ impl Section {
                             as *const section::header::Compression,
                     )
                 };
-                let content_size: u32 = (section_size - (section_data_offset + compression_header_size))
+                let content_size: u32 = section_size
+                    .checked_sub(section_data_offset + compression_header_size)
+                    .ok_or(FirmwareFileSystemError::InvalidHeader)?
                     .try_into()
                     .map_err(|_| FirmwareFileSystemError::InvalidHeader)?;
                 (
@@ -362,8 +364,11 @@ impl Section {
                     .get(section_data_offset + guid_header_size..data_offset)
                     .ok_or(FirmwareFileSystemError::InvalidHeader)?
                     .to_vec();
-                let content_size: u32 =
-                    (section_size - data_offset).try_into().map_err(|_| FirmwareFileSystemError::InvalidHeader)?;
+                let content_size: u32 = section_size
+                    .checked_sub(data_offset)
+                    .ok_or(FirmwareFileSystemError::InvalidHeader)?
+                    .try_into()
+                    .map_err(|_| FirmwareFileSystemError::InvalidHeader)?;
                 (SectionHeader::GuidDefined(guid_defined_header, guid_specific_data, content_size), data_offset)
             }
             section::raw_type::VERSION => {
@@ -379,7 +384,9 @@ impl Section {
                             as *const section::header::Version,
                     )
                 };
-                let content_size: u32 = (section_size - (section_data_offset + version_header_size))
+                let content_size: u32 = section_size
+                    .checked_sub(section_data_offset + version_header_size)
+                    .ok_or(FirmwareFileSystemError::InvalidHeader)?
                     .try_into()
                     .map_err(|_| FirmwareFileSystemError::InvalidHeader)?;
                 (SectionHeader::Version(version_header, content_size), section_data_offset + version_header_size)
@@ -397,7 +404,9 @@ impl Section {
                             as *const section::header::FreeformSubtypeGuid,
                     )
                 };
-                let content_size: u32 = (section_size - (section_data_offset + freeform_subtype_size))
+                let content_size: u32 = section_size
+                    .checked_sub(section_data_offset + freeform_subtype_size)
+                    .ok_or(FirmwareFileSystemError::InvalidHeader)?
                     .try_into()
                     .map_err(|_| FirmwareFileSystemError::InvalidHeader)?;
                 (
@@ -406,7 +415,9 @@ impl Section {
                 )
             }
             _ => {
-                let content_size: u32 = (section_size - section_data_offset)
+                let content_size: u32 = section_size
+                    .checked_sub(section_data_offset)
+                    .ok_or(FirmwareFileSystemError::InvalidHeader)?
                     .try_into()
                     .map_err(|_| FirmwareFileSystemError::InvalidHeader)?;
                 (SectionHeader::Standard(section_header.section_type, content_size), section_data_offset)

--- a/sdk/patina_ffs/src/volume.rs
+++ b/sdk/patina_ffs/src/volume.rs
@@ -1267,6 +1267,66 @@ mod test {
     }
 
     #[test]
+    fn section_with_undersized_size_field_should_error() {
+        set_logger();
+
+        // For each of these buffers the declared section size is smaller than the header(s) it
+        // must contain. The buffer itself is large enough to hold the headers, so the size/header
+        // checks that only look at buffer length pass, and the content-size computation must not
+        // underflow (or slice a reverse range) but instead return InvalidHeader.
+
+        // Standard (PE32) section with size (2) smaller than the common header (4).
+        let undersized_standard: [u8; 4] = [0x02, 0x00, 0x00, 0x10];
+        assert!(matches!(Section::new_from_buffer(&undersized_standard), Err(FirmwareFileSystemError::InvalidHeader)));
+
+        // Compression section with size (8) smaller than common header + compression header (4 + 5).
+        let undersized_compression: [u8; 9] = [0x08, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00];
+        assert!(matches!(
+            Section::new_from_buffer(&undersized_compression),
+            Err(FirmwareFileSystemError::InvalidHeader)
+        ));
+
+        // GuidDefined section whose data_offset (10) points before the end of the common + guid
+        // header (4 + 20), which would produce a reverse slice range.
+        let reverse_range_guid_defined: [u8; 24] = [
+            0x18, 0x00, 0x00, 0x02, // Header (size = 24)
+            0x01, 0x23, 0x45, 0x67, 0x89, 0xAB, 0xCD, 0xEF, 0x01, 0x23, 0x45, 0x67, 0x89, 0xAB, 0xCD,
+            0xEF, // GUID
+            0x0A, 0x00, // Data offset = 10 (before end of header)
+            0x00, 0x00, // Attributes
+        ];
+        assert!(matches!(
+            Section::new_from_buffer(&reverse_range_guid_defined),
+            Err(FirmwareFileSystemError::InvalidHeader)
+        ));
+
+        // GuidDefined section whose data_offset (24) exceeds the declared section size (20).
+        let undersized_guid_defined: [u8; 24] = [
+            0x14, 0x00, 0x00, 0x02, // Header (size = 20)
+            0x01, 0x23, 0x45, 0x67, 0x89, 0xAB, 0xCD, 0xEF, 0x01, 0x23, 0x45, 0x67, 0x89, 0xAB, 0xCD,
+            0xEF, // GUID
+            0x18, 0x00, // Data offset = 24 (> section size)
+            0x00, 0x00, // Attributes
+        ];
+        assert!(matches!(
+            Section::new_from_buffer(&undersized_guid_defined),
+            Err(FirmwareFileSystemError::InvalidHeader)
+        ));
+
+        // Version section with size (5) smaller than common header + version header (4 + 2).
+        let undersized_version: [u8; 6] = [0x05, 0x00, 0x00, 0x14, 0x00, 0x00];
+        assert!(matches!(Section::new_from_buffer(&undersized_version), Err(FirmwareFileSystemError::InvalidHeader)));
+
+        // FreeformSubtypeGuid section with size (10) smaller than common + freeform header (4 + 16).
+        let undersized_freeform: [u8; 20] = [
+            0x0A, 0x00, 0x00, 0x18, // Header (size = 10)
+            0x01, 0x23, 0x45, 0x67, 0x89, 0xAB, 0xCD, 0xEF, 0x01, 0x23, 0x45, 0x67, 0x89, 0xAB, 0xCD,
+            0xEF, // GUID
+        ];
+        assert!(matches!(Section::new_from_buffer(&undersized_freeform), Err(FirmwareFileSystemError::InvalidHeader)));
+    }
+
+    #[test]
     fn test_firmware_volume_serialization() -> Result<(), Box<dyn Error>> {
         set_logger();
         let paths = &[


### PR DESCRIPTION
## Description

Fixes #1625 

Some code in `patina_ffs` for parsing sections and files computes content offsets by subtracting header sizes from untrusted size fields, or by slicing between two untrusted offsets, without validating that the declared size is large enough for the header.

This can produce subtraction underflow and reverse range panics.

This change uses checked subtraction returning an `InvalidHeader` error on size mismatches.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [x] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

- `cargo make all`
- QEMU ArmVirt & Q35 boot to EFI shell

## Integration Instructions

- N/A