### PR TITLE
sdk: Prevent unbounded recursion in FFS section extraction

### DIFF
--- a/sdk/patina_ffs/src/err.rs
+++ b/sdk/patina_ffs/src/err.rs
@@ -32,6 +32,8 @@ pub enum FirmwareFileSystemError {
     NotLeaf,
     /// Composing the FFS structure failed.
     ComposeFailed,
+    /// The maximum supported nesting depth of encapsulation sections was exceeded.
+    RecursionLimitExceeded,
 }
 
 impl From<FirmwareFileSystemError> for EfiError {
@@ -45,7 +47,8 @@ impl From<FirmwareFileSystemError> for EfiError {
             FirmwareFileSystemError::InvalidHeader
             | FirmwareFileSystemError::InvalidBlockMap
             | FirmwareFileSystemError::InvalidState
-            | FirmwareFileSystemError::DataCorrupt => EfiError::VolumeCorrupted,
+            | FirmwareFileSystemError::DataCorrupt
+            | FirmwareFileSystemError::RecursionLimitExceeded => EfiError::VolumeCorrupted,
             FirmwareFileSystemError::ComposeFailed => EfiError::DeviceError,
         }
     }

--- a/sdk/patina_ffs/src/section.rs
+++ b/sdk/patina_ffs/src/section.rs
@@ -22,6 +22,13 @@ use crate::FirmwareFileSystemError;
 
 const MAX_STANDARD_SECTION_SIZE: usize = 0x1000000;
 
+/// Maximum depth of nested encapsulation sections that [`Section::extract`] will traverse.
+///
+/// Firmware volumes are generally trusted, but this bound provides defense-in-depth against
+/// malformed inputs that would otherwise cause unbounded recursion. The limit is intentionally
+/// generous.
+const MAX_ENCAPSULATION_DEPTH: usize = 16;
+
 /// Extracts the payload of an encapsulation section into raw bytes.
 ///
 /// An implementation should return:
@@ -521,9 +528,27 @@ impl Section {
     ///
     /// If the extractor returns `Unsupported`, the method is a no-op. Otherwise, the returned
     /// bytes are parsed into immediate sub-sections and marked as extracted.
+    ///
+    /// Nested encapsulation sections are traversed recursively up to `MAX_ENCAPSULATION_DEPTH`
+    /// levels deep. Inputs that exceed this bound result in `RecursionLimitExceeded` as a
+    /// guard against unbounded recursion.
     pub fn extract(&mut self, extractor: &dyn SectionExtractor) -> Result<(), FirmwareFileSystemError> {
+        self.extract_with_depth(extractor, 0)
+    }
+
+    /// Recursive worker for [`Section::extract`] that tracks the current encapsulation nesting
+    /// `depth` and rejects inputs that would exceed [`MAX_ENCAPSULATION_DEPTH`].
+    fn extract_with_depth(
+        &mut self,
+        extractor: &dyn SectionExtractor,
+        depth: usize,
+    ) -> Result<(), FirmwareFileSystemError> {
         if !matches!(&self.data, SectionData::Encapsulation(x) if !x.extracted) {
             return Ok(()); //nothing to do for non-encapsulation sections or already extracted encapsulation sections.
+        }
+
+        if depth >= MAX_ENCAPSULATION_DEPTH {
+            return Err(FirmwareFileSystemError::RecursionLimitExceeded);
         }
 
         let extracted_data = match extractor.extract(self) {
@@ -535,7 +560,7 @@ impl Section {
             SectionIterator::new(&extracted_data).collect::<Result<Vec<_>, FirmwareFileSystemError>>()?;
 
         for section in sections.iter_mut() {
-            section.extract(extractor)?;
+            section.extract_with_depth(extractor, depth + 1)?;
         }
 
         match &mut self.data {

--- a/sdk/patina_ffs/src/volume.rs
+++ b/sdk/patina_ffs/src/volume.rs
@@ -1165,6 +1165,30 @@ mod test {
     }
 
     #[test]
+    fn section_extract_should_limit_recursion_depth() {
+        set_logger();
+
+        // An empty compression (encapsulation) section.
+        const COMPRESSION_SECTION: [u8; 0x11] =
+            [0x11, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00];
+
+        // Extractor that always gives a fresh, unextracted encapsulation section, that will
+        // keep driving `Section::extract` into unbounded recursion.
+        struct InfiniteExtractor {}
+        impl SectionExtractor for InfiniteExtractor {
+            fn extract(&self, _section: &Section) -> Result<Vec<u8>, FirmwareFileSystemError> {
+                Ok(COMPRESSION_SECTION.to_vec())
+            }
+        }
+
+        let mut section = Section::new_from_buffer(&COMPRESSION_SECTION).unwrap();
+        assert_eq!(
+            section.extract(&InfiniteExtractor {}).unwrap_err(),
+            FirmwareFileSystemError::RecursionLimitExceeded
+        );
+    }
+
+    #[test]
     fn section_should_have_correct_metadata() -> Result<(), Box<dyn Error>> {
         set_logger();
         let empty_pe32: [u8; 4] = [0x04, 0x00, 0x00, 0x10];


### PR DESCRIPTION
## Description

Resolves #1623

Firmware volumes (and FFS sections) are generally trusted coming from signed and verified sources. However, a malformed (or malicious) firmware volume could contain a deeply nested structure of encapsulation sections that would cause unbounded recursion in `Section::extract()`.

This change limits maximum recursion depth to 16 levels. In practice, only a handful of encapsulation sections are nested in most real-world scenarios.

A new `FirmwareFileSystemError::RecursionLimitExceeded` error is added and returned when the limit is exceeded to distinguish this case.

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [x] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

- `cargo make all` (with new unit tests)
- QEMU ArmVirt & Q35 boot to EFI shell

## Integration Instructions

- N/A