### PR TITLE
Harden HOB parsing [Rebase & FF]

### DIFF
--- a/sdk/patina/src/pi/hob.rs
+++ b/sdk/patina/src/pi/hob.rs
@@ -963,7 +963,14 @@ impl<'a> Iterator for HobIter<'a> {
                 GUID_EXTENSION => {
                     let hob = (self.hob_ptr as *const GuidHob).as_ref().expect(NOT_NULL);
                     let data_ptr = self.hob_ptr.byte_add(mem::size_of::<GuidHob>()) as *const u8;
-                    let data_len = hob.header.length as usize - mem::size_of::<GuidHob>();
+                    // A well-formed GUID extension HOB length that covers at least `GuidHob` header.
+                    debug_assert!(
+                        hob.header.length as usize >= mem::size_of::<GuidHob>(),
+                        "GUID extension HOB length {} is smaller than the GuidHob header size {}",
+                        hob.header.length,
+                        mem::size_of::<GuidHob>()
+                    );
+                    let data_len = (hob.header.length as usize).saturating_sub(mem::size_of::<GuidHob>());
                     Hob::GuidHob(hob, slice::from_raw_parts(data_ptr, data_len))
                 }
                 FV => Hob::FirmwareVolume((self.hob_ptr as *const FirmwareVolume).as_ref().expect(NOT_NULL)),

--- a/sdk/patina/src/pi/hob/hob_list.rs
+++ b/sdk/patina/src/pi/hob/hob_list.rs
@@ -261,7 +261,14 @@ impl<'a> HobList<'a> {
                     let (guid_hob, data) = unsafe {
                         let hob = hob_header.cast::<GuidHob>().as_ref().expect(NOT_NULL);
                         let data_ptr = hob_header.byte_add(mem::size_of::<GuidHob>()) as *mut u8;
-                        let data_len = hob.header.length as usize - mem::size_of::<GuidHob>();
+                        // A well-formed GUID extension HOB length that covers at least `GuidHob` header.
+                        debug_assert!(
+                            hob.header.length as usize >= mem::size_of::<GuidHob>(),
+                            "GUID extension HOB length {} is smaller than the GuidHob header size {}",
+                            hob.header.length,
+                            mem::size_of::<GuidHob>()
+                        );
+                        let data_len = (hob.header.length as usize).saturating_sub(mem::size_of::<GuidHob>());
                         (hob, slice::from_raw_parts(data_ptr, data_len))
                     };
                     self.0.push(Hob::GuidHob(guid_hob, data));
@@ -691,6 +698,46 @@ mod tests {
             count += 1;
         });
         assert_eq!(count, 9);
+    }
+
+    #[test]
+    fn test_hoblist_discover_undersized_guid_hob_does_not_underflow() {
+        // A GUID extension HOB whose declared length is smaller than the `GuidHob` header is malformed.
+        let guid_hob_size = size_of::<hob::GuidHob>();
+        let header_size = size_of::<hob::header::Hob>();
+        let malformed_len = (guid_hob_size - header_size) as u16;
+        assert!(
+            (malformed_len as usize) >= header_size,
+            "test HOB length must be large enough for the discover loop to advance"
+        );
+
+        // Layout: [undersized GUID_EXTENSION header | ... | END_OF_HOB_LIST].
+        let write_header = |buf: &mut [u8], offset: usize, r#type: u16, length: u16| {
+            let header = hob::header::Hob { r#type, length, reserved: 0 };
+            // SAFETY: Test code - `header::Hob` is `repr(C)` plain data serialized into the test-allocated buffer.
+            let bytes = unsafe { from_raw_parts(&header as *const _ as *const u8, size_of::<hob::header::Hob>()) };
+            buf[offset..offset + bytes.len()].copy_from_slice(bytes);
+        };
+
+        let mut buf: Vec<u8> = std::vec![0u8; guid_hob_size];
+        write_header(&mut buf, 0, hob::GUID_EXTENSION, malformed_len);
+        write_header(&mut buf, malformed_len as usize, hob::END_OF_HOB_LIST, header_size as u16);
+
+        let mut hoblist = HobList::new();
+        hoblist.discover_hobs(buf.as_ptr() as *const c_void);
+        assert_eq!(hoblist.len(), 1);
+        match hoblist.iter().next().unwrap() {
+            Hob::GuidHob(_, data) => assert!(data.is_empty(), "an undersized GUID HOB must give empty data"),
+            other => panic!("expected GuidHob, got {other:?}"),
+        }
+
+        // SAFETY: Test code. The buffer begins with a valid GUID_EXTENSION HOB header constructed in the test.
+        let first = Hob::GuidHob(unsafe { (buf.as_ptr() as *const hob::GuidHob).as_ref().unwrap() }, &[]);
+        for hob in &first {
+            if let Hob::GuidHob(_, data) = hob {
+                assert!(data.is_empty(), "HobIter should give empty data for an undersized GUID HOB");
+            }
+        }
     }
 
     #[test]

