### PR TITLE
Switch from coverage_nightly to coverage

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -80,7 +80,7 @@ undocumented_unsafe_blocks = "warn"
 [workspace.lints.rust]
 # Set by cargo-llvm-cov during coverage runs. Declared here so gating
 # `coverage_attribute` behind it does not trigger unexpected_cfgs warnings.
-unexpected_cfgs = { level = "warn", check-cfg = ['cfg(coverage_nightly)'] }
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(coverage)'] }
 
 # Profile used to build workspace dependencies for `mdbook test`. Inherits from `dev`
 # but disables LTO so that the resulting rlibs contain machine code and can be linked

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -241,7 +241,7 @@ install_crate = false
 clear = true
 # `coverage_attribute` is deliberately excluded from the default allow-features in
 # .cargo/config.toml so ungated `#[coverage(off)]` fails to compile. Coverage runs set the
-# `coverage_nightly` cfg (set by cargo-llvm-cov), which needs the feature, so re-add it here.
+# `coverage` cfg (set by cargo-llvm-cov), which needs the feature, so re-add it here.
 # Note: RUSTFLAGS replaces build.rustflags.
 env = { RUSTFLAGS = "-Z allow-features=c_variadic,allocator_api,coverage_attribute" }
 command = "cargo"

--- a/components/patina_acpi/src/acpi_protocol.rs
+++ b/components/patina_acpi/src/acpi_protocol.rs
@@ -258,7 +258,7 @@ impl AcpiGetProtocol {
 type AcpiNotifyFnExt = fn(*const AcpiTableHeader, u32, usize) -> efi::Status;
 
 #[cfg(test)]
-#[cfg_attr(coverage_nightly, coverage(off))]
+#[cfg_attr(coverage, coverage(off))]
 mod tests {
     use super::*;
 

--- a/components/patina_acpi/src/component.rs
+++ b/components/patina_acpi/src/component.rs
@@ -70,7 +70,7 @@ impl AcpiComponent {
 
     /// Initializes the ACPI system.
     /// Ignore coverage due to the use of `StandardBootServices`.
-    #[cfg_attr(coverage_nightly, coverage(off))]
+    #[cfg_attr(coverage, coverage(off))]
     fn entry_point(
         self,
         storage: &mut Storage,

--- a/components/patina_acpi/src/error.rs
+++ b/components/patina_acpi/src/error.rs
@@ -116,7 +116,7 @@ impl From<AcpiError> for efi::Status {
 }
 
 #[cfg(test)]
-#[cfg_attr(coverage_nightly, coverage(off))]
+#[cfg_attr(coverage, coverage(off))]
 mod tests {
     use super::*;
 

--- a/components/patina_acpi/src/integration_test.rs
+++ b/components/patina_acpi/src/integration_test.rs
@@ -37,7 +37,7 @@ struct MockLargeTable {
     data: [u8; 32],
 }
 
-#[cfg_attr(coverage_nightly, coverage(off))]
+#[cfg_attr(coverage, coverage(off))]
 #[patina_test]
 fn acpi_test(table_manager: Service<AcpiTableManager>) -> patina_test::error::Result {
     let original_length = table_manager.iter_tables().len();
@@ -95,7 +95,7 @@ fn acpi_test(table_manager: Service<AcpiTableManager>) -> patina_test::error::Re
     Ok(())
 }
 
-#[cfg_attr(coverage_nightly, coverage(off))]
+#[cfg_attr(coverage, coverage(off))]
 #[patina_test]
 fn acpi_protocol_test(bs: StandardBootServices) -> patina_test::error::Result {
     // SAFETY: there is only one reference to the `AcpiTableProtocol` during this test.

--- a/components/patina_acpi/src/lib.rs
+++ b/components/patina_acpi/src/lib.rs
@@ -38,7 +38,7 @@
 
 #![cfg_attr(all(not(feature = "std"), not(test), not(feature = "mockall")), no_std)]
 #![deny(missing_docs)]
-#![cfg_attr(coverage_nightly, feature(coverage_attribute))]
+#![cfg_attr(coverage, feature(coverage_attribute))]
 #![feature(allocator_api)]
 
 extern crate alloc;

--- a/components/patina_acpi/src/service.rs
+++ b/components/patina_acpi/src/service.rs
@@ -166,7 +166,7 @@ pub(crate) trait AcpiProvider {
 }
 
 #[cfg(test)]
-#[cfg_attr(coverage_nightly, coverage(off))]
+#[cfg_attr(coverage, coverage(off))]
 mod tests {
     use alloc::boxed::Box;
     use core::mem;

--- a/components/patina_adv_logger/src/component.rs
+++ b/components/patina_adv_logger/src/component.rs
@@ -110,7 +110,7 @@ where
 }
 
 #[cfg(test)]
-#[cfg_attr(coverage_nightly, coverage(off))]
+#[cfg_attr(coverage, coverage(off))]
 mod tests {
     use super::*;
     use crate::{

--- a/components/patina_adv_logger/src/integration_test.rs
+++ b/components/patina_adv_logger/src/integration_test.rs
@@ -17,7 +17,7 @@ use r_efi::efi;
 
 use crate::{memory_log, protocol::AdvancedLoggerProtocol, reader::AdvancedLogReader};
 
-#[cfg_attr(coverage_nightly, coverage(off))]
+#[cfg_attr(coverage, coverage(off))]
 #[patina_test]
 fn adv_logger_test(bs: StandardBootServices) -> patina_test::error::Result {
     const DIRECT_STR: &str = "adv_logger_test: Direct log message!!!";

--- a/components/patina_adv_logger/src/lib.rs
+++ b/components/patina_adv_logger/src/lib.rs
@@ -6,7 +6,7 @@
 )]
 #![cfg_attr(all(not(feature = "std"), not(test), not(doc)), no_std)]
 #![deny(missing_docs)]
-#![cfg_attr(coverage_nightly, feature(coverage_attribute))]
+#![cfg_attr(coverage, feature(coverage_attribute))]
 
 #[cfg(any(feature = "alloc", test, doc))]
 extern crate alloc;

--- a/components/patina_adv_logger/src/logger.rs
+++ b/components/patina_adv_logger/src/logger.rs
@@ -347,7 +347,7 @@ where
 }
 
 #[cfg(test)]
-#[cfg_attr(coverage_nightly, coverage(off))]
+#[cfg_attr(coverage, coverage(off))]
 mod tests {
     use core::{ffi::c_void, ptr};
 

--- a/components/patina_adv_logger/src/reader.rs
+++ b/components/patina_adv_logger/src/reader.rs
@@ -152,7 +152,7 @@ impl<'a> Iterator for AdvLogIterator<'a> {
 }
 
 #[cfg(test)]
-#[cfg_attr(coverage_nightly, coverage(off))]
+#[cfg_attr(coverage, coverage(off))]
 mod tests {
     extern crate std;
     use core::{mem::size_of, sync::atomic::Ordering};

--- a/components/patina_adv_logger/src/writer.rs
+++ b/components/patina_adv_logger/src/writer.rs
@@ -190,7 +190,7 @@ impl AdvancedLogWriter {
 }
 
 #[cfg(all(test, feature = "reader"))]
-#[cfg_attr(coverage_nightly, coverage(off))]
+#[cfg_attr(coverage, coverage(off))]
 mod tests {
     extern crate std;
     use alloc::boxed::Box;

--- a/components/patina_mm/src/component/communicator.rs
+++ b/components/patina_mm/src/component/communicator.rs
@@ -70,14 +70,14 @@ pub struct RealMmExecutor {
 
 impl RealMmExecutor {
     /// Creates a new MM executor instance.
-    #[cfg_attr(coverage_nightly, coverage(off))]
+    #[cfg_attr(coverage, coverage(off))]
     pub fn new(sw_mmi_trigger_service: Service<dyn SwMmiTrigger>) -> Self {
         Self { sw_mmi_trigger_service }
     }
 }
 
 impl MmExecutor for RealMmExecutor {
-    #[cfg_attr(coverage_nightly, coverage(off))]
+    #[cfg_attr(coverage, coverage(off))]
     fn execute_mm(&self, _comm_buffer: &mut CommunicateBuffer) -> Result<(), Status> {
         log::debug!(target: "mm_comm", "Triggering SW MMI for MM communication");
         self.sw_mmi_trigger_service.trigger_sw_mmi(0xFF, 0).map_err(|err| {
@@ -174,7 +174,7 @@ impl<E: MmExecutor + 'static> MmCommunicator<E> {
     }
 
     /// Set communication buffers for testing purposes.
-    #[cfg_attr(coverage_nightly, coverage(off))]
+    #[cfg_attr(coverage, coverage(off))]
     pub fn set_test_comm_buffers(&self, buffers: Vec<CommunicateBuffer>) {
         *self.comm_buffers.borrow_mut() = buffers;
     }
@@ -193,7 +193,7 @@ impl MmCommunicator {
     ///
     /// This function is marked with `#[coverage(off)]` because it requires StandardBootServices
     /// which is not available in unit tests. It is tested through integration tests.
-    #[cfg_attr(coverage_nightly, coverage(off))]
+    #[cfg_attr(coverage, coverage(off))]
     fn entry_point(
         mut self,
         storage: &mut Storage,
@@ -370,7 +370,7 @@ impl Default for MmCommunicator {
 }
 
 #[cfg(test)]
-#[cfg_attr(coverage_nightly, coverage(off))]
+#[cfg_attr(coverage, coverage(off))]
 mod tests {
     use super::*;
     use crate::{

--- a/components/patina_mm/src/component/communicator/comm_buffer_update.rs
+++ b/components/patina_mm/src/component/communicator/comm_buffer_update.rs
@@ -163,7 +163,7 @@ pub(super) fn apply_pending_buffer_update(
 /// 3. Raw pointer manipulation of protocol data
 ///
 /// ELements of the protocol update process are unit tested but the notification function as a whole is not.
-#[cfg_attr(coverage_nightly, coverage(off))]
+#[cfg_attr(coverage, coverage(off))]
 extern "efiapi" fn protocol_notify_callback(_event: r_efi::efi::Event, context: &'static ProtocolNotifyContext) {
     log::trace!(target: "mm_comm", "=== Protocol callback ENTRY ===");
     log::info!(target: "mm_comm", "Protocol notify callback triggered for {}", mm_comm_buffer_update::GUID);

--- a/components/patina_mm/src/component/sw_mmi_manager.rs
+++ b/components/patina_mm/src/component/sw_mmi_manager.rs
@@ -101,7 +101,7 @@ impl SwMmiManager {
 unsafe impl SwMmiTrigger for SwMmiManager {
     // This is tested in integration tests, but it is difficult to unit test with little value returned due to
     // the nature of hardware I/O port operations.
-    #[cfg_attr(coverage_nightly, coverage(off))]
+    #[cfg_attr(coverage, coverage(off))]
     fn trigger_sw_mmi(&self, _cmd_port_value: u8, _data_port_value: u8) -> patina::error::Result<()> {
         log::debug!(target: "sw_mmi", "Triggering SW MMI with cmd_port_value=0x{:02X}, data_port_value=0x{:02X}", _cmd_port_value, _data_port_value);
 
@@ -163,14 +163,14 @@ unsafe impl SwMmiTrigger for SwMmiManager {
 }
 
 impl Default for SwMmiManager {
-    #[cfg_attr(coverage_nightly, coverage(off))]
+    #[cfg_attr(coverage, coverage(off))]
     fn default() -> Self {
         Self::new()
     }
 }
 
 #[cfg(test)]
-#[cfg_attr(coverage_nightly, coverage(off))]
+#[cfg_attr(coverage, coverage(off))]
 mod tests {
     use super::*;
     use crate::{

--- a/components/patina_mm/src/config.rs
+++ b/components/patina_mm/src/config.rs
@@ -610,7 +610,7 @@ impl CommunicateBuffer {
     }
 }
 
-#[cfg_attr(coverage_nightly, coverage(off))]
+#[cfg_attr(coverage, coverage(off))]
 impl fmt::Debug for CommunicateBuffer {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         writelncrlf!(f, "CommunicateBuffer(id: 0x{:X}. len: 0x{:X})", self.id(), self.len())?;
@@ -747,7 +747,7 @@ impl AcpiBase {
 }
 
 #[cfg(test)]
-#[cfg_attr(coverage_nightly, coverage(off))]
+#[cfg_attr(coverage, coverage(off))]
 mod tests {
     use super::*;
 

--- a/components/patina_mm/src/lib.rs
+++ b/components/patina_mm/src/lib.rs
@@ -5,7 +5,7 @@
 )]
 #![cfg_attr(all(not(feature = "std"), not(test), not(feature = "mockall")), no_std)]
 #![deny(missing_docs)]
-#![cfg_attr(coverage_nightly, feature(coverage_attribute))]
+#![cfg_attr(coverage, feature(coverage_attribute))]
 
 extern crate alloc;
 

--- a/components/patina_performance/src/component/performance.rs
+++ b/components/patina_performance/src/component/performance.rs
@@ -118,7 +118,7 @@ impl Performance {
     }
 
     /// Entry point of [`Performance`]
-    #[cfg_attr(coverage_nightly, coverage(off))] // This is tested via the generic version, see _entry_point.
+    #[cfg_attr(coverage, coverage(off))] // This is tested via the generic version, see _entry_point.
     fn entry_point(
         self,
         hob: Option<Hob<PerformanceConfig>>,

--- a/components/patina_performance/src/component/protocol.rs
+++ b/components/patina_performance/src/component/protocol.rs
@@ -25,7 +25,7 @@ use patina::{
 };
 use r_efi::efi;
 
-#[cfg_attr(coverage_nightly, coverage(off))]
+#[cfg_attr(coverage, coverage(off))]
 // EDK II Performance Measurement Protocol implementation.
 //
 /// Skip coverage as this function is tested via the generic version, (_create_performance_measurement).

--- a/components/patina_performance/src/lib.rs
+++ b/components/patina_performance/src/lib.rs
@@ -6,7 +6,7 @@
 )]
 #![cfg_attr(not(test), no_std)]
 #![deny(missing_docs)]
-#![cfg_attr(coverage_nightly, feature(coverage_attribute))]
+#![cfg_attr(coverage, feature(coverage_attribute))]
 
 extern crate alloc;
 

--- a/components/patina_samples/src/lib.rs
+++ b/components/patina_samples/src/lib.rs
@@ -17,7 +17,7 @@
 //!
 #![cfg_attr(not(feature = "std"), no_std)]
 #![deny(missing_docs)]
-#![cfg_attr(coverage_nightly, feature(coverage_attribute))]
-#![cfg_attr(coverage_nightly, coverage(off))] // Disable all coverage instrumentation for sample code
+#![cfg_attr(coverage, feature(coverage_attribute))]
+#![cfg_attr(coverage, coverage(off))] // Disable all coverage instrumentation for sample code
 pub mod component;
 pub mod smbios_platform;

--- a/components/patina_smbios/Cargo.toml
+++ b/components/patina_smbios/Cargo.toml
@@ -32,4 +32,4 @@ ci_features = []
 undocumented_unsafe_blocks = "warn"
 
 [lints.rust]
-unexpected_cfgs = { level = "warn", check-cfg = ['cfg(coverage_nightly)'] }
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(coverage)'] }

--- a/components/patina_smbios/src/component.rs
+++ b/components/patina_smbios/src/component.rs
@@ -94,7 +94,7 @@ impl SmbiosProvider {
     }
 
     /// Initialize the SMBIOS provider and register it as a service
-    #[cfg_attr(coverage_nightly, coverage(off))] // Component integration - tested via integration tests
+    #[cfg_attr(coverage, coverage(off))] // Component integration - tested via integration tests
     pub fn entry_point(self, storage: &mut Storage) -> Result<()> {
         let cfg = self.config;
 

--- a/components/patina_smbios/src/lib.rs
+++ b/components/patina_smbios/src/lib.rs
@@ -311,7 +311,7 @@
 
 #![cfg_attr(all(not(feature = "std"), not(test), not(feature = "mockall")), no_std)]
 #![deny(missing_docs)]
-#![cfg_attr(coverage_nightly, feature(coverage_attribute))]
+#![cfg_attr(coverage, feature(coverage_attribute))]
 
 // SMBIOS tables require little-endian byte order. The SmbiosRecord derive macro
 // uses zerocopy::IntoBytes::as_bytes() which returns native byte order.

--- a/components/patina_smbios/src/manager.rs
+++ b/components/patina_smbios/src/manager.rs
@@ -47,7 +47,7 @@ use self::protocol::{SmbiosProtocol, SmbiosProtocolInternal};
 ///
 /// Returns the protocol handle on success. The caller is responsible for managing the
 /// protocol lifetime (though in practice, UEFI protocols persist for the system lifetime).
-#[cfg_attr(coverage_nightly, coverage(off))] // Protocol installation - tested via integration tests
+#[cfg_attr(coverage, coverage(off))] // Protocol installation - tested via integration tests
 pub fn install_smbios_protocol(
     major_version: u8,
     minor_version: u8,

--- a/components/patina_smbios/src/manager/protocol.rs
+++ b/components/patina_smbios/src/manager/protocol.rs
@@ -85,7 +85,7 @@ impl SmbiosProtocolInternal {
     ///
     /// This constructor is tested via integration (Q35 platform component)
     /// as it requires 'static boot services which cannot be mocked in unit tests.
-    #[cfg_attr(coverage_nightly, coverage(off))]
+    #[cfg_attr(coverage, coverage(off))]
     pub(super) fn new(
         major_version: u8,
         minor_version: u8,
@@ -103,7 +103,7 @@ impl SmbiosProtocol {
     ///
     /// This function is only safe to call from the C UEFI protocol layer where the
     /// caller guarantees that `record` points to a complete, valid SMBIOS record.
-    #[cfg_attr(coverage_nightly, coverage(off))] // FFI function - tested via integration tests
+    #[cfg_attr(coverage, coverage(off))] // FFI function - tested via integration tests
     extern "efiapi" fn add_ext(
         protocol: *const SmbiosProtocol,
         producer_handle: efi::Handle,
@@ -199,7 +199,7 @@ impl SmbiosProtocol {
         }
     }
 
-    #[cfg_attr(coverage_nightly, coverage(off))] // FFI function - tested via integration tests
+    #[cfg_attr(coverage, coverage(off))] // FFI function - tested via integration tests
     extern "efiapi" fn update_string_ext(
         protocol: *const SmbiosProtocol,
         smbios_handle: *mut SmbiosHandle,
@@ -249,7 +249,7 @@ impl SmbiosProtocol {
         }
     }
 
-    #[cfg_attr(coverage_nightly, coverage(off))] // FFI function - tested via integration tests
+    #[cfg_attr(coverage, coverage(off))] // FFI function - tested via integration tests
     extern "efiapi" fn remove_ext(protocol: *const SmbiosProtocol, smbios_handle: SmbiosHandle) -> efi::Status {
         // Safety check: validate protocol pointer before dereferencing
         if protocol.is_null() {
@@ -279,7 +279,7 @@ impl SmbiosProtocol {
         }
     }
 
-    #[cfg_attr(coverage_nightly, coverage(off))] // FFI function - tested via integration tests
+    #[cfg_attr(coverage, coverage(off))] // FFI function - tested via integration tests
     extern "efiapi" fn get_next_ext(
         protocol: *const SmbiosProtocol,
         smbios_handle: *mut SmbiosHandle,

--- a/components/patina_test/src/__private_api.rs
+++ b/components/patina_test/src/__private_api.rs
@@ -166,7 +166,7 @@ where
 }
 
 #[cfg(test)]
-#[cfg_attr(coverage_nightly, coverage(off))]
+#[cfg_attr(coverage, coverage(off))]
 mod tests {
     use super::*;
 

--- a/components/patina_test/src/component.rs
+++ b/components/patina_test/src/component.rs
@@ -98,7 +98,7 @@ impl TestRunner {
     }
 
     /// The entry point for the test runner component.
-    #[cfg_attr(coverage_nightly, coverage(off))]
+    #[cfg_attr(coverage, coverage(off))]
     fn entry_point(self, storage: &mut Storage) -> patina::error::Result<()> {
         let test_list: &'static [__private_api::TestCase] = __private_api::test_cases();
         self.register_tests(test_list, storage)
@@ -139,7 +139,7 @@ impl TestRunner {
 }
 
 #[cfg(test)]
-#[cfg_attr(coverage_nightly, coverage(off))]
+#[cfg_attr(coverage, coverage(off))]
 pub(crate) mod tests {
     extern crate std;
 

--- a/components/patina_test/src/lib.rs
+++ b/components/patina_test/src/lib.rs
@@ -5,7 +5,7 @@
 )]
 #![no_std]
 #![deny(missing_docs)]
-#![cfg_attr(coverage_nightly, feature(coverage_attribute))]
+#![cfg_attr(coverage, feature(coverage_attribute))]
 extern crate alloc;
 
 #[doc(hidden)]

--- a/components/patina_test/src/service.rs
+++ b/components/patina_test/src/service.rs
@@ -161,7 +161,7 @@ impl TestRecord {
         }
     }
 
-    #[cfg_attr(coverage_nightly, coverage(off))]
+    #[cfg_attr(coverage, coverage(off))]
     /// An EFIAPI compatible event callback to disable a timer event at ReadyToBoot
     extern "efiapi" fn disable_timer(rtb_event: r_efi::efi::Event, context: *mut core::ffi::c_void) {
         // SAFETY: We set up the context pointer in `run_tests` to point to a valid tuple of (Event, StandardBootServices).
@@ -305,7 +305,7 @@ impl Display for Recorder {
 }
 
 #[cfg(test)]
-#[cfg_attr(coverage_nightly, coverage(off))]
+#[cfg_attr(coverage, coverage(off))]
 mod tests {
     extern crate std;
 

--- a/core/patina_debugger/src/arch.rs
+++ b/core/patina_debugger/src/arch.rs
@@ -20,11 +20,11 @@ use crate::ExceptionInfo;
 
 cfg_if::cfg_if! {
     if #[cfg(target_arch = "x86_64")] {
-        #[cfg_attr(coverage_nightly, coverage(off))]
+        #[cfg_attr(coverage, coverage(off))]
         mod x64;
         pub type SystemArch = x64::X64Arch;
     } else if #[cfg(target_arch = "aarch64")] {
-        #[cfg_attr(coverage_nightly, coverage(off))]
+        #[cfg_attr(coverage, coverage(off))]
         mod aarch64;
         pub type SystemArch = aarch64::Aarch64Arch;
     }

--- a/core/patina_debugger/src/lib.rs
+++ b/core/patina_debugger/src/lib.rs
@@ -102,15 +102,15 @@
 //! SPDX-License-Identifier: Apache-2.0
 //!
 #![cfg_attr(not(test), no_std)]
-#![cfg_attr(coverage_nightly, feature(coverage_attribute))]
+#![cfg_attr(coverage, feature(coverage_attribute))]
 
-#[cfg_attr(coverage_nightly, coverage(off))]
+#[cfg_attr(coverage, coverage(off))]
 // The debugger needs integration test infrastructure. Disabling coverage until this is completed.
 mod arch;
-#[cfg_attr(coverage_nightly, coverage(off))]
+#[cfg_attr(coverage, coverage(off))]
 // The debugger needs integration test infrastructure. Disabling coverage until this is completed.
 mod dbg_target;
-#[cfg_attr(coverage_nightly, coverage(off))]
+#[cfg_attr(coverage, coverage(off))]
 // The debugger needs integration test infrastructure. Disabling coverage until this is completed.
 mod debugger;
 mod memory;
@@ -227,7 +227,7 @@ pub fn set_debugger<T: SerialIO>(debugger: &'static PatinaDebugger<T>) {
 /// Initializes the debugger. This will install the debugger into the exception
 /// handlers using the provided interrupt manager. This routine may invoke a debug
 /// break depending on configuration.
-#[cfg_attr(coverage_nightly, coverage(off))] // Initializing the debugger requires integration testing infrastructure. Disabling coverage until this is completed.
+#[cfg_attr(coverage, coverage(off))] // Initializing the debugger requires integration testing infrastructure. Disabling coverage until this is completed.
 pub fn initialize(interrupt_manager: &mut dyn InterruptManager, timer: Option<&'static dyn ArchTimerFunctionality>) {
     if let Some(debugger) = DEBUGGER.get() {
         debugger.initialize(interrupt_manager, timer);
@@ -380,7 +380,7 @@ impl core::fmt::Display for ExceptionType {
     }
 }
 
-#[cfg_attr(coverage_nightly, coverage(off))]
+#[cfg_attr(coverage, coverage(off))]
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/core/patina_debugger/src/memory.rs
+++ b/core/patina_debugger/src/memory.rs
@@ -173,7 +173,7 @@ fn check_paging_range<P: PatinaPageTable>(page_table: &P, start_address: u64, le
 }
 
 #[cfg(test)]
-#[cfg_attr(coverage_nightly, coverage(off))]
+#[cfg_attr(coverage, coverage(off))]
 mod tests {
 
     use super::*;

--- a/core/patina_debugger/src/system/alloc.rs
+++ b/core/patina_debugger/src/system/alloc.rs
@@ -147,7 +147,7 @@ struct MonitorCallback {
 }
 
 #[cfg(test)]
-#[cfg_attr(coverage_nightly, coverage(off))]
+#[cfg_attr(coverage, coverage(off))]
 mod tests {
     use super::*;
 

--- a/core/patina_debugger/src/system/no_alloc.rs
+++ b/core/patina_debugger/src/system/no_alloc.rs
@@ -63,7 +63,7 @@ impl SystemStateTrait for SystemState {
 }
 
 #[cfg(test)]
-#[cfg_attr(coverage_nightly, coverage(off))]
+#[cfg_attr(coverage, coverage(off))]
 mod tests {
     extern crate alloc;
     use alloc::string::String;

--- a/core/patina_debugger/src/transport.rs
+++ b/core/patina_debugger/src/transport.rs
@@ -98,7 +98,7 @@ impl Drop for LoggingSuspender {
 }
 
 #[cfg(test)]
-#[cfg_attr(coverage_nightly, coverage(off))]
+#[cfg_attr(coverage, coverage(off))]
 mod tests {
     use super::*;
     use mockall::mock;

--- a/core/patina_internal_core/src/collections/bst.rs
+++ b/core/patina_internal_core/src/collections/bst.rs
@@ -675,7 +675,7 @@ where
 }
 
 #[cfg(test)]
-#[cfg_attr(coverage_nightly, coverage(off))]
+#[cfg_attr(coverage, coverage(off))]
 #[allow(clippy::undocumented_unsafe_blocks)]
 mod tests {
     use crate::collections::{Bst, node_size};

--- a/core/patina_internal_core/src/collections/node.rs
+++ b/core/patina_internal_core/src/collections/node.rs
@@ -674,7 +674,7 @@ impl<D: SliceKey> SliceKey for Node<D> {
 }
 
 #[cfg(test)]
-#[cfg_attr(coverage_nightly, coverage(off))]
+#[cfg_attr(coverage, coverage(off))]
 mod tests {
     use super::*;
 

--- a/core/patina_internal_core/src/collections/rbt.rs
+++ b/core/patina_internal_core/src/collections/rbt.rs
@@ -914,7 +914,7 @@ where
 }
 
 #[cfg(test)]
-#[cfg_attr(coverage_nightly, coverage(off))]
+#[cfg_attr(coverage, coverage(off))]
 #[allow(clippy::undocumented_unsafe_blocks)]
 mod tests {
     extern crate std;

--- a/core/patina_internal_core/src/collections/sorted_slice.rs
+++ b/core/patina_internal_core/src/collections/sorted_slice.rs
@@ -203,7 +203,7 @@ where
 }
 
 #[cfg(test)]
-#[cfg_attr(coverage_nightly, coverage(off))]
+#[cfg_attr(coverage, coverage(off))]
 mod tests {
     extern crate std;
     use super::*;

--- a/core/patina_internal_core/src/depex.rs
+++ b/core/patina_internal_core/src/depex.rs
@@ -382,7 +382,7 @@ impl Iterator for DepexParser {
 }
 
 #[cfg(test)]
-#[cfg_attr(coverage_nightly, coverage(off))]
+#[cfg_attr(coverage, coverage(off))]
 mod tests {
     extern crate std;
     use alloc::vec;

--- a/core/patina_internal_core/src/lib.rs
+++ b/core/patina_internal_core/src/lib.rs
@@ -12,7 +12,7 @@
 //! SPDX-License-Identifier: Apache-2.0
 //!
 #![no_std]
-#![cfg_attr(coverage_nightly, feature(coverage_attribute))]
+#![cfg_attr(coverage, feature(coverage_attribute))]
 
 extern crate alloc;
 

--- a/core/patina_internal_cpu/src/cpu/aarch64/cache.rs
+++ b/core/patina_internal_cpu/src/cpu/aarch64/cache.rs
@@ -93,7 +93,7 @@ pub(crate) fn flush_data_cache_range(start: efi::PhysicalAddress, length: u64, o
 }
 
 #[cfg(test)]
-#[cfg_attr(coverage_nightly, coverage(off))]
+#[cfg_attr(coverage, coverage(off))]
 mod tests {
     use super::*;
 

--- a/core/patina_internal_cpu/src/cpu/aarch64/cpu.rs
+++ b/core/patina_internal_cpu/src/cpu/aarch64/cpu.rs
@@ -30,7 +30,7 @@ impl EfiCpuAarch64 {
 
     /// Causes the CPU to enter a low power state until the next interrupt.
     // This routine only does bare-metal hardware access, so no coverage.
-    #[cfg_attr(coverage_nightly, coverage(off))]
+    #[cfg_attr(coverage, coverage(off))]
     pub fn sleep() {
         #[cfg(not(test))]
         // SAFETY: The caller is expected to ensure that they want to wait for an interrupt
@@ -84,7 +84,7 @@ impl Cpu for EfiCpuAarch64 {
 }
 
 #[cfg(test)]
-#[cfg_attr(coverage_nightly, coverage(off))]
+#[cfg_attr(coverage, coverage(off))]
 mod tests {
     use super::*;
 

--- a/core/patina_internal_cpu/src/cpu/stub.rs
+++ b/core/patina_internal_cpu/src/cpu/stub.rs
@@ -26,7 +26,7 @@ impl EfiCpuStub {
     }
     /// Causes the CPU to enter a low power state until the next interrupt.
     // Trivial emulation of hardware access, so no coverage.
-    #[cfg_attr(coverage_nightly, coverage(off))]
+    #[cfg_attr(coverage, coverage(off))]
     pub fn sleep() {}
 }
 

--- a/core/patina_internal_cpu/src/cpu/x64/cpu.rs
+++ b/core/patina_internal_cpu/src/cpu/x64/cpu.rs
@@ -92,7 +92,7 @@ impl EfiCpuX64 {
 
     /// Causes the CPU to enter a low power state until the next interrupt.
     // This routine only does bare-metal hardware access, so no coverage.
-    #[cfg_attr(coverage_nightly, coverage(off))]
+    #[cfg_attr(coverage, coverage(off))]
     pub fn sleep() {
         #[cfg(not(test))]
         // SAFETY: The caller is expected to ensure that they want to halt the CPU until the next interrupt
@@ -105,7 +105,7 @@ impl EfiCpuX64 {
         // unimplemented!();
     }
 
-    #[cfg_attr(coverage_nightly, coverage(off))]
+    #[cfg_attr(coverage, coverage(off))]
     fn initialize_fpu(&self) {
         #[cfg(not(test))]
         // SAFETY: This assembly writes only hard coded values to CR4 register, and MMX and FPU control words. No
@@ -173,7 +173,7 @@ impl Cpu for EfiCpuX64 {
         Ok((timer_value, self.timer_period))
     }
 
-    #[cfg_attr(coverage_nightly, coverage(off))]
+    #[cfg_attr(coverage, coverage(off))]
     fn cache_writeback_granule(&self) -> u32 {
         CACHE_WRITEBACK_GRANULE
     }
@@ -186,7 +186,7 @@ impl Default for EfiCpuX64 {
 }
 
 #[cfg(test)]
-#[cfg_attr(coverage_nightly, coverage(off))]
+#[cfg_attr(coverage, coverage(off))]
 mod tests {
 
     use super::*;

--- a/core/patina_internal_cpu/src/cpu/x64/gdt.rs
+++ b/core/patina_internal_cpu/src/cpu/x64/gdt.rs
@@ -191,7 +191,7 @@ struct GdtPointer {
     base: u64,
 }
 
-#[cfg_attr(coverage_nightly, coverage(off))]
+#[cfg_attr(coverage, coverage(off))]
 pub fn init() {
     let gdt_ptr = GDT.as_ptr() as usize;
     if gdt_ptr >= SIZE_4GB {
@@ -232,7 +232,7 @@ pub fn init() {
 }
 
 #[cfg(test)]
-#[cfg_attr(coverage_nightly, coverage(off))]
+#[cfg_attr(coverage, coverage(off))]
 mod tests {
     use super::*;
 

--- a/core/patina_internal_cpu/src/interrupts.rs
+++ b/core/patina_internal_cpu/src/interrupts.rs
@@ -21,10 +21,10 @@ use patina::{error::EfiError, pi::protocols::cpu_arch::EfiSystemContext};
 mod exception_handling;
 
 // The aarch64 module contains all exception handlers and architecture specific code, of little testing value.
-#[cfg_attr(coverage_nightly, coverage(off))]
+#[cfg_attr(coverage, coverage(off))]
 #[cfg(any(target_arch = "aarch64", test))]
 mod aarch64;
-#[cfg_attr(coverage_nightly, coverage(off))]
+#[cfg_attr(coverage, coverage(off))]
 #[cfg(not(target_os = "uefi"))]
 mod stub;
 #[cfg(any(target_arch = "x86_64", test))]
@@ -41,15 +41,15 @@ cfg_if::cfg_if! {
         pub type Interrupts = stub::InterruptsStub;
 
         /// Enables CPU interrupts.
-        #[cfg_attr(coverage_nightly, coverage(off))]
+        #[cfg_attr(coverage, coverage(off))]
         pub fn enable_interrupts() {}
 
         /// Disables CPU interrupts.
-        #[cfg_attr(coverage_nightly, coverage(off))]
+        #[cfg_attr(coverage, coverage(off))]
         pub fn disable_interrupts() {}
 
         /// Gets the current state of CPU interrupts.
-        #[cfg_attr(coverage_nightly, coverage(off))]
+        #[cfg_attr(coverage, coverage(off))]
         pub fn get_interrupt_state() -> Result<bool, EfiError> {
             Ok(false)
         }
@@ -219,7 +219,7 @@ pub trait InterruptHandler<T = ExceptionContextArch>: Sync {
     fn handle_interrupt(&'static self, exception_type: ExceptionType, context: &mut ExceptionContext<T>);
 }
 
-#[cfg_attr(coverage_nightly, coverage(off))]
+#[cfg_attr(coverage, coverage(off))]
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/core/patina_internal_cpu/src/interrupts/aarch64.rs
+++ b/core/patina_internal_cpu/src/interrupts/aarch64.rs
@@ -74,7 +74,7 @@ impl super::EfiExceptionInfoDump for ExceptionContextAArch64 {
     }
 }
 
-#[cfg_attr(coverage_nightly, coverage(off))]
+#[cfg_attr(coverage, coverage(off))]
 #[allow(unused)]
 pub fn enable_interrupts() {
     cfg_if::cfg_if! {
@@ -86,7 +86,7 @@ pub fn enable_interrupts() {
     }
 }
 
-#[cfg_attr(coverage_nightly, coverage(off))]
+#[cfg_attr(coverage, coverage(off))]
 #[allow(unused)]
 pub fn disable_interrupts() {
     cfg_if::cfg_if! {
@@ -98,7 +98,7 @@ pub fn disable_interrupts() {
     }
 }
 
-#[cfg_attr(coverage_nightly, coverage(off))]
+#[cfg_attr(coverage, coverage(off))]
 #[allow(unused)]
 pub fn get_interrupt_state() -> Result<bool, EfiError> {
     cfg_if::cfg_if! {

--- a/core/patina_internal_cpu/src/interrupts/aarch64/interrupt_manager.rs
+++ b/core/patina_internal_cpu/src/interrupts/aarch64/interrupt_manager.rs
@@ -63,7 +63,7 @@ impl InterruptsAarch64 {
 
 impl InterruptManager for InterruptsAarch64 {}
 
-#[cfg_attr(coverage_nightly, coverage(off))]
+#[cfg_attr(coverage, coverage(off))]
 fn enable_fiq() {
     cfg_if::cfg_if! {
         if #[cfg(not(test))]  {
@@ -74,7 +74,7 @@ fn enable_fiq() {
     }
 }
 
-#[cfg_attr(coverage_nightly, coverage(off))]
+#[cfg_attr(coverage, coverage(off))]
 fn disable_fiq() {
     cfg_if::cfg_if! {
         if #[cfg(not(test))]  {
@@ -85,7 +85,7 @@ fn disable_fiq() {
     }
 }
 
-#[cfg_attr(coverage_nightly, coverage(off))]
+#[cfg_attr(coverage, coverage(off))]
 fn get_fiq_state() -> Result<bool, EfiError> {
     cfg_if::cfg_if! {
         if #[cfg(not(test))]  {
@@ -97,7 +97,7 @@ fn get_fiq_state() -> Result<bool, EfiError> {
     }
 }
 
-#[cfg_attr(coverage_nightly, coverage(off))]
+#[cfg_attr(coverage, coverage(off))]
 fn enable_async_abort() {
     cfg_if::cfg_if! {
         if #[cfg(not(test))]  {
@@ -108,7 +108,7 @@ fn enable_async_abort() {
     }
 }
 
-#[cfg_attr(coverage_nightly, coverage(off))]
+#[cfg_attr(coverage, coverage(off))]
 fn initialize_exception() -> Result<(), EfiError> {
     // Set the stack pointer for EL0 to be used for synchronous exceptions
     #[cfg(not(test))]

--- a/core/patina_internal_cpu/src/interrupts/exception_handling.rs
+++ b/core/patina_internal_cpu/src/interrupts/exception_handling.rs
@@ -78,7 +78,7 @@ pub(crate) fn unregister_exception_handler(exception_type: ExceptionType) -> Res
 }
 
 // This function does actually have coverage but no_mangle functions confuse the coverage tool.
-#[cfg_attr(coverage_nightly, coverage(off))]
+#[cfg_attr(coverage, coverage(off))]
 /// The architecture agnostic entry of the exception handler stack.
 ///
 /// This will be invoked by the architectures assembly entry and so requires
@@ -117,7 +117,7 @@ extern "efiapi" fn exception_handler(exception_type: usize, context: &mut Except
 }
 
 #[cfg(test)]
-#[cfg_attr(coverage_nightly, coverage(off))]
+#[cfg_attr(coverage, coverage(off))]
 mod tests {
     extern crate std;
 

--- a/core/patina_internal_cpu/src/interrupts/x64/interrupt_manager.rs
+++ b/core/patina_internal_cpu/src/interrupts/x64/interrupt_manager.rs
@@ -59,7 +59,7 @@ impl InterruptsX64 {
 
 impl InterruptManager for InterruptsX64 {}
 
-#[cfg_attr(coverage_nightly, coverage(off))]
+#[cfg_attr(coverage, coverage(off))]
 /// Default handler for double faults.
 extern "efiapi" fn double_fault_handler(_exception_type: isize, context: EfiSystemContext) {
     // SAFETY: We don't have any choice here, we are in an exception and have to do our best
@@ -84,7 +84,7 @@ extern "efiapi" fn double_fault_handler(_exception_type: isize, context: EfiSyst
     panic!("EXCEPTION: Double Fault");
 }
 
-#[cfg_attr(coverage_nightly, coverage(off))]
+#[cfg_attr(coverage, coverage(off))]
 /// Default handler for GP faults.
 extern "efiapi" fn general_protection_fault_handler(_exception_type: isize, context: EfiSystemContext) {
     // SAFETY: We don't have any choice here, we are in an exception and have to do our best
@@ -118,7 +118,7 @@ extern "efiapi" fn general_protection_fault_handler(_exception_type: isize, cont
     panic!("EXCEPTION: GP FAULT");
 }
 
-#[cfg_attr(coverage_nightly, coverage(off))]
+#[cfg_attr(coverage, coverage(off))]
 /// Default handler for page faults.
 extern "efiapi" fn page_fault_handler(_exception_type: isize, context: EfiSystemContext) {
     // SAFETY: We don't have any choice here, we are in an exception and have to do our best
@@ -169,7 +169,7 @@ extern "efiapi" fn page_fault_handler(_exception_type: isize, context: EfiSystem
     panic!("EXCEPTION: PAGE FAULT");
 }
 
-#[cfg_attr(coverage_nightly, coverage(off))]
+#[cfg_attr(coverage, coverage(off))]
 // see Intel SDM Vol 3A section 7.15
 fn interpret_page_fault_exception_data(exception_data: u64) {
     log::error!("Error Code: {exception_data:#X?}");
@@ -202,7 +202,7 @@ fn interpret_page_fault_exception_data(exception_data: u64) {
     }
 }
 
-#[cfg_attr(coverage_nightly, coverage(off))]
+#[cfg_attr(coverage, coverage(off))]
 // see Intel SDM Vol 3A section 7.15
 fn interpret_gp_fault_exception_data(exception_data: u64) {
     if exception_data != 0 {
@@ -213,7 +213,7 @@ fn interpret_gp_fault_exception_data(exception_data: u64) {
 }
 
 // There is no value in coverage for this function.
-#[cfg_attr(coverage_nightly, coverage(off))]
+#[cfg_attr(coverage, coverage(off))]
 /// Dumps the page table entries for the given CR2. This uses the active page tables as they should be the same as the
 /// ones at the time of the fault.
 ///
@@ -238,7 +238,7 @@ fn dump_pte(cr2: u64) {
     }
 }
 
-#[cfg_attr(coverage_nightly, coverage(off))]
+#[cfg_attr(coverage, coverage(off))]
 #[cfg(test)]
 mod test {
     extern crate std;

--- a/core/patina_internal_cpu/src/lib.rs
+++ b/core/patina_internal_cpu/src/lib.rs
@@ -9,7 +9,7 @@
 //! SPDX-License-Identifier: Apache-2.0
 //!
 #![cfg_attr(all(not(feature = "std"), not(test)), no_std)]
-#![cfg_attr(coverage_nightly, feature(coverage_attribute))]
+#![cfg_attr(coverage, feature(coverage_attribute))]
 
 pub mod cpu;
 pub mod interrupts;

--- a/core/patina_internal_cpu/src/paging/aarch64.rs
+++ b/core/patina_internal_cpu/src/paging/aarch64.rs
@@ -78,7 +78,7 @@ where
 }
 
 /// Create an AArch64 paging instance under the general PatinaPageTable trait.
-#[cfg_attr(coverage_nightly, coverage(off))]
+#[cfg_attr(coverage, coverage(off))]
 pub fn create_cpu_aarch64_paging<A: PageAllocator + 'static>(
     page_allocator: A,
 ) -> Result<impl PatinaPageTable, efi::Status> {
@@ -89,7 +89,7 @@ pub fn create_cpu_aarch64_paging<A: PageAllocator + 'static>(
 ///
 /// ## Safety
 /// The caller must ensure no other entity is concurrently modifying the page tables.
-#[cfg_attr(coverage_nightly, coverage(off))]
+#[cfg_attr(coverage, coverage(off))]
 pub unsafe fn open_active_cpu_aarch64_paging<A: PageAllocator + 'static>(
     page_allocator: A,
 ) -> Result<impl PatinaPageTable, PtError> {
@@ -99,7 +99,7 @@ pub unsafe fn open_active_cpu_aarch64_paging<A: PageAllocator + 'static>(
 }
 
 #[cfg(test)]
-#[cfg_attr(coverage_nightly, coverage(off))]
+#[cfg_attr(coverage, coverage(off))]
 mod tests {
 
     use super::*;

--- a/core/patina_internal_cpu/src/paging/x64.rs
+++ b/core/patina_internal_cpu/src/paging/x64.rs
@@ -143,7 +143,7 @@ fn apply_caching_attributes<M: Mtrr>(
 }
 
 /// Create an x86_64 paging instance under the general PatinaPageTable trait.
-#[cfg_attr(coverage_nightly, coverage(off))]
+#[cfg_attr(coverage, coverage(off))]
 pub fn create_cpu_x64_paging<A: PageAllocator + 'static>(
     page_allocator: A,
 ) -> Result<impl PatinaPageTable, efi::Status> {
@@ -158,7 +158,7 @@ pub fn create_cpu_x64_paging<A: PageAllocator + 'static>(
 ///
 /// ## Safety
 /// The caller must ensure no other entity is concurrently modifying the page tables.
-#[cfg_attr(coverage_nightly, coverage(off))]
+#[cfg_attr(coverage, coverage(off))]
 pub unsafe fn open_active_cpu_x64_paging<A: PageAllocator + 'static>(
     page_allocator: A,
 ) -> Result<impl PatinaPageTable, PtError> {
@@ -181,7 +181,7 @@ fn mtrr_err_to_efi_status(err: MtrrError) -> EfiError {
 }
 
 #[cfg(test)]
-#[cfg_attr(coverage_nightly, coverage(off))]
+#[cfg_attr(coverage, coverage(off))]
 mod tests {
     use super::*;
     use mockall::mock;

--- a/core/patina_stacktrace/resolve_stacktrace/src/main.rs
+++ b/core/patina_stacktrace/resolve_stacktrace/src/main.rs
@@ -1,4 +1,4 @@
-#![cfg_attr(coverage_nightly, feature(coverage_attribute))]
+#![cfg_attr(coverage, feature(coverage_attribute))]
 //! A tool that resolves raw stack traces using offline PDB parsing. It reads
 //! symbols for each frame and prints the resolved stack trace showing source
 //! file locations, demangled function names, and instruction offsets.
@@ -35,7 +35,7 @@ struct StackFrame {
 /// Look up debug info for each parsed stack frame and attach file, line, and
 /// symbol data. Coverage is off because this function depends on external PDB
 /// files
-#[cfg_attr(coverage_nightly, coverage(off))]
+#[cfg_attr(coverage, coverage(off))]
 fn resolve_stack_frames(pdb_directory: &Path, mut stack_frames: Vec<StackFrame>) -> Vec<StackFrame> {
     for stack_frame in &mut stack_frames {
         let mut pdb_path: PathBuf = pdb_directory.join(&stack_frame.module_name);
@@ -120,7 +120,7 @@ fn create_stack_frame(line: &str) -> Option<StackFrame> {
 
 /// Collect the PDB directory and stack trace text from stdin. Coverage is off
 /// because this is I/O code.
-#[cfg_attr(coverage_nightly, coverage(off))]
+#[cfg_attr(coverage, coverage(off))]
 fn read_inputs() -> Result<(PathBuf, Vec<String>), String> {
     let mut pdb_directory = String::new();
     print!("Enter the PDB directory path (leave empty to use STACKTRACE_PDB_DIR env): ");
@@ -190,7 +190,7 @@ fn create_stack_frames(stack_frames: Vec<String>) -> Vec<StackFrame> {
 
 /// Render the resolved stack frames as a formatted table for display. Coverage
 /// is off because this function do not return a value.
-#[cfg_attr(coverage_nightly, coverage(off))]
+#[cfg_attr(coverage, coverage(off))]
 fn dump_stack_frames(stack_frames: Vec<StackFrame>) {
     let mut table = Table::new();
     table.load_preset(UTF8_FULL).set_content_arrangement(ContentArrangement::DynamicFullWidth).set_header(vec![
@@ -232,7 +232,7 @@ fn main() -> Result<(), String> {
 }
 
 #[cfg(test)]
-#[cfg_attr(coverage_nightly, coverage(off))]
+#[cfg_attr(coverage, coverage(off))]
 mod tests {
     use super::*;
 

--- a/core/patina_stacktrace/src/aarch64/runtime_function.rs
+++ b/core/patina_stacktrace/src/aarch64/runtime_function.rs
@@ -263,7 +263,7 @@ impl<'a> RuntimeFunction<'a> {
 }
 
 #[cfg(test)]
-#[cfg_attr(coverage_nightly, coverage(off))]
+#[cfg_attr(coverage, coverage(off))]
 mod tests {
     use super::*;
     use std::vec::Vec;

--- a/core/patina_stacktrace/src/aarch64/unwind.rs
+++ b/core/patina_stacktrace/src/aarch64/unwind.rs
@@ -1009,7 +1009,7 @@ impl UnwindCode {
 }
 
 #[cfg(test)]
-#[cfg_attr(coverage_nightly, coverage(off))]
+#[cfg_attr(coverage, coverage(off))]
 mod tests {
     use super::*;
 

--- a/core/patina_stacktrace/src/byte_reader.rs
+++ b/core/patina_stacktrace/src/byte_reader.rs
@@ -97,7 +97,7 @@ pub(crate) unsafe fn read_pointer64(pointer: u64) -> StResult<u64> {
 }
 
 #[cfg(test)]
-#[cfg_attr(coverage_nightly, coverage(off))]
+#[cfg_attr(coverage, coverage(off))]
 mod tests {
     use super::*;
 

--- a/core/patina_stacktrace/src/error.rs
+++ b/core/patina_stacktrace/src/error.rs
@@ -154,7 +154,7 @@ impl Error {
 }
 
 #[cfg(test)]
-#[cfg_attr(coverage_nightly, coverage(off))]
+#[cfg_attr(coverage, coverage(off))]
 mod tests {
     use super::Error;
 

--- a/core/patina_stacktrace/src/lib.rs
+++ b/core/patina_stacktrace/src/lib.rs
@@ -167,7 +167,7 @@
 //! More reference test cases live in `src\x64\tests\*.rs`.
 
 #![cfg_attr(all(not(feature = "std"), not(test)), no_std)]
-#![cfg_attr(coverage_nightly, feature(coverage_attribute))]
+#![cfg_attr(coverage, feature(coverage_attribute))]
 
 mod byte_reader;
 pub mod error;

--- a/core/patina_stacktrace/src/pe.rs
+++ b/core/patina_stacktrace/src/pe.rs
@@ -63,7 +63,7 @@ impl PE<'_> {
     // for at least one page on every probe performed by this routine. The
     // caller guarantees that probing the surrounding pages does not perform
     // an out-of-bounds or use-after-free memory access.
-    #[cfg_attr(coverage_nightly, coverage(off))]
+    #[cfg_attr(coverage, coverage(off))]
     pub(crate) unsafe fn locate_image(mut rip: u64) -> StResult<Self> {
         let original_rip = rip;
 
@@ -245,7 +245,7 @@ impl PE<'_> {
 }
 
 #[cfg(test)]
-#[cfg_attr(coverage_nightly, coverage(off))]
+#[cfg_attr(coverage, coverage(off))]
 mod tests {
     use super::*;
     use crate::error::Error;

--- a/core/patina_stacktrace/src/stacktrace.rs
+++ b/core/patina_stacktrace/src/stacktrace.rs
@@ -70,7 +70,7 @@ impl StackTrace {
     /// 6 0000005E2AEFFD10      00007FFB8FF95AEC       kernel32+12310
     /// 7 0000005E2AEFFD50      0000000000000000       ntdll+75AEC
     /// ```
-    #[cfg_attr(coverage_nightly, coverage(off))]
+    #[cfg_attr(coverage, coverage(off))]
     #[inline(never)]
     pub unsafe fn dump_with(mut stack_frame: StackFrame) -> StResult<()> {
         let mut i = 0;
@@ -139,7 +139,7 @@ impl StackTrace {
     /// 6 0000005E2AEFFD10      00007FFB8FF95AEC       kernel32+12310
     /// 7 0000005E2AEFFD50      0000000000000000       ntdll+75AEC
     /// ```
-    #[cfg_attr(coverage_nightly, coverage(off))]
+    #[cfg_attr(coverage, coverage(off))]
     #[inline(never)]
     pub unsafe fn dump() -> StResult<()> {
         let mut stack_frame = StackFrame::default();
@@ -239,7 +239,7 @@ impl StackTrace {
     /// UefiMain
     /// ~/repos/patina-qemu/MU_BASECORE/ShellPkg/Application/Shell/Shell.c:372
     /// ```
-    #[cfg_attr(coverage_nightly, coverage(off))]
+    #[cfg_attr(coverage, coverage(off))]
     #[inline(never)]
     pub unsafe fn dump_with_fp_chain(_stack_frame: StackFrame) -> StResult<()> {
         cfg_if::cfg_if! {
@@ -303,7 +303,7 @@ impl StackTrace {
 }
 
 #[cfg(test)]
-#[cfg_attr(coverage_nightly, coverage(off))]
+#[cfg_attr(coverage, coverage(off))]
 mod tests {
     use super::StackFrame;
 

--- a/core/patina_stacktrace/src/x64/runtime_function.rs
+++ b/core/patina_stacktrace/src/x64/runtime_function.rs
@@ -111,7 +111,7 @@ impl<'a> RuntimeFunction<'a> {
 }
 
 #[cfg(test)]
-#[cfg_attr(coverage_nightly, coverage(off))]
+#[cfg_attr(coverage, coverage(off))]
 mod tests {
     use super::*;
     use crate::{error::Error, pe::PE, stacktrace::StackFrame};

--- a/core/patina_stacktrace/src/x64/unwind.rs
+++ b/core/patina_stacktrace/src/x64/unwind.rs
@@ -203,7 +203,7 @@ impl UnwindCode {
     }
 
     /// Test function that parses all unwind codes.
-    #[cfg_attr(coverage_nightly, coverage(off))]
+    #[cfg_attr(coverage, coverage(off))]
     #[cfg(all(target_os = "windows", target_arch = "x86_64", test))]
     pub(crate) fn _parse(bytes: &[u8], frame_register_offset: u32) -> StResult<Vec<UnwindCode>> {
         let byte_count = bytes.len();
@@ -257,7 +257,7 @@ impl UnwindCode {
 }
 
 #[cfg(test)]
-#[cfg_attr(coverage_nightly, coverage(off))]
+#[cfg_attr(coverage, coverage(off))]
 mod tests {
     use super::*;
 

--- a/patina_dxe_core/src/allocator.rs
+++ b/patina_dxe_core/src/allocator.rs
@@ -10,7 +10,7 @@ mod fixed_size_block_allocator;
 mod uefi_allocator;
 
 #[cfg(test)]
-#[cfg_attr(coverage_nightly, coverage(off))]
+#[cfg_attr(coverage, coverage(off))]
 mod usage_tests;
 
 use core::{
@@ -984,7 +984,7 @@ unsafe extern "efiapi" fn get_memory_map(
 }
 
 /// Dumps bin manager peak tracking data at debug level.
-#[cfg_attr(coverage_nightly, coverage(off))]
+#[cfg_attr(coverage, coverage(off))]
 fn dump_memory_bin_stats() {
     let bin_manager = MEMORY_BIN_MANAGER.lock();
     if bin_manager.is_initialized() {
@@ -1001,7 +1001,7 @@ fn dump_memory_bin_stats() {
 }
 
 /// Dumps per-allocator page counts at trace level.
-#[cfg_attr(coverage_nightly, coverage(off))]
+#[cfg_attr(coverage, coverage(off))]
 fn dump_allocator_details() {
     log::trace!(target: "allocations", "Allocator page counts:");
     for (alloc, _) in STATIC_ALLOCATORS.iter() {
@@ -1028,7 +1028,7 @@ pub fn terminate_memory_map(map_key: usize) -> Result<(), EfiError> {
     }
 }
 
-#[cfg_attr(coverage_nightly, coverage(off))]
+#[cfg_attr(coverage, coverage(off))]
 pub fn install_memory_type_info_table(system_table: &mut EfiSystemTable) -> Result<(), EfiError> {
     let bin_manager = MEMORY_BIN_MANAGER.lock();
     if !bin_manager.is_initialized() || bin_manager.memory_type_information().is_empty() {
@@ -1298,7 +1298,7 @@ pub fn init_memory_support(hob_list: &HobList) {
 /// Note: A local `MemoryBinManager` is used during initialization to avoid holding the global lock
 /// during GCD allocations (which would cause re-entrant lock panics since allocation recording also
 /// acquires the lock).
-#[cfg_attr(coverage_nightly, coverage(off))]
+#[cfg_attr(coverage, coverage(off))]
 fn initialize_memory_bins(hob_list: &HobList, memory_type_info: &[EFiMemoryTypeInformation]) {
     if MEMORY_BIN_MANAGER.lock().is_initialized() {
         return;
@@ -1324,7 +1324,7 @@ fn initialize_memory_bins(hob_list: &HobList, memory_type_info: &[EFiMemoryTypeI
 }
 
 /// Attempts to find a PEI-provided bin range from a Resource Descriptor HOB.
-#[cfg_attr(coverage_nightly, coverage(off))]
+#[cfg_attr(coverage, coverage(off))]
 fn find_pei_bin_range(
     hob_list: &HobList,
     memory_type_info: &[EFiMemoryTypeInformation],
@@ -1337,7 +1337,7 @@ fn find_pei_bin_range(
 /// Allocates a single contiguous block from the GCD for all bin types.
 ///
 /// The block is freed back to the GCD immediately so that it can be reclaimed for per-type ranges.
-#[cfg_attr(coverage_nightly, coverage(off))]
+#[cfg_attr(coverage, coverage(off))]
 fn allocate_contiguous_bin_range(memory_type_info: &[EFiMemoryTypeInformation]) -> Option<(efi::PhysicalAddress, u64)> {
     log::info!(target: "memory_bin", "No PEI bin region found. Allocating a contiguous bin range from the GCD.");
 
@@ -1629,7 +1629,7 @@ pub(crate) unsafe fn reset_allocators() {
 }
 
 #[cfg(test)]
-#[cfg_attr(coverage_nightly, coverage(off))]
+#[cfg_attr(coverage, coverage(off))]
 mod tests {
 
     use crate::{

--- a/patina_dxe_core/src/allocator/fixed_size_block_allocator.rs
+++ b/patina_dxe_core/src/allocator/fixed_size_block_allocator.rs
@@ -669,14 +669,14 @@ impl SpinLockedFixedSizeBlockAllocator {
     }
 
     /// Returns the reserved memory range, if any.
-    #[cfg_attr(coverage_nightly, coverage(off))]
+    #[cfg_attr(coverage, coverage(off))]
     pub fn reserved_range(&self) -> Option<Range<efi::PhysicalAddress>> {
         self.inner.lock().reserved_range.clone()
     }
 
     /// Returns the memory type for this allocator.
     #[allow(dead_code)]
-    #[cfg_attr(coverage_nightly, coverage(off))]
+    #[cfg_attr(coverage, coverage(off))]
     pub fn memory_type(&self) -> efi::MemoryType {
         self.inner.lock().memory_type()
     }
@@ -845,7 +845,7 @@ impl PageAllocator for SpinLockedFixedSizeBlockAllocator {
 }
 
 #[cfg(test)]
-#[cfg_attr(coverage_nightly, coverage(off))]
+#[cfg_attr(coverage, coverage(off))]
 mod tests {
     extern crate std;
     use crate::{

--- a/patina_dxe_core/src/allocator/uefi_allocator.rs
+++ b/patina_dxe_core/src/allocator/uefi_allocator.rs
@@ -270,7 +270,7 @@ where
     }
 }
 #[cfg(test)]
-#[cfg_attr(coverage_nightly, coverage(off))]
+#[cfg_attr(coverage, coverage(off))]
 mod tests {
     extern crate std;
     use core::cmp::max;

--- a/patina_dxe_core/src/component_dispatcher.rs
+++ b/patina_dxe_core/src/component_dispatcher.rs
@@ -151,35 +151,35 @@ impl ComponentDispatcher {
     }
 
     /// Adds a service to storage.
-    #[cfg_attr(coverage_nightly, coverage(off))]
+    #[cfg_attr(coverage, coverage(off))]
     #[inline(always)]
     pub(crate) fn add_service<S: IntoService + 'static>(&mut self, service: S) {
         self.storage.add_service(service);
     }
 
     /// Locks the configurations in storage, preventing further modifications.
-    #[cfg_attr(coverage_nightly, coverage(off))]
+    #[cfg_attr(coverage, coverage(off))]
     #[inline(always)]
     pub(crate) fn lock_configs(&mut self) {
         self.storage.lock_configs();
     }
 
     /// Sets the Boot Services table in storage.
-    #[cfg_attr(coverage_nightly, coverage(off))]
+    #[cfg_attr(coverage, coverage(off))]
     #[inline(always)]
     pub(crate) fn set_boot_services(&mut self, bs: StandardBootServices) {
         self.storage.set_boot_services(bs);
     }
 
     /// Sets the Runtime Services table in storage.
-    #[cfg_attr(coverage_nightly, coverage(off))]
+    #[cfg_attr(coverage, coverage(off))]
     #[inline(always)]
     pub(crate) fn set_runtime_services(&mut self, rs: StandardRuntimeServices) {
         self.storage.set_runtime_services(rs);
     }
 
     /// Sets the core Image Handle in storage.
-    #[cfg_attr(coverage_nightly, coverage(off))]
+    #[cfg_attr(coverage, coverage(off))]
     #[inline(always)]
     pub(crate) fn set_image_handle(&mut self, handle: efi::Handle) {
         self.storage.set_image_handle(handle);
@@ -235,7 +235,7 @@ impl ComponentDispatcher {
     }
 
     /// Logs all components that were not dispatched, and the parameter that was not satisfied that prevented dispatch.
-    #[cfg_attr(coverage_nightly, coverage(off))]
+    #[cfg_attr(coverage, coverage(off))]
     pub(crate) fn display_not_dispatched(&self) {
         if !self.components.is_empty() || !self.rejected.is_empty() {
             let name_len = "name".len();
@@ -268,7 +268,7 @@ impl ComponentDispatcher {
 }
 
 #[cfg(test)]
-#[cfg_attr(coverage_nightly, coverage(off))]
+#[cfg_attr(coverage, coverage(off))]
 mod tests {
     use patina::{component::component, pi::hob::GuidHob};
 

--- a/patina_dxe_core/src/config_tables/memory_attributes_table.rs
+++ b/patina_dxe_core/src/config_tables/memory_attributes_table.rs
@@ -249,7 +249,7 @@ pub fn core_install_memory_attributes_table() {
 }
 
 #[cfg(test)]
-#[cfg_attr(coverage_nightly, coverage(off))]
+#[cfg_attr(coverage, coverage(off))]
 mod tests {
     extern crate std;
     use super::*;

--- a/patina_dxe_core/src/cpu.rs
+++ b/patina_dxe_core/src/cpu.rs
@@ -73,7 +73,7 @@ impl GicBases {
     /// Access to these registers are exclusive to this GicBases instance.
     ///
     /// Caller must guarantee that access to these registers is exclusive to this GicBases instance.
-    #[cfg_attr(coverage_nightly, coverage(off))]
+    #[cfg_attr(coverage, coverage(off))]
     pub unsafe fn new(gicd_base: u64, gicr_base: u64) -> Self {
         GicBases { gicd: gicd_base, gicr: gicr_base }
     }
@@ -113,7 +113,7 @@ pub trait CpuInfo {
     }
 }
 
-#[cfg_attr(coverage_nightly, coverage(off))]
+#[cfg_attr(coverage, coverage(off))]
 pub fn initialize_cpu_subsystem() -> crate::error::Result<(EfiCpu, Interrupts)> {
     let mut cpu = EfiCpu::default();
     cpu.initialize().inspect_err(|err| {
@@ -129,7 +129,7 @@ pub fn initialize_cpu_subsystem() -> crate::error::Result<(EfiCpu, Interrupts)> 
 }
 
 #[cfg(test)]
-#[cfg_attr(coverage_nightly, coverage(off))]
+#[cfg_attr(coverage, coverage(off))]
 mod tests {
     use super::*;
 

--- a/patina_dxe_core/src/cpu/cpu_arch_protocol.rs
+++ b/patina_dxe_core/src/cpu/cpu_arch_protocol.rs
@@ -269,7 +269,7 @@ impl CpuArchProtocolInstaller {
 }
 
 #[cfg(test)]
-#[cfg_attr(coverage_nightly, coverage(off))]
+#[cfg_attr(coverage, coverage(off))]
 mod tests {
     use crate::test_support;
 

--- a/patina_dxe_core/src/cpu/hw_interrupt_protocol.rs
+++ b/patina_dxe_core/src/cpu/hw_interrupt_protocol.rs
@@ -492,7 +492,7 @@ pub(crate) struct HwInterruptProtocolInstaller {
 #[component]
 impl HwInterruptProtocolInstaller {
     /// Creates a new `HwInterruptProtocolInstaller` instance.
-    #[cfg_attr(coverage_nightly, coverage(off))]
+    #[cfg_attr(coverage, coverage(off))]
     pub fn new(gic_bases: GicBases) -> Self {
         Self { gic_bases }
     }

--- a/patina_dxe_core/src/cpu/perf_timer.rs
+++ b/patina_dxe_core/src/cpu/perf_timer.rs
@@ -20,7 +20,7 @@ pub(crate) struct PerfTimer {
 
 impl ArchTimerFunctionality for PerfTimer {
     /// Value of the counter (ticks).
-    #[cfg_attr(coverage_nightly, coverage(off))]
+    #[cfg_attr(coverage, coverage(off))]
     fn cpu_count(&self) -> u64 {
         arch_cpu_count()
     }
@@ -57,7 +57,7 @@ impl Default for PerfTimer {
 /// Returns the current CPU count using architecture-specific methods.
 ///
 /// Skip coverage as any value could be valid, including 0.
-#[cfg_attr(coverage_nightly, coverage(off))]
+#[cfg_attr(coverage, coverage(off))]
 fn arch_cpu_count() -> u64 {
     #[cfg(target_arch = "x86_64")]
     {
@@ -75,7 +75,7 @@ fn arch_cpu_count() -> u64 {
 /// platform-specific configuration is provided.
 ///
 /// Skip coverage as any value could be valid, including 0.
-#[cfg_attr(coverage_nightly, coverage(off))]
+#[cfg_attr(coverage, coverage(off))]
 pub(crate) fn arch_perf_frequency() -> u64 {
     // Try to get TSC frequency from CPUID (most Intel and AMD platforms).
     #[cfg(target_arch = "x86_64")]
@@ -124,7 +124,7 @@ pub(crate) fn arch_perf_frequency() -> u64 {
 }
 
 #[cfg(test)]
-#[cfg_attr(coverage_nightly, coverage(off))]
+#[cfg_attr(coverage, coverage(off))]
 mod tests {
     use super::*;
 

--- a/patina_dxe_core/src/driver_services.rs
+++ b/patina_dxe_core/src/driver_services.rs
@@ -638,7 +638,7 @@ pub fn init_driver_services(st: &mut EfiSystemTable) {
 }
 
 #[cfg(test)]
-#[cfg_attr(coverage_nightly, coverage(off))]
+#[cfg_attr(coverage, coverage(off))]
 mod tests {
     use super::*;
     use crate::{protocol_db::DXE_CORE_HANDLE, test_support};

--- a/patina_dxe_core/src/dxe_dispatch_service.rs
+++ b/patina_dxe_core/src/dxe_dispatch_service.rs
@@ -23,14 +23,14 @@ use crate::{Core, PlatformInfo};
 #[service(dyn DxeDispatch)]
 pub(crate) struct CoreDxeDispatch<P: PlatformInfo>(&'static Core<P>);
 
-#[cfg_attr(coverage_nightly, coverage(off))]
+#[cfg_attr(coverage, coverage(off))]
 impl<P: PlatformInfo> CoreDxeDispatch<P> {
     pub(crate) fn new(core: &'static Core<P>) -> Self {
         Self(core)
     }
 }
 
-#[cfg_attr(coverage_nightly, coverage(off))]
+#[cfg_attr(coverage, coverage(off))]
 impl<P: PlatformInfo> DxeDispatch for CoreDxeDispatch<P> {
     fn dispatch(&self) -> Result<bool> {
         self.0.pi_dispatcher.dispatch()

--- a/patina_dxe_core/src/dxe_services.rs
+++ b/patina_dxe_core/src/dxe_services.rs
@@ -445,7 +445,7 @@ impl<P: PlatformInfo> Core<P> {
         efi::Status::SUCCESS
     }
 
-    #[cfg_attr(coverage_nightly, coverage(off))]
+    #[cfg_attr(coverage, coverage(off))]
     extern "efiapi" fn dispatch_efiapi() -> efi::Status {
         match Self::instance().pi_dispatcher.dispatcher() {
             Err(err) => err.into(),
@@ -484,7 +484,7 @@ impl<P: PlatformInfo> Core<P> {
 }
 
 #[cfg(test)]
-#[cfg_attr(coverage_nightly, coverage(off))]
+#[cfg_attr(coverage, coverage(off))]
 mod tests {
     use super::*;
     use crate::{MockCore, test_support};

--- a/patina_dxe_core/src/event_db.rs
+++ b/patina_dxe_core/src/event_db.rs
@@ -843,7 +843,7 @@ unsafe impl Send for SpinLockedEventDb {}
 unsafe impl Sync for SpinLockedEventDb {}
 
 #[cfg(test)]
-#[cfg_attr(coverage_nightly, coverage(off))]
+#[cfg_attr(coverage, coverage(off))]
 mod tests {
     extern crate std;
     use core::{iter, str::FromStr};

--- a/patina_dxe_core/src/events.rs
+++ b/patina_dxe_core/src/events.rs
@@ -400,7 +400,7 @@ pub fn init_events_support(st: &mut EfiSystemTable) {
 }
 
 #[cfg(test)]
-#[cfg_attr(coverage_nightly, coverage(off))]
+#[cfg_attr(coverage, coverage(off))]
 mod tests {
     use super::*;
     use crate::test_support;

--- a/patina_dxe_core/src/gcd.rs
+++ b/patina_dxe_core/src/gcd.rs
@@ -507,7 +507,7 @@ pub fn init_gcd(physical_hob_list: *const c_void) {
     }
 }
 
-#[cfg_attr(coverage_nightly, coverage(off))]
+#[cfg_attr(coverage, coverage(off))]
 /// Initialize the patina-paging crate
 ///
 /// # Arguments
@@ -734,7 +734,7 @@ fn parse_resource_descriptor_hob(hob: &Hob) -> Option<(hob::ResourceDescriptor, 
 }
 
 #[cfg(test)]
-#[cfg_attr(coverage_nightly, coverage(off))]
+#[cfg_attr(coverage, coverage(off))]
 mod tests {
     use core::ffi::c_void;
 

--- a/patina_dxe_core/src/gcd/spin_locked_gcd.rs
+++ b/patina_dxe_core/src/gcd/spin_locked_gcd.rs
@@ -577,7 +577,7 @@ impl GCD {
         }
     }
 
-    #[cfg_attr(coverage_nightly, coverage(off))]
+    #[cfg_attr(coverage, coverage(off))]
     fn allocate_memory_space_null(
         _gcd: &mut GCD,
         _allocate_type: AllocateType,
@@ -652,7 +652,7 @@ impl GCD {
             .map_err(|e| e.into())
     }
 
-    #[cfg_attr(coverage_nightly, coverage(off))]
+    #[cfg_attr(coverage, coverage(off))]
     fn free_memory_space_null(
         _gcd: &mut GCD,
         _base_address: usize,
@@ -2027,7 +2027,7 @@ impl SpinLockedGcd {
     /// Creates a new uninitialized GCD. [`Self::init`] must be invoked before any other functions or they will return
     /// [`EfiError::NotReady`]. An optional callback can be provided which will be invoked whenever an operation
     /// changes the GCD map.
-    #[cfg_attr(coverage_nightly, coverage(off))]
+    #[cfg_attr(coverage, coverage(off))]
     pub const fn new(memory_change_callback: Option<MapChangeCallback>) -> Self {
         Self {
             memory: tpl_mutex::TplMutex::new(
@@ -2058,7 +2058,7 @@ impl SpinLockedGcd {
     /// # Safety
     /// The caller must ensure that the memory region specified by `base_address` and `len` is freely usable RAM and
     /// will never be used by any other part of the system at any time.
-    #[cfg_attr(coverage_nightly, coverage(off))]
+    #[cfg_attr(coverage, coverage(off))]
     pub(crate) unsafe fn init_memory_blocks(
         &self,
         memory_type: dxe_services::GcdMemoryType,
@@ -2071,7 +2071,7 @@ impl SpinLockedGcd {
         unsafe { self.memory.lock().init_memory_blocks(memory_type, base_address, len, attributes, capabilities) }
     }
 
-    #[cfg_attr(coverage_nightly, coverage(off))]
+    #[cfg_attr(coverage, coverage(off))]
     pub fn prioritize_32_bit_memory(&self, value: bool) {
         self.memory.lock().prioritize_32_bit_memory = value;
     }
@@ -2580,7 +2580,7 @@ impl SpinLockedGcd {
     ///
     /// # Documentation
     /// UEFI Platform Initialization Specification, Release 1.8, Section II-7.2.4.4
-    #[cfg_attr(coverage_nightly, coverage(off))]
+    #[cfg_attr(coverage, coverage(off))]
     pub fn remove_memory_space(&self, base_address: usize, len: usize) -> Result<(), EfiError> {
         let result = self.memory.lock().remove_memory_space(base_address, len);
         if result.is_ok() {
@@ -2737,7 +2737,7 @@ impl SpinLockedGcd {
     ///
     /// # Documentation
     /// UEFI Platform Initialization Specification, Release 1.8, Section II-7.2.4.3
-    #[cfg_attr(coverage_nightly, coverage(off))]
+    #[cfg_attr(coverage, coverage(off))]
     pub fn free_memory_space(&self, base_address: usize, len: usize) -> Result<(), EfiError> {
         self.free_memory_space_internal(base_address, len, MemoryStateTransition::Free)
     }
@@ -2751,7 +2751,7 @@ impl SpinLockedGcd {
     ///
     /// # Documentation
     /// UEFI Platform Initialization Specification, Release 1.8, Section II-7.2.4.3
-    #[cfg_attr(coverage_nightly, coverage(off))]
+    #[cfg_attr(coverage, coverage(off))]
     pub fn free_memory_space_preserving_ownership(&self, base_address: usize, len: usize) -> Result<(), EfiError> {
         self.free_memory_space_internal(base_address, len, MemoryStateTransition::FreePreservingOwnership)
     }
@@ -3081,7 +3081,7 @@ impl<'a> Iterator for DescRangeIterator<'a> {
 }
 
 #[cfg(test)]
-#[cfg_attr(coverage_nightly, coverage(off))]
+#[cfg_attr(coverage, coverage(off))]
 mod tests {
     //! GCD (Global Coherency Domain) test module.
     //!

--- a/patina_dxe_core/src/lib.rs
+++ b/patina_dxe_core/src/lib.rs
@@ -62,7 +62,7 @@
 #![cfg_attr(all(not(feature = "std"), not(test)), no_std)]
 #![feature(c_variadic)]
 #![feature(allocator_api)]
-#![cfg_attr(coverage_nightly, feature(coverage_attribute))]
+#![cfg_attr(coverage, feature(coverage_attribute))]
 
 extern crate alloc;
 
@@ -104,10 +104,10 @@ use spin::Once;
 
 #[cfg(test)]
 #[macro_use]
-#[cfg_attr(coverage_nightly, coverage(off))]
+#[cfg_attr(coverage, coverage(off))]
 pub mod test_support;
 
-#[cfg_attr(coverage_nightly, coverage(off))]
+#[cfg_attr(coverage, coverage(off))]
 mod core_patina_tests;
 
 use core::{
@@ -315,7 +315,7 @@ pub struct Core<P: PlatformInfo> {
     pi_dispatcher: PiDispatcher<P>,
 }
 
-#[cfg_attr(coverage_nightly, coverage(off))]
+#[cfg_attr(coverage, coverage(off))]
 impl<P: PlatformInfo> Core<P> {
     /// Creates a new instance of the DXE Core in the NoAlloc phase.
     pub const fn new(section_extractor: P::Extractor) -> Self {
@@ -673,7 +673,7 @@ fn call_bds() -> ! {
 }
 
 #[cfg(test)]
-#[cfg_attr(coverage_nightly, coverage(off))]
+#[cfg_attr(coverage, coverage(off))]
 mod tests {
     use crate::test_support::with_global_lock;
 

--- a/patina_dxe_core/src/memory_bin.rs
+++ b/patina_dxe_core/src/memory_bin.rs
@@ -47,7 +47,7 @@ const LOG_TARGET: &str = "memory_bin";
 /// Returns a human-readable name for a UEFI memory type.
 ///
 /// Returns a `&'static str` for all standard types. Returns `"Unknown"` for unrecognized values.
-#[cfg_attr(coverage_nightly, coverage(off))]
+#[cfg_attr(coverage, coverage(off))]
 pub(crate) fn memory_type_name(memory_type: efi::MemoryType) -> &'static str {
     match memory_type {
         efi::RESERVED_MEMORY_TYPE => "ReservedMemoryType",
@@ -115,7 +115,7 @@ struct MemoryBinStatistics {
 
 impl MemoryBinStatistics {
     /// Creates default statistics for a memory type with the given special/runtime flags.
-    #[cfg_attr(coverage_nightly, coverage(off))]
+    #[cfg_attr(coverage, coverage(off))]
     const fn new(special: bool, runtime: bool) -> Self {
         Self {
             base_address: 0,
@@ -936,7 +936,7 @@ pub(crate) fn extract_memory_type_info_from_hob(hob_list: &HobList) -> Option<Ve
 }
 
 #[cfg(test)]
-#[cfg_attr(coverage_nightly, coverage(off))]
+#[cfg_attr(coverage, coverage(off))]
 mod tests {
     use super::*;
     use patina::base::{SIZE_64KB, UEFI_PAGE_SIZE};
@@ -964,7 +964,7 @@ mod tests {
     /// Initializes a `MemoryBinManager` from the given memory type info at the given base address.
     ///
     /// Uses `contiguous_alloc_size` to compute a range large enough for all bins.
-    #[cfg_attr(coverage_nightly, coverage(off))]
+    #[cfg_attr(coverage, coverage(off))]
     fn init_bins(manager: &mut MemoryBinManager, base: u64, info: &[EFiMemoryTypeInformation]) {
         crate::test_support::init_test_logger();
         let range_size = MemoryBinManager::contiguous_alloc_size(info).unwrap() as u64;

--- a/patina_dxe_core/src/memory_manager.rs
+++ b/patina_dxe_core/src/memory_manager.rs
@@ -91,7 +91,7 @@ impl MemoryManager for CoreMemoryManager {
 
     // Coverage is turned off since this is a simple wrapper function that would necessitate
     // complex mocking to test.
-    #[cfg_attr(coverage_nightly, coverage(off))]
+    #[cfg_attr(coverage, coverage(off))]
     fn get_allocator(&self, memory_type: EfiMemoryType) -> Result<&'static dyn core::alloc::Allocator, MemoryError> {
         let allocator =
             crate::allocator::core_get_allocator(memory_type.into()).map_err(|_| MemoryError::UnsupportedMemoryType)?;
@@ -216,7 +216,7 @@ fn allow_allocations_for_type(memory_type: EfiMemoryType) -> Result<(), MemoryEr
 }
 
 #[patina_test]
-#[cfg_attr(coverage_nightly, coverage(off))]
+#[cfg_attr(coverage, coverage(off))]
 #[allow(clippy::indexing_slicing)]
 fn memory_manager_allocations_test(mm: Service<dyn MemoryManager>) -> patina_test::error::Result {
     // Allocate a page, and make sure it is accessible.

--- a/patina_dxe_core/src/misc_boot_services.rs
+++ b/patina_dxe_core/src/misc_boot_services.rs
@@ -140,7 +140,7 @@ extern "efiapi" fn set_watchdog_timer(
     }
 }
 // Requires excessive Mocking for the OK case.
-#[cfg_attr(coverage_nightly, coverage(off))]
+#[cfg_attr(coverage, coverage(off))]
 // This callback is invoked when the Metronome Architectural protocol is installed. It initializes the
 // METRONOME_ARCH_PTR to point to the Metronome Architectural protocol interface.
 extern "efiapi" fn metronome_arch_available(event: efi::Event, _context: *mut c_void) {
@@ -160,7 +160,7 @@ extern "efiapi" fn metronome_arch_available(event: efi::Event, _context: *mut c_
     }
 }
 // Requires excessive Mocking for the OK case.
-#[cfg_attr(coverage_nightly, coverage(off))]
+#[cfg_attr(coverage, coverage(off))]
 // This callback is invoked when the Watchdog Timer Architectural protocol is installed. It initializes the
 // WATCHDOG_ARCH_PTR to point to the Watchdog Timer Architectural protocol interface.
 extern "efiapi" fn watchdog_arch_available(event: efi::Event, _context: *mut c_void) {
@@ -310,7 +310,7 @@ pub fn init_misc_boot_services_support(st: &mut EfiSystemTable) {
 }
 
 #[cfg(test)]
-#[cfg_attr(coverage_nightly, coverage(off))]
+#[cfg_attr(coverage, coverage(off))]
 mod tests {
     use super::*;
     use crate::{

--- a/patina_dxe_core/src/pecoff.rs
+++ b/patina_dxe_core/src/pecoff.rs
@@ -549,7 +549,7 @@ pub fn get_section<'a>(target: &str, pe_info: &UefiPeInfo, image: &'a [u8]) -> e
 }
 
 #[cfg(test)]
-#[cfg_attr(coverage_nightly, coverage(off))]
+#[cfg_attr(coverage, coverage(off))]
 mod tests {
     use crate::test_support;
 

--- a/patina_dxe_core/src/pecoff/error.rs
+++ b/patina_dxe_core/src/pecoff/error.rs
@@ -42,7 +42,7 @@ impl From<goblin::error::Error> for Error {
 }
 
 #[cfg(test)]
-#[cfg_attr(coverage_nightly, coverage(off))]
+#[cfg_attr(coverage, coverage(off))]
 mod tests {
     use super::*;
 

--- a/patina_dxe_core/src/pi_dispatcher.rs
+++ b/patina_dxe_core/src/pi_dispatcher.rs
@@ -244,7 +244,7 @@ impl<P: PlatformInfo> PiDispatcher<P> {
 
     /// Installs any firmware volumes from FV HOBs in the hob list
     #[inline(always)]
-    #[cfg_attr(coverage_nightly, coverage(off))]
+    #[cfg_attr(coverage, coverage(off))]
     pub fn install_firmware_volumes_from_hoblist(
         &self,
         hob_list: &patina::pi::hob::HobList,
@@ -504,26 +504,26 @@ impl<P: PlatformInfo> PiDispatcher<P> {
 
     /// Schedules a driver for execution.
     #[inline(always)]
-    #[cfg_attr(coverage_nightly, coverage(off))]
+    #[cfg_attr(coverage, coverage(off))]
     pub fn schedule(&self, handle: efi::Handle, file: &efi::Guid) -> Result<(), EfiError> {
         self.dispatcher_context.lock().schedule(handle, file)
     }
 
     /// Marks a driver as trusted for execution.
     #[inline(always)]
-    #[cfg_attr(coverage_nightly, coverage(off))]
+    #[cfg_attr(coverage, coverage(off))]
     pub fn trust(&self, handle: efi::Handle, file: &efi::Guid) -> Result<(), EfiError> {
         self.dispatcher_context.lock().trust(handle, file)
     }
 
     #[inline(always)]
-    #[cfg_attr(coverage_nightly, coverage(off))]
+    #[cfg_attr(coverage, coverage(off))]
     fn add_fv_handles(&self, new_handles: Vec<efi::Handle>) -> Result<(), EfiError> {
         self.dispatcher_context.lock().add_fv_handles(new_handles, &self.section_extractor)
     }
 
     #[inline(always)]
-    #[cfg_attr(coverage_nightly, coverage(off))]
+    #[cfg_attr(coverage, coverage(off))]
     /// Caller must ensure that the base address is a valid firmware volume.
     pub unsafe fn install_firmware_volume(
         &self,
@@ -883,7 +883,7 @@ impl DispatcherContext {
 unsafe impl Send for DispatcherContext {}
 
 #[cfg(test)]
-#[cfg_attr(coverage_nightly, coverage(off))]
+#[cfg_attr(coverage, coverage(off))]
 mod tests {
     use core::sync::atomic::AtomicBool;
     use std::{fs::File, io::Read, vec};

--- a/patina_dxe_core/src/pi_dispatcher/debug_image_info_table.rs
+++ b/patina_dxe_core/src/pi_dispatcher/debug_image_info_table.rs
@@ -326,7 +326,7 @@ fn drop_debug_image_info(info: &mut efi::DebugImageInfo) {
 }
 
 #[cfg(test)]
-#[cfg_attr(coverage_nightly, coverage(off))]
+#[cfg_attr(coverage, coverage(off))]
 mod tests {
     use super::*;
     use crate::test_support;

--- a/patina_dxe_core/src/pi_dispatcher/fv.rs
+++ b/patina_dxe_core/src/pi_dispatcher/fv.rs
@@ -435,7 +435,7 @@ impl<P: PlatformInfo> FvProtocolData<P> {
 }
 
 // FV / FVB EFIAPI compliant protocol method implementations.
-#[cfg_attr(coverage_nightly, coverage(off))]
+#[cfg_attr(coverage, coverage(off))]
 impl<P: PlatformInfo> FvProtocolData<P> {
     /// EFIAPI compliant FVB protocol GetAttributes method.
     extern "efiapi" fn fvb_get_attributes_efiapi(
@@ -889,7 +889,7 @@ pub fn device_path_bytes_for_fv_file(fv_handle: efi::Handle, file_name: efi::Gui
 }
 
 #[cfg(test)]
-#[cfg_attr(coverage_nightly, coverage(off))]
+#[cfg_attr(coverage, coverage(off))]
 mod tests {
     use super::*;
     use crate::{MockComponentInfo, MockCpuInfo, MockMemoryInfo, test_support};

--- a/patina_dxe_core/src/pi_dispatcher/image.rs
+++ b/patina_dxe_core/src/pi_dispatcher/image.rs
@@ -82,7 +82,7 @@ pub const ENTRY_POINT_STACK_SIZE: usize = 0x100000;
 const _: () = assert!(STACK_ALIGNMENT < UEFI_PAGE_SIZE);
 
 // dummy function used to initialize PrivateImageData.entry_point.
-#[cfg_attr(coverage_nightly, coverage(off))]
+#[cfg_attr(coverage, coverage(off))]
 extern "efiapi" fn unimplemented_entry_point(
     _handle: efi::Handle,
     _system_table: *mut efi::SystemTable,
@@ -815,7 +815,7 @@ impl<P: super::PlatformInfo> super::PiDispatcher<P> {
     ///   structure in readable memory for the duration of the call.
     /// - `image_handle` is null-checked and returns `INVALID_PARAMETER` if null; if non-null,
     ///   it must point to writable memory suitable for storing an `efi::Handle`.
-    #[cfg_attr(coverage_nightly, coverage(off))]
+    #[cfg_attr(coverage, coverage(off))]
     pub(super) unsafe extern "efiapi" fn load_image_efiapi(
         boot_policy: efi::Boolean,
         parent_image_handle: efi::Handle,
@@ -965,7 +965,7 @@ impl<P: super::PlatformInfo> super::PiDispatcher<P> {
     /// If `exit_data_size` and `exit_data` are non-null, they must point to
     /// valid writable memory. The caller owns the returned exit data buffer.
     ///
-    #[cfg_attr(coverage_nightly, coverage(off))]
+    #[cfg_attr(coverage, coverage(off))]
     pub(super) unsafe extern "efiapi" fn start_image_efiapi(
         image_handle: efi::Handle,
         exit_data_size: *mut usize,
@@ -1091,7 +1091,7 @@ impl<P: super::PlatformInfo> super::PiDispatcher<P> {
         Ok(())
     }
 
-    #[cfg_attr(coverage_nightly, coverage(off))]
+    #[cfg_attr(coverage, coverage(off))]
     /// Unloads a previously loaded image.
     ///
     /// # Safety Considerations
@@ -1199,7 +1199,7 @@ impl<P: super::PlatformInfo> super::PiDispatcher<P> {
     /// to a valid buffer of at least `exit_data_size` bytes. This pointer is
     /// stored and later returned to the caller of `start_image` to retrieve the
     /// exit data.
-    #[cfg_attr(coverage_nightly, coverage(off))]
+    #[cfg_attr(coverage, coverage(off))]
     pub(super) unsafe extern "efiapi" fn exit_efiapi(
         image_handle: efi::Handle,
         status: efi::Status,
@@ -1593,7 +1593,7 @@ impl Buffer {
 }
 
 #[cfg(test)]
-#[cfg_attr(coverage_nightly, coverage(off))]
+#[cfg_attr(coverage, coverage(off))]
 mod tests {
     extern crate std;
     use super::*;

--- a/patina_dxe_core/src/protocol_db.rs
+++ b/patina_dxe_core/src/protocol_db.rs
@@ -883,7 +883,7 @@ unsafe impl Send for SpinLockedProtocolDb {}
 unsafe impl Sync for SpinLockedProtocolDb {}
 
 #[cfg(test)]
-#[cfg_attr(coverage_nightly, coverage(off))]
+#[cfg_attr(coverage, coverage(off))]
 mod tests {
     extern crate std;
     use core::str::FromStr;

--- a/patina_dxe_core/src/runtime.rs
+++ b/patina_dxe_core/src/runtime.rs
@@ -170,7 +170,7 @@ pub fn remove_runtime_image(image_handle: efi::Handle) -> Result<(), EfiError> {
 }
 
 #[cfg(test)]
-#[cfg_attr(coverage_nightly, coverage(off))]
+#[cfg_attr(coverage, coverage(off))]
 mod tests {
     use super::*;
     use crate::test_support;

--- a/patina_dxe_core/src/systemtables.rs
+++ b/patina_dxe_core/src/systemtables.rs
@@ -90,17 +90,17 @@ impl EfiRuntimeServicesTable {
     // checksummed.
     fn default_runtime_services_table() -> efi::RuntimeServices {
         //private unimplemented stub functions used to initialize the table.
-        #[cfg_attr(coverage_nightly, coverage(off))]
+        #[cfg_attr(coverage, coverage(off))]
         extern "efiapi" fn get_time_unimplemented(_: *mut efi::Time, _: *mut efi::TimeCapabilities) -> efi::Status {
             efi::Status::from_usize(EFI_NOT_AVAILABLE_YET)
         }
 
-        #[cfg_attr(coverage_nightly, coverage(off))]
+        #[cfg_attr(coverage, coverage(off))]
         extern "efiapi" fn set_time_unimplemented(_: *mut efi::Time) -> efi::Status {
             efi::Status::from_usize(EFI_NOT_AVAILABLE_YET)
         }
 
-        #[cfg_attr(coverage_nightly, coverage(off))]
+        #[cfg_attr(coverage, coverage(off))]
         extern "efiapi" fn get_wakeup_time_unimplemented(
             _: *mut efi::Boolean,
             _: *mut efi::Boolean,
@@ -109,12 +109,12 @@ impl EfiRuntimeServicesTable {
             efi::Status::from_usize(EFI_NOT_AVAILABLE_YET)
         }
 
-        #[cfg_attr(coverage_nightly, coverage(off))]
+        #[cfg_attr(coverage, coverage(off))]
         extern "efiapi" fn set_wakeup_time_unimplemented(_: efi::Boolean, _: *mut efi::Time) -> efi::Status {
             efi::Status::from_usize(EFI_NOT_AVAILABLE_YET)
         }
 
-        #[cfg_attr(coverage_nightly, coverage(off))]
+        #[cfg_attr(coverage, coverage(off))]
         extern "efiapi" fn set_virtual_address_map_unimplemented(
             _: usize,
             _: usize,
@@ -124,12 +124,12 @@ impl EfiRuntimeServicesTable {
             efi::Status::from_usize(EFI_NOT_AVAILABLE_YET)
         }
 
-        #[cfg_attr(coverage_nightly, coverage(off))]
+        #[cfg_attr(coverage, coverage(off))]
         extern "efiapi" fn convert_pointer_unimplemented(_: usize, _: *mut *mut c_void) -> efi::Status {
             efi::Status::from_usize(EFI_NOT_AVAILABLE_YET)
         }
 
-        #[cfg_attr(coverage_nightly, coverage(off))]
+        #[cfg_attr(coverage, coverage(off))]
         extern "efiapi" fn get_variable_unimplemented(
             _: *mut efi::Char16,
             _: *mut efi::Guid,
@@ -140,7 +140,7 @@ impl EfiRuntimeServicesTable {
             efi::Status::from_usize(EFI_NOT_AVAILABLE_YET)
         }
 
-        #[cfg_attr(coverage_nightly, coverage(off))]
+        #[cfg_attr(coverage, coverage(off))]
         extern "efiapi" fn get_next_variable_name_unimplemented(
             _: *mut usize,
             _: *mut efi::Char16,
@@ -149,7 +149,7 @@ impl EfiRuntimeServicesTable {
             efi::Status::from_usize(EFI_NOT_AVAILABLE_YET)
         }
 
-        #[cfg_attr(coverage_nightly, coverage(off))]
+        #[cfg_attr(coverage, coverage(off))]
         extern "efiapi" fn set_variable_unimplemented(
             _: *mut efi::Char16,
             _: *mut efi::Guid,
@@ -160,15 +160,15 @@ impl EfiRuntimeServicesTable {
             efi::Status::from_usize(EFI_NOT_AVAILABLE_YET)
         }
 
-        #[cfg_attr(coverage_nightly, coverage(off))]
+        #[cfg_attr(coverage, coverage(off))]
         extern "efiapi" fn get_next_high_mono_count_unimplemented(_: *mut u32) -> efi::Status {
             efi::Status::from_usize(EFI_NOT_AVAILABLE_YET)
         }
 
-        #[cfg_attr(coverage_nightly, coverage(off))]
+        #[cfg_attr(coverage, coverage(off))]
         extern "efiapi" fn reset_system_unimplemented(_: efi::ResetType, _: efi::Status, _: usize, _: *mut c_void) {}
 
-        #[cfg_attr(coverage_nightly, coverage(off))]
+        #[cfg_attr(coverage, coverage(off))]
         extern "efiapi" fn update_capsule_unimplemented(
             _: *mut *mut efi::CapsuleHeader,
             _: usize,
@@ -177,7 +177,7 @@ impl EfiRuntimeServicesTable {
             efi::Status::from_usize(EFI_NOT_AVAILABLE_YET)
         }
 
-        #[cfg_attr(coverage_nightly, coverage(off))]
+        #[cfg_attr(coverage, coverage(off))]
         extern "efiapi" fn query_capsule_capabilities_unimplemented(
             _: *mut *mut efi::CapsuleHeader,
             _: usize,
@@ -187,7 +187,7 @@ impl EfiRuntimeServicesTable {
             efi::Status::from_usize(EFI_NOT_AVAILABLE_YET)
         }
 
-        #[cfg_attr(coverage_nightly, coverage(off))]
+        #[cfg_attr(coverage, coverage(off))]
         extern "efiapi" fn query_variable_info_unimplemented(
             _: u32,
             _: *mut u64,
@@ -286,15 +286,15 @@ impl EfiBootServicesTable {
     // checksummed.
     fn default_boot_services_table() -> efi::BootServices {
         //private unimplemented stub functions used to initialize the table.
-        #[cfg_attr(coverage_nightly, coverage(off))]
+        #[cfg_attr(coverage, coverage(off))]
         extern "efiapi" fn raise_tpl_unimplemented(_: efi::Tpl) -> efi::Tpl {
             efi::TPL_APPLICATION
         }
 
-        #[cfg_attr(coverage_nightly, coverage(off))]
+        #[cfg_attr(coverage, coverage(off))]
         extern "efiapi" fn restore_tpl_unimplemented(_: efi::Tpl) {}
 
-        #[cfg_attr(coverage_nightly, coverage(off))]
+        #[cfg_attr(coverage, coverage(off))]
         extern "efiapi" fn allocate_pages_unimplemented(
             _: efi::AllocateType,
             _: efi::MemoryType,
@@ -304,12 +304,12 @@ impl EfiBootServicesTable {
             efi::Status::from_usize(EFI_NOT_AVAILABLE_YET)
         }
 
-        #[cfg_attr(coverage_nightly, coverage(off))]
+        #[cfg_attr(coverage, coverage(off))]
         extern "efiapi" fn free_pages_unimplemented(_: efi::PhysicalAddress, _: usize) -> efi::Status {
             efi::Status::from_usize(EFI_NOT_AVAILABLE_YET)
         }
 
-        #[cfg_attr(coverage_nightly, coverage(off))]
+        #[cfg_attr(coverage, coverage(off))]
         extern "efiapi" fn get_memory_map_unimplemented(
             _: *mut usize,
             _: *mut efi::MemoryDescriptor,
@@ -320,7 +320,7 @@ impl EfiBootServicesTable {
             efi::Status::from_usize(EFI_NOT_AVAILABLE_YET)
         }
 
-        #[cfg_attr(coverage_nightly, coverage(off))]
+        #[cfg_attr(coverage, coverage(off))]
         extern "efiapi" fn allocate_pool_unimplemented(
             _: efi::MemoryType,
             _: usize,
@@ -329,12 +329,12 @@ impl EfiBootServicesTable {
             efi::Status::from_usize(EFI_NOT_AVAILABLE_YET)
         }
 
-        #[cfg_attr(coverage_nightly, coverage(off))]
+        #[cfg_attr(coverage, coverage(off))]
         extern "efiapi" fn free_pool_unimplemented(_: *mut c_void) -> efi::Status {
             efi::Status::from_usize(EFI_NOT_AVAILABLE_YET)
         }
 
-        #[cfg_attr(coverage_nightly, coverage(off))]
+        #[cfg_attr(coverage, coverage(off))]
         extern "efiapi" fn create_event_unimplemented(
             _: u32,
             _: efi::Tpl,
@@ -345,32 +345,32 @@ impl EfiBootServicesTable {
             efi::Status::from_usize(EFI_NOT_AVAILABLE_YET)
         }
 
-        #[cfg_attr(coverage_nightly, coverage(off))]
+        #[cfg_attr(coverage, coverage(off))]
         extern "efiapi" fn set_timer_unimplemented(_: efi::Event, _: efi::TimerDelay, _: u64) -> efi::Status {
             efi::Status::from_usize(EFI_NOT_AVAILABLE_YET)
         }
 
-        #[cfg_attr(coverage_nightly, coverage(off))]
+        #[cfg_attr(coverage, coverage(off))]
         extern "efiapi" fn wait_for_event_unimplemented(_: usize, _: *mut efi::Event, _: *mut usize) -> efi::Status {
             efi::Status::from_usize(EFI_NOT_AVAILABLE_YET)
         }
 
-        #[cfg_attr(coverage_nightly, coverage(off))]
+        #[cfg_attr(coverage, coverage(off))]
         extern "efiapi" fn signal_event_unimplemented(_: efi::Event) -> efi::Status {
             efi::Status::from_usize(EFI_NOT_AVAILABLE_YET)
         }
 
-        #[cfg_attr(coverage_nightly, coverage(off))]
+        #[cfg_attr(coverage, coverage(off))]
         extern "efiapi" fn close_event_unimplemented(_: efi::Event) -> efi::Status {
             efi::Status::from_usize(EFI_NOT_AVAILABLE_YET)
         }
 
-        #[cfg_attr(coverage_nightly, coverage(off))]
+        #[cfg_attr(coverage, coverage(off))]
         extern "efiapi" fn check_event_unimplemented(_: efi::Event) -> efi::Status {
             efi::Status::from_usize(EFI_NOT_AVAILABLE_YET)
         }
 
-        #[cfg_attr(coverage_nightly, coverage(off))]
+        #[cfg_attr(coverage, coverage(off))]
         extern "efiapi" fn install_protocol_interface_unimplemented(
             _: *mut efi::Handle,
             _: *mut efi::Guid,
@@ -380,7 +380,7 @@ impl EfiBootServicesTable {
             efi::Status::from_usize(EFI_NOT_AVAILABLE_YET)
         }
 
-        #[cfg_attr(coverage_nightly, coverage(off))]
+        #[cfg_attr(coverage, coverage(off))]
         extern "efiapi" fn reinstall_protocol_interface_unimplemented(
             _: efi::Handle,
             _: *mut efi::Guid,
@@ -390,7 +390,7 @@ impl EfiBootServicesTable {
             efi::Status::from_usize(EFI_NOT_AVAILABLE_YET)
         }
 
-        #[cfg_attr(coverage_nightly, coverage(off))]
+        #[cfg_attr(coverage, coverage(off))]
         extern "efiapi" fn uninstall_protocol_interface_unimplemented(
             _: efi::Handle,
             _: *mut efi::Guid,
@@ -399,7 +399,7 @@ impl EfiBootServicesTable {
             efi::Status::from_usize(EFI_NOT_AVAILABLE_YET)
         }
 
-        #[cfg_attr(coverage_nightly, coverage(off))]
+        #[cfg_attr(coverage, coverage(off))]
         extern "efiapi" fn handle_protocol_unimplemented(
             _: efi::Handle,
             _: *mut efi::Guid,
@@ -408,7 +408,7 @@ impl EfiBootServicesTable {
             efi::Status::from_usize(EFI_NOT_AVAILABLE_YET)
         }
 
-        #[cfg_attr(coverage_nightly, coverage(off))]
+        #[cfg_attr(coverage, coverage(off))]
         extern "efiapi" fn register_protocol_notify_unimplemented(
             _: *mut efi::Guid,
             _: efi::Event,
@@ -417,7 +417,7 @@ impl EfiBootServicesTable {
             efi::Status::from_usize(EFI_NOT_AVAILABLE_YET)
         }
 
-        #[cfg_attr(coverage_nightly, coverage(off))]
+        #[cfg_attr(coverage, coverage(off))]
         extern "efiapi" fn locate_handle_unimplemented(
             _: efi::LocateSearchType,
             _: *mut efi::Guid,
@@ -428,7 +428,7 @@ impl EfiBootServicesTable {
             efi::Status::from_usize(EFI_NOT_AVAILABLE_YET)
         }
 
-        #[cfg_attr(coverage_nightly, coverage(off))]
+        #[cfg_attr(coverage, coverage(off))]
         extern "efiapi" fn locate_device_path_unimplemented(
             _: *mut efi::Guid,
             _: *mut *mut efi::protocols::device_path::Protocol,
@@ -437,12 +437,12 @@ impl EfiBootServicesTable {
             efi::Status::from_usize(EFI_NOT_AVAILABLE_YET)
         }
 
-        #[cfg_attr(coverage_nightly, coverage(off))]
+        #[cfg_attr(coverage, coverage(off))]
         extern "efiapi" fn install_configuration_table_unimplemented(_: *mut efi::Guid, _: *mut c_void) -> efi::Status {
             efi::Status::from_usize(EFI_NOT_AVAILABLE_YET)
         }
 
-        #[cfg_attr(coverage_nightly, coverage(off))]
+        #[cfg_attr(coverage, coverage(off))]
         extern "efiapi" fn load_image_unimplemented(
             _: efi::Boolean,
             _: efi::Handle,
@@ -454,7 +454,7 @@ impl EfiBootServicesTable {
             efi::Status::from_usize(EFI_NOT_AVAILABLE_YET)
         }
 
-        #[cfg_attr(coverage_nightly, coverage(off))]
+        #[cfg_attr(coverage, coverage(off))]
         extern "efiapi" fn start_image_unimplemented(
             _: efi::Handle,
             _: *mut usize,
@@ -463,7 +463,7 @@ impl EfiBootServicesTable {
             efi::Status::from_usize(EFI_NOT_AVAILABLE_YET)
         }
 
-        #[cfg_attr(coverage_nightly, coverage(off))]
+        #[cfg_attr(coverage, coverage(off))]
         extern "efiapi" fn exit_unimplemented(
             _: efi::Handle,
             _: efi::Status,
@@ -473,27 +473,27 @@ impl EfiBootServicesTable {
             efi::Status::from_usize(EFI_NOT_AVAILABLE_YET)
         }
 
-        #[cfg_attr(coverage_nightly, coverage(off))]
+        #[cfg_attr(coverage, coverage(off))]
         extern "efiapi" fn unload_image_unimplemented(_: efi::Handle) -> efi::Status {
             efi::Status::from_usize(EFI_NOT_AVAILABLE_YET)
         }
 
-        #[cfg_attr(coverage_nightly, coverage(off))]
+        #[cfg_attr(coverage, coverage(off))]
         extern "efiapi" fn exit_boot_services_unimplemented(_: efi::Handle, _: usize) -> efi::Status {
             efi::Status::from_usize(EFI_NOT_AVAILABLE_YET)
         }
 
-        #[cfg_attr(coverage_nightly, coverage(off))]
+        #[cfg_attr(coverage, coverage(off))]
         extern "efiapi" fn get_next_monotonic_count_unimplemented(_: *mut u64) -> efi::Status {
             efi::Status::from_usize(EFI_NOT_AVAILABLE_YET)
         }
 
-        #[cfg_attr(coverage_nightly, coverage(off))]
+        #[cfg_attr(coverage, coverage(off))]
         extern "efiapi" fn stall_unimplemented(_: usize) -> efi::Status {
             efi::Status::from_usize(EFI_NOT_AVAILABLE_YET)
         }
 
-        #[cfg_attr(coverage_nightly, coverage(off))]
+        #[cfg_attr(coverage, coverage(off))]
         extern "efiapi" fn set_watchdog_timer_unimplemented(
             _: usize,
             _: u64,
@@ -503,7 +503,7 @@ impl EfiBootServicesTable {
             efi::Status::from_usize(EFI_NOT_AVAILABLE_YET)
         }
 
-        #[cfg_attr(coverage_nightly, coverage(off))]
+        #[cfg_attr(coverage, coverage(off))]
         extern "efiapi" fn connect_controller_unimplemented(
             _: efi::Handle,
             _: *mut efi::Handle,
@@ -513,7 +513,7 @@ impl EfiBootServicesTable {
             efi::Status::from_usize(EFI_NOT_AVAILABLE_YET)
         }
 
-        #[cfg_attr(coverage_nightly, coverage(off))]
+        #[cfg_attr(coverage, coverage(off))]
         extern "efiapi" fn disconnect_controller_unimplemented(
             _: efi::Handle,
             _: efi::Handle,
@@ -522,7 +522,7 @@ impl EfiBootServicesTable {
             efi::Status::from_usize(EFI_NOT_AVAILABLE_YET)
         }
 
-        #[cfg_attr(coverage_nightly, coverage(off))]
+        #[cfg_attr(coverage, coverage(off))]
         extern "efiapi" fn open_protocol_unimplemented(
             _: efi::Handle,
             _: *mut efi::Guid,
@@ -534,7 +534,7 @@ impl EfiBootServicesTable {
             efi::Status::from_usize(EFI_NOT_AVAILABLE_YET)
         }
 
-        #[cfg_attr(coverage_nightly, coverage(off))]
+        #[cfg_attr(coverage, coverage(off))]
         extern "efiapi" fn close_protocol_unimplemented(
             _: efi::Handle,
             _: *mut efi::Guid,
@@ -544,7 +544,7 @@ impl EfiBootServicesTable {
             efi::Status::from_usize(EFI_NOT_AVAILABLE_YET)
         }
 
-        #[cfg_attr(coverage_nightly, coverage(off))]
+        #[cfg_attr(coverage, coverage(off))]
         extern "efiapi" fn open_protocol_information_unimplemented(
             _: efi::Handle,
             _: *mut efi::Guid,
@@ -554,7 +554,7 @@ impl EfiBootServicesTable {
             efi::Status::from_usize(EFI_NOT_AVAILABLE_YET)
         }
 
-        #[cfg_attr(coverage_nightly, coverage(off))]
+        #[cfg_attr(coverage, coverage(off))]
         extern "efiapi" fn protocols_per_handle_unimplemented(
             _: efi::Handle,
             _: *mut *mut *mut efi::Guid,
@@ -563,7 +563,7 @@ impl EfiBootServicesTable {
             efi::Status::from_usize(EFI_NOT_AVAILABLE_YET)
         }
 
-        #[cfg_attr(coverage_nightly, coverage(off))]
+        #[cfg_attr(coverage, coverage(off))]
         extern "efiapi" fn locate_handle_buffer_unimplemented(
             _: efi::LocateSearchType,
             _: *mut efi::Guid,
@@ -574,7 +574,7 @@ impl EfiBootServicesTable {
             efi::Status::from_usize(EFI_NOT_AVAILABLE_YET)
         }
 
-        #[cfg_attr(coverage_nightly, coverage(off))]
+        #[cfg_attr(coverage, coverage(off))]
         extern "efiapi" fn locate_protocol_unimplemented(
             _: *mut efi::Guid,
             _: *mut c_void,
@@ -583,7 +583,7 @@ impl EfiBootServicesTable {
             efi::Status::from_usize(EFI_NOT_AVAILABLE_YET)
         }
 
-        #[cfg_attr(coverage_nightly, coverage(off))]
+        #[cfg_attr(coverage, coverage(off))]
         extern "efiapi" fn install_multiple_protocol_interfaces_unimplemented(
             _: *mut efi::Handle,
             _: *mut c_void,
@@ -592,7 +592,7 @@ impl EfiBootServicesTable {
             efi::Status::from_usize(EFI_NOT_AVAILABLE_YET)
         }
 
-        #[cfg_attr(coverage_nightly, coverage(off))]
+        #[cfg_attr(coverage, coverage(off))]
         extern "efiapi" fn uninstall_multiple_protocol_interfaces_unimplemented(
             _: efi::Handle,
             _: *mut c_void,
@@ -601,18 +601,18 @@ impl EfiBootServicesTable {
             efi::Status::from_usize(EFI_NOT_AVAILABLE_YET)
         }
 
-        #[cfg_attr(coverage_nightly, coverage(off))]
+        #[cfg_attr(coverage, coverage(off))]
         extern "efiapi" fn calculate_crc32_unimplemented(_: *mut c_void, _: usize, _: *mut u32) -> efi::Status {
             efi::Status::from_usize(EFI_NOT_AVAILABLE_YET)
         }
 
-        #[cfg_attr(coverage_nightly, coverage(off))]
+        #[cfg_attr(coverage, coverage(off))]
         extern "efiapi" fn copy_mem_unimplemented(_: *mut c_void, _: *mut c_void, _: usize) {}
 
-        #[cfg_attr(coverage_nightly, coverage(off))]
+        #[cfg_attr(coverage, coverage(off))]
         extern "efiapi" fn set_mem_unimplemented(_: *mut c_void, _: usize, _: u8) {}
 
-        #[cfg_attr(coverage_nightly, coverage(off))]
+        #[cfg_attr(coverage, coverage(off))]
         extern "efiapi" fn create_event_ex_unimplemented(
             _: u32,
             _: efi::Tpl,
@@ -924,7 +924,7 @@ impl SystemTableChecksumInstaller {
 }
 
 #[cfg(test)]
-#[cfg_attr(coverage_nightly, coverage(off))]
+#[cfg_attr(coverage, coverage(off))]
 mod tests {
     use super::*;
     use crate::test_support;

--- a/patina_dxe_core/src/test_support.rs
+++ b/patina_dxe_core/src/test_support.rs
@@ -734,7 +734,7 @@ pub(crate) fn init_test_logger() {
 }
 
 #[cfg(test)]
-#[cfg_attr(coverage_nightly, coverage(off))]
+#[cfg_attr(coverage, coverage(off))]
 mod tests {
     use super::*;
     use crate::{

--- a/patina_dxe_core/src/tpl_mutex.rs
+++ b/patina_dxe_core/src/tpl_mutex.rs
@@ -137,7 +137,7 @@ impl<T: ?Sized> Drop for TplGuard<'_, T> {
 }
 
 #[cfg(test)]
-#[cfg_attr(coverage_nightly, coverage(off))]
+#[cfg_attr(coverage, coverage(off))]
 mod tests {
 
     use crate::{

--- a/sdk/patina/src/arch.rs
+++ b/sdk/patina/src/arch.rs
@@ -9,15 +9,15 @@
 
 cfg_if::cfg_if! {
     if #[cfg(test)] {
-        #[cfg_attr(coverage_nightly, coverage(off))]
+        #[cfg_attr(coverage, coverage(off))]
         mod null;
         type Arch = null::NullArch;
     } else if #[cfg(target_arch = "aarch64")] {
-        #[cfg_attr(coverage_nightly, coverage(off))] // Architecture code cannot be unit tested.
+        #[cfg_attr(coverage, coverage(off))] // Architecture code cannot be unit tested.
         pub mod aarch64;
         type Arch = aarch64::AArch64;
     } else if #[cfg(target_arch = "x86_64")] {
-        #[cfg_attr(coverage_nightly, coverage(off))] // Architecture code cannot be unit tested.
+        #[cfg_attr(coverage, coverage(off))] // Architecture code cannot be unit tested.
         pub mod x64;
         type Arch = x64::X64;
     }

--- a/sdk/patina/src/base.rs
+++ b/sdk/patina/src/base.rs
@@ -426,7 +426,7 @@ macro_rules! writelncrlf {
 }
 
 #[cfg(test)]
-#[cfg_attr(coverage_nightly, coverage(off))]
+#[cfg_attr(coverage, coverage(off))]
 mod tests {
     use super::*;
 

--- a/sdk/patina/src/base/guid.rs
+++ b/sdk/patina/src/base/guid.rs
@@ -639,7 +639,7 @@ const fn char_to_val(c: char) -> u8 {
 }
 
 #[cfg(test)]
-#[cfg_attr(coverage_nightly, coverage(off))]
+#[cfg_attr(coverage, coverage(off))]
 mod tests {
     use super::*;
     use core::mem::{align_of, size_of};

--- a/sdk/patina/src/base/memory_map.rs
+++ b/sdk/patina/src/base/memory_map.rs
@@ -33,7 +33,7 @@ use r_efi::efi;
 /// let descriptors: Vec<efi::MemoryDescriptor> = vec![]; // Get from get_memory_map()
 /// memory_map::print_details(&descriptors);
 /// ```
-#[cfg_attr(coverage_nightly, coverage(off))]
+#[cfg_attr(coverage, coverage(off))]
 pub fn print_details(descriptors: &[efi::MemoryDescriptor]) {
     log::info!(target: "memory_map_test", "\n");
     log::info!(target: "memory_map_test", "UEFI Memory Map ({} descriptors):", descriptors.len());

--- a/sdk/patina/src/boot_services.rs
+++ b/sdk/patina/src/boot_services.rs
@@ -2061,7 +2061,7 @@ impl BootServices for StandardBootServices {
 }
 
 #[cfg(test)]
-#[cfg_attr(coverage_nightly, coverage(off))]
+#[cfg_attr(coverage, coverage(off))]
 mod tests {
     use crate::BinaryGuid;
     use c_ptr::CPtr;

--- a/sdk/patina/src/boot_services/c_ptr.rs
+++ b/sdk/patina/src/boot_services/c_ptr.rs
@@ -242,7 +242,7 @@ unsafe impl<T> CPtr<'_> for NonNull<T> {
 }
 
 #[cfg(test)]
-#[cfg_attr(coverage_nightly, coverage(off))]
+#[cfg_attr(coverage, coverage(off))]
 mod tests {
     use core::ptr;
 

--- a/sdk/patina/src/component.rs
+++ b/sdk/patina/src/component.rs
@@ -212,7 +212,7 @@ pub mod prelude {
 }
 
 #[cfg(test)]
-#[cfg_attr(coverage_nightly, coverage(off))]
+#[cfg_attr(coverage, coverage(off))]
 mod tests {
     extern crate std;
 

--- a/sdk/patina/src/component/hob.rs
+++ b/sdk/patina/src/component/hob.rs
@@ -292,7 +292,7 @@ impl<'h, T: FromHob + 'static> IntoIterator for &Hob<'h, T> {
 }
 
 #[cfg(test)]
-#[cfg_attr(coverage_nightly, coverage(off))]
+#[cfg_attr(coverage, coverage(off))]
 mod tests {
     use crate as patina;
     use crate::{

--- a/sdk/patina/src/component/metadata.rs
+++ b/sdk/patina/src/component/metadata.rs
@@ -178,7 +178,7 @@ impl fmt::Debug for PrettyFixedBitSet<'_> {
 }
 
 #[cfg(test)]
-#[cfg_attr(coverage_nightly, coverage(off))]
+#[cfg_attr(coverage, coverage(off))]
 mod tests {
     use super::*;
     extern crate std;

--- a/sdk/patina/src/component/params.rs
+++ b/sdk/patina/src/component/params.rs
@@ -849,7 +849,7 @@ impl_component_param_tuple!(T1, T2, T3, T4, T5);
 impl_component_param_tuple!(T1, T2, T3, T4, T5, T6);
 
 #[cfg(test)]
-#[cfg_attr(coverage_nightly, coverage(off))]
+#[cfg_attr(coverage, coverage(off))]
 mod tests {
     use core::sync::atomic::AtomicBool;
 

--- a/sdk/patina/src/component/service.rs
+++ b/sdk/patina/src/component/service.rs
@@ -416,7 +416,7 @@ unsafe impl<T: ?Sized + 'static> Param for Service<T> {
 }
 
 #[cfg(test)]
-#[cfg_attr(coverage_nightly, coverage(off))]
+#[cfg_attr(coverage, coverage(off))]
 mod tests {
     use super::{IntoService, *};
 

--- a/sdk/patina/src/component/service/memory.rs
+++ b/sdk/patina/src/component/service/memory.rs
@@ -829,7 +829,7 @@ pub enum PageAllocationStrategy {
 pub use mock::StdMemoryManager;
 
 #[cfg(any(test, feature = "mockall"))]
-#[cfg_attr(coverage_nightly, coverage(off))]
+#[cfg_attr(coverage, coverage(off))]
 mod mock {
     extern crate std;
     use std::{
@@ -917,7 +917,7 @@ mod mock {
 }
 
 #[cfg(test)]
-#[cfg_attr(coverage_nightly, coverage(off))]
+#[cfg_attr(coverage, coverage(off))]
 mod tests {
     use core::{
         alloc::Layout,

--- a/sdk/patina/src/component/storage.rs
+++ b/sdk/patina/src/component/storage.rs
@@ -616,7 +616,7 @@ unsafe impl Param for &Storage {
 }
 
 #[cfg(test)]
-#[cfg_attr(coverage_nightly, coverage(off))]
+#[cfg_attr(coverage, coverage(off))]
 mod tests {
     use super::*;
 

--- a/sdk/patina/src/component/struct_component.rs
+++ b/sdk/patina/src/component/struct_component.rs
@@ -114,7 +114,7 @@ where
 }
 
 #[cfg(test)]
-#[cfg_attr(coverage_nightly, coverage(off))]
+#[cfg_attr(coverage, coverage(off))]
 mod tests {
     use crate as patina;
     use crate::component::{

--- a/sdk/patina/src/component/type_name.rs
+++ b/sdk/patina/src/component/type_name.rs
@@ -33,7 +33,7 @@ pub(crate) fn normalize(name: &str) -> String {
 }
 
 #[cfg(test)]
-#[cfg_attr(coverage_nightly, coverage(off))]
+#[cfg_attr(coverage, coverage(off))]
 mod tests {
     use super::*;
 

--- a/sdk/patina/src/device_path/paths.rs
+++ b/sdk/patina/src/device_path/paths.rs
@@ -379,7 +379,7 @@ impl Display for DevicePath {
 }
 
 #[cfg(test)]
-#[cfg_attr(coverage_nightly, coverage(off))]
+#[cfg_attr(coverage, coverage(off))]
 mod tests {
     use super::*;
     use core::assert_eq;

--- a/sdk/patina/src/device_path/walker.rs
+++ b/sdk/patina/src/device_path/walker.rs
@@ -462,7 +462,7 @@ fn protocol_to_subtype_str(protocol: efi::protocols::device_path::Protocol) -> &
 }
 
 #[cfg(test)]
-#[cfg_attr(coverage_nightly, coverage(off))]
+#[cfg_attr(coverage, coverage(off))]
 mod tests {
     use core::mem::size_of;
 

--- a/sdk/patina/src/driver_binding.rs
+++ b/sdk/patina/src/driver_binding.rs
@@ -308,7 +308,7 @@ impl<T: DriverBinding + 'static, U: BootServices + 'static> UefiDriverBinding<T,
 }
 
 #[cfg(test)]
-#[cfg_attr(coverage_nightly, coverage(off))]
+#[cfg_attr(coverage, coverage(off))]
 mod tests {
     use core::{
         mem::MaybeUninit,

--- a/sdk/patina/src/hash.rs
+++ b/sdk/patina/src/hash.rs
@@ -59,7 +59,7 @@ impl Hasher for Xorshift64starHasher {
 }
 
 #[cfg(test)]
-#[cfg_attr(coverage_nightly, coverage(off))]
+#[cfg_attr(coverage, coverage(off))]
 mod tests {
     use super::*;
 

--- a/sdk/patina/src/lib.rs
+++ b/sdk/patina/src/lib.rs
@@ -17,7 +17,7 @@
 #![cfg_attr(all(not(feature = "std"), not(test), not(feature = "mockall")), no_std)]
 #![cfg_attr(any(test, feature = "alloc"), feature(allocator_api))]
 #![allow(static_mut_refs)]
-#![cfg_attr(coverage_nightly, feature(coverage_attribute))]
+#![cfg_attr(coverage, feature(coverage_attribute))]
 
 #[cfg(any(test, feature = "alloc"))]
 extern crate alloc;

--- a/sdk/patina/src/management_mode/comm_buffer_hob.rs
+++ b/sdk/patina/src/management_mode/comm_buffer_hob.rs
@@ -67,7 +67,7 @@ pub struct MmCommBufferStatus {
 }
 
 impl Default for MmCommBufferStatus {
-    #[cfg_attr(coverage_nightly, coverage(off))]
+    #[cfg_attr(coverage, coverage(off))]
     fn default() -> Self {
         Self::new()
     }

--- a/sdk/patina/src/performance/globals.rs
+++ b/sdk/patina/src/performance/globals.rs
@@ -121,7 +121,7 @@ pub fn set_load_image_count(count: u32) {
 }
 
 /// Set performance component static state.
-#[cfg_attr(coverage_nightly, coverage(off))]
+#[cfg_attr(coverage, coverage(off))]
 pub fn set_static_state(
     boot_services: StandardBootServices,
     timer: Service<dyn ArchTimerFunctionality>,
@@ -130,14 +130,14 @@ pub fn set_static_state(
 }
 
 /// Get performance component static state.
-#[cfg_attr(coverage_nightly, coverage(off))]
+#[cfg_attr(coverage, coverage(off))]
 pub fn get_static_state()
 -> Option<(&'static StandardBootServices, &'static TplMutex<FBPT>, &'static Service<dyn ArchTimerFunctionality>)> {
     STATIC_STATE.inner()
 }
 
 #[cfg(test)]
-#[cfg_attr(coverage_nightly, coverage(off))]
+#[cfg_attr(coverage, coverage(off))]
 mod tests {
     use crate as patina;
     use crate::component::service::IntoService;

--- a/sdk/patina/src/performance/logging.rs
+++ b/sdk/patina/src/performance/logging.rs
@@ -479,7 +479,7 @@ pub fn perf_end_ex(
 }
 
 #[cfg(test)]
-#[cfg_attr(coverage_nightly, coverage(off))]
+#[cfg_attr(coverage, coverage(off))]
 mod tests {
     use super::*;
 

--- a/sdk/patina/src/performance/measurement.rs
+++ b/sdk/patina/src/performance/measurement.rs
@@ -510,7 +510,7 @@ fn get_module_guid_from_handle(
 }
 
 #[cfg(test)]
-#[cfg_attr(coverage_nightly, coverage(off))]
+#[cfg_attr(coverage, coverage(off))]
 mod tests {
     use super::*;
 

--- a/sdk/patina/src/performance/record.rs
+++ b/sdk/patina/src/performance/record.rs
@@ -623,7 +623,7 @@ pub fn record_type_name(record_type: u16) -> &'static str {
 }
 
 #[cfg(test)]
-#[cfg_attr(coverage_nightly, coverage(off))]
+#[cfg_attr(coverage, coverage(off))]
 mod tests {
     use super::*;
     use core::{assert_eq, slice, unreachable};

--- a/sdk/patina/src/performance/record/hob.rs
+++ b/sdk/patina/src/performance/record/hob.rs
@@ -62,7 +62,7 @@ impl FromHob for HobPerformanceData {
 }
 
 impl HobPerformanceDataExtractor for Hob<'_, HobPerformanceData> {
-    #[cfg_attr(coverage_nightly, coverage(off))]
+    #[cfg_attr(coverage, coverage(off))]
     fn extract_hob_perf_data(&self) -> Result<(u32, PerformanceRecordBuffer), Error> {
         merge_hob_performance_buffer(self.iter())
     }
@@ -85,7 +85,7 @@ where
 }
 
 #[cfg(test)]
-#[cfg_attr(coverage_nightly, coverage(off))]
+#[cfg_attr(coverage, coverage(off))]
 pub mod tests {
     use core::assert_eq;
 

--- a/sdk/patina/src/performance/record/known.rs
+++ b/sdk/patina/src/performance/record/known.rs
@@ -248,7 +248,7 @@ impl TryFrom<u16> for KnownPerfId {
 }
 
 #[cfg(test)]
-#[cfg_attr(coverage_nightly, coverage(off))]
+#[cfg_attr(coverage, coverage(off))]
 mod tests {
     use core::{assert_eq, convert::From, ptr};
 

--- a/sdk/patina/src/performance/table.rs
+++ b/sdk/patina/src/performance/table.rs
@@ -302,7 +302,7 @@ impl Default for FirmwareBasicBootPerfDataRecord {
 }
 
 #[cfg(test)]
-#[cfg_attr(coverage_nightly, coverage(off))]
+#[cfg_attr(coverage, coverage(off))]
 mod tests {
     use super::*;
 

--- a/sdk/patina/src/pi/dxe_services.rs
+++ b/sdk/patina/src/pi/dxe_services.rs
@@ -460,7 +460,7 @@ impl Default for IoSpaceDescriptor {
 }
 
 #[cfg(test)]
-#[cfg_attr(coverage_nightly, coverage(off))]
+#[cfg_attr(coverage, coverage(off))]
 mod tests {
     use super::*;
 

--- a/sdk/patina/src/runtime_services.rs
+++ b/sdk/patina/src/runtime_services.rs
@@ -504,7 +504,7 @@ impl Clone for MockRuntimeServices {
 }
 
 #[cfg(test)]
-#[cfg_attr(coverage_nightly, coverage(off))]
+#[cfg_attr(coverage, coverage(off))]
 pub(crate) mod test {
     use super::*;
     use core::{mem, slice};

--- a/sdk/patina/src/runtime_services/variable_services.rs
+++ b/sdk/patina/src/runtime_services/variable_services.rs
@@ -153,7 +153,7 @@ impl<R: RuntimeServices> FallibleStreamingIterator for VariableNameIterator<'_, 
 }
 
 #[cfg(test)]
-#[cfg_attr(coverage_nightly, coverage(off))]
+#[cfg_attr(coverage, coverage(off))]
 mod test {
     use r_efi::efi;
 

--- a/sdk/patina/src/serial/virtio.rs
+++ b/sdk/patina/src/serial/virtio.rs
@@ -155,7 +155,7 @@ impl<const N: usize, const B: usize> crate::serial::SerialIO for VirtioSerial<N,
 }
 
 #[cfg(test)]
-#[cfg_attr(coverage_nightly, coverage(off))]
+#[cfg_attr(coverage, coverage(off))]
 mod tests {
     #![allow(clippy::indexing_slicing)]
 

--- a/sdk/patina/src/serial/virtio/mmio.rs
+++ b/sdk/patina/src/serial/virtio/mmio.rs
@@ -240,7 +240,7 @@ impl VirtioMmio {
 }
 
 #[cfg(test)]
-#[cfg_attr(coverage_nightly, coverage(off))]
+#[cfg_attr(coverage, coverage(off))]
 impl VirtioMmioRegs {
     pub(super) fn new_fake(device_id: u32) -> Self {
         // SAFETY: This is a fake register set, the state will be initialized later.
@@ -259,7 +259,7 @@ impl VirtioMmioRegs {
 }
 
 #[cfg(test)]
-#[cfg_attr(coverage_nightly, coverage(off))]
+#[cfg_attr(coverage, coverage(off))]
 mod tests {
     use super::*;
 

--- a/sdk/patina/src/serial/virtio/queue.rs
+++ b/sdk/patina/src/serial/virtio/queue.rs
@@ -277,7 +277,7 @@ impl<const N: usize, const B: usize> VirtQueue<N, B> {
 }
 
 #[cfg(test)]
-#[cfg_attr(coverage_nightly, coverage(off))]
+#[cfg_attr(coverage, coverage(off))]
 impl<const N: usize, const B: usize> VirtQueue<N, B> {
     pub(super) fn test_drain_tx(&mut self) -> alloc::vec::Vec<alloc::vec::Vec<u8>> {
         use alloc::vec::Vec;

--- a/sdk/patina/src/tpl_mutex.rs
+++ b/sdk/patina/src/tpl_mutex.rs
@@ -161,7 +161,7 @@ unsafe impl<T: ?Sized + Send, B: BootServices + Send> Send for TplMutex<T, B> {}
 unsafe impl<T: ?Sized + Sync, B: BootServices> Sync for TplMutexGuard<'_, T, B> {}
 
 #[cfg(test)]
-#[cfg_attr(coverage_nightly, coverage(off))]
+#[cfg_attr(coverage, coverage(off))]
 mod tests {
     use super::*;
     use crate::boot_services::MockBootServices;

--- a/sdk/patina_ffs_extractors/src/brotli.rs
+++ b/sdk/patina_ffs_extractors/src/brotli.rs
@@ -58,7 +58,7 @@ pub struct BrotliSectionExtractor;
 
 impl BrotliSectionExtractor {
     /// Creates a new `BrotliSectionExtractor` instance.
-    #[cfg_attr(coverage_nightly, coverage(off))]
+    #[cfg_attr(coverage, coverage(off))]
     pub const fn new() -> Self {
         Self {}
     }
@@ -117,7 +117,7 @@ impl SectionExtractor for BrotliSectionExtractor {
 }
 
 #[cfg(test)]
-#[cfg_attr(coverage_nightly, coverage(off))]
+#[cfg_attr(coverage, coverage(off))]
 mod tests {
     use crate::tests::create_brotli_section;
 

--- a/sdk/patina_ffs_extractors/src/composite.rs
+++ b/sdk/patina_ffs_extractors/src/composite.rs
@@ -83,7 +83,7 @@ impl SectionExtractor for CompositeSectionExtractor {
 }
 
 #[cfg(test)]
-#[cfg_attr(coverage_nightly, coverage(off))]
+#[cfg_attr(coverage, coverage(off))]
 mod tests {
     use super::*;
 

--- a/sdk/patina_ffs_extractors/src/crc32.rs
+++ b/sdk/patina_ffs_extractors/src/crc32.rs
@@ -18,7 +18,7 @@ pub struct Crc32SectionExtractor;
 
 impl Crc32SectionExtractor {
     /// Creates a new `Crc32SectionExtractor` instance.
-    #[cfg_attr(coverage_nightly, coverage(off))]
+    #[cfg_attr(coverage, coverage(off))]
     pub const fn new() -> Self {
         Self {}
     }
@@ -44,7 +44,7 @@ impl SectionExtractor for Crc32SectionExtractor {
 }
 
 #[cfg(test)]
-#[cfg_attr(coverage_nightly, coverage(off))]
+#[cfg_attr(coverage, coverage(off))]
 mod tests {
     use crate::tests::create_crc32_section;
 

--- a/sdk/patina_ffs_extractors/src/lib.rs
+++ b/sdk/patina_ffs_extractors/src/lib.rs
@@ -19,7 +19,7 @@
 //!
 //! SPDX-License-Identifier: Apache-2.0
 //!
-#![cfg_attr(coverage_nightly, feature(coverage_attribute))]
+#![cfg_attr(coverage, feature(coverage_attribute))]
 #![cfg_attr(not(feature = "std"), no_std)]
 extern crate alloc;
 
@@ -49,7 +49,7 @@ pub use null::NullSectionExtractor;
 const DECOMPRESSION_MAX_MEMORY_LIMIT: u32 = patina::base::SIZE_512MB as u32;
 
 #[cfg(test)]
-#[cfg_attr(coverage_nightly, coverage(off))]
+#[cfg_attr(coverage, coverage(off))]
 mod tests {
     use alloc::{vec, vec::Vec};
     use patina::pi::fw_fs::{

--- a/sdk/patina_ffs_extractors/src/lzma.rs
+++ b/sdk/patina_ffs_extractors/src/lzma.rs
@@ -27,7 +27,7 @@ pub struct LzmaSectionExtractor;
 
 impl LzmaSectionExtractor {
     /// Creates a new `LzmaSectionExtractor` instance.
-    #[cfg_attr(coverage_nightly, coverage(off))]
+    #[cfg_attr(coverage, coverage(off))]
     pub const fn new() -> Self {
         Self {}
     }
@@ -76,7 +76,7 @@ impl SectionExtractor for LzmaSectionExtractor {
 }
 
 #[cfg(test)]
-#[cfg_attr(coverage_nightly, coverage(off))]
+#[cfg_attr(coverage, coverage(off))]
 mod tests {
     use crate::tests::create_lzma_section;
 

--- a/sdk/patina_ffs_extractors/src/null.rs
+++ b/sdk/patina_ffs_extractors/src/null.rs
@@ -15,14 +15,14 @@ pub struct NullSectionExtractor;
 
 impl NullSectionExtractor {
     /// Creates a new `NullSectionExtractor` instance.
-    #[cfg_attr(coverage_nightly, coverage(off))]
+    #[cfg_attr(coverage, coverage(off))]
     pub const fn new() -> Self {
         Self {}
     }
 }
 
 impl SectionExtractor for NullSectionExtractor {
-    #[cfg_attr(coverage_nightly, coverage(off))]
+    #[cfg_attr(coverage, coverage(off))]
     fn extract(&self, _: &patina_ffs::section::Section) -> Result<Vec<u8>, FirmwareFileSystemError> {
         Err(FirmwareFileSystemError::Unsupported)
     }

--- a/sdk/patina_macro/src/hob_macro.rs
+++ b/sdk/patina_macro/src/hob_macro.rs
@@ -148,7 +148,7 @@ pub fn hob_config2(item: proc_macro2::TokenStream) -> proc_macro2::TokenStream {
 }
 
 #[cfg(test)]
-#[cfg_attr(coverage_nightly, coverage(off))]
+#[cfg_attr(coverage, coverage(off))]
 mod tests {
     use super::*;
     use proc_macro2::TokenStream;

--- a/sdk/patina_macro/src/lib.rs
+++ b/sdk/patina_macro/src/lib.rs
@@ -7,7 +7,7 @@
 //! SPDX-License-Identifier: Apache-2.0
 //!
 
-#![cfg_attr(coverage_nightly, feature(coverage_attribute))]
+#![cfg_attr(coverage, feature(coverage_attribute))]
 
 mod hob_macro;
 mod service_macro;

--- a/sdk/patina_macro/src/service_macro.rs
+++ b/sdk/patina_macro/src/service_macro.rs
@@ -199,7 +199,7 @@ pub(crate) fn service2(item: proc_macro2::TokenStream) -> proc_macro2::TokenStre
 }
 
 #[cfg(test)]
-#[cfg_attr(coverage_nightly, coverage(off))]
+#[cfg_attr(coverage, coverage(off))]
 mod tests {
     use super::*;
     use quote::quote;

--- a/sdk/patina_macro/src/test_macro.rs
+++ b/sdk/patina_macro/src/test_macro.rs
@@ -203,7 +203,7 @@ fn generate_expanded_test_case(
 }
 
 #[cfg(test)]
-#[cfg_attr(coverage_nightly, coverage(off))]
+#[cfg_attr(coverage, coverage(off))]
 mod tests {
     use super::*;
 

--- a/sdk/patina_macro/src/validate_params_macro.rs
+++ b/sdk/patina_macro/src/validate_params_macro.rs
@@ -501,7 +501,7 @@ pub(crate) fn check_param_conflicts(func: &ItemFn) -> Result<(), TokenStream> {
 }
 
 #[cfg(test)]
-#[cfg_attr(coverage_nightly, coverage(off))]
+#[cfg_attr(coverage, coverage(off))]
 mod tests {
     use super::*;
     use quote::quote;


### PR DESCRIPTION
## Description

Since the repo is currently using the stable toolchain, switch from gating `coverage_attribute` on `coverage_nightly` to `coverage` per https://github.com/taiki-e/cargo-llvm-cov.

This is set automatically by `cargo-llvm-cov`.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

- `cargo make coverage`

Checked the environment configured by `cargo-llvm-cov` in my local workspace:

```
cargo llvm-cov show-env

info: cargo-llvm-cov currently setting cfg(coverage); you can opt-out it by passing --no-cfg-coverage
RUSTFLAGS="-Z allow-features=c_variadic,allocator_api -C instrument-coverage --cfg=coverage --cfg=trybuild_no_target"
LLVM_PROFILE_FILE=patina\target\patina-%p-%16m.profraw
CARGO_LLVM_COV=1
CARGO_LLVM_COV_SHOW_ENV=1
CARGO_LLVM_COV_TARGET_DIR=patina\target
```

Checked codecov reports before and after. Before is on the left and after on the right in the image below.

<img width="2093" height="138" alt="image" src="https://github.com/user-attachments/assets/fb8ea720-396c-406c-8809-c86c1434c007" />

## Integration Instructions

- N/A

---

- patina-devops synced files will be updated in a single PR in that repo.