### PR TITLE
docs: Embed UEFI Forum BrightTALK video

### DIFF
--- a/docs/src/introduction.md
+++ b/docs/src/introduction.md
@@ -136,3 +136,15 @@ Patina in a hands-on way, where developers share their screen while walking thro
     allowfullscreen>
   </iframe>
 </div>
+
+## UEFI Forum June 2026 - The State of Rust in UEFI and Q&A
+
+<div style="text-align: center; margin: 20px 0;">
+  <iframe width="853" height="480"
+    src="https://www.youtube.com/embed/KpWeqlWUj2s"
+    title="YouTube: The State of Rust in UEFI and Q&A"
+    frameborder="0"
+    allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+    allowfullscreen>
+  </iframe>
+</div>


### PR DESCRIPTION
## Description

Embeds the YouTube video from the June 2026 UEFI Forum BrightTALK - "The State of Rust in UEFI and Q&A" into the introduction.md page so it is more easily discoverable for those viewing introductory documentation.

Additional talk info:

- BrightTALK: https://www.brighttalk.com/webcast/18206/669463
- YouTube: https://www.youtube.com/watch?v=KpWeqlWUj2s

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [x] Includes documentation?

## How This Was Tested

- `cargo make serve-mdbook`
- `cargo make all`

## Integration Instructions

- N/A