### PR TITLE
Fix incorrect RFC number for shared core library

### DIFF
--- a/docs/src/rfc/text/0031-shared-core-library.md
+++ b/docs/src/rfc/text/0031-shared-core-library.md
@@ -13,6 +13,7 @@ This RFC builds on the crate organization and naming conventions established by
 - 2026-06-26: Initial RFC created.
 - 2026-06-29: Renames proposed crate to `patina_internal_core`, and opted to leave CPU
               crate independent for now.
+- 2026-07-13: Fixed incorrect RFC number
 
 ## Motivation
 


### PR DESCRIPTION
## Description

This commit fixes an incorrect RFC number for the shared core library RFC, changing it from 0000 to 0031.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [x] Includes documentation?

## How This Was Tested

N/A

## Integration Instructions

N/A
