### PR TITLE
[major] patina_debugger: remove deprecated `without_transport_init` function

### DIFF
--- a/core/patina_debugger/src/debugger.rs
+++ b/core/patina_debugger/src/debugger.rs
@@ -157,21 +157,6 @@ impl<T: SerialIO> PatinaDebugger<T> {
         self
     }
 
-    /// Deprecated API that previously prevented the debugger from initializing the transport. This is now the default
-    /// behavior and so this function now has no effect and should not be used. This will be removed in a future version.
-    ///
-    /// ## DEPRECATED
-    ///
-    /// The transport is no longer initialized by default. This function has no effect and is deprecated. It will be
-    /// removed in a future version. For implementations that require transport initialization, use `with_transport_init`.
-    ///
-    #[deprecated(
-        note = "This function has no effect and is deprecated. It will be removed in a future version. This call may be safely removed."
-    )]
-    pub const fn without_transport_init(self) -> Self {
-        self
-    }
-
     /// Enables the debugger to initialize the transport. This is typically only required if the transport is not shared
     /// with the logging device. Initializing the transport when it is shared may lead to unexpected behavior.
     pub const fn with_transport_init(mut self) -> Self {


### PR DESCRIPTION
## Description

This function removes the deprecated `without_transport_init` function for the next major release. This function is now a no-op and the inverse function `with_transport_init` is now the control for this behavior.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [x] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

N/A

## Integration Instructions

Callers should remove use of `without_transport_init` which is already deprecated
