### PR TITLE
patina_dxe_core: Consistently apply test guards [Rebase & FF]

### DIFF
--- a/patina_dxe_core/src/allocator.rs
+++ b/patina_dxe_core/src/allocator.rs
@@ -1657,6 +1657,12 @@ mod tests {
     /// Cleans up global state after `f` returns.
     fn with_locked_state<F: Fn(*const c_void) + std::panic::RefUnwindSafe>(gcd_init: GcdInit, f: F) {
         test_support::with_global_lock(|| {
+            // Reset shared global state on exit (even if setup or `f` panics) so nothing leaks to
+            // the next test, and up front so this test starts clean regardless of what a prior test
+            // left behind.
+            let _guard = test_support::StateGuard::new(test_support::reset_global_state);
+            test_support::reset_global_state();
+
             let physical_hob_list = match gcd_init {
                 GcdInit::WithSize(gcd_size) => {
                     // SAFETY: multiple functions modify global state. Functions are
@@ -1684,17 +1690,6 @@ mod tests {
                     physical_hob_list
                 }
             };
-
-            let _guard = test_support::StateGuard::new(|| {
-                // SAFETY: Cleanup code runs with global lock held, resetting
-                // global state that was initialized above.
-                unsafe {
-                    GCD.reset();
-                    PROTOCOL_DB.reset();
-                    reset_allocators();
-                    ALLOCATORS.lock().reset();
-                }
-            });
 
             f(physical_hob_list);
         })

--- a/patina_dxe_core/src/allocator.rs
+++ b/patina_dxe_core/src/allocator.rs
@@ -1656,13 +1656,7 @@ mod tests {
     ///
     /// Cleans up global state after `f` returns.
     fn with_locked_state<F: Fn(*const c_void) + std::panic::RefUnwindSafe>(gcd_init: GcdInit, f: F) {
-        test_support::with_global_lock(|| {
-            // Reset shared global state on exit (even if setup or `f` panics) so nothing leaks to
-            // the next test, and up front so this test starts clean regardless of what a prior test
-            // left behind.
-            let _guard = test_support::StateGuard::new(test_support::reset_global_state);
-            test_support::reset_global_state();
-
+        test_support::with_clean_global_lock(|| {
             let physical_hob_list = match gcd_init {
                 GcdInit::WithSize(gcd_size) => {
                     // SAFETY: multiple functions modify global state. Functions are

--- a/patina_dxe_core/src/allocator/usage_tests/uefi_memory_map.rs
+++ b/patina_dxe_core/src/allocator/usage_tests/uefi_memory_map.rs
@@ -310,10 +310,7 @@ mod tests {
 
         /// Execute the test scenario and validate results
         pub fn run_test(&self) {
-            test_support::with_global_lock(|| {
-                // Reset global state on exit (even if setup panics) so nothing leaks to the next test.
-                let _guard = test_support::StateGuard::new(test_support::reset_global_state);
-
+            test_support::with_clean_global_lock(|| {
                 test_support::init_test_logger();
                 let hob_list_ptr = self.build_custom_hob_list();
 

--- a/patina_dxe_core/src/allocator/usage_tests/uefi_memory_map.rs
+++ b/patina_dxe_core/src/allocator/usage_tests/uefi_memory_map.rs
@@ -311,6 +311,9 @@ mod tests {
         /// Execute the test scenario and validate results
         pub fn run_test(&self) {
             test_support::with_global_lock(|| {
+                // Reset global state on exit (even if setup panics) so nothing leaks to the next test.
+                let _guard = test_support::StateGuard::new(test_support::reset_global_state);
+
                 test_support::init_test_logger();
                 let hob_list_ptr = self.build_custom_hob_list();
 

--- a/patina_dxe_core/src/config_tables/memory_attributes_table.rs
+++ b/patina_dxe_core/src/config_tables/memory_attributes_table.rs
@@ -263,15 +263,10 @@ mod tests {
     use patina::{base::UEFI_PAGE_SIZE, uefi_size_to_pages};
 
     fn with_locked_state<F: Fn() + std::panic::RefUnwindSafe>(f: F) {
-        test_support::with_global_lock(|| {
-            // Reset global state and POST_RTB on exit (even if setup or `f` panics) so nothing
-            // leaks to the next test.
-            let _guard = test_support::StateGuard::new(|| {
-                test_support::reset_global_state();
-                POST_RTB.reset();
-            });
-
+        test_support::with_clean_global_lock(|| {
+            let _post_rtb_guard = test_support::StateGuard::new(|| POST_RTB.reset());
             POST_RTB.reset();
+
             // SAFETY: Test-only initialization under the global lock.
             unsafe {
                 test_support::init_test_gcd(None);

--- a/patina_dxe_core/src/config_tables/memory_attributes_table.rs
+++ b/patina_dxe_core/src/config_tables/memory_attributes_table.rs
@@ -264,8 +264,14 @@ mod tests {
 
     fn with_locked_state<F: Fn() + std::panic::RefUnwindSafe>(f: F) {
         test_support::with_global_lock(|| {
-            POST_RTB.reset();
+            // Reset global state and POST_RTB on exit (even if setup or `f` panics) so nothing
+            // leaks to the next test.
+            let _guard = test_support::StateGuard::new(|| {
+                test_support::reset_global_state();
+                POST_RTB.reset();
+            });
 
+            POST_RTB.reset();
             // SAFETY: Test-only initialization under the global lock.
             unsafe {
                 test_support::init_test_gcd(None);
@@ -273,8 +279,6 @@ mod tests {
                 init_system_table();
             }
             f();
-
-            POST_RTB.reset();
         })
         .unwrap();
     }

--- a/patina_dxe_core/src/events.rs
+++ b/patina_dxe_core/src/events.rs
@@ -408,6 +408,9 @@ mod tests {
 
     fn with_locked_state<F: Fn() + std::panic::RefUnwindSafe>(f: F) {
         test_support::with_global_lock(|| {
+            // Reset global state on exit (even if setup or `f` panics) so nothing leaks to the next test.
+            let _guard = test_support::StateGuard::new(test_support::reset_global_state);
+
             test_support::init_test_logger();
             // SAFETY: Test-only initialization of global services under the global lock.
             unsafe {
@@ -415,16 +418,6 @@ mod tests {
                 crate::test_support::reset_allocators();
                 crate::test_support::init_test_protocol_db();
             }
-
-            let _guard = test_support::StateGuard::new(|| {
-                // SAFETY: Cleanup code runs with global lock held, resetting
-                // global state that was initialized above.
-                unsafe {
-                    crate::GCD.reset();
-                    crate::PROTOCOL_DB.reset();
-                    crate::allocator::reset_allocators();
-                }
-            });
 
             f();
         })

--- a/patina_dxe_core/src/events.rs
+++ b/patina_dxe_core/src/events.rs
@@ -407,10 +407,7 @@ mod tests {
     use std::{ptr, sync::atomic::Ordering};
 
     fn with_locked_state<F: Fn() + std::panic::RefUnwindSafe>(f: F) {
-        test_support::with_global_lock(|| {
-            // Reset global state on exit (even if setup or `f` panics) so nothing leaks to the next test.
-            let _guard = test_support::StateGuard::new(test_support::reset_global_state);
-
+        test_support::with_clean_global_lock(|| {
             test_support::init_test_logger();
             // SAFETY: Test-only initialization of global services under the global lock.
             unsafe {

--- a/patina_dxe_core/src/gcd.rs
+++ b/patina_dxe_core/src/gcd.rs
@@ -754,10 +754,7 @@ mod tests {
     const MEM_SIZE: u64 = 0x200000;
 
     fn with_locked_state<F: Fn() + std::panic::RefUnwindSafe>(f: F) {
-        test_support::with_global_lock(|| {
-            // Reset global state on exit (even if `f` panics) so nothing leaks to the next test.
-            let _guard = test_support::StateGuard::new(test_support::reset_global_state);
-
+        test_support::with_clean_global_lock(|| {
             test_support::init_test_logger();
             // SAFETY: Test code - resetting the global GCD state for test isolation.
             // The test lock is used to prevent concurrent access.

--- a/patina_dxe_core/src/gcd.rs
+++ b/patina_dxe_core/src/gcd.rs
@@ -755,6 +755,9 @@ mod tests {
 
     fn with_locked_state<F: Fn() + std::panic::RefUnwindSafe>(f: F) {
         test_support::with_global_lock(|| {
+            // Reset global state on exit (even if `f` panics) so nothing leaks to the next test.
+            let _guard = test_support::StateGuard::new(test_support::reset_global_state);
+
             test_support::init_test_logger();
             // SAFETY: Test code - resetting the global GCD state for test isolation.
             // The test lock is used to prevent concurrent access.

--- a/patina_dxe_core/src/memory_attributes_protocol.rs
+++ b/patina_dxe_core/src/memory_attributes_protocol.rs
@@ -324,6 +324,9 @@ mod tests {
 
     fn with_locked_state<F: Fn() + std::panic::RefUnwindSafe>(f: F) {
         test_support::with_global_lock(|| {
+            // Reset global state on exit (even if `f` panics) so nothing leaks to the next test.
+            let _guard = test_support::StateGuard::new(test_support::reset_global_state);
+
             test_support::init_test_logger();
             // SAFETY: Test code - resetting the global GCD state for test isolation.
             // The test lock is used to prevent concurrent access.

--- a/patina_dxe_core/src/memory_attributes_protocol.rs
+++ b/patina_dxe_core/src/memory_attributes_protocol.rs
@@ -323,10 +323,7 @@ mod tests {
     use std::{cell::RefCell, ptr, rc::Rc};
 
     fn with_locked_state<F: Fn() + std::panic::RefUnwindSafe>(f: F) {
-        test_support::with_global_lock(|| {
-            // Reset global state on exit (even if `f` panics) so nothing leaks to the next test.
-            let _guard = test_support::StateGuard::new(test_support::reset_global_state);
-
+        test_support::with_clean_global_lock(|| {
             test_support::init_test_logger();
             // SAFETY: Test code - resetting the global GCD state for test isolation.
             // The test lock is used to prevent concurrent access.

--- a/patina_dxe_core/src/misc_boot_services.rs
+++ b/patina_dxe_core/src/misc_boot_services.rs
@@ -325,10 +325,7 @@ mod tests {
     where
         F: Fn(&mut EfiSystemTable) + std::panic::RefUnwindSafe,
     {
-        test_support::with_global_lock(|| {
-            // Reset global state on exit (even if setup or `f` panics) so nothing leaks to the next test.
-            let _guard = test_support::StateGuard::new(test_support::reset_global_state);
-
+        test_support::with_clean_global_lock(|| {
             test_support::init_test_logger();
             // SAFETY: Test code only - initializing test infrastructure with the test lock held
             // to prevent concurrent access during initialization.

--- a/patina_dxe_core/src/misc_boot_services.rs
+++ b/patina_dxe_core/src/misc_boot_services.rs
@@ -326,6 +326,9 @@ mod tests {
         F: Fn(&mut EfiSystemTable) + std::panic::RefUnwindSafe,
     {
         test_support::with_global_lock(|| {
+            // Reset global state on exit (even if setup or `f` panics) so nothing leaks to the next test.
+            let _guard = test_support::StateGuard::new(test_support::reset_global_state);
+
             test_support::init_test_logger();
             // SAFETY: Test code only - initializing test infrastructure with the test lock held
             // to prevent concurrent access during initialization.
@@ -334,15 +337,6 @@ mod tests {
                 crate::test_support::init_test_protocol_db();
             }
             crate::systemtables::init_system_table();
-
-            let _guard = test_support::StateGuard::new(|| {
-                // SAFETY: Cleanup code runs with global lock held, resetting
-                // global state that was initialized above.
-                unsafe {
-                    crate::GCD.reset();
-                    crate::PROTOCOL_DB.reset();
-                }
-            });
 
             let mut st_guard = systemtables::SYSTEM_TABLE.lock();
             let st = st_guard.as_mut().expect("System Table not initialized!");

--- a/patina_dxe_core/src/pecoff.rs
+++ b/patina_dxe_core/src/pecoff.rs
@@ -842,6 +842,9 @@ mod tests {
     #[test]
     fn flatten_runtime_relocation_data_serializes_supported_types() {
         test_support::with_global_lock(|| {
+            // Reset global state on exit (even if `f` panics) so nothing leaks to the next test.
+            let _guard = test_support::StateGuard::new(test_support::reset_global_state);
+
             test_support::init_test_logger();
             // SAFETY: Initialization for testing under the global lock so the runtime services data
             // allocator can service allocations.

--- a/patina_dxe_core/src/pecoff.rs
+++ b/patina_dxe_core/src/pecoff.rs
@@ -841,10 +841,7 @@ mod tests {
 
     #[test]
     fn flatten_runtime_relocation_data_serializes_supported_types() {
-        test_support::with_global_lock(|| {
-            // Reset global state on exit (even if `f` panics) so nothing leaks to the next test.
-            let _guard = test_support::StateGuard::new(test_support::reset_global_state);
-
+        test_support::with_clean_global_lock(|| {
             test_support::init_test_logger();
             // SAFETY: Initialization for testing under the global lock so the runtime services data
             // allocator can service allocations.

--- a/patina_dxe_core/src/pi_dispatcher.rs
+++ b/patina_dxe_core/src/pi_dispatcher.rs
@@ -926,6 +926,9 @@ mod tests {
         F: Fn() + std::panic::RefUnwindSafe,
     {
         test_support::with_global_lock(|| {
+            // Reset global state on exit (even if setup panics) so nothing leaks to the next test.
+            let _guard = test_support::StateGuard::new(test_support::reset_global_state);
+
             // SAFETY: Test-only initialization of the protocol database occurs under the global lock.
             unsafe { test_support::init_test_protocol_db() };
             f();

--- a/patina_dxe_core/src/pi_dispatcher.rs
+++ b/patina_dxe_core/src/pi_dispatcher.rs
@@ -925,10 +925,7 @@ mod tests {
     where
         F: Fn() + std::panic::RefUnwindSafe,
     {
-        test_support::with_global_lock(|| {
-            // Reset global state on exit (even if setup panics) so nothing leaks to the next test.
-            let _guard = test_support::StateGuard::new(test_support::reset_global_state);
-
+        test_support::with_clean_global_lock(|| {
             // SAFETY: Test-only initialization of the protocol database occurs under the global lock.
             unsafe { test_support::init_test_protocol_db() };
             f();

--- a/patina_dxe_core/src/pi_dispatcher/image.rs
+++ b/patina_dxe_core/src/pi_dispatcher/image.rs
@@ -1653,16 +1653,12 @@ mod tests {
     fn with_locked_state<F: Fn() + std::panic::RefUnwindSafe>(f: F) {
         // SAFETY: Test code only - initializing test infrastructure within the global test lock.
         test_support::with_global_lock(|| unsafe {
+            // Reset global state on exit (even if setup or `f` panics) so nothing leaks to the next test.
+            let _guard = test_support::StateGuard::new(test_support::reset_global_state);
+
             test_support::init_test_gcd(None);
             test_support::init_test_protocol_db();
             init_system_table();
-
-            let _guard = test_support::StateGuard::new(|| {
-                // SAFETY: Cleanup code runs with global lock held, resetting
-                // global state that was initialized above.
-                crate::GCD.reset();
-                crate::PROTOCOL_DB.reset();
-            });
 
             f();
         })

--- a/patina_dxe_core/src/pi_dispatcher/image.rs
+++ b/patina_dxe_core/src/pi_dispatcher/image.rs
@@ -1652,10 +1652,7 @@ mod tests {
 
     fn with_locked_state<F: Fn() + std::panic::RefUnwindSafe>(f: F) {
         // SAFETY: Test code only - initializing test infrastructure within the global test lock.
-        test_support::with_global_lock(|| unsafe {
-            // Reset global state on exit (even if setup or `f` panics) so nothing leaks to the next test.
-            let _guard = test_support::StateGuard::new(test_support::reset_global_state);
-
+        test_support::with_clean_global_lock(|| unsafe {
             test_support::init_test_gcd(None);
             test_support::init_test_protocol_db();
             init_system_table();

--- a/patina_dxe_core/src/runtime.rs
+++ b/patina_dxe_core/src/runtime.rs
@@ -219,10 +219,7 @@ mod tests {
     }
 
     fn with_locked_state<F: Fn() + std::panic::RefUnwindSafe>(f: F) {
-        test_support::with_global_lock(|| {
-            // Reset global state on exit (even if setup or `f` panics) so nothing leaks to the next test.
-            let _guard = test_support::StateGuard::new(test_support::reset_global_state);
-
+        test_support::with_clean_global_lock(|| {
             test_support::init_test_logger();
             // SAFETY: Test code only - initializing test infrastructure with the test lock held
             // prevents concurrent access during initialization.

--- a/patina_dxe_core/src/runtime.rs
+++ b/patina_dxe_core/src/runtime.rs
@@ -220,6 +220,9 @@ mod tests {
 
     fn with_locked_state<F: Fn() + std::panic::RefUnwindSafe>(f: F) {
         test_support::with_global_lock(|| {
+            // Reset global state on exit (even if setup or `f` panics) so nothing leaks to the next test.
+            let _guard = test_support::StateGuard::new(test_support::reset_global_state);
+
             test_support::init_test_logger();
             // SAFETY: Test code only - initializing test infrastructure with the test lock held
             // prevents concurrent access during initialization.

--- a/patina_dxe_core/src/test_support.rs
+++ b/patina_dxe_core/src/test_support.rs
@@ -268,6 +268,27 @@ pub(crate) fn with_global_lock<F: Fn() + std::panic::RefUnwindSafe>(f: F) -> Res
     })
 }
 
+/// Like [`with_global_lock`], but additionally resets the shared global state via
+/// [`reset_global_state`] both before running `f` (so the test starts from a clean slate
+/// regardless of what a prior test left behind) and after `f` returns or panics (so nothing
+/// leaks to the next test).
+///
+/// This is the preferred entry point for tests that mutate the global GCD, protocol database, or
+/// allocators as it makes correct cleanup automatic.
+///
+/// Tests that also mutate *other* global state (for example the system table pointer or a
+/// per-module static) should register an additional [`StateGuard`] inside the closure to reset
+/// that state or use [`with_global_lock`] directly, since [`reset_global_state`] intentionally
+/// does not touch subsystem-specific state.
+pub(crate) fn with_clean_global_lock<F: Fn() + std::panic::RefUnwindSafe>(f: F) -> Result<(), Box<dyn Any + Send>> {
+    with_global_lock(|| {
+        // Reset on exit (even if `f` panics), and up front, so the test both starts and ends clean.
+        let _guard = StateGuard::new(reset_global_state);
+        reset_global_state();
+        f();
+    })
+}
+
 /// Allocates a chunk of memory of the specified size from the system allocator.
 ///
 /// The memory allocated will be 64Kb aligned to simplify alignment requirements such

--- a/patina_dxe_core/src/test_support.rs
+++ b/patina_dxe_core/src/test_support.rs
@@ -333,6 +333,29 @@ pub(crate) unsafe fn reset_allocators() {
     unsafe { crate::allocator::reset_allocators() }
 }
 
+/// Resets the shared global state that tests mutate: the [`GCD`], the protocol database
+/// (`PROTOCOL_DB`), and the allocators to a clean, uninitialized state.
+///
+/// Every reset performed here is idempotent and independent of whether the corresponding subsystem
+/// was initialized, and no test relies on inheriting any of this state (each consumer re-initializes
+/// what it needs on entry). It is recommended to register it in a [`StateGuard`] before test setup
+/// so that cleanup runs even if setup panics.
+///
+/// This intentionally does not reset subsystem-specific state (for example the system table or
+/// per-module statics) so it is more broadly applicable.
+///
+/// ## Locking
+/// Must be called with the global test lock held (see [`with_global_lock`]). It does not acquire
+/// the lock itself.
+pub(crate) fn reset_global_state() {
+    // SAFETY: Callers hold the global test lock, so no other test can access the state concurrently.
+    unsafe {
+        GCD.reset();
+        PROTOCOL_DB.reset();
+        reset_allocators();
+    }
+}
+
 /// Reset and re-initialize the protocol database to default empty state.
 ///
 /// ## Safety


### PR DESCRIPTION
## Description

Resolves #1637

Currently, tests use `test_support::with_global_lock()` to often wrap the test and its setup/teardown logic inside the global test lock. This ensures everything happens exclusively while holding the lock.

Over time, test cleanup because more intricate and an issue so a "test guard" (`test_support::StateGuard`) was added that accepts a generic cleanup closure where the guard ensures that the cleanup code is run even if the test panics (as it is at the same scope as the test invocation).

This all works well enough but:

1. Some module tests are missing a guard.
2. Common globals (GCD, protocol database, and allocator state) should really always be reset before each test.
3. Guard creation often occurrred after test initialization logic which meant it was not in place to clean if the initialization logic itself panicked.

This change adds a generic `test_support::reset_global_state()` function that can conveniently be used in guards, adds a guard to missing patina_dxe_core test modules, and moves guard creation to the top of test wrappers.

---

Specifically, in this most recent case of flakiness, it appears that tests in runtime.rs were leaving dirty state in the globals getting picked up by init code in allocator.rs that was occasionally failing because of it. Those runtime.rs tests now exit in clean state due to the guard added.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [x] Includes tests?
- [x] Includes documentation?

## How This Was Tested

- `cargo make all`
- `cargo make test` about 10 times

## Integration Instructions

- N/A