--- a/sdk/patina/src/pi/hob/hob_list.rs
+++ b/sdk/patina/src/pi/hob/hob_list.rs
@@ -212,14 +212,20 @@ impl<'a> HobList<'a> {
     /// ```
     pub fn discover_hobs(&mut self, hob_list: *const c_void) {
         const NOT_NULL: &str = "Ptr should not be NULL";
-        fn assert_hob_size<T>(hob: &header::Hob) {
+        // Validates that a HOB's declared length matches the size of the type it will be cast to.
+        //
+        // A size mismatch panics in debug builds and logs a warning and returns `false` in release builds.
+        fn hob_size_ok<T>(hob: &header::Hob) -> bool {
             let hob_len = hob.length as usize;
             let hob_size = mem::size_of::<T>();
-            assert_eq!(
-                hob_len, hob_size,
-                "Trying to cast hob of length {hob_len} into a pointer of size {hob_size}. Hob type: {:?}",
-                hob.r#type
-            );
+            if hob_len != hob_size {
+                crate::log_debug_assert!(
+                    "Ignoring malformed HOB: type {:?} has length {hob_len} but expected size {hob_size}.",
+                    hob.r#type
+                );
+                return false;
+            }
+            true
         }
 
         let mut hob_header: *const header::Hob = hob_list as *const header::Hob;
@@ -229,11 +235,12 @@ impl<'a> HobList<'a> {
             let current_header = unsafe { hob_header.cast::<header::Hob>().as_ref().expect(NOT_NULL) };
             match current_header.r#type {
                 HANDOFF => {
-                    assert_hob_size::<PhaseHandoffInformationTable>(current_header);
-                    // SAFETY: HOB type is HANDOFF and size was validated. Cast to specific HOB type is valid.
-                    let phit_hob =
-                        unsafe { hob_header.cast::<PhaseHandoffInformationTable>().as_ref().expect(NOT_NULL) };
-                    self.0.push(Hob::Handoff(phit_hob));
+                    if hob_size_ok::<PhaseHandoffInformationTable>(current_header) {
+                        // SAFETY: HOB type is HANDOFF and size was validated. Cast to specific HOB type is valid.
+                        let phit_hob =
+                            unsafe { hob_header.cast::<PhaseHandoffInformationTable>().as_ref().expect(NOT_NULL) };
+                        self.0.push(Hob::Handoff(phit_hob));
+                    }
                 }
                 MEMORY_ALLOCATION => {
                     if current_header.length == mem::size_of::<MemoryAllocationModule>() as u16 {
@@ -241,19 +248,19 @@ impl<'a> HobList<'a> {
                         let mem_alloc_hob =
                             unsafe { hob_header.cast::<MemoryAllocationModule>().as_ref().expect(NOT_NULL) };
                         self.0.push(Hob::MemoryAllocationModule(mem_alloc_hob));
-                    } else {
-                        assert_hob_size::<MemoryAllocation>(current_header);
+                    } else if hob_size_ok::<MemoryAllocation>(current_header) {
                         // SAFETY: HOB type is MEMORY_ALLOCATION and size was validated.
                         let mem_alloc_hob = unsafe { hob_header.cast::<MemoryAllocation>().as_ref().expect(NOT_NULL) };
                         self.0.push(Hob::MemoryAllocation(mem_alloc_hob));
                     }
                 }
                 RESOURCE_DESCRIPTOR => {
-                    assert_hob_size::<ResourceDescriptor>(current_header);
-                    // SAFETY: HOB type is RESOURCE_DESCRIPTOR and size was validated.
-                    let resource_desc_hob =
-                        unsafe { hob_header.cast::<ResourceDescriptor>().as_ref().expect(NOT_NULL) };
-                    self.0.push(Hob::ResourceDescriptor(resource_desc_hob));
+                    if hob_size_ok::<ResourceDescriptor>(current_header) {
+                        // SAFETY: HOB type is RESOURCE_DESCRIPTOR and size was validated.
+                        let resource_desc_hob =
+                            unsafe { hob_header.cast::<ResourceDescriptor>().as_ref().expect(NOT_NULL) };
+                        self.0.push(Hob::ResourceDescriptor(resource_desc_hob));
+                    }
                 }
                 GUID_EXTENSION => {
                     // SAFETY: HOB type is GUID_EXTENSION. GuidHob header is valid, and data follows immediately after.
@@ -274,41 +281,47 @@ impl<'a> HobList<'a> {
                     self.0.push(Hob::GuidHob(guid_hob, data));
                 }
                 FV => {
-                    assert_hob_size::<FirmwareVolume>(current_header);
-                    // SAFETY: HOB type is FV and size was validated.
-                    let fv_hob = unsafe { hob_header.cast::<FirmwareVolume>().as_ref().expect(NOT_NULL) };
-                    self.0.push(Hob::FirmwareVolume(fv_hob));
+                    if hob_size_ok::<FirmwareVolume>(current_header) {
+                        // SAFETY: HOB type is FV and size was validated.
+                        let fv_hob = unsafe { hob_header.cast::<FirmwareVolume>().as_ref().expect(NOT_NULL) };
+                        self.0.push(Hob::FirmwareVolume(fv_hob));
+                    }
                 }
                 FV2 => {
-                    assert_hob_size::<FirmwareVolume2>(current_header);
-                    // SAFETY: HOB type is FV2 and size was validated.
-                    let fv2_hob = unsafe { hob_header.cast::<FirmwareVolume2>().as_ref().expect(NOT_NULL) };
-                    self.0.push(Hob::FirmwareVolume2(fv2_hob));
+                    if hob_size_ok::<FirmwareVolume2>(current_header) {
+                        // SAFETY: HOB type is FV2 and size was validated.
+                        let fv2_hob = unsafe { hob_header.cast::<FirmwareVolume2>().as_ref().expect(NOT_NULL) };
+                        self.0.push(Hob::FirmwareVolume2(fv2_hob));
+                    }
                 }
                 FV3 => {
-                    assert_hob_size::<FirmwareVolume3>(current_header);
-                    // SAFETY: HOB type is FV3 and size was validated.
-                    let fv3_hob = unsafe { hob_header.cast::<FirmwareVolume3>().as_ref().expect(NOT_NULL) };
-                    self.0.push(Hob::FirmwareVolume3(fv3_hob));
+                    if hob_size_ok::<FirmwareVolume3>(current_header) {
+                        // SAFETY: HOB type is FV3 and size was validated.
+                        let fv3_hob = unsafe { hob_header.cast::<FirmwareVolume3>().as_ref().expect(NOT_NULL) };
+                        self.0.push(Hob::FirmwareVolume3(fv3_hob));
+                    }
                 }
                 CPU => {
-                    assert_hob_size::<Cpu>(current_header);
-                    // SAFETY: HOB type is CPU and size was validated.
-                    let cpu_hob = unsafe { hob_header.cast::<Cpu>().as_ref().expect(NOT_NULL) };
-                    self.0.push(Hob::Cpu(cpu_hob));
+                    if hob_size_ok::<Cpu>(current_header) {
+                        // SAFETY: HOB type is CPU and size was validated.
+                        let cpu_hob = unsafe { hob_header.cast::<Cpu>().as_ref().expect(NOT_NULL) };
+                        self.0.push(Hob::Cpu(cpu_hob));
+                    }
                 }
                 UEFI_CAPSULE => {
-                    assert_hob_size::<Capsule>(current_header);
-                    // SAFETY: HOB type is UEFI_CAPSULE and size was validated.
-                    let capsule_hob = unsafe { hob_header.cast::<Capsule>().as_ref().expect(NOT_NULL) };
-                    self.0.push(Hob::Capsule(capsule_hob));
+                    if hob_size_ok::<Capsule>(current_header) {
+                        // SAFETY: HOB type is UEFI_CAPSULE and size was validated.
+                        let capsule_hob = unsafe { hob_header.cast::<Capsule>().as_ref().expect(NOT_NULL) };
+                        self.0.push(Hob::Capsule(capsule_hob));
+                    }
                 }
                 RESOURCE_DESCRIPTOR2 => {
-                    assert_hob_size::<ResourceDescriptorV2>(current_header);
-                    // SAFETY: HOB type is RESOURCE_DESCRIPTOR2 and size was validated.
-                    let resource_desc_hob =
-                        unsafe { hob_header.cast::<ResourceDescriptorV2>().as_ref().expect(NOT_NULL) };
-                    self.0.push(Hob::ResourceDescriptorV2(resource_desc_hob));
+                    if hob_size_ok::<ResourceDescriptorV2>(current_header) {
+                        // SAFETY: HOB type is RESOURCE_DESCRIPTOR2 and size was validated.
+                        let resource_desc_hob =
+                            unsafe { hob_header.cast::<ResourceDescriptorV2>().as_ref().expect(NOT_NULL) };
+                        self.0.push(Hob::ResourceDescriptorV2(resource_desc_hob));
+                    }
                 }
                 END_OF_HOB_LIST => {
                     break;


### PR DESCRIPTION
## Description

**Prevent underflow when calculating GUID HOB data length**

Resolves #1627

A valid GUID HOB must have a HOB length that coverages at least
the GUID HOB header. A debug assert is added to catch cases where
that is not true during develop (debug builds).

To prevent underflow when the HOB length is reported as
less than the GUID HOB header size, saturating subtraction
is used (preventing an oversized slice).

---

**sdk: Handle malformed HOBs more robustly**

Softens `assert_hob_size()` in `discover_hobs()` to avoid panics in
release builds (ignoring a malformed HOB entry). Malformed entries
are logged and skipped instead. Debug builds still panic.

---

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [x] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

- `cargo make all` (with new unit tests)
- QEMU ArmVirt & Q35 boot to EFI shell

## Integration Instructions

- N/A