### PR TITLE
Prevent panic in CRC32 section extractor on oversized GUID data

### DIFF
--- a/sdk/patina_ffs_extractors/src/crc32.rs
+++ b/sdk/patina_ffs_extractors/src/crc32.rs
@@ -29,10 +29,8 @@ impl SectionExtractor for Crc32SectionExtractor {
         if let SectionHeader::GuidDefined(guid_header, crc_header, _) = section.header()
             && guid_header.section_definition_guid == fw_fs::guid::CRC32_SECTION
         {
-            if crc_header.len() < 4 {
-                Err(FirmwareFileSystemError::DataCorrupt)?;
-            }
-            let crc32 = u32::from_le_bytes((**crc_header).try_into().unwrap());
+            let crc32_bytes = crc_header.get(..4).ok_or(FirmwareFileSystemError::DataCorrupt)?;
+            let crc32 = u32::from_le_bytes(crc32_bytes.try_into().unwrap());
             let content = section.try_content_as_slice()?;
             if crc32 != crc32fast::hash(content) {
                 //TODO: in EDK2 C reference implementation, data is returned along with EFI_AUTH_STATUS_TEST_FAILED.
@@ -88,6 +86,34 @@ mod tests {
         let result = extractor.extract(&section).expect("Empty content with valid CRC should succeed");
 
         assert_eq!(result, content);
+    }
+
+    #[test]
+    fn test_crc32_extractor_oversized_guid_data() {
+        // A malformed section whose GUID-specific data is larger than the 4-byte CRC32 value
+        // should only have the first 4 bytes interpreted as the checksum.
+        let content = b"Hello, CRC32!";
+        let crc32 = crc32fast::hash(content);
+        let mut guid_data = crc32.to_le_bytes().to_vec();
+        guid_data.extend_from_slice(&[0xAA, 0xBB, 0xCC, 0xDD]); // give trailing bytes beyond the CRC32
+        let section = create_crc32_section(content, guid_data);
+
+        let extractor = Crc32SectionExtractor;
+        let result = extractor.extract(&section).expect("Oversized GUID data with a valid CRC should succeed");
+
+        assert_eq!(result, content);
+    }
+
+    #[test]
+    fn test_crc32_extractor_truncated_guid_data() {
+        // GUID-specific data shorter than 4 bytes should just return a DataCorrupt error.
+        let content = b"Hello, CRC32!";
+        let section = create_crc32_section(content, [0x00, 0x01].to_vec()); // only 2 bytes
+
+        let extractor = Crc32SectionExtractor;
+        let result = extractor.extract(&section);
+
+        assert!(matches!(result, Err(FirmwareFileSystemError::DataCorrupt)));
     }
 
     #[test]


### PR DESCRIPTION
## Description

Fixes #1622

The CRC32 extractor validated a minimum GUID-specific data length of 4 bytes but then converted the entire slice with `try_into::<[u8; 4]>()`, which requires exactly 4 bytes. A GUID-defined section whose `data_offset` placed more than 4 bytes into the GUID data area caused the conversion to fail and the following `unwrap()` to panic.

This change slices the first 4 bytes with `get(..4)` before the conversion so the checksum read is infallible. This handles both the too-short case (clean `DataCorrupt` error) and the too-long case (only the leading CRC32 bytes are read, per the PI spec).

Adds tests covering oversized and truncated GUID-specific data.

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [x] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

- `cargo make all` (with new unit tests)
- QEMU ArmVirt & Q35 boot to EFI shell

## Integration Instructions

- N/A