### PR TITLE
Devpath macros

### DIFF
--- a/cspell.yml
+++ b/cspell.yml
@@ -223,6 +223,7 @@ words:
   - unmaps
   - unrecovered
   - unreg
+  - unrepresentable
   - unregisters
   - unspec
   - unsynchronized

--- a/cspell.yml
+++ b/cspell.yml
@@ -223,8 +223,8 @@ words:
   - unmaps
   - unrecovered
   - unreg
-  - unrepresentable
   - unregisters
+  - unrepresentable
   - unspec
   - unsynchronized
   - variadics

--- a/sdk/patina/README.md
+++ b/sdk/patina/README.md
@@ -38,9 +38,6 @@ The SDK is organized into the following root-level modules.
 | **standard** | Strict definitions of industry standards. |
 | **uefi** | UEFI specification definitions and wrappers. |
 
-An optional invocation-local `vendors { ... };` registry can define named vendor hardware nodes with fixed GUIDs and
-typed payload fields. See the `devpath!` API documentation for the schema syntax and supported field encodings.
-
 ## Feature Overview
 
 | Feature | Purpose |

--- a/sdk/patina/README.md
+++ b/sdk/patina/README.md
@@ -38,6 +38,9 @@ The SDK is organized into the following root-level modules.
 | **standard** | Strict definitions of industry standards. |
 | **uefi** | UEFI specification definitions and wrappers. |
 
+An optional invocation-local `vendors { ... };` registry can define named vendor hardware nodes with fixed GUIDs and
+typed payload fields. See the `devpath!` API documentation for the schema syntax and supported field encodings.
+
 ## Feature Overview
 
 | Feature | Purpose |

--- a/sdk/patina/src/lib.rs
+++ b/sdk/patina/src/lib.rs
@@ -21,9 +21,9 @@ extern crate alloc;
 mod base;
 pub use base::*;
 pub use guid::{BinaryGuid, Guid, GuidError, OwnedGuid};
-pub use string::{Char8Array, Char8Str, Char16Array, Char16Str, StringError};
 #[doc(inline)]
 pub use patina_macro::devpath;
+pub use string::{Char8Array, Char8Str, Char16Array, Char16Str, StringError};
 
 #[cfg(any(test, feature = "alloc"))]
 pub use base::string::{Char8String, Char16String};

--- a/sdk/patina/src/lib.rs
+++ b/sdk/patina/src/lib.rs
@@ -22,6 +22,8 @@ mod base;
 pub use base::*;
 pub use guid::{BinaryGuid, Guid, GuidError, OwnedGuid};
 pub use string::{Char8Array, Char8Str, Char16Array, Char16Str, StringError};
+#[doc(inline)]
+pub use patina_macro::devpath;
 
 #[cfg(any(test, feature = "alloc"))]
 pub use base::string::{Char8String, Char16String};

--- a/sdk/patina/tests/compile_fail_tests.rs
+++ b/sdk/patina/tests/compile_fail_tests.rs
@@ -30,5 +30,6 @@ fn compile_fail_tests() {
     t.compile_fail("tests/ui/devpath_invalid_symbol.rs");
     t.compile_fail("tests/ui/devpath_overflow.rs");
     t.compile_fail("tests/ui/devpath_invalid_fields.rs");
+    t.compile_fail("tests/ui/devpath_vendor_schema.rs");
     t.pass("tests/ui/multiple_storage_allowed.rs");
 }

--- a/sdk/patina/tests/compile_fail_tests.rs
+++ b/sdk/patina/tests/compile_fail_tests.rs
@@ -23,5 +23,12 @@ fn compile_fail_tests() {
     t.compile_fail("tests/ui/duplicate_storage_mut.rs");
     t.compile_fail("tests/ui/storage_and_storage_mut_conflict.rs");
     t.compile_fail("tests/ui/storage_mut_and_storage_conflict.rs");
+    t.compile_fail("tests/ui/devpath_non_literal.rs");
+    t.compile_fail("tests/ui/devpath_malformed.rs");
+    t.compile_fail("tests/ui/devpath_unknown_node.rs");
+    t.compile_fail("tests/ui/devpath_wrong_arity.rs");
+    t.compile_fail("tests/ui/devpath_invalid_symbol.rs");
+    t.compile_fail("tests/ui/devpath_overflow.rs");
+    t.compile_fail("tests/ui/devpath_invalid_fields.rs");
     t.pass("tests/ui/multiple_storage_allowed.rs");
 }

--- a/sdk/patina/tests/devpath.rs
+++ b/sdk/patina/tests/devpath.rs
@@ -88,6 +88,7 @@ mod runtime_cross_checks {
                 runtime_path(HardDrive::new_gpt(1, 0x800, 0x1000, guid)),
             ),
             (&devpath!("EFI"), runtime_path(FilePath::new("EFI"))),
+            (&devpath!(r"\EFI\BOOT\BOOTX64.EFI"), runtime_path(FilePath::new(r"\EFI\BOOT\BOOTX64.EFI"))),
         ];
 
         for (macro_path, runtime_path) in cases {

--- a/sdk/patina/tests/devpath.rs
+++ b/sdk/patina/tests/devpath.rs
@@ -1,0 +1,92 @@
+//! Integration tests for the public `devpath!` macro.
+//!
+//! ## License
+//!
+//! Copyright (c) Microsoft Corporation.
+//!
+//! SPDX-License-Identifier: Apache-2.0
+
+use patina::devpath;
+
+const REQUESTED_PATH: [u8; 22] = devpath!("PciRoot(0)/Pci(0x11,0)");
+
+#[test]
+fn test_devpath_public_macro_returns_owned_array() {
+    let mut path = devpath!("PciRoot(0)/Pci(0x11,0)");
+    path[0] = 0xff;
+
+    assert_eq!(REQUESTED_PATH[0], 0x02);
+    assert_eq!(path[0], 0xff);
+}
+
+#[test]
+fn test_devpath_public_macro_encodes_multiple_instances() {
+    let path: [u8; 20] = devpath!("Pci(1,0),USB(2,1)");
+
+    assert_eq!(
+        path,
+        [
+            0x01, 0x01, 0x06, 0x00, 0x00, 0x01, 0x7f, 0x01, 0x04, 0x00, 0x03, 0x05, 0x06, 0x00, 0x02, 0x01, 0x7f, 0xff,
+            0x04, 0x00,
+        ]
+    );
+}
+
+#[cfg(feature = "unstable-device-path")]
+mod runtime_cross_checks {
+    use patina::{
+        device_path::{
+            node_defs::{Controller, FilePath, HardDrive, NvmExpress, PcCard, Pci, Sata},
+            paths::DevicePathBuf,
+        },
+        devpath,
+    };
+
+    fn runtime_path<T>(node: T) -> DevicePathBuf
+    where
+        T: patina::device_path::parse_node::DevicePathNode,
+    {
+        DevicePathBuf::from_device_path_node_iter(core::iter::once(node))
+    }
+
+    #[test]
+    fn test_devpath_matches_runtime_fixed_hardware_nodes() {
+        // Limit cross-checks to runtime nodes whose writers have packed wire layouts.
+        let cases: &[(&[u8], DevicePathBuf)] = &[
+            (&devpath!("Pci(0x11,0)"), runtime_path(Pci { function: 0, device: 0x11 })),
+            (&devpath!("PcCard(2)"), runtime_path(PcCard { function_number: 2 })),
+            (&devpath!("Ctrl(7)"), runtime_path(Controller { number: 7 })),
+        ];
+
+        for (macro_path, runtime_path) in cases {
+            assert_eq!(*macro_path, runtime_path.as_bytes());
+        }
+    }
+
+    #[test]
+    fn test_devpath_matches_runtime_storage_and_variable_nodes() {
+        let guid = [0x33, 0x22, 0x11, 0x00, 0x55, 0x44, 0x77, 0x66, 0x88, 0x99, 0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff];
+        let cases: &[(&[u8], DevicePathBuf)] = &[
+            (&devpath!("Sata(2,0,1)"), runtime_path(Sata::new(2, 0, 1))),
+            (&devpath!("NVMe(1,12-34-56-78-9a-bc-de-f0)"), runtime_path(NvmExpress::new(1, 0x1234_5678_9abc_def0))),
+            (
+                &devpath!("HD(1,GPT,00112233-4455-6677-8899-aabbccddeeff,0x800,0x1000)"),
+                runtime_path(HardDrive::new_gpt(1, 0x800, 0x1000, guid)),
+            ),
+            (&devpath!("EFI"), runtime_path(FilePath::new("EFI"))),
+        ];
+
+        for (macro_path, runtime_path) in cases {
+            assert_eq!(*macro_path, runtime_path.as_bytes());
+        }
+    }
+
+    #[test]
+    fn test_devpath_matches_runtime_composed_path() {
+        let mut runtime = runtime_path(Pci { function: 0, device: 0x11 });
+        let controller = runtime_path(Controller { number: 7 });
+        runtime.append_device_path(&controller);
+
+        assert_eq!(devpath!("Pci(0x11,0)/Ctrl(7)"), runtime.as_bytes());
+    }
+}

--- a/sdk/patina/tests/devpath.rs
+++ b/sdk/patina/tests/devpath.rs
@@ -10,13 +10,34 @@ use patina::devpath;
 
 const REQUESTED_PATH: [u8; 22] = devpath!("PciRoot(0)/Pci(0x11,0)");
 const CUSTOM_VENDOR_PATH: [u8; 39] = devpath!(
-    vendors {
+    vendor-defined {
         AcmeController {
+            type: hardware,
             guid: "00112233-4455-6677-8899-aabbccddeeff",
             fields: [port: u8, flags: u16le],
         },
     };
     "PciRoot(0)/AcmeController(flags=0x1234,port=3)"
+);
+const CUSTOM_VENDOR_MESSAGING_PATH: [u8; 27] = devpath!(
+    vendor-defined {
+        AcmeTransport {
+            type: messaging,
+            guid: "00112233-4455-6677-8899-aabbccddeeff",
+            fields: [channel: u8, flags: u16le],
+        },
+    };
+    "AcmeTransport(flags=0x1234,channel=3)"
+);
+const CUSTOM_VENDOR_MEDIA_PATH: [u8; 27] = devpath!(
+    vendor-defined {
+        AcmeMedia {
+            type: media,
+            guid: "00112233-4455-6677-8899-aabbccddeeff",
+            fields: [instance: u8, flags: u16le],
+        },
+    };
+    "AcmeMedia(flags=0x1234,instance=3)"
 );
 
 #[test]
@@ -44,6 +65,16 @@ fn test_devpath_public_macro_encodes_multiple_instances() {
 #[test]
 fn test_devpath_public_macro_encodes_vendor_hardware_schema() {
     assert_eq!(CUSTOM_VENDOR_PATH, devpath!("PciRoot(0)/VenHw(00112233-4455-6677-8899-aabbccddeeff,033412)"));
+}
+
+#[test]
+fn test_devpath_public_macro_encodes_vendor_messaging_schema() {
+    assert_eq!(CUSTOM_VENDOR_MESSAGING_PATH, devpath!("VenMsg(00112233-4455-6677-8899-aabbccddeeff,033412)"));
+}
+
+#[test]
+fn test_devpath_public_macro_encodes_vendor_media_schema() {
+    assert_eq!(CUSTOM_VENDOR_MEDIA_PATH, devpath!("VenMedia(00112233-4455-6677-8899-aabbccddeeff,033412)"));
 }
 
 #[cfg(feature = "unstable-device-path")]

--- a/sdk/patina/tests/devpath.rs
+++ b/sdk/patina/tests/devpath.rs
@@ -9,6 +9,15 @@
 use patina::devpath;
 
 const REQUESTED_PATH: [u8; 22] = devpath!("PciRoot(0)/Pci(0x11,0)");
+const CUSTOM_VENDOR_PATH: [u8; 39] = devpath!(
+    vendors {
+        AcmeController {
+            guid: "00112233-4455-6677-8899-aabbccddeeff",
+            fields: [port: u8, flags: u16le],
+        },
+    };
+    "PciRoot(0)/AcmeController(flags=0x1234,port=3)"
+);
 
 #[test]
 fn test_devpath_public_macro_returns_owned_array() {
@@ -32,19 +41,24 @@ fn test_devpath_public_macro_encodes_multiple_instances() {
     );
 }
 
+#[test]
+fn test_devpath_public_macro_encodes_vendor_hardware_schema() {
+    assert_eq!(CUSTOM_VENDOR_PATH, devpath!("PciRoot(0)/VenHw(00112233-4455-6677-8899-aabbccddeeff,033412)"));
+}
+
 #[cfg(feature = "unstable-device-path")]
 mod runtime_cross_checks {
     use patina::{
-        device_path::{
+        devpath,
+        uefi::device_path::{
             node_defs::{Controller, FilePath, HardDrive, NvmExpress, PcCard, Pci, Sata},
             paths::DevicePathBuf,
         },
-        devpath,
     };
 
     fn runtime_path<T>(node: T) -> DevicePathBuf
     where
-        T: patina::device_path::parse_node::DevicePathNode,
+        T: patina::uefi::device_path::parse_node::DevicePathNode,
     {
         DevicePathBuf::from_device_path_node_iter(core::iter::once(node))
     }

--- a/sdk/patina/tests/ui/devpath_invalid_fields.rs
+++ b/sdk/patina/tests/ui/devpath_invalid_fields.rs
@@ -1,0 +1,10 @@
+//! `devpath!` rejects malformed structured fields.
+
+use patina::devpath;
+
+const _: [u8; 0] = devpath!("VenHw(not-a-guid)");
+const _: [u8; 0] = devpath!("IPv4(999.0.0.1)");
+const _: [u8; 0] = devpath!("MAC(0011,1)");
+const _: [u8; 0] = devpath!("Path(1,1,0)");
+
+fn main() {}

--- a/sdk/patina/tests/ui/devpath_invalid_fields.stderr
+++ b/sdk/patina/tests/ui/devpath_invalid_fields.stderr
@@ -1,0 +1,23 @@
+error: Guid is not a valid GUID in node `VenHw`, argument 1 at character 6
+ --> tests/ui/devpath_invalid_fields.rs:5:29
+  |
+5 | const _: [u8; 0] = devpath!("VenHw(not-a-guid)");
+  |                             ^^^^^^^^^^^^^^^^^^^
+
+error: RemoteIp is not a valid IPv4 address in node `IPv4`, argument 1 at character 5
+ --> tests/ui/devpath_invalid_fields.rs:6:29
+  |
+6 | const _: [u8; 0] = devpath!("IPv4(999.0.0.1)");
+  |                             ^^^^^^^^^^^^^^^^^
+
+error: MacAddr must be exactly 6 bytes when IfType is 0 or 1 in node `MAC`, argument 1 at character 4
+ --> tests/ui/devpath_invalid_fields.rs:7:29
+  |
+7 | const _: [u8; 0] = devpath!("MAC(0011,1)");
+  |                             ^^^^^^^^^^^^^
+
+error: Data must contain two hexadecimal digits per byte in node `Path`, argument 3 at character 9
+ --> tests/ui/devpath_invalid_fields.rs:8:29
+  |
+8 | const _: [u8; 0] = devpath!("Path(1,1,0)");
+  |                             ^^^^^^^^^^^^^

--- a/sdk/patina/tests/ui/devpath_invalid_symbol.rs
+++ b/sdk/patina/tests/ui/devpath_invalid_symbol.rs
@@ -1,0 +1,7 @@
+//! `devpath!` rejects invalid symbolic values.
+
+use patina::devpath;
+
+const _: [u8; 0] = devpath!("Ata(Tertiary,Master,0)");
+
+fn main() {}

--- a/sdk/patina/tests/ui/devpath_invalid_symbol.stderr
+++ b/sdk/patina/tests/ui/devpath_invalid_symbol.stderr
@@ -1,0 +1,5 @@
+error: Controller is not a valid integer in node `Ata`, argument 1 at character 4
+ --> tests/ui/devpath_invalid_symbol.rs:5:29
+  |
+5 | const _: [u8; 0] = devpath!("Ata(Tertiary,Master,0)");
+  |                             ^^^^^^^^^^^^^^^^^^^^^^^^

--- a/sdk/patina/tests/ui/devpath_malformed.rs
+++ b/sdk/patina/tests/ui/devpath_malformed.rs
@@ -1,0 +1,7 @@
+//! `devpath!` rejects malformed grammar.
+
+use patina::devpath;
+
+const _: [u8; 0] = devpath!("Pci(1,0");
+
+fn main() {}

--- a/sdk/patina/tests/ui/devpath_malformed.stderr
+++ b/sdk/patina/tests/ui/devpath_malformed.stderr
@@ -1,0 +1,5 @@
+error: unmatched opening parenthesis in node `Pci` at character 0
+ --> tests/ui/devpath_malformed.rs:5:29
+  |
+5 | const _: [u8; 0] = devpath!("Pci(1,0");
+  |                             ^^^^^^^^^

--- a/sdk/patina/tests/ui/devpath_non_literal.rs
+++ b/sdk/patina/tests/ui/devpath_non_literal.rs
@@ -1,0 +1,8 @@
+//! `devpath!` only accepts a string literal.
+
+use patina::devpath;
+
+const DEVICE_PATH: &str = "Pci(1,0)";
+const _: [u8; 0] = devpath!(DEVICE_PATH);
+
+fn main() {}

--- a/sdk/patina/tests/ui/devpath_non_literal.stderr
+++ b/sdk/patina/tests/ui/devpath_non_literal.stderr
@@ -1,0 +1,5 @@
+error: `devpath!` expects exactly one string literal
+ --> tests/ui/devpath_non_literal.rs:6:29
+  |
+6 | const _: [u8; 0] = devpath!(DEVICE_PATH);
+  |                             ^^^^^^^^^^^

--- a/sdk/patina/tests/ui/devpath_overflow.rs
+++ b/sdk/patina/tests/ui/devpath_overflow.rs
@@ -1,0 +1,7 @@
+//! `devpath!` rejects integers outside their wire field.
+
+use patina::devpath;
+
+const _: [u8; 0] = devpath!("Ctrl(0x100000000)");
+
+fn main() {}

--- a/sdk/patina/tests/ui/devpath_overflow.stderr
+++ b/sdk/patina/tests/ui/devpath_overflow.stderr
@@ -1,0 +1,5 @@
+error: Controller exceeds the 32-bit range in node `Ctrl`, argument 1 at character 5
+ --> tests/ui/devpath_overflow.rs:5:29
+  |
+5 | const _: [u8; 0] = devpath!("Ctrl(0x100000000)");
+  |                             ^^^^^^^^^^^^^^^^^^^

--- a/sdk/patina/tests/ui/devpath_unknown_node.rs
+++ b/sdk/patina/tests/ui/devpath_unknown_node.rs
@@ -1,0 +1,7 @@
+//! `devpath!` rejects unknown node names.
+
+use patina::devpath;
+
+const _: [u8; 0] = devpath!("Unknown(1)");
+
+fn main() {}

--- a/sdk/patina/tests/ui/devpath_unknown_node.stderr
+++ b/sdk/patina/tests/ui/devpath_unknown_node.stderr
@@ -1,0 +1,5 @@
+error: unknown device path node `Unknown` in node `Unknown` at character 0
+ --> tests/ui/devpath_unknown_node.rs:5:29
+  |
+5 | const _: [u8; 0] = devpath!("Unknown(1)");
+  |                             ^^^^^^^^^^^^

--- a/sdk/patina/tests/ui/devpath_vendor_schema.rs
+++ b/sdk/patina/tests/ui/devpath_vendor_schema.rs
@@ -3,8 +3,9 @@
 use patina::devpath;
 
 const _: [u8; 0] = devpath!(
-    vendors {
+    vendor-defined {
         Pci {
+            type: hardware,
             guid: "00112233-4455-6677-8899-aabbccddeeff",
             fields: [],
         },

--- a/sdk/patina/tests/ui/devpath_vendor_schema.rs
+++ b/sdk/patina/tests/ui/devpath_vendor_schema.rs
@@ -1,0 +1,15 @@
+//! `devpath!` rejects vendor schemas that redefine built-in nodes.
+
+use patina::devpath;
+
+const _: [u8; 0] = devpath!(
+    vendors {
+        Pci {
+            guid: "00112233-4455-6677-8899-aabbccddeeff",
+            fields: [],
+        },
+    };
+    "Pci()"
+);
+
+fn main() {}

--- a/sdk/patina/tests/ui/devpath_vendor_schema.stderr
+++ b/sdk/patina/tests/ui/devpath_vendor_schema.stderr
@@ -1,0 +1,5 @@
+error: `Pci` is a built-in device path node and cannot be redefined
+ --> tests/ui/devpath_vendor_schema.rs:7:9
+  |
+7 |         Pci {
+  |         ^^^

--- a/sdk/patina/tests/ui/devpath_wrong_arity.rs
+++ b/sdk/patina/tests/ui/devpath_wrong_arity.rs
@@ -1,0 +1,7 @@
+//! `devpath!` rejects missing required arguments.
+
+use patina::devpath;
+
+const _: [u8; 0] = devpath!("Pci(1)");
+
+fn main() {}

--- a/sdk/patina/tests/ui/devpath_wrong_arity.stderr
+++ b/sdk/patina/tests/ui/devpath_wrong_arity.stderr
@@ -1,0 +1,5 @@
+error: Function is required in node `Pci` at character 0
+ --> tests/ui/devpath_wrong_arity.rs:5:29
+  |
+5 | const _: [u8; 0] = devpath!("Pci(1)");
+  |                             ^^^^^^^^

--- a/sdk/patina_macro/README.md
+++ b/sdk/patina_macro/README.md
@@ -96,3 +96,23 @@ fn watchdog_negative_path() -> Result {
     Ok(())
 }
 ```
+
+### `devpath!`
+
+- Converts a UEFI 2.11 Device Path From Text string literal into an owned `[u8; N]` at compile time.
+- Supports standard device path nodes, aliases, decimal and hexadecimal integers, named parameters, and multiple
+  device path instances.
+- Inserts End Instance nodes between top-level comma-separated instances and an End Entire node after the final
+  instance.
+- Requires no runtime parser, allocation, or Patina device-path feature in the consuming crate.
+- Reports malformed syntax, invalid fields, unknown nodes, and unrepresentable values as compile-time errors.
+
+```rust
+use patina::devpath;
+
+const PCI_DEVICE_PATH: [u8; 22] = devpath!("PciRoot(0)/Pci(0x11,0)");
+const MULTI_INSTANCE_PATH: [u8; 20] = devpath!("Pci(1,0),USB(2,1)");
+```
+
+The input must be exactly one string literal. Separate nodes with `/` or `\`; use a top-level comma to separate
+device path instances.

--- a/sdk/patina_macro/README.md
+++ b/sdk/patina_macro/README.md
@@ -99,13 +99,14 @@ fn watchdog_negative_path() -> Result {
 
 ### `devpath!`
 
-- Converts a UEFI 2.11 Device Path From Text string literal into an owned `[u8; N]` at compile time.
+- Converts a Device Path from a text string literal into an owned `[u8; N]` at compile time.
 - Supports standard device path nodes, aliases, decimal and hexadecimal integers, named parameters, and multiple
   device path instances.
 - Inserts End Instance nodes between top-level comma-separated instances and an End Entire node after the final
   instance.
 - Requires no runtime parser, allocation, or Patina device-path feature in the consuming crate.
 - Reports malformed syntax, invalid fields, unknown nodes, and unrepresentable values as compile-time errors.
+- Supports syntax for specifying vendor-defined hardware, messaging and media device path nodes.
 
 ```rust
 use patina::devpath;
@@ -114,15 +115,16 @@ const PCI_DEVICE_PATH: [u8; 22] = devpath!("PciRoot(0)/Pci(0x11,0)");
 const MULTI_INSTANCE_PATH: [u8; 20] = devpath!("Pci(1,0),USB(2,1)");
 ```
 
-Without a vendor registry, the input must be exactly one string literal. Separate nodes with `/`; backslashes are
-preserved in file path nodes. Use a top-level comma to separate device path instances.
+The macro accepts one device path string, optionally preceded by a `vendor-defined` registry. Within the string,
+separate nodes with `/` and device path instances with a top-level comma. Backslashes are preserved in file path nodes.
 
-Invocation-local vendor hardware shortcuts can be declared before the device path:
+The registry defines invocation-local shortcuts for vendor hardware, messaging, and media nodes:
 
 ```rust
 const VENDOR_PATH: &[u8] = &devpath!(
-    vendors {
+    vendor-defined {
         AcmeController {
+            type: hardware,
             guid: "00112233-4455-6677-8899-aabbccddeeff",
             fields: [port: u8, flags: u16le],
         },
@@ -131,6 +133,7 @@ const VENDOR_PATH: &[u8] = &devpath!(
 );
 ```
 
-Each shortcut expands to a UEFI vendor hardware (`VenHw`) node. Fields are required and may be supplied positionally or
-by name. Supported field types are `u8`, `u16le`, `u32le`, `u64le`, `guid` (EFI byte order), `uuid` (RFC byte order),
-and `bytes` (hexadecimal byte data). Built-in node names cannot be redefined.
+The required `type` property selects a UEFI vendor hardware (`VenHw`), vendor messaging (`VenMsg`), or vendor media
+(`VenMedia`) node using `hardware`, `messaging`, or `media`, respectively. Fields are required and may be supplied
+positionally or by name. Supported field types are `u8`, `u16le`, `u32le`, `u64le`, `guid` (EFI byte order), `uuid`
+(RFC byte order), and `bytes` (hexadecimal byte data). Built-in node names cannot be redefined.

--- a/sdk/patina_macro/README.md
+++ b/sdk/patina_macro/README.md
@@ -114,5 +114,23 @@ const PCI_DEVICE_PATH: [u8; 22] = devpath!("PciRoot(0)/Pci(0x11,0)");
 const MULTI_INSTANCE_PATH: [u8; 20] = devpath!("Pci(1,0),USB(2,1)");
 ```
 
-The input must be exactly one string literal. Separate nodes with `/` or `\`; use a top-level comma to separate
-device path instances.
+Without a vendor registry, the input must be exactly one string literal. Separate nodes with `/` or `\`; use a
+top-level comma to separate device path instances.
+
+Invocation-local vendor hardware shortcuts can be declared before the device path:
+
+```rust
+const VENDOR_PATH: &[u8] = &devpath!(
+    vendors {
+        AcmeController {
+            guid: "00112233-4455-6677-8899-aabbccddeeff",
+            fields: [port: u8, flags: u16le],
+        },
+    };
+    "PciRoot(0)/AcmeController(port=3,flags=0x1234)"
+);
+```
+
+Each shortcut expands to a UEFI vendor hardware (`VenHw`) node. Fields are required and may be supplied positionally or
+by name. Supported field types are `u8`, `u16le`, `u32le`, `u64le`, `guid` (EFI byte order), `uuid` (RFC byte order),
+and `bytes` (hexadecimal byte data). Built-in node names cannot be redefined.

--- a/sdk/patina_macro/README.md
+++ b/sdk/patina_macro/README.md
@@ -114,8 +114,8 @@ const PCI_DEVICE_PATH: [u8; 22] = devpath!("PciRoot(0)/Pci(0x11,0)");
 const MULTI_INSTANCE_PATH: [u8; 20] = devpath!("Pci(1,0),USB(2,1)");
 ```
 
-Without a vendor registry, the input must be exactly one string literal. Separate nodes with `/` or `\`; use a
-top-level comma to separate device path instances.
+Without a vendor registry, the input must be exactly one string literal. Separate nodes with `/`; backslashes are
+preserved in file path nodes. Use a top-level comma to separate device path instances.
 
 Invocation-local vendor hardware shortcuts can be declared before the device path:
 

--- a/sdk/patina_macro/src/device_path_encoder.rs
+++ b/sdk/patina_macro/src/device_path_encoder.rs
@@ -1,0 +1,294 @@
+//! Checked binary encoding helpers for UEFI device paths.
+//!
+//! ## License
+//!
+//! Copyright (c) Microsoft Corporation.
+//!
+//! SPDX-License-Identifier: Apache-2.0
+
+use std::net::{Ipv4Addr, Ipv6Addr};
+
+use crate::{
+    device_path_nodes::encode_node,
+    device_path_parser::{DevicePathError, ParsedDevicePath, ParsedNode, parse_device_path},
+};
+
+const END_INSTANCE: [u8; 4] = [0x7f, 0x01, 0x04, 0x00];
+const END_ENTIRE: [u8; 4] = [0x7f, 0xff, 0x04, 0x00];
+
+/// Parse and encode a complete UEFI text device path.
+pub(crate) fn encode_device_path(input: &str) -> Result<Vec<u8>, DevicePathError> {
+    let path = parse_device_path(input)?;
+    encode_parsed_device_path(&path)
+}
+
+fn encode_parsed_device_path(path: &ParsedDevicePath) -> Result<Vec<u8>, DevicePathError> {
+    let mut bytes = Vec::new();
+    for (instance_index, instance) in path.instances.iter().enumerate() {
+        for node in instance {
+            bytes.extend_from_slice(&encode_node(node)?);
+        }
+        if instance_index + 1 == path.instances.len() {
+            bytes.extend_from_slice(&END_ENTIRE);
+        } else {
+            bytes.extend_from_slice(&END_INSTANCE);
+        }
+    }
+    Ok(bytes)
+}
+
+/// A checked writer for one packed UEFI device path node.
+pub(crate) struct NodeWriter {
+    offset: usize,
+    bytes: Vec<u8>,
+}
+
+impl NodeWriter {
+    pub(crate) fn new(node: &ParsedNode, r#type: u8, subtype: u8) -> Self {
+        Self { offset: node.offset, bytes: vec![r#type, subtype, 0, 0] }
+    }
+
+    pub(crate) fn byte(&mut self, value: u8) {
+        self.bytes.push(value);
+    }
+
+    pub(crate) fn bytes(&mut self, value: &[u8]) {
+        self.bytes.extend_from_slice(value);
+    }
+
+    pub(crate) fn u16(&mut self, value: u16) {
+        self.bytes.extend_from_slice(&value.to_le_bytes());
+    }
+
+    pub(crate) fn u32(&mut self, value: u32) {
+        self.bytes.extend_from_slice(&value.to_le_bytes());
+    }
+
+    pub(crate) fn u64(&mut self, value: u64) {
+        self.bytes.extend_from_slice(&value.to_le_bytes());
+    }
+
+    pub(crate) fn ascii_nul(&mut self, value: &str, field: &str) -> Result<(), DevicePathError> {
+        if !value.is_ascii() {
+            return Err(DevicePathError::new(self.offset, format!("{field} must contain only ASCII characters")));
+        }
+        self.bytes.extend_from_slice(value.as_bytes());
+        self.bytes.push(0);
+        Ok(())
+    }
+
+    pub(crate) fn utf16(&mut self, value: &str, nul_terminated: bool) {
+        for code_unit in value.encode_utf16() {
+            self.u16(code_unit);
+        }
+        if nul_terminated {
+            self.u16(0);
+        }
+    }
+
+    pub(crate) fn finish(mut self) -> Result<Vec<u8>, DevicePathError> {
+        let length = u16::try_from(self.bytes.len())
+            .map_err(|_| DevicePathError::new(self.offset, "device path node exceeds the 65535-byte length limit"))?;
+        self.bytes
+            .get_mut(2..4)
+            .expect("a node writer always contains a four-byte header")
+            .copy_from_slice(&length.to_le_bytes());
+        Ok(self.bytes)
+    }
+}
+
+pub(crate) fn parse_unsigned(value: &str, bits: u32, offset: usize, field: &str) -> Result<u64, DevicePathError> {
+    if value.is_empty() {
+        return Err(DevicePathError::new(offset, format!("{field} is required")));
+    }
+    if value.starts_with('+') || value.starts_with('-') {
+        return Err(DevicePathError::new(offset, format!("{field} must be an unsigned integer")));
+    }
+
+    let (digits, radix) =
+        value.strip_prefix("0x").or_else(|| value.strip_prefix("0X")).map_or((value, 10), |digits| (digits, 16));
+    if digits.is_empty() {
+        return Err(DevicePathError::new(offset, format!("{field} is not a valid integer")));
+    }
+
+    let parsed = u64::from_str_radix(digits, radix)
+        .map_err(|_| DevicePathError::new(offset, format!("{field} is not a valid integer")))?;
+    let maximum = if bits == 64 { u64::MAX } else { (1u64 << bits) - 1 };
+    if parsed > maximum {
+        return Err(DevicePathError::new(offset, format!("{field} exceeds the {bits}-bit range")));
+    }
+    Ok(parsed)
+}
+
+pub(crate) fn parse_u8(value: &str, offset: usize, field: &str) -> Result<u8, DevicePathError> {
+    Ok(parse_unsigned(value, 8, offset, field)? as u8)
+}
+
+pub(crate) fn parse_u16(value: &str, offset: usize, field: &str) -> Result<u16, DevicePathError> {
+    Ok(parse_unsigned(value, 16, offset, field)? as u16)
+}
+
+pub(crate) fn parse_u32(value: &str, offset: usize, field: &str) -> Result<u32, DevicePathError> {
+    Ok(parse_unsigned(value, 32, offset, field)? as u32)
+}
+
+pub(crate) fn parse_u64(value: &str, offset: usize, field: &str) -> Result<u64, DevicePathError> {
+    parse_unsigned(value, 64, offset, field)
+}
+
+pub(crate) fn parse_hex_bytes(value: &str, offset: usize, field: &str) -> Result<Vec<u8>, DevicePathError> {
+    let compact: String = value.chars().filter(|character| *character != '-').collect();
+    if !compact.len().is_multiple_of(2) {
+        return Err(DevicePathError::new(offset, format!("{field} must contain two hexadecimal digits per byte")));
+    }
+
+    compact
+        .as_bytes()
+        .chunks_exact(2)
+        .map(|pair| {
+            let digits = std::str::from_utf8(pair).expect("hex digits are valid UTF-8");
+            u8::from_str_radix(digits, 16)
+                .map_err(|_| DevicePathError::new(offset, format!("{field} contains a non-hexadecimal byte")))
+        })
+        .collect()
+}
+
+pub(crate) fn parse_fixed_hex<const N: usize>(
+    value: &str,
+    offset: usize,
+    field: &str,
+) -> Result<[u8; N], DevicePathError> {
+    let bytes = parse_hex_bytes(value, offset, field)?;
+    bytes.try_into().map_err(|bytes: Vec<u8>| {
+        DevicePathError::new(offset, format!("{field} must be exactly {N} bytes, not {}", bytes.len()))
+    })
+}
+
+pub(crate) fn parse_efi_guid(value: &str, offset: usize, field: &str) -> Result<[u8; 16], DevicePathError> {
+    let guid = uuid::Uuid::parse_str(value)
+        .map_err(|_| DevicePathError::new(offset, format!("{field} is not a valid GUID")))?;
+    let (data1, data2, data3, data4) = guid.as_fields();
+    let mut bytes = [0u8; 16];
+    bytes[0..4].copy_from_slice(&data1.to_le_bytes());
+    bytes[4..6].copy_from_slice(&data2.to_le_bytes());
+    bytes[6..8].copy_from_slice(&data3.to_le_bytes());
+    bytes[8..16].copy_from_slice(data4);
+    Ok(bytes)
+}
+
+pub(crate) fn parse_uuid_bytes(value: &str, offset: usize, field: &str) -> Result<[u8; 16], DevicePathError> {
+    let guid = uuid::Uuid::parse_str(value)
+        .map_err(|_| DevicePathError::new(offset, format!("{field} is not a valid UUID")))?;
+    Ok(*guid.as_bytes())
+}
+
+pub(crate) fn parse_eisa_id(value: &str, offset: usize, field: &str) -> Result<u32, DevicePathError> {
+    if value == "0" {
+        return Ok(0);
+    }
+    let bytes = value.as_bytes();
+    let [first, second, third, product_0, product_1, product_2, product_3] = bytes else {
+        return Err(DevicePathError::new(offset, format!("{field} is not a valid seven-character EISA ID")));
+    };
+    if ![first, second, third].iter().all(|byte| byte.is_ascii_alphabetic())
+        || ![product_0, product_1, product_2, product_3].iter().all(|byte| byte.is_ascii_hexdigit())
+    {
+        return Err(DevicePathError::new(offset, format!("{field} is not a valid seven-character EISA ID")));
+    }
+
+    let first = (first.to_ascii_uppercase() - b'A' + 1) as u32;
+    let second = (second.to_ascii_uppercase() - b'A' + 1) as u32;
+    let third = (third.to_ascii_uppercase() - b'A' + 1) as u32;
+    let product = u16::from_str_radix(value.get(3..).expect("validated EISA ID has an ASCII product suffix"), 16)
+        .map_err(|_| DevicePathError::new(offset, format!("{field} has an invalid product identifier")))?;
+    Ok((u32::from(product) << 16) | (first << 10) | (second << 5) | third)
+}
+
+pub(crate) fn parse_ipv4(value: &str, offset: usize, field: &str) -> Result<[u8; 4], DevicePathError> {
+    let address = value
+        .parse::<Ipv4Addr>()
+        .map_err(|_| DevicePathError::new(offset, format!("{field} is not a valid IPv4 address")))?;
+    Ok(address.octets())
+}
+
+pub(crate) fn parse_ipv6(value: &str, offset: usize, field: &str) -> Result<[u8; 16], DevicePathError> {
+    let address = value
+        .parse::<Ipv6Addr>()
+        .map_err(|_| DevicePathError::new(offset, format!("{field} is not a valid IPv6 address")))?;
+    Ok(address.octets())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_encode_requested_example() {
+        assert_eq!(
+            encode_device_path("PciRoot(0)/Pci(0x11,0)").expect("path should encode"),
+            [
+                0x02, 0x01, 0x0c, 0x00, 0xd0, 0x41, 0x03, 0x0a, 0x00, 0x00, 0x00, 0x00, 0x01, 0x01, 0x06, 0x00, 0x00,
+                0x11, 0x7f, 0xff, 0x04, 0x00,
+            ]
+        );
+    }
+
+    #[test]
+    fn test_parse_efi_guid_uses_uefi_byte_order() {
+        assert_eq!(
+            parse_efi_guid("00112233-4455-6677-8899-aabbccddeeff", 0, "Guid").expect("GUID should parse"),
+            [0x33, 0x22, 0x11, 0x00, 0x55, 0x44, 0x77, 0x66, 0x88, 0x99, 0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff]
+        );
+    }
+
+    #[test]
+    fn test_encode_multiple_instances_inserts_both_end_node_types() {
+        assert_eq!(
+            encode_device_path("Pci(1,0),USB(2,1)").expect("path should encode"),
+            [
+                0x01, 0x01, 0x06, 0x00, 0x00, 0x01, 0x7f, 0x01, 0x04, 0x00, 0x03, 0x05, 0x06, 0x00, 0x02, 0x01, 0x7f,
+                0xff, 0x04, 0x00,
+            ]
+        );
+    }
+
+    #[test]
+    fn test_encode_uefi_ipv4_example() {
+        assert_eq!(
+            encode_device_path("IPv4(192.168.0.100,TCP,Static,192.168.0.1)").expect("path should encode"),
+            [
+                0x03, 0x0c, 0x1b, 0x00, 0xc0, 0xa8, 0x00, 0x01, 0xc0, 0xa8, 0x00, 0x64, 0x00, 0x00, 0x00, 0x00, 0x06,
+                0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x7f, 0xff, 0x04, 0x00,
+            ]
+        );
+    }
+
+    #[test]
+    fn test_encode_uefi_hard_drive_example() {
+        assert_eq!(
+            encode_device_path("HD(1,GPT,15E39A00-1DD2-1000-8D7F-00A0C92408FC,0x22,0x2710000)")
+                .expect("path should encode"),
+            [
+                0x04, 0x01, 0x2a, 0x00, 0x01, 0x00, 0x00, 0x00, 0x22, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+                0x00, 0x71, 0x02, 0x00, 0x00, 0x00, 0x00, 0x00, 0x9a, 0xe3, 0x15, 0xd2, 0x1d, 0x00, 0x10, 0x8d, 0x7f,
+                0x00, 0xa0, 0xc9, 0x24, 0x08, 0xfc, 0x02, 0x02, 0x7f, 0xff, 0x04, 0x00,
+            ]
+        );
+    }
+
+    #[test]
+    fn test_encode_file_path_uses_utf16_surrogate_pairs() {
+        assert_eq!(
+            encode_device_path("\u{1f4c1}").expect("path should encode"),
+            [0x04, 0x04, 0x0a, 0x00, 0x3d, 0xd8, 0xc1, 0xdc, 0x00, 0x00, 0x7f, 0xff, 0x04, 0x00]
+        );
+    }
+
+    #[test]
+    fn test_encode_rejects_oversized_node() {
+        let path = "a".repeat(32_765);
+        let error = encode_device_path(&path).expect_err("oversized file path should fail");
+
+        assert_eq!(error.message, "device path node exceeds the 65535-byte length limit");
+    }
+}

--- a/sdk/patina_macro/src/device_path_encoder.rs
+++ b/sdk/patina_macro/src/device_path_encoder.rs
@@ -9,7 +9,7 @@
 use std::net::{Ipv4Addr, Ipv6Addr};
 
 use crate::{
-    device_path_nodes::encode_node,
+    device_path_nodes::{VendorHardwareSchema, encode_node},
     device_path_parser::{DevicePathError, ParsedDevicePath, ParsedNode, parse_device_path},
 };
 
@@ -18,15 +18,26 @@ const END_ENTIRE: [u8; 4] = [0x7f, 0xff, 0x04, 0x00];
 
 /// Parse and encode a complete UEFI text device path.
 pub(crate) fn encode_device_path(input: &str) -> Result<Vec<u8>, DevicePathError> {
-    let path = parse_device_path(input)?;
-    encode_parsed_device_path(&path)
+    encode_device_path_with_vendors(input, &[])
 }
 
-fn encode_parsed_device_path(path: &ParsedDevicePath) -> Result<Vec<u8>, DevicePathError> {
+/// Parse and encode a complete UEFI text device path with custom vendor nodes.
+pub(crate) fn encode_device_path_with_vendors(
+    input: &str,
+    vendor_hardware_schemas: &[VendorHardwareSchema],
+) -> Result<Vec<u8>, DevicePathError> {
+    let path = parse_device_path(input)?;
+    encode_parsed_device_path(&path, vendor_hardware_schemas)
+}
+
+fn encode_parsed_device_path(
+    path: &ParsedDevicePath,
+    vendor_hardware_schemas: &[VendorHardwareSchema],
+) -> Result<Vec<u8>, DevicePathError> {
     let mut bytes = Vec::new();
     for (instance_index, instance) in path.instances.iter().enumerate() {
         for node in instance {
-            bytes.extend_from_slice(&encode_node(node)?);
+            bytes.extend_from_slice(&encode_node(node, vendor_hardware_schemas)?);
         }
         if instance_index + 1 == path.instances.len() {
             bytes.extend_from_slice(&END_ENTIRE);
@@ -164,9 +175,8 @@ pub(crate) fn parse_fixed_hex<const N: usize>(
     })
 }
 
-pub(crate) fn parse_efi_guid(value: &str, offset: usize, field: &str) -> Result<[u8; 16], DevicePathError> {
-    let guid = uuid::Uuid::parse_str(value)
-        .map_err(|_| DevicePathError::new(offset, format!("{field} is not a valid GUID")))?;
+pub(crate) fn efi_guid_bytes(value: &str) -> Result<[u8; 16], uuid::Error> {
+    let guid = uuid::Uuid::parse_str(value)?;
     let (data1, data2, data3, data4) = guid.as_fields();
     let mut bytes = [0u8; 16];
     bytes[0..4].copy_from_slice(&data1.to_le_bytes());
@@ -174,6 +184,10 @@ pub(crate) fn parse_efi_guid(value: &str, offset: usize, field: &str) -> Result<
     bytes[6..8].copy_from_slice(&data3.to_le_bytes());
     bytes[8..16].copy_from_slice(data4);
     Ok(bytes)
+}
+
+pub(crate) fn parse_efi_guid(value: &str, offset: usize, field: &str) -> Result<[u8; 16], DevicePathError> {
+    efi_guid_bytes(value).map_err(|_| DevicePathError::new(offset, format!("{field} is not a valid GUID")))
 }
 
 pub(crate) fn parse_uuid_bytes(value: &str, offset: usize, field: &str) -> Result<[u8; 16], DevicePathError> {

--- a/sdk/patina_macro/src/device_path_encoder.rs
+++ b/sdk/patina_macro/src/device_path_encoder.rs
@@ -9,7 +9,7 @@
 use std::net::{Ipv4Addr, Ipv6Addr};
 
 use crate::{
-    device_path_nodes::{VendorHardwareSchema, encode_node},
+    device_path_nodes::{VendorDefinedSchema, encode_node},
     device_path_parser::{DevicePathError, ParsedDevicePath, ParsedNode, parse_device_path},
 };
 
@@ -18,26 +18,26 @@ const END_ENTIRE: [u8; 4] = [0x7f, 0xff, 0x04, 0x00];
 
 /// Parse and encode a complete UEFI text device path.
 pub(crate) fn encode_device_path(input: &str) -> Result<Vec<u8>, DevicePathError> {
-    encode_device_path_with_vendors(input, &[])
+    encode_device_path_with_vendor_defined(input, &[])
 }
 
 /// Parse and encode a complete UEFI text device path with custom vendor nodes.
-pub(crate) fn encode_device_path_with_vendors(
+pub(crate) fn encode_device_path_with_vendor_defined(
     input: &str,
-    vendor_hardware_schemas: &[VendorHardwareSchema],
+    vendor_defined_schemas: &[VendorDefinedSchema],
 ) -> Result<Vec<u8>, DevicePathError> {
     let path = parse_device_path(input)?;
-    encode_parsed_device_path(&path, vendor_hardware_schemas)
+    encode_parsed_device_path(&path, vendor_defined_schemas)
 }
 
 fn encode_parsed_device_path(
     path: &ParsedDevicePath,
-    vendor_hardware_schemas: &[VendorHardwareSchema],
+    vendor_defined_schemas: &[VendorDefinedSchema],
 ) -> Result<Vec<u8>, DevicePathError> {
     let mut bytes = Vec::new();
     for (instance_index, instance) in path.instances.iter().enumerate() {
         for node in instance {
-            bytes.extend_from_slice(&encode_node(node, vendor_hardware_schemas)?);
+            bytes.extend_from_slice(&encode_node(node, vendor_defined_schemas)?);
         }
         if instance_index + 1 == path.instances.len() {
             bytes.extend_from_slice(&END_ENTIRE);

--- a/sdk/patina_macro/src/device_path_macro.rs
+++ b/sdk/patina_macro/src/device_path_macro.rs
@@ -16,45 +16,53 @@ use syn::{
 };
 
 use crate::{
-    device_path_encoder::{efi_guid_bytes, encode_device_path, encode_device_path_with_vendors},
-    device_path_nodes::{VendorHardwareField, VendorHardwareFieldType, VendorHardwareSchema, is_builtin_node_name},
+    device_path_encoder::{efi_guid_bytes, encode_device_path, encode_device_path_with_vendor_defined},
+    device_path_nodes::{
+        VendorDefinedField, VendorDefinedFieldType, VendorDefinedSchema, VendorDefinedType, is_builtin_node_name,
+    },
     device_path_parser::DevicePathError,
 };
 
 mod keyword {
-    syn::custom_keyword!(vendors);
+    syn::custom_keyword!(vendor);
+    syn::custom_keyword!(defined);
     syn::custom_keyword!(guid);
     syn::custom_keyword!(fields);
+    syn::custom_keyword!(hardware);
+    syn::custom_keyword!(messaging);
+    syn::custom_keyword!(media);
 }
 
 struct DevicePathInput {
-    vendor_hardware_schemas: Vec<VendorHardwareSchema>,
+    vendor_defined_schemas: Vec<VendorDefinedSchema>,
     literal: LitStr,
 }
 
 impl Parse for DevicePathInput {
     fn parse(input: ParseStream<'_>) -> syn::Result<Self> {
-        let vendor_hardware_schemas =
-            if input.peek(keyword::vendors) { parse_vendor_hardware_schemas(input)? } else { Vec::new() };
+        let vendor_defined_schemas =
+            if input.peek(keyword::vendor) { parse_vendor_defined_schemas(input)? } else { Vec::new() };
         let literal = input
             .parse::<LitStr>()
             .map_err(|_| syn::Error::new(input.span(), "`devpath!` expects exactly one string literal"))?;
         if !input.is_empty() {
             return Err(syn::Error::new(input.span(), "`devpath!` accepts exactly one string literal"));
         }
-        Ok(Self { vendor_hardware_schemas, literal })
+        Ok(Self { vendor_defined_schemas, literal })
     }
 }
 
-fn parse_vendor_hardware_schemas(input: ParseStream<'_>) -> syn::Result<Vec<VendorHardwareSchema>> {
-    input.parse::<keyword::vendors>()?;
+fn parse_vendor_defined_schemas(input: ParseStream<'_>) -> syn::Result<Vec<VendorDefinedSchema>> {
+    input.parse::<keyword::vendor>()?;
+    input.parse::<Token![-]>()?;
+    input.parse::<keyword::defined>()?;
     let content;
     braced!(content in input);
-    let schemas = content.parse_terminated(VendorHardwareSchemaInput::parse, Token![,])?;
+    let schemas = content.parse_terminated(VendorDefinedSchemaInput::parse, Token![,])?;
     input.parse::<Token![;]>()?;
 
     if schemas.is_empty() {
-        return Err(syn::Error::new(content.span(), "`vendors` must declare at least one vendor hardware schema"));
+        return Err(syn::Error::new(content.span(), "`vendor-defined` must declare at least one schema"));
     }
 
     let mut names = HashSet::new();
@@ -69,7 +77,7 @@ fn parse_vendor_hardware_schemas(input: ParseStream<'_>) -> syn::Result<Vec<Vend
         if !names.insert(schema.schema.name.clone()) {
             return Err(syn::Error::new(
                 schema.name_span,
-                format!("vendor hardware schema `{}` was declared more than once", schema.schema.name),
+                format!("vendor-defined schema `{}` was declared more than once", schema.schema.name),
             ));
         }
         parsed.push(schema.schema);
@@ -77,19 +85,34 @@ fn parse_vendor_hardware_schemas(input: ParseStream<'_>) -> syn::Result<Vec<Vend
     Ok(parsed)
 }
 
-struct VendorHardwareSchemaInput {
+struct VendorDefinedSchemaInput {
     name_span: proc_macro2::Span,
-    schema: VendorHardwareSchema,
+    schema: VendorDefinedSchema,
 }
 
-impl Parse for VendorHardwareSchemaInput {
+impl Parse for VendorDefinedSchemaInput {
     fn parse(input: ParseStream<'_>) -> syn::Result<Self> {
         let name = input.parse::<Ident>()?;
-        validate_schema_identifier(&name, "vendor hardware schema name")?;
+        validate_schema_identifier(&name, "vendor-defined schema name")?;
         let name_span = name.span();
         let content;
         braced!(content in input);
 
+        content.parse::<Token![type]>()?;
+        content.parse::<Token![:]>()?;
+        let vendor_type = if content.peek(keyword::hardware) {
+            content.parse::<keyword::hardware>()?;
+            VendorDefinedType::Hardware
+        } else if content.peek(keyword::messaging) {
+            content.parse::<keyword::messaging>()?;
+            VendorDefinedType::Messaging
+        } else if content.peek(keyword::media) {
+            content.parse::<keyword::media>()?;
+            VendorDefinedType::Media
+        } else {
+            return Err(content.error("vendor-defined `type` must be `hardware`, `messaging`, or `media`"));
+        };
+        content.parse::<Token![,]>()?;
         content.parse::<keyword::guid>()?;
         content.parse::<Token![:]>()?;
         let guid = content.parse::<LitStr>()?;
@@ -98,23 +121,23 @@ impl Parse for VendorHardwareSchemaInput {
         content.parse::<Token![:]>()?;
         let fields_content;
         bracketed!(fields_content in content);
-        let fields = fields_content.parse_terminated(VendorHardwareFieldInput::parse, Token![,])?;
+        let fields = fields_content.parse_terminated(VendorDefinedFieldInput::parse, Token![,])?;
         if content.peek(Token![,]) {
             content.parse::<Token![,]>()?;
         }
         if !content.is_empty() {
-            return Err(content.error("expected only `guid` and `fields` in a vendor hardware schema"));
+            return Err(content.error("expected only `type`, `guid`, and `fields` in a vendor-defined schema"));
         }
 
         let guid_bytes = efi_guid_bytes(&guid.value())
-            .map_err(|_| syn::Error::new(guid.span(), "vendor hardware `guid` is not a valid GUID"))?;
+            .map_err(|_| syn::Error::new(guid.span(), "vendor-defined `guid` is not a valid GUID"))?;
         let mut field_names = HashSet::new();
         let mut parsed_fields = Vec::with_capacity(fields.len());
         for field in fields {
             if !field_names.insert(field.field.name.clone()) {
                 return Err(syn::Error::new(
                     field.name_span,
-                    format!("vendor hardware field `{}` was declared more than once", field.field.name),
+                    format!("vendor-defined field `{}` was declared more than once", field.field.name),
                 ));
             }
             parsed_fields.push(field.field);
@@ -122,30 +145,35 @@ impl Parse for VendorHardwareSchemaInput {
 
         Ok(Self {
             name_span,
-            schema: VendorHardwareSchema { name: name.to_string(), guid: guid_bytes, fields: parsed_fields },
+            schema: VendorDefinedSchema {
+                name: name.to_string(),
+                vendor_type,
+                guid: guid_bytes,
+                fields: parsed_fields,
+            },
         })
     }
 }
 
-struct VendorHardwareFieldInput {
+struct VendorDefinedFieldInput {
     name_span: proc_macro2::Span,
-    field: VendorHardwareField,
+    field: VendorDefinedField,
 }
 
-impl Parse for VendorHardwareFieldInput {
+impl Parse for VendorDefinedFieldInput {
     fn parse(input: ParseStream<'_>) -> syn::Result<Self> {
         let name = input.parse::<Ident>()?;
-        validate_schema_identifier(&name, "vendor hardware field name")?;
+        validate_schema_identifier(&name, "vendor-defined field name")?;
         let name_span = name.span();
         input.parse::<Token![:]>()?;
         let field_type = input.parse::<Ident>()?;
-        let field_type = VendorHardwareFieldType::from_name(&field_type.to_string()).ok_or_else(|| {
+        let field_type = VendorDefinedFieldType::from_name(&field_type.to_string()).ok_or_else(|| {
             syn::Error::new(
                 field_type.span(),
-                "unsupported vendor hardware field type; expected `u8`, `u16le`, `u32le`, `u64le`, `guid`, `uuid`, or `bytes`",
+                "unsupported vendor-defined field type; expected `u8`, `u16le`, `u32le`, `u64le`, `guid`, `uuid`, or `bytes`",
             )
         })?;
-        Ok(Self { name_span, field: VendorHardwareField { name: name.to_string(), field_type } })
+        Ok(Self { name_span, field: VendorDefinedField { name: name.to_string(), field_type } })
     }
 }
 
@@ -171,10 +199,10 @@ pub(crate) fn devpath2(input: TokenStream) -> TokenStream {
 fn expand_devpath(input: TokenStream) -> syn::Result<TokenStream> {
     let input = syn::parse2::<DevicePathInput>(input)?;
     let value = input.literal.value();
-    let bytes = if input.vendor_hardware_schemas.is_empty() {
+    let bytes = if input.vendor_defined_schemas.is_empty() {
         encode_device_path(&value)
     } else {
-        encode_device_path_with_vendors(&value, &input.vendor_hardware_schemas)
+        encode_device_path_with_vendor_defined(&value, &input.vendor_defined_schemas)
     }
     .map_err(|error| syn::Error::new(input.literal.span(), format_device_path_error(&value, &error)))?;
     let bytes = bytes.into_iter().map(Literal::u8_suffixed);
@@ -300,8 +328,9 @@ mod tests {
     #[test]
     fn test_devpath_encodes_vendor_hardware_schema() {
         let custom = devpath2(quote!(
-            vendors {
+            vendor-defined {
                 AcmeController {
+                    type: hardware,
                     guid: "00112233-4455-6677-8899-aabbccddeeff",
                     fields: [port: u8, flags: u16le],
                 },
@@ -314,10 +343,45 @@ mod tests {
     }
 
     #[test]
-    fn test_devpath_encodes_all_vendor_hardware_field_types() {
+    fn test_devpath_encodes_vendor_messaging_schema() {
+        let custom = devpath2(quote!(
+            vendor-defined {
+                AcmeTransport {
+                    type: messaging,
+                    guid: "00112233-4455-6677-8899-aabbccddeeff",
+                    fields: [channel: u8, flags: u16le],
+                },
+            };
+            "AcmeTransport(3,0x1234)"
+        ));
+        let canonical = devpath2(quote!("VenMsg(00112233-4455-6677-8899-aabbccddeeff,033412)"));
+
+        assert_eq!(custom.to_string(), canonical.to_string());
+    }
+
+    #[test]
+    fn test_devpath_encodes_vendor_media_schema() {
+        let custom = devpath2(quote!(
+            vendor-defined {
+                AcmeMedia {
+                    type: media,
+                    guid: "00112233-4455-6677-8899-aabbccddeeff",
+                    fields: [instance: u8, flags: u16le],
+                },
+            };
+            "AcmeMedia(3,0x1234)"
+        ));
+        let canonical = devpath2(quote!("VenMedia(00112233-4455-6677-8899-aabbccddeeff,033412)"));
+
+        assert_eq!(custom.to_string(), canonical.to_string());
+    }
+
+    #[test]
+    fn test_devpath_encodes_all_vendor_defined_field_types() {
         let input = syn::parse2::<DevicePathInput>(quote!(
-            vendors {
+            vendor-defined {
                 VendorData {
+                    type: hardware,
                     guid: "00112233-4455-6677-8899-aabbccddeeff",
                     fields: [
                         byte: u8,
@@ -333,7 +397,7 @@ mod tests {
             "VendorData(1,0x0203,0x04050607,0x08090a0b0c0d0e0f,00112233-4455-6677-8899-aabbccddeeff,00112233-4455-6677-8899-aabbccddeeff,aabb)"
         ))
         .expect("schema should parse");
-        let bytes = encode_device_path_with_vendors(&input.literal.value(), &input.vendor_hardware_schemas)
+        let bytes = encode_device_path_with_vendor_defined(&input.literal.value(), &input.vendor_defined_schemas)
             .expect("vendor node should encode");
 
         assert_eq!(
@@ -348,12 +412,13 @@ mod tests {
     }
 
     #[test]
-    fn test_devpath_rejects_invalid_vendor_hardware_schemas() {
+    fn test_devpath_rejects_invalid_vendor_defined_schemas() {
         for (input, expected) in [
             (
                 quote!(
-                    vendors {
+                    vendor-defined {
                         Pci {
+                            type: hardware,
                             guid: "00112233-4455-6677-8899-aabbccddeeff",
                             fields: [],
                         },
@@ -364,8 +429,9 @@ mod tests {
             ),
             (
                 quote!(
-                    vendors {
+                    vendor-defined {
                         Acme {
+                            type: hardware,
                             guid: "not-a-guid",
                             fields: [],
                         },
@@ -376,27 +442,29 @@ mod tests {
             ),
             (
                 quote!(
-                    vendors {
+                    vendor-defined {
                         Acme {
+                            type: hardware,
                             guid: "00112233-4455-6677-8899-aabbccddeeff",
                             fields: [port: u24le],
                         },
                     };
                     "Acme(1)"
                 ),
-                "unsupported vendor hardware field type",
+                "unsupported vendor-defined field type",
             ),
             (
                 quote!(
-                    vendors {};
+                    vendor-defined {};
                     "Pci(1,0)"
                 ),
-                "must declare at least one vendor hardware schema",
+                "must declare at least one schema",
             ),
             (
                 quote!(
-                    vendors {
+                    vendor-defined {
                         Acme {
+                            type: hardware,
                             guid: "00112233-4455-6677-8899-aabbccddeeff",
                             fields: [port: u8, port: u16le],
                         },
@@ -407,12 +475,14 @@ mod tests {
             ),
             (
                 quote!(
-                    vendors {
+                    vendor-defined {
                         Acme {
+                            type: hardware,
                             guid: "00112233-4455-6677-8899-aabbccddeeff",
                             fields: [],
                         },
                         Acme {
+                            type: messaging,
                             guid: "11223344-5566-7788-99aa-bbccddeeff00",
                             fields: [],
                         },
@@ -420,6 +490,19 @@ mod tests {
                     "Acme()"
                 ),
                 "schema `Acme` was declared more than once",
+            ),
+            (
+                quote!(
+                    vendor-defined {
+                        Acme {
+                            type: bios,
+                            guid: "00112233-4455-6677-8899-aabbccddeeff",
+                            fields: [],
+                        },
+                    };
+                    "Acme()"
+                ),
+                "`type` must be `hardware`, `messaging`, or `media`",
             ),
         ] {
             assert!(devpath2(input).to_string().contains(expected));

--- a/sdk/patina_macro/src/device_path_macro.rs
+++ b/sdk/patina_macro/src/device_path_macro.rs
@@ -1,0 +1,184 @@
+//! Procedural macro front end for compile-time UEFI device paths.
+//!
+//! ## License
+//!
+//! Copyright (c) Microsoft Corporation.
+//!
+//! SPDX-License-Identifier: Apache-2.0
+
+use proc_macro2::{Literal, TokenStream};
+use quote::quote;
+use syn::{
+    LitStr,
+    parse::{Parse, ParseStream},
+};
+
+use crate::{device_path_encoder::encode_device_path, device_path_parser::DevicePathError};
+
+struct DevicePathInput {
+    literal: LitStr,
+}
+
+impl Parse for DevicePathInput {
+    fn parse(input: ParseStream<'_>) -> syn::Result<Self> {
+        let literal = input
+            .parse::<LitStr>()
+            .map_err(|_| syn::Error::new(input.span(), "`devpath!` expects exactly one string literal"))?;
+        if !input.is_empty() {
+            return Err(syn::Error::new(input.span(), "`devpath!` accepts exactly one string literal"));
+        }
+        Ok(Self { literal })
+    }
+}
+
+/// Expand a UEFI text device path into an owned byte-array literal.
+pub(crate) fn devpath2(input: TokenStream) -> TokenStream {
+    match expand_devpath(input) {
+        Ok(tokens) => tokens,
+        Err(error) => error.into_compile_error(),
+    }
+}
+
+fn expand_devpath(input: TokenStream) -> syn::Result<TokenStream> {
+    let input = syn::parse2::<DevicePathInput>(input)?;
+    let value = input.literal.value();
+    let bytes = encode_device_path(&value)
+        .map_err(|error| syn::Error::new(input.literal.span(), format_device_path_error(&value, &error)))?;
+    let bytes = bytes.into_iter().map(Literal::u8_suffixed);
+    Ok(quote!([#(#bytes),*]))
+}
+
+fn format_device_path_error(input: &str, error: &DevicePathError) -> String {
+    let byte_offset = error.offset.min(input.len());
+    let character_offset = input.get(..byte_offset).map_or(byte_offset, |prefix| prefix.chars().count());
+    let context = device_path_error_context(input, byte_offset);
+    format!("{} in {context} at character {character_offset}", error.message)
+}
+
+fn device_path_error_context(input: &str, offset: usize) -> String {
+    let (node_start, node_end) = find_node_range(input, offset);
+    let node = input.get(node_start..node_end).unwrap_or("");
+    let Some(open_parenthesis) = node.find('(') else {
+        return "file path node".to_owned();
+    };
+
+    let name = node.get(..open_parenthesis).unwrap_or("<unknown>");
+    let argument_start = node_start + open_parenthesis + 1;
+    if offset < argument_start {
+        return format!("node `{name}`");
+    }
+
+    let relative_offset = offset.min(node_end).saturating_sub(argument_start);
+    let arguments = input.get(argument_start..node_end).unwrap_or("");
+    let (argument_index, argument) = argument_at_offset(arguments, relative_offset);
+    if let Some(parameter) = parameter_name(argument) {
+        format!("node `{name}`, parameter `{parameter}`")
+    } else {
+        format!("node `{name}`, argument {argument_index}")
+    }
+}
+
+fn find_node_range(input: &str, offset: usize) -> (usize, usize) {
+    let mut node_start = 0;
+    let mut depth = 0usize;
+    let mut quoted = false;
+
+    for (index, character) in input.char_indices() {
+        if character == '"' {
+            quoted = !quoted;
+            continue;
+        }
+        if quoted {
+            continue;
+        }
+
+        match character {
+            '(' => depth += 1,
+            ')' => depth = depth.saturating_sub(1),
+            '/' | '\\' | ',' if depth == 0 => {
+                if offset <= index {
+                    return (node_start, index);
+                }
+                node_start = index + character.len_utf8();
+            }
+            _ => {}
+        }
+    }
+
+    (node_start, input.len())
+}
+
+fn argument_at_offset(arguments: &str, offset: usize) -> (usize, &str) {
+    let mut argument_start = 0;
+    let mut argument_index = 1;
+    let mut quoted = false;
+
+    for (index, character) in arguments.char_indices() {
+        if character == '"' {
+            quoted = !quoted;
+        } else if character == ',' && !quoted {
+            if offset <= index {
+                return (argument_index, arguments.get(argument_start..index).unwrap_or(""));
+            }
+            argument_start = index + character.len_utf8();
+            argument_index += 1;
+        }
+    }
+
+    (argument_index, arguments.get(argument_start..).unwrap_or(""))
+}
+
+fn parameter_name(argument: &str) -> Option<&str> {
+    let equals = argument.find('=')?;
+    let name = argument.get(..equals)?;
+    (!name.is_empty() && name.bytes().all(|byte| byte.is_ascii_alphanumeric())).then_some(name)
+}
+
+#[cfg(test)]
+mod tests {
+    use quote::quote;
+
+    use super::*;
+
+    #[test]
+    fn test_devpath_expands_to_owned_u8_array() {
+        let expansion = devpath2(quote!("PciRoot(0)/Pci(0x11,0)"));
+
+        assert_eq!(
+            expansion.to_string(),
+            "[2u8 , 1u8 , 12u8 , 0u8 , 208u8 , 65u8 , 3u8 , 10u8 , 0u8 , 0u8 , 0u8 , 0u8 , 1u8 , 1u8 , 6u8 , 0u8 , 0u8 , 17u8 , 127u8 , 255u8 , 4u8 , 0u8]"
+        );
+    }
+
+    #[test]
+    fn test_devpath_rejects_non_literal_input() {
+        let expansion = devpath2(quote!(DEVICE_PATH));
+
+        assert!(expansion.to_string().contains("expects exactly one string literal"));
+    }
+
+    #[test]
+    fn test_devpath_rejects_additional_tokens() {
+        let expansion = devpath2(quote!("Pci(1,0)", "USB(1,0)"));
+
+        assert!(expansion.to_string().contains("accepts exactly one string literal"));
+    }
+
+    #[test]
+    fn test_devpath_reports_node_and_argument_context() {
+        let expansion = devpath2(quote!("Pci(1,9)"));
+        let message = expansion.to_string();
+
+        assert!(message.contains("node `Pci`, argument 2"));
+        assert!(message.contains("character 6"));
+    }
+
+    #[test]
+    fn test_devpath_reports_named_parameter_and_unicode_character_offset() {
+        let expansion = devpath2(quote!("é/Pci(Device=32,Function=0)"));
+        let message = expansion.to_string();
+
+        assert!(message.contains("node `Pci`, parameter `Device`"));
+        assert!(message.contains("character 13"));
+    }
+}

--- a/sdk/patina_macro/src/device_path_macro.rs
+++ b/sdk/patina_macro/src/device_path_macro.rs
@@ -6,29 +6,158 @@
 //!
 //! SPDX-License-Identifier: Apache-2.0
 
+use std::collections::HashSet;
+
 use proc_macro2::{Literal, TokenStream};
 use quote::quote;
 use syn::{
-    LitStr,
+    Ident, LitStr, Token, braced, bracketed,
     parse::{Parse, ParseStream},
 };
 
-use crate::{device_path_encoder::encode_device_path, device_path_parser::DevicePathError};
+use crate::{
+    device_path_encoder::{efi_guid_bytes, encode_device_path, encode_device_path_with_vendors},
+    device_path_nodes::{VendorHardwareField, VendorHardwareFieldType, VendorHardwareSchema, is_builtin_node_name},
+    device_path_parser::DevicePathError,
+};
+
+mod keyword {
+    syn::custom_keyword!(vendors);
+    syn::custom_keyword!(guid);
+    syn::custom_keyword!(fields);
+}
 
 struct DevicePathInput {
+    vendor_hardware_schemas: Vec<VendorHardwareSchema>,
     literal: LitStr,
 }
 
 impl Parse for DevicePathInput {
     fn parse(input: ParseStream<'_>) -> syn::Result<Self> {
+        let vendor_hardware_schemas =
+            if input.peek(keyword::vendors) { parse_vendor_hardware_schemas(input)? } else { Vec::new() };
         let literal = input
             .parse::<LitStr>()
             .map_err(|_| syn::Error::new(input.span(), "`devpath!` expects exactly one string literal"))?;
         if !input.is_empty() {
             return Err(syn::Error::new(input.span(), "`devpath!` accepts exactly one string literal"));
         }
-        Ok(Self { literal })
+        Ok(Self { vendor_hardware_schemas, literal })
     }
+}
+
+fn parse_vendor_hardware_schemas(input: ParseStream<'_>) -> syn::Result<Vec<VendorHardwareSchema>> {
+    input.parse::<keyword::vendors>()?;
+    let content;
+    braced!(content in input);
+    let schemas = content.parse_terminated(VendorHardwareSchemaInput::parse, Token![,])?;
+    input.parse::<Token![;]>()?;
+
+    if schemas.is_empty() {
+        return Err(syn::Error::new(content.span(), "`vendors` must declare at least one vendor hardware schema"));
+    }
+
+    let mut names = HashSet::new();
+    let mut parsed = Vec::with_capacity(schemas.len());
+    for schema in schemas {
+        if is_builtin_node_name(&schema.schema.name) {
+            return Err(syn::Error::new(
+                schema.name_span,
+                format!("`{}` is a built-in device path node and cannot be redefined", schema.schema.name),
+            ));
+        }
+        if !names.insert(schema.schema.name.clone()) {
+            return Err(syn::Error::new(
+                schema.name_span,
+                format!("vendor hardware schema `{}` was declared more than once", schema.schema.name),
+            ));
+        }
+        parsed.push(schema.schema);
+    }
+    Ok(parsed)
+}
+
+struct VendorHardwareSchemaInput {
+    name_span: proc_macro2::Span,
+    schema: VendorHardwareSchema,
+}
+
+impl Parse for VendorHardwareSchemaInput {
+    fn parse(input: ParseStream<'_>) -> syn::Result<Self> {
+        let name = input.parse::<Ident>()?;
+        validate_schema_identifier(&name, "vendor hardware schema name")?;
+        let name_span = name.span();
+        let content;
+        braced!(content in input);
+
+        content.parse::<keyword::guid>()?;
+        content.parse::<Token![:]>()?;
+        let guid = content.parse::<LitStr>()?;
+        content.parse::<Token![,]>()?;
+        content.parse::<keyword::fields>()?;
+        content.parse::<Token![:]>()?;
+        let fields_content;
+        bracketed!(fields_content in content);
+        let fields = fields_content.parse_terminated(VendorHardwareFieldInput::parse, Token![,])?;
+        if content.peek(Token![,]) {
+            content.parse::<Token![,]>()?;
+        }
+        if !content.is_empty() {
+            return Err(content.error("expected only `guid` and `fields` in a vendor hardware schema"));
+        }
+
+        let guid_bytes = efi_guid_bytes(&guid.value())
+            .map_err(|_| syn::Error::new(guid.span(), "vendor hardware `guid` is not a valid GUID"))?;
+        let mut field_names = HashSet::new();
+        let mut parsed_fields = Vec::with_capacity(fields.len());
+        for field in fields {
+            if !field_names.insert(field.field.name.clone()) {
+                return Err(syn::Error::new(
+                    field.name_span,
+                    format!("vendor hardware field `{}` was declared more than once", field.field.name),
+                ));
+            }
+            parsed_fields.push(field.field);
+        }
+
+        Ok(Self {
+            name_span,
+            schema: VendorHardwareSchema { name: name.to_string(), guid: guid_bytes, fields: parsed_fields },
+        })
+    }
+}
+
+struct VendorHardwareFieldInput {
+    name_span: proc_macro2::Span,
+    field: VendorHardwareField,
+}
+
+impl Parse for VendorHardwareFieldInput {
+    fn parse(input: ParseStream<'_>) -> syn::Result<Self> {
+        let name = input.parse::<Ident>()?;
+        validate_schema_identifier(&name, "vendor hardware field name")?;
+        let name_span = name.span();
+        input.parse::<Token![:]>()?;
+        let field_type = input.parse::<Ident>()?;
+        let field_type = VendorHardwareFieldType::from_name(&field_type.to_string()).ok_or_else(|| {
+            syn::Error::new(
+                field_type.span(),
+                "unsupported vendor hardware field type; expected `u8`, `u16le`, `u32le`, `u64le`, `guid`, `uuid`, or `bytes`",
+            )
+        })?;
+        Ok(Self { name_span, field: VendorHardwareField { name: name.to_string(), field_type } })
+    }
+}
+
+fn validate_schema_identifier(identifier: &Ident, description: &str) -> syn::Result<()> {
+    let value = identifier.to_string();
+    if !value.bytes().all(|byte| byte.is_ascii_alphanumeric()) {
+        return Err(syn::Error::new(
+            identifier.span(),
+            format!("{description} must contain only alphanumeric characters"),
+        ));
+    }
+    Ok(())
 }
 
 /// Expand a UEFI text device path into an owned byte-array literal.
@@ -42,8 +171,12 @@ pub(crate) fn devpath2(input: TokenStream) -> TokenStream {
 fn expand_devpath(input: TokenStream) -> syn::Result<TokenStream> {
     let input = syn::parse2::<DevicePathInput>(input)?;
     let value = input.literal.value();
-    let bytes = encode_device_path(&value)
-        .map_err(|error| syn::Error::new(input.literal.span(), format_device_path_error(&value, &error)))?;
+    let bytes = if input.vendor_hardware_schemas.is_empty() {
+        encode_device_path(&value)
+    } else {
+        encode_device_path_with_vendors(&value, &input.vendor_hardware_schemas)
+    }
+    .map_err(|error| syn::Error::new(input.literal.span(), format_device_path_error(&value, &error)))?;
     let bytes = bytes.into_iter().map(Literal::u8_suffixed);
     Ok(quote!([#(#bytes),*]))
 }
@@ -162,6 +295,135 @@ mod tests {
         let expansion = devpath2(quote!("Pci(1,0)", "USB(1,0)"));
 
         assert!(expansion.to_string().contains("accepts exactly one string literal"));
+    }
+
+    #[test]
+    fn test_devpath_encodes_vendor_hardware_schema() {
+        let custom = devpath2(quote!(
+            vendors {
+                AcmeController {
+                    guid: "00112233-4455-6677-8899-aabbccddeeff",
+                    fields: [port: u8, flags: u16le],
+                },
+            };
+            "AcmeController(3,0x1234)"
+        ));
+        let canonical = devpath2(quote!("VenHw(00112233-4455-6677-8899-aabbccddeeff,033412)"));
+
+        assert_eq!(custom.to_string(), canonical.to_string());
+    }
+
+    #[test]
+    fn test_devpath_encodes_all_vendor_hardware_field_types() {
+        let input = syn::parse2::<DevicePathInput>(quote!(
+            vendors {
+                VendorData {
+                    guid: "00112233-4455-6677-8899-aabbccddeeff",
+                    fields: [
+                        byte: u8,
+                        word: u16le,
+                        dword: u32le,
+                        qword: u64le,
+                        efiGuid: guid,
+                        rfcUuid: uuid,
+                        data: bytes,
+                    ],
+                },
+            };
+            "VendorData(1,0x0203,0x04050607,0x08090a0b0c0d0e0f,00112233-4455-6677-8899-aabbccddeeff,00112233-4455-6677-8899-aabbccddeeff,aabb)"
+        ))
+        .expect("schema should parse");
+        let bytes = encode_device_path_with_vendors(&input.literal.value(), &input.vendor_hardware_schemas)
+            .expect("vendor node should encode");
+
+        assert_eq!(
+            &bytes[20..],
+            &[
+                0x01, 0x03, 0x02, 0x07, 0x06, 0x05, 0x04, 0x0f, 0x0e, 0x0d, 0x0c, 0x0b, 0x0a, 0x09, 0x08, 0x33, 0x22,
+                0x11, 0x00, 0x55, 0x44, 0x77, 0x66, 0x88, 0x99, 0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff, 0x00, 0x11, 0x22,
+                0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99, 0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff, 0xaa, 0xbb, 0x7f, 0xff,
+                0x04, 0x00,
+            ]
+        );
+    }
+
+    #[test]
+    fn test_devpath_rejects_invalid_vendor_hardware_schemas() {
+        for (input, expected) in [
+            (
+                quote!(
+                    vendors {
+                        Pci {
+                            guid: "00112233-4455-6677-8899-aabbccddeeff",
+                            fields: [],
+                        },
+                    };
+                    "Pci()"
+                ),
+                "built-in device path node",
+            ),
+            (
+                quote!(
+                    vendors {
+                        Acme {
+                            guid: "not-a-guid",
+                            fields: [],
+                        },
+                    };
+                    "Acme()"
+                ),
+                "is not a valid GUID",
+            ),
+            (
+                quote!(
+                    vendors {
+                        Acme {
+                            guid: "00112233-4455-6677-8899-aabbccddeeff",
+                            fields: [port: u24le],
+                        },
+                    };
+                    "Acme(1)"
+                ),
+                "unsupported vendor hardware field type",
+            ),
+            (
+                quote!(
+                    vendors {};
+                    "Pci(1,0)"
+                ),
+                "must declare at least one vendor hardware schema",
+            ),
+            (
+                quote!(
+                    vendors {
+                        Acme {
+                            guid: "00112233-4455-6677-8899-aabbccddeeff",
+                            fields: [port: u8, port: u16le],
+                        },
+                    };
+                    "Acme(1,2)"
+                ),
+                "field `port` was declared more than once",
+            ),
+            (
+                quote!(
+                    vendors {
+                        Acme {
+                            guid: "00112233-4455-6677-8899-aabbccddeeff",
+                            fields: [],
+                        },
+                        Acme {
+                            guid: "11223344-5566-7788-99aa-bbccddeeff00",
+                            fields: [],
+                        },
+                    };
+                    "Acme()"
+                ),
+                "schema `Acme` was declared more than once",
+            ),
+        ] {
+            assert!(devpath2(input).to_string().contains(expected));
+        }
     }
 
     #[test]

--- a/sdk/patina_macro/src/device_path_nodes.rs
+++ b/sdk/patina_macro/src/device_path_nodes.rs
@@ -37,9 +37,9 @@ const VIRTUAL_CD_GUID: &str = "3d5abd30-4175-87ce-6d64-d2ade523c4bb";
 const PERSISTENT_VIRTUAL_DISK_GUID: &str = "5cea02c9-4d07-69d3-269f-4496fbe096f9";
 const PERSISTENT_VIRTUAL_CD_GUID: &str = "08018188-42cd-bb48-100f-5387d53ded3d";
 
-/// Encoding of one custom vendor hardware payload field.
+/// Encoding of one custom vendor-defined payload field.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub(crate) enum VendorHardwareFieldType {
+pub(crate) enum VendorDefinedFieldType {
     U8,
     U16Le,
     U32Le,
@@ -49,7 +49,7 @@ pub(crate) enum VendorHardwareFieldType {
     Bytes,
 }
 
-impl VendorHardwareFieldType {
+impl VendorDefinedFieldType {
     pub(crate) fn from_name(name: &str) -> Option<Self> {
         match name {
             "u8" => Some(Self::U8),
@@ -64,19 +64,38 @@ impl VendorHardwareFieldType {
     }
 }
 
-/// One named field in a custom vendor hardware payload.
+/// One named field in a custom vendor-defined payload.
 #[derive(Debug, Eq, PartialEq)]
-pub(crate) struct VendorHardwareField {
+pub(crate) struct VendorDefinedField {
     pub(crate) name: String,
-    pub(crate) field_type: VendorHardwareFieldType,
+    pub(crate) field_type: VendorDefinedFieldType,
 }
 
-/// A user-declared shortcut for a vendor hardware device path node.
+/// Device path node type for a user-declared vendor-defined shortcut.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum VendorDefinedType {
+    Hardware,
+    Messaging,
+    Media,
+}
+
+impl VendorDefinedType {
+    fn node_type_and_subtype(self) -> (u8, u8) {
+        match self {
+            Self::Hardware => (1, 4),
+            Self::Messaging => (3, 10),
+            Self::Media => (4, 3),
+        }
+    }
+}
+
+/// A user-declared shortcut for a vendor-defined device path node.
 #[derive(Debug, Eq, PartialEq)]
-pub(crate) struct VendorHardwareSchema {
+pub(crate) struct VendorDefinedSchema {
     pub(crate) name: String,
+    pub(crate) vendor_type: VendorDefinedType,
     pub(crate) guid: [u8; 16],
-    pub(crate) fields: Vec<VendorHardwareField>,
+    pub(crate) fields: Vec<VendorDefinedField>,
 }
 
 /// Return whether a name is reserved by a built-in UEFI node or shortcut.
@@ -179,12 +198,12 @@ pub(crate) fn is_builtin_node_name(name: &str) -> bool {
 /// Encode one parsed node.
 pub(crate) fn encode_node(
     node: &ParsedNode,
-    vendor_hardware_schemas: &[VendorHardwareSchema],
+    vendor_defined_schemas: &[VendorDefinedSchema],
 ) -> Result<Vec<u8>, DevicePathError> {
     match &node.kind {
         ParsedNodeKind::FilePath(path) => encode_file_path(node, path),
         ParsedNodeKind::Canonical { name, arguments } => {
-            encode_canonical(node, name, arguments, vendor_hardware_schemas)
+            encode_canonical(node, name, arguments, vendor_defined_schemas)
         }
     }
 }
@@ -193,7 +212,7 @@ fn encode_canonical(
     node: &ParsedNode,
     name: &str,
     arguments: &[ParsedArgument],
-    vendor_hardware_schemas: &[VendorHardwareSchema],
+    vendor_defined_schemas: &[VendorDefinedSchema],
 ) -> Result<Vec<u8>, DevicePathError> {
     match name {
         "Path" => encode_generic(node, arguments, None),
@@ -286,9 +305,9 @@ fn encode_canonical(
         "PersistentVirtualCD" => encode_ram_disk(node, arguments, Some(PERSISTENT_VIRTUAL_CD_GUID)),
         "BbsPath" => encode_generic(node, arguments, Some(5)),
         "BBS" => encode_bbs(node, arguments),
-        _ => vendor_hardware_schemas.iter().find(|schema| schema.name == name).map_or_else(
+        _ => vendor_defined_schemas.iter().find(|schema| schema.name == name).map_or_else(
             || Err(DevicePathError::new(node.offset, format!("unknown device path node `{name}`"))),
-            |schema| encode_vendor_hardware(node, arguments, schema),
+            |schema| encode_vendor_defined(node, arguments, schema),
         ),
     }
 }
@@ -449,38 +468,39 @@ fn encode_vendor(
     writer.finish()
 }
 
-fn encode_vendor_hardware(
+fn encode_vendor_defined(
     node: &ParsedNode,
     arguments: &[ParsedArgument],
-    schema: &VendorHardwareSchema,
+    schema: &VendorDefinedSchema,
 ) -> Result<Vec<u8>, DevicePathError> {
     let names: Vec<&str> = schema.fields.iter().map(|field| field.name.as_str()).collect();
     let args = ResolvedArgs::new(node, arguments, &names)?;
-    let mut writer = NodeWriter::new(node, 1, 4);
+    let (node_type, subtype) = schema.vendor_type.node_type_and_subtype();
+    let mut writer = NodeWriter::new(node, node_type, subtype);
     writer.bytes(&schema.guid);
 
     for (index, field) in schema.fields.iter().enumerate() {
         let argument = args.required(index)?;
         match field.field_type {
-            VendorHardwareFieldType::U8 => {
+            VendorDefinedFieldType::U8 => {
                 writer.byte(parse_u8(&argument.value, argument.offset, &field.name)?);
             }
-            VendorHardwareFieldType::U16Le => {
+            VendorDefinedFieldType::U16Le => {
                 writer.u16(parse_u16(&argument.value, argument.offset, &field.name)?);
             }
-            VendorHardwareFieldType::U32Le => {
+            VendorDefinedFieldType::U32Le => {
                 writer.u32(parse_u32(&argument.value, argument.offset, &field.name)?);
             }
-            VendorHardwareFieldType::U64Le => {
+            VendorDefinedFieldType::U64Le => {
                 writer.u64(parse_u64(&argument.value, argument.offset, &field.name)?);
             }
-            VendorHardwareFieldType::Guid => {
+            VendorDefinedFieldType::Guid => {
                 writer.bytes(&parse_efi_guid(&argument.value, argument.offset, &field.name)?);
             }
-            VendorHardwareFieldType::Uuid => {
+            VendorDefinedFieldType::Uuid => {
                 writer.bytes(&parse_uuid_bytes(&argument.value, argument.offset, &field.name)?);
             }
-            VendorHardwareFieldType::Bytes => {
+            VendorDefinedFieldType::Bytes => {
                 writer.bytes(&parse_hex_bytes(&argument.value, argument.offset, &field.name)?);
             }
         }

--- a/sdk/patina_macro/src/device_path_nodes.rs
+++ b/sdk/patina_macro/src/device_path_nodes.rs
@@ -1,0 +1,1468 @@
+//! UEFI device path node text-to-binary conversions.
+//!
+//! Binary node layouts, type and subtype values, and field semantics follow the
+//! [UEFI 2.11 Device Path Nodes specification][device-path-nodes]. Text syntax,
+//! parameter ordering, defaults, and aliases follow [Text Representation
+//! Basics][text-representation] and the [Text Device Node Reference][text-nodes].
+//!
+//! [device-path-nodes]: https://uefi.org/specs/UEFI/2.11/10_Protocols_Device_Path_Protocol.html#device-path-nodes
+//! [text-representation]: https://uefi.org/specs/UEFI/2.11/10_Protocols_Device_Path_Protocol.html#text-representation-basics
+//! [text-nodes]: https://uefi.org/specs/UEFI/2.11/10_Protocols_Device_Path_Protocol.html#text-device-node-reference
+//!
+//! ## License
+//!
+//! Copyright (c) Microsoft Corporation.
+//!
+//! SPDX-License-Identifier: Apache-2.0
+
+use crate::{
+    device_path_encoder::{
+        NodeWriter, parse_efi_guid, parse_eisa_id, parse_fixed_hex, parse_hex_bytes, parse_ipv4, parse_ipv6, parse_u8,
+        parse_u16, parse_u32, parse_u64, parse_unsigned, parse_uuid_bytes,
+    },
+    device_path_parser::{DevicePathError, ParsedArgument, ParsedNode, ParsedNodeKind},
+};
+
+const PC_ANSI_GUID: &str = "e0c14753-f9be-11d2-9a0c-0090273fc14d";
+const VT_100_GUID: &str = "dfa66065-b419-11d3-9a2d-0090273fc14d";
+const VT_100_PLUS_GUID: &str = "7baec70b-57e0-4c76-8e87-2f9e28088343";
+const VT_UTF8_GUID: &str = "ad15a0d6-8bec-4acf-a073-d01de77e2d88";
+const UART_FLOW_CONTROL_GUID: &str = "37499a9d-542f-4c89-a026-35da142094e4";
+const SAS_GUID: &str = "d487ddb4-008b-11d9-afdc-001083ffca4d";
+const DEBUG_PORT_GUID: &str = "eba4e8d2-3858-41ec-a281-2647ba9660d0";
+const VIRTUAL_DISK_GUID: &str = "77ab535a-45fc-624b-5560-f7b281d1f96e";
+const VIRTUAL_CD_GUID: &str = "3d5abd30-4175-87ce-6d64-d2ade523c4bb";
+const PERSISTENT_VIRTUAL_DISK_GUID: &str = "5cea02c9-4d07-69d3-269f-4496fbe096f9";
+const PERSISTENT_VIRTUAL_CD_GUID: &str = "08018188-42cd-bb48-100f-5387d53ded3d";
+
+/// Encode one parsed node.
+pub(crate) fn encode_node(node: &ParsedNode) -> Result<Vec<u8>, DevicePathError> {
+    match &node.kind {
+        ParsedNodeKind::FilePath(path) => encode_file_path(node, path),
+        ParsedNodeKind::Canonical { name, arguments } => encode_canonical(node, name, arguments),
+    }
+}
+
+fn encode_canonical(node: &ParsedNode, name: &str, arguments: &[ParsedArgument]) -> Result<Vec<u8>, DevicePathError> {
+    match name {
+        "Path" => encode_generic(node, arguments, None),
+        "HardwarePath" => encode_generic(node, arguments, Some(1)),
+        "Pci" => encode_pci(node, arguments),
+        "PcCard" => encode_pc_card(node, arguments),
+        "MemoryMapped" => encode_memory_mapped(node, arguments),
+        "VenHw" => encode_vendor(node, arguments, 1, 4),
+        "Ctrl" => encode_controller(node, arguments),
+        "BMC" => encode_bmc(node, arguments),
+        "AcpiPath" => encode_generic(node, arguments, Some(2)),
+        "Acpi" => encode_acpi(node, arguments, None),
+        "PciRoot" => encode_acpi(node, arguments, Some("PNP0A03")),
+        "PcieRoot" => encode_acpi(node, arguments, Some("PNP0A08")),
+        "Floppy" => encode_acpi(node, arguments, Some("PNP0604")),
+        "Keyboard" => encode_acpi(node, arguments, Some("PNP0301")),
+        "Serial" => encode_acpi(node, arguments, Some("PNP0501")),
+        "ParallelPort" => encode_acpi(node, arguments, Some("PNP0401")),
+        "AcpiEx" => encode_acpi_ex(node, arguments),
+        "AcpiExp" => encode_acpi_exp(node, arguments),
+        "AcpiAdr" => encode_acpi_adr(node, arguments),
+        "NvdimmAcpiAdr" => encode_nvdimm_acpi_adr(node, arguments),
+        "Msg" => encode_generic(node, arguments, Some(3)),
+        "Ata" => encode_ata(node, arguments),
+        "Scsi" => encode_scsi(node, arguments),
+        "Fibre" => encode_fibre(node, arguments),
+        "FibreEx" => encode_fibre_ex(node, arguments),
+        "I1394" => encode_i1394(node, arguments),
+        "USB" => encode_usb(node, arguments),
+        "I2O" => encode_i2o(node, arguments),
+        "Infiniband" => encode_infiniband(node, arguments),
+        "VenMsg" => encode_vendor(node, arguments, 3, 10),
+        "VenPcAnsi" => encode_guid_vendor_shortcut(node, arguments, PC_ANSI_GUID),
+        "VenVt100" => encode_guid_vendor_shortcut(node, arguments, VT_100_GUID),
+        "VenVt100Plus" => encode_guid_vendor_shortcut(node, arguments, VT_100_PLUS_GUID),
+        "VenUtf8" => encode_guid_vendor_shortcut(node, arguments, VT_UTF8_GUID),
+        "UartFlowCtrl" => encode_uart_flow_control(node, arguments),
+        "SAS" => encode_sas(node, arguments),
+        "DebugPort" => encode_guid_vendor_shortcut(node, arguments, DEBUG_PORT_GUID),
+        "MAC" => encode_mac(node, arguments),
+        "IPv4" => encode_ipv4(node, arguments),
+        "IPv6" => encode_ipv6(node, arguments),
+        "Uart" => encode_uart(node, arguments),
+        "UsbClass" => encode_usb_class(node, arguments, None, None),
+        "UsbAudio" => encode_usb_class(node, arguments, Some(1), None),
+        "UsbCDCControl" => encode_usb_class(node, arguments, Some(2), None),
+        "UsbHID" => encode_usb_class(node, arguments, Some(3), None),
+        "UsbImage" => encode_usb_class(node, arguments, Some(6), None),
+        "UsbPrinter" => encode_usb_class(node, arguments, Some(7), None),
+        "UsbMassStorage" => encode_usb_class(node, arguments, Some(8), None),
+        "UsbHub" => encode_usb_class(node, arguments, Some(9), None),
+        "UsbCDCData" => encode_usb_class(node, arguments, Some(10), None),
+        "UsbSmartCard" => encode_usb_class(node, arguments, Some(11), None),
+        "UsbVideo" => encode_usb_class(node, arguments, Some(14), None),
+        "UsbDiagnostic" => encode_usb_class(node, arguments, Some(220), None),
+        "UsbWireless" => encode_usb_class(node, arguments, Some(224), None),
+        "UsbDeviceFirmwareUpdate" => encode_usb_class(node, arguments, Some(254), Some(1)),
+        "UsbIrdaBridge" => encode_usb_class(node, arguments, Some(254), Some(2)),
+        "UsbTestAndMeasurement" => encode_usb_class(node, arguments, Some(254), Some(3)),
+        "UsbWwid" => encode_usb_wwid(node, arguments),
+        "Unit" => encode_unit(node, arguments),
+        "Sata" => encode_sata(node, arguments),
+        "iSCSI" => encode_iscsi(node, arguments),
+        "Vlan" => encode_vlan(node, arguments),
+        "SasEx" => encode_sas_ex(node, arguments),
+        "NVMe" => encode_nvme(node, arguments),
+        "Uri" => encode_uri(node, arguments),
+        "UFS" => encode_ufs(node, arguments),
+        "SD" => encode_sd_emmc(node, arguments, 26),
+        "Bluetooth" => encode_bluetooth(node, arguments),
+        "Wi-Fi" => encode_wifi(node, arguments),
+        "eMMC" => encode_sd_emmc(node, arguments, 29),
+        "BluetoothLE" => encode_bluetooth_le(node, arguments),
+        "Dns" => encode_dns(node, arguments),
+        "NVDIMM" => encode_nvdimm(node, arguments),
+        "RestService" => encode_rest_service(node, arguments),
+        "NVMEoF" => encode_nvme_of(node, arguments),
+        "MediaPath" => encode_generic(node, arguments, Some(4)),
+        "HD" => encode_hard_drive(node, arguments),
+        "CDROM" => encode_cdrom(node, arguments),
+        "VenMedia" => encode_vendor(node, arguments, 4, 3),
+        "Media" => encode_media(node, arguments),
+        "FvFile" => encode_fv(node, arguments, 6),
+        "Fv" => encode_fv(node, arguments, 7),
+        "Offset" => encode_offset(node, arguments),
+        "RamDisk" => encode_ram_disk(node, arguments, None),
+        "VirtualDisk" => encode_ram_disk(node, arguments, Some(VIRTUAL_DISK_GUID)),
+        "VirtualCD" => encode_ram_disk(node, arguments, Some(VIRTUAL_CD_GUID)),
+        "PersistentVirtualDisk" => encode_ram_disk(node, arguments, Some(PERSISTENT_VIRTUAL_DISK_GUID)),
+        "PersistentVirtualCD" => encode_ram_disk(node, arguments, Some(PERSISTENT_VIRTUAL_CD_GUID)),
+        "BbsPath" => encode_generic(node, arguments, Some(5)),
+        "BBS" => encode_bbs(node, arguments),
+        _ => Err(DevicePathError::new(node.offset, format!("unknown device path node `{name}`"))),
+    }
+}
+
+struct ResolvedArgs<'a> {
+    node_offset: usize,
+    names: &'static [&'static str],
+    values: Vec<Option<&'a ParsedArgument>>,
+}
+
+impl<'a> ResolvedArgs<'a> {
+    fn new(
+        node: &ParsedNode,
+        arguments: &'a [ParsedArgument],
+        names: &'static [&'static str],
+    ) -> Result<Self, DevicePathError> {
+        let mut values = vec![None; names.len()];
+        let mut positional_index = 0;
+
+        for argument in arguments {
+            let index = if let Some(name) = &argument.name {
+                names.iter().position(|candidate| candidate == name).ok_or_else(|| {
+                    DevicePathError::new(argument.offset, format!("unknown parameter `{name}` for this node"))
+                })?
+            } else {
+                while values.get(positional_index).is_some_and(Option::is_some) {
+                    positional_index += 1;
+                }
+                if positional_index >= names.len() {
+                    return Err(DevicePathError::new(argument.offset, "too many parameters for this node"));
+                }
+                let index = positional_index;
+                positional_index += 1;
+                index
+            };
+
+            let slot = values.get_mut(index).expect("parameter index is derived from the parameter name table");
+            if slot.is_some() {
+                return Err(DevicePathError::new(
+                    argument.offset,
+                    format!(
+                        "parameter `{}` was provided more than once",
+                        names.get(index).expect("parameter index is derived from the parameter name table")
+                    ),
+                ));
+            }
+            *slot = Some(argument);
+        }
+
+        Ok(Self { node_offset: node.offset, names, values })
+    }
+
+    fn optional(&self, index: usize) -> Option<&'a ParsedArgument> {
+        self.values.get(index).copied().flatten().filter(|argument| !argument.value.is_empty())
+    }
+
+    fn required(&self, index: usize) -> Result<&'a ParsedArgument, DevicePathError> {
+        self.optional(index).ok_or_else(|| {
+            DevicePathError::new(
+                self.node_offset,
+                format!(
+                    "{} is required",
+                    self.names.get(index).expect("parameter index is derived from the parameter name table")
+                ),
+            )
+        })
+    }
+
+    fn text(&self, index: usize, default: &'static str) -> &'a str {
+        self.optional(index).map_or(default, |argument| argument.value.as_str())
+    }
+
+    fn offset(&self, index: usize) -> usize {
+        self.values.get(index).copied().flatten().map_or(self.node_offset, |argument| argument.offset)
+    }
+}
+
+fn ensure_no_arguments(_node: &ParsedNode, arguments: &[ParsedArgument]) -> Result<(), DevicePathError> {
+    if let Some(argument) = arguments.first() {
+        return Err(DevicePathError::new(argument.offset, "this node does not accept parameters"));
+    }
+    Ok(())
+}
+
+fn encode_generic(
+    node: &ParsedNode,
+    arguments: &[ParsedArgument],
+    fixed_type: Option<u8>,
+) -> Result<Vec<u8>, DevicePathError> {
+    let names: &'static [&'static str] =
+        if fixed_type.is_some() { &["Subtype", "Data"] } else { &["Type", "Subtype", "Data"] };
+    let args = ResolvedArgs::new(node, arguments, names)?;
+    let (r#type, subtype_index) = if let Some(r#type) = fixed_type {
+        (r#type, 0)
+    } else {
+        let argument = args.required(0)?;
+        (parse_u8(&argument.value, argument.offset, "Type")?, 1)
+    };
+    let subtype = args.required(subtype_index)?;
+    let data = args
+        .optional(subtype_index + 1)
+        .map_or(Ok(Vec::new()), |argument| parse_hex_bytes(&argument.value, argument.offset, "Data"))?;
+
+    let mut writer = NodeWriter::new(node, r#type, parse_u8(&subtype.value, subtype.offset, "Subtype")?);
+    writer.bytes(&data);
+    writer.finish()
+}
+
+fn encode_pci(node: &ParsedNode, arguments: &[ParsedArgument]) -> Result<Vec<u8>, DevicePathError> {
+    let args = ResolvedArgs::new(node, arguments, &["Device", "Function"])?;
+    let device = args.required(0)?;
+    let function = args.required(1)?;
+    let device = parse_u8(&device.value, device.offset, "Device")?;
+    let function = parse_u8(&function.value, function.offset, "Function")?;
+    if device > 31 {
+        return Err(DevicePathError::new(args.offset(0), "Device must be between 0 and 31"));
+    }
+    if function > 7 {
+        return Err(DevicePathError::new(args.offset(1), "Function must be between 0 and 7"));
+    }
+
+    let mut writer = NodeWriter::new(node, 1, 1);
+    writer.byte(function);
+    writer.byte(device);
+    writer.finish()
+}
+
+fn encode_pc_card(node: &ParsedNode, arguments: &[ParsedArgument]) -> Result<Vec<u8>, DevicePathError> {
+    let args = ResolvedArgs::new(node, arguments, &["Function"])?;
+    let function = args.required(0)?;
+    let mut writer = NodeWriter::new(node, 1, 2);
+    writer.byte(parse_u8(&function.value, function.offset, "Function")?);
+    writer.finish()
+}
+
+fn encode_memory_mapped(node: &ParsedNode, arguments: &[ParsedArgument]) -> Result<Vec<u8>, DevicePathError> {
+    let args = ResolvedArgs::new(node, arguments, &["EfiMemoryType", "StartingAddress", "EndingAddress"])?;
+    let memory_type = args.required(0)?;
+    let start = args.required(1)?;
+    let end = args.required(2)?;
+    let mut writer = NodeWriter::new(node, 1, 3);
+    writer.u32(parse_u32(&memory_type.value, memory_type.offset, "EfiMemoryType")?);
+    writer.u64(parse_u64(&start.value, start.offset, "StartingAddress")?);
+    writer.u64(parse_u64(&end.value, end.offset, "EndingAddress")?);
+    writer.finish()
+}
+
+fn encode_vendor(
+    node: &ParsedNode,
+    arguments: &[ParsedArgument],
+    r#type: u8,
+    subtype: u8,
+) -> Result<Vec<u8>, DevicePathError> {
+    let args = ResolvedArgs::new(node, arguments, &["Guid", "Data"])?;
+    let guid = args.required(0)?;
+    let data = args
+        .optional(1)
+        .map_or(Ok(Vec::new()), |argument| parse_hex_bytes(&argument.value, argument.offset, "Data"))?;
+    let mut writer = NodeWriter::new(node, r#type, subtype);
+    writer.bytes(&parse_efi_guid(&guid.value, guid.offset, "Guid")?);
+    writer.bytes(&data);
+    writer.finish()
+}
+
+fn encode_controller(node: &ParsedNode, arguments: &[ParsedArgument]) -> Result<Vec<u8>, DevicePathError> {
+    let args = ResolvedArgs::new(node, arguments, &["Controller"])?;
+    let controller = args.required(0)?;
+    let mut writer = NodeWriter::new(node, 1, 5);
+    writer.u32(parse_u32(&controller.value, controller.offset, "Controller")?);
+    writer.finish()
+}
+
+fn encode_bmc(node: &ParsedNode, arguments: &[ParsedArgument]) -> Result<Vec<u8>, DevicePathError> {
+    let args = ResolvedArgs::new(node, arguments, &["Type", "Address"])?;
+    let interface_type = args.required(0)?;
+    let address = args.required(1)?;
+    let mut writer = NodeWriter::new(node, 1, 6);
+    writer.byte(parse_u8(&interface_type.value, interface_type.offset, "Type")?);
+    writer.u64(parse_u64(&address.value, address.offset, "Address")?);
+    writer.finish()
+}
+
+fn encode_acpi(
+    node: &ParsedNode,
+    arguments: &[ParsedArgument],
+    fixed_hid: Option<&str>,
+) -> Result<Vec<u8>, DevicePathError> {
+    let names: &'static [&'static str] = if fixed_hid.is_some() { &["UID"] } else { &["HID", "UID"] };
+    let args = ResolvedArgs::new(node, arguments, names)?;
+    let (hid, uid_index) = if let Some(hid) = fixed_hid {
+        (parse_eisa_id(hid, node.offset, "HID")?, 0)
+    } else {
+        let hid = args.required(0)?;
+        (parse_eisa_id(&hid.value, hid.offset, "HID")?, 1)
+    };
+    let uid = args.optional(uid_index).map_or(Ok(0), |argument| parse_u32(&argument.value, argument.offset, "UID"))?;
+
+    let mut writer = NodeWriter::new(node, 2, 1);
+    writer.u32(hid);
+    writer.u32(uid);
+    writer.finish()
+}
+
+fn encode_acpi_ex(node: &ParsedNode, arguments: &[ParsedArgument]) -> Result<Vec<u8>, DevicePathError> {
+    let args = ResolvedArgs::new(node, arguments, &["HID", "CID", "UID", "HIDSTR", "CIDSTR", "UIDSTR"])?;
+    let hid = args.optional(0).map_or(Ok(0), |argument| parse_eisa_id(&argument.value, argument.offset, "HID"))?;
+    let cid = args.optional(1).map_or(Ok(0), |argument| parse_eisa_id(&argument.value, argument.offset, "CID"))?;
+    let uid = args.optional(2).map_or(Ok(0), |argument| parse_u32(&argument.value, argument.offset, "UID"))?;
+    let hid_string = args.text(3, "");
+    let cid_string = args.text(4, "");
+    let uid_string = args.text(5, "");
+
+    if hid == 0 && hid_string.is_empty() {
+        return Err(DevicePathError::new(node.offset, "either HID or HIDSTR is required"));
+    }
+    if cid != 0 && !cid_string.is_empty() {
+        return Err(DevicePathError::new(args.offset(4), "CID and CIDSTR cannot both be non-default"));
+    }
+    if uid != 0 && !uid_string.is_empty() {
+        return Err(DevicePathError::new(args.offset(5), "UID and UIDSTR cannot both be non-default"));
+    }
+
+    let mut writer = NodeWriter::new(node, 2, 2);
+    writer.u32(hid);
+    writer.u32(uid);
+    writer.u32(cid);
+    writer.ascii_nul(hid_string, "HIDSTR")?;
+    writer.ascii_nul(uid_string, "UIDSTR")?;
+    writer.ascii_nul(cid_string, "CIDSTR")?;
+    writer.finish()
+}
+
+fn encode_acpi_exp(node: &ParsedNode, arguments: &[ParsedArgument]) -> Result<Vec<u8>, DevicePathError> {
+    let args = ResolvedArgs::new(node, arguments, &["HID", "CID", "UIDSTR"])?;
+    let hid = args.required(0)?;
+    let cid = args.optional(1);
+    let uid_string = args.required(2)?;
+    let mut writer = NodeWriter::new(node, 2, 2);
+    writer.u32(parse_eisa_id(&hid.value, hid.offset, "HID")?);
+    writer.u32(0);
+    writer.u32(cid.map_or(Ok(0), |argument| parse_eisa_id(&argument.value, argument.offset, "CID"))?);
+    writer.ascii_nul("", "HIDSTR")?;
+    writer.ascii_nul(&uid_string.value, "UIDSTR")?;
+    writer.ascii_nul("", "CIDSTR")?;
+    writer.finish()
+}
+
+fn encode_acpi_adr(node: &ParsedNode, arguments: &[ParsedArgument]) -> Result<Vec<u8>, DevicePathError> {
+    if arguments.is_empty() {
+        return Err(DevicePathError::new(node.offset, "at least one DisplayDevice is required"));
+    }
+    if let Some(argument) = arguments.iter().find(|argument| argument.name.is_some()) {
+        return Err(DevicePathError::new(argument.offset, "AcpiAdr does not accept named parameters"));
+    }
+    let mut writer = NodeWriter::new(node, 2, 3);
+    for argument in arguments {
+        writer.u32(parse_u32(&argument.value, argument.offset, "DisplayDevice")?);
+    }
+    writer.finish()
+}
+
+fn encode_nvdimm_acpi_adr(node: &ParsedNode, arguments: &[ParsedArgument]) -> Result<Vec<u8>, DevicePathError> {
+    let args = ResolvedArgs::new(node, arguments, &["NFITDeviceHandle"])?;
+    let handle = args.required(0)?;
+    let mut writer = NodeWriter::new(node, 2, 4);
+    writer.u32(parse_u32(&handle.value, handle.offset, "NFITDeviceHandle")?);
+    writer.finish()
+}
+
+fn encode_file_path(node: &ParsedNode, path: &str) -> Result<Vec<u8>, DevicePathError> {
+    let mut writer = NodeWriter::new(node, 4, 4);
+    writer.utf16(path, true);
+    writer.finish()
+}
+
+fn encode_ata(node: &ParsedNode, arguments: &[ParsedArgument]) -> Result<Vec<u8>, DevicePathError> {
+    let args = ResolvedArgs::new(node, arguments, &["Controller", "Drive", "LUN"])?;
+    let controller = args.required(0)?;
+    let drive = args.required(1)?;
+    let lun = args.required(2)?;
+    let controller =
+        parse_u8_keyword(&controller.value, controller.offset, "Controller", &[("Primary", 0), ("Secondary", 1)])?;
+    let drive = parse_u8_keyword(&drive.value, drive.offset, "Drive", &[("Master", 0), ("Slave", 1)])?;
+    if controller > 1 {
+        return Err(DevicePathError::new(args.offset(0), "Controller must be Primary, Secondary, 0, or 1"));
+    }
+    if drive > 1 {
+        return Err(DevicePathError::new(args.offset(1), "Drive must be Master, Slave, 0, or 1"));
+    }
+
+    let mut writer = NodeWriter::new(node, 3, 1);
+    writer.byte(controller);
+    writer.byte(drive);
+    writer.u16(parse_u16(&lun.value, lun.offset, "LUN")?);
+    writer.finish()
+}
+
+fn encode_scsi(node: &ParsedNode, arguments: &[ParsedArgument]) -> Result<Vec<u8>, DevicePathError> {
+    let args = ResolvedArgs::new(node, arguments, &["PUN", "LUN"])?;
+    let pun = args.required(0)?;
+    let lun = args.required(1)?;
+    let mut writer = NodeWriter::new(node, 3, 2);
+    writer.u16(parse_u16(&pun.value, pun.offset, "PUN")?);
+    writer.u16(parse_u16(&lun.value, lun.offset, "LUN")?);
+    writer.finish()
+}
+
+fn encode_fibre(node: &ParsedNode, arguments: &[ParsedArgument]) -> Result<Vec<u8>, DevicePathError> {
+    let args = ResolvedArgs::new(node, arguments, &["WWN", "LUN"])?;
+    let wwn = args.required(0)?;
+    let lun = args.required(1)?;
+    let mut writer = NodeWriter::new(node, 3, 3);
+    writer.u32(0);
+    writer.u64(parse_u64(&wwn.value, wwn.offset, "WWN")?);
+    writer.u64(parse_u64(&lun.value, lun.offset, "LUN")?);
+    writer.finish()
+}
+
+fn encode_fibre_ex(node: &ParsedNode, arguments: &[ParsedArgument]) -> Result<Vec<u8>, DevicePathError> {
+    let args = ResolvedArgs::new(node, arguments, &["WWN", "LUN"])?;
+    let wwn = args.required(0)?;
+    let lun = args.required(1)?;
+    let mut writer = NodeWriter::new(node, 3, 21);
+    writer.bytes(&parse_fixed_hex::<8>(&wwn.value, wwn.offset, "WWN")?);
+    writer.bytes(&parse_fixed_hex::<8>(&lun.value, lun.offset, "LUN")?);
+    writer.finish()
+}
+
+fn encode_i1394(node: &ParsedNode, arguments: &[ParsedArgument]) -> Result<Vec<u8>, DevicePathError> {
+    let args = ResolvedArgs::new(node, arguments, &["GUID"])?;
+    let guid = args.required(0)?;
+    let mut writer = NodeWriter::new(node, 3, 4);
+    writer.u32(0);
+    writer.u64(parse_u64(&guid.value, guid.offset, "GUID")?);
+    writer.finish()
+}
+
+fn encode_usb(node: &ParsedNode, arguments: &[ParsedArgument]) -> Result<Vec<u8>, DevicePathError> {
+    let args = ResolvedArgs::new(node, arguments, &["Port", "Interface"])?;
+    let port = args.required(0)?;
+    let interface = args.required(1)?;
+    let mut writer = NodeWriter::new(node, 3, 5);
+    writer.byte(parse_u8(&port.value, port.offset, "Port")?);
+    writer.byte(parse_u8(&interface.value, interface.offset, "Interface")?);
+    writer.finish()
+}
+
+fn encode_i2o(node: &ParsedNode, arguments: &[ParsedArgument]) -> Result<Vec<u8>, DevicePathError> {
+    let args = ResolvedArgs::new(node, arguments, &["TID"])?;
+    let tid = args.required(0)?;
+    let mut writer = NodeWriter::new(node, 3, 6);
+    writer.u32(parse_u32(&tid.value, tid.offset, "TID")?);
+    writer.finish()
+}
+
+fn encode_infiniband(node: &ParsedNode, arguments: &[ParsedArgument]) -> Result<Vec<u8>, DevicePathError> {
+    let args = ResolvedArgs::new(node, arguments, &["Flags", "Guid", "ServiceId", "TargetId", "DeviceId"])?;
+    let flags = args.required(0)?;
+    let guid = args.required(1)?;
+    let service_id = args.required(2)?;
+    let target_id = args.required(3)?;
+    let device_id = args.required(4)?;
+    let mut writer = NodeWriter::new(node, 3, 9);
+    writer.u32(parse_u32(&flags.value, flags.offset, "Flags")?);
+    writer.bytes(&parse_efi_guid(&guid.value, guid.offset, "Guid")?);
+    writer.u64(parse_u64(&service_id.value, service_id.offset, "ServiceId")?);
+    writer.u64(parse_u64(&target_id.value, target_id.offset, "TargetId")?);
+    writer.u64(parse_u64(&device_id.value, device_id.offset, "DeviceId")?);
+    writer.finish()
+}
+
+fn encode_guid_vendor_shortcut(
+    node: &ParsedNode,
+    arguments: &[ParsedArgument],
+    guid: &str,
+) -> Result<Vec<u8>, DevicePathError> {
+    ensure_no_arguments(node, arguments)?;
+    let mut writer = NodeWriter::new(node, 3, 10);
+    writer.bytes(&parse_efi_guid(guid, node.offset, "Guid")?);
+    writer.finish()
+}
+
+fn encode_uart_flow_control(node: &ParsedNode, arguments: &[ParsedArgument]) -> Result<Vec<u8>, DevicePathError> {
+    let args = ResolvedArgs::new(node, arguments, &["Value"])?;
+    let value = args.required(0)?;
+    let value = parse_u8_keyword(&value.value, value.offset, "Value", &[("None", 0), ("Hardware", 1), ("XonXoff", 2)])?;
+    if value > 2 {
+        return Err(DevicePathError::new(args.offset(0), "Value must be None, Hardware, XonXoff, 0, 1, or 2"));
+    }
+    let mut writer = NodeWriter::new(node, 3, 10);
+    writer.bytes(&parse_efi_guid(UART_FLOW_CONTROL_GUID, node.offset, "Guid")?);
+    writer.u32(u32::from(value));
+    writer.finish()
+}
+
+fn encode_sas(node: &ParsedNode, arguments: &[ParsedArgument]) -> Result<Vec<u8>, DevicePathError> {
+    let args = ResolvedArgs::new(
+        node,
+        arguments,
+        &["Address", "LUN", "RTP", "SASSATA", "Location", "Connect", "DriveBay", "Reserved"],
+    )?;
+    let address = args.required(0)?;
+    let topology = encode_sas_topology(&args, 3, 4, 5, 6)?;
+    let mut writer = NodeWriter::new(node, 3, 10);
+    writer.bytes(&parse_efi_guid(SAS_GUID, node.offset, "Guid")?);
+    writer.u32(args.optional(7).map_or(Ok(0), |argument| parse_u32(&argument.value, argument.offset, "Reserved"))?);
+    writer.u64(parse_u64(&address.value, address.offset, "Address")?);
+    writer.u64(args.optional(1).map_or(Ok(0), |argument| parse_u64(&argument.value, argument.offset, "LUN"))?);
+    writer.u16(topology);
+    writer.u16(args.optional(2).map_or(Ok(0), |argument| parse_u16(&argument.value, argument.offset, "RTP"))?);
+    writer.finish()
+}
+
+fn encode_mac(node: &ParsedNode, arguments: &[ParsedArgument]) -> Result<Vec<u8>, DevicePathError> {
+    let args = ResolvedArgs::new(node, arguments, &["MacAddr", "IfType"])?;
+    let address = args.required(0)?;
+    let if_type = args.optional(1).map_or(Ok(0), |argument| parse_u8(&argument.value, argument.offset, "IfType"))?;
+    let address = parse_hex_bytes(&address.value, address.offset, "MacAddr")?;
+    if address.len() > 32 {
+        return Err(DevicePathError::new(args.offset(0), "MacAddr cannot exceed 32 bytes"));
+    }
+    if matches!(if_type, 0 | 1) && address.len() != 6 {
+        return Err(DevicePathError::new(args.offset(0), "MacAddr must be exactly 6 bytes when IfType is 0 or 1"));
+    }
+
+    let mut writer = NodeWriter::new(node, 3, 11);
+    writer.bytes(&address);
+    writer.bytes(&vec![0; 32 - address.len()]);
+    writer.byte(if_type);
+    writer.finish()
+}
+
+fn encode_ipv4(node: &ParsedNode, arguments: &[ParsedArgument]) -> Result<Vec<u8>, DevicePathError> {
+    let args = ResolvedArgs::new(
+        node,
+        arguments,
+        &["RemoteIp", "Protocol", "Type", "LocalIp", "GatewayIPAddress", "SubnetMask"],
+    )?;
+    let remote = args.required(0)?;
+    let protocol = parse_network_protocol(args.optional(1), "Protocol")?;
+    let address_type = match args.text(2, "DHCP") {
+        "DHCP" => 0,
+        "Static" => 1,
+        _ => return Err(DevicePathError::new(args.offset(2), "Type must be DHCP or Static")),
+    };
+    let local = parse_ipv4(args.text(3, "0.0.0.0"), args.offset(3), "LocalIp")?;
+    let gateway = parse_ipv4(args.text(4, "0.0.0.0"), args.offset(4), "GatewayIPAddress")?;
+    let subnet = parse_ipv4(args.text(5, "0.0.0.0"), args.offset(5), "SubnetMask")?;
+
+    let mut writer = NodeWriter::new(node, 3, 12);
+    writer.bytes(&local);
+    writer.bytes(&parse_ipv4(&remote.value, remote.offset, "RemoteIp")?);
+    writer.u16(0);
+    writer.u16(0);
+    writer.u16(u16::from(protocol));
+    writer.byte(address_type);
+    writer.bytes(&gateway);
+    writer.bytes(&subnet);
+    writer.finish()
+}
+
+fn encode_ipv6(node: &ParsedNode, arguments: &[ParsedArgument]) -> Result<Vec<u8>, DevicePathError> {
+    let args = ResolvedArgs::new(
+        node,
+        arguments,
+        &["RemoteIp", "Protocol", "IPAddressOrigin", "LocalIp", "PrefixLength", "GatewayIPAddress"],
+    )?;
+    let remote = args.required(0)?;
+    let protocol = parse_network_protocol(args.optional(1), "Protocol")?;
+    let origin = match args.text(2, "Static") {
+        "Static" => 0,
+        "StatelessAutoConfigure" => 1,
+        "StatefulAutoConfigure" => 2,
+        _ => {
+            return Err(DevicePathError::new(
+                args.offset(2),
+                "IPAddressOrigin must be Static, StatelessAutoConfigure, or StatefulAutoConfigure",
+            ));
+        }
+    };
+    let local = parse_ipv6(args.text(3, "::"), args.offset(3), "LocalIp")?;
+    let prefix =
+        args.optional(4).map_or(Ok(0), |argument| parse_u8(&argument.value, argument.offset, "PrefixLength"))?;
+    if prefix > 128 {
+        return Err(DevicePathError::new(args.offset(4), "PrefixLength must be between 0 and 128"));
+    }
+    let gateway = parse_ipv6(args.text(5, "::"), args.offset(5), "GatewayIPAddress")?;
+
+    let mut writer = NodeWriter::new(node, 3, 13);
+    writer.bytes(&local);
+    writer.bytes(&parse_ipv6(&remote.value, remote.offset, "RemoteIp")?);
+    writer.u16(0);
+    writer.u16(0);
+    writer.u16(u16::from(protocol));
+    writer.byte(origin);
+    writer.byte(prefix);
+    writer.bytes(&gateway);
+    writer.finish()
+}
+
+fn encode_uart(node: &ParsedNode, arguments: &[ParsedArgument]) -> Result<Vec<u8>, DevicePathError> {
+    let args = ResolvedArgs::new(node, arguments, &["Baud", "DataBits", "Parity", "StopBits"])?;
+    let baud = args.optional(0).map_or(Ok(115_200), |argument| parse_u64(&argument.value, argument.offset, "Baud"))?;
+    let data_bits =
+        args.optional(1).map_or(Ok(8), |argument| parse_u8(&argument.value, argument.offset, "DataBits"))?;
+    let parity_text = args.text(2, "0");
+    let parity_keyword = matches!(parity_text, "D" | "N" | "E" | "O" | "M" | "S");
+    let parity = if parity_keyword {
+        match parity_text {
+            "D" => 0,
+            "N" => 1,
+            "E" => 2,
+            "O" => 3,
+            "M" => 4,
+            "S" => 5,
+            _ => unreachable!("matched all parity keywords"),
+        }
+    } else {
+        parse_u8(parity_text, args.offset(2), "Parity")?
+    };
+    let stop_text = args.text(3, "0");
+    let stop_bits = if parity_keyword {
+        match stop_text {
+            "D" => 0,
+            "1" => 1,
+            "1.5" => 2,
+            "2" => 3,
+            _ => {
+                return Err(DevicePathError::new(args.offset(3), "StopBits must use keyword form with keyword Parity"));
+            }
+        }
+    } else {
+        if matches!(stop_text, "D" | "1.5") {
+            return Err(DevicePathError::new(args.offset(3), "StopBits must use integer form with integer Parity"));
+        }
+        parse_u8(stop_text, args.offset(3), "StopBits")?
+    };
+
+    let mut writer = NodeWriter::new(node, 3, 14);
+    writer.u32(0);
+    writer.u64(baud);
+    writer.byte(data_bits);
+    writer.byte(parity);
+    writer.byte(stop_bits);
+    writer.finish()
+}
+
+fn encode_usb_class(
+    node: &ParsedNode,
+    arguments: &[ParsedArgument],
+    fixed_class: Option<u8>,
+    fixed_subclass: Option<u8>,
+) -> Result<Vec<u8>, DevicePathError> {
+    let names: &'static [&'static str] = match (fixed_class, fixed_subclass) {
+        (None, None) => &["VID", "PID", "Class", "SubClass", "Protocol"],
+        (Some(_), None) => &["VID", "PID", "SubClass", "Protocol"],
+        (Some(_), Some(_)) => &["VID", "PID", "Protocol"],
+        (None, Some(_)) => unreachable!("a fixed subclass requires a fixed class"),
+    };
+    let args = ResolvedArgs::new(node, arguments, names)?;
+    let vid = args.optional(0).map_or(Ok(0xffff), |argument| parse_u16(&argument.value, argument.offset, "VID"))?;
+    let pid = args.optional(1).map_or(Ok(0xffff), |argument| parse_u16(&argument.value, argument.offset, "PID"))?;
+    let mut index = 2;
+    let class = if let Some(class) = fixed_class {
+        class
+    } else {
+        let value =
+            args.optional(index).map_or(Ok(0xff), |argument| parse_u8(&argument.value, argument.offset, "Class"))?;
+        index += 1;
+        value
+    };
+    let subclass = if let Some(subclass) = fixed_subclass {
+        subclass
+    } else {
+        let value =
+            args.optional(index).map_or(Ok(0xff), |argument| parse_u8(&argument.value, argument.offset, "SubClass"))?;
+        index += 1;
+        value
+    };
+    let protocol =
+        args.optional(index).map_or(Ok(0xff), |argument| parse_u8(&argument.value, argument.offset, "Protocol"))?;
+
+    let mut writer = NodeWriter::new(node, 3, 15);
+    writer.u16(vid);
+    writer.u16(pid);
+    writer.byte(class);
+    writer.byte(subclass);
+    writer.byte(protocol);
+    writer.finish()
+}
+
+fn encode_usb_wwid(node: &ParsedNode, arguments: &[ParsedArgument]) -> Result<Vec<u8>, DevicePathError> {
+    let args = ResolvedArgs::new(node, arguments, &["VID", "PID", "InterfaceNumber", "WWID"])?;
+    let vid = args.required(0)?;
+    let pid = args.required(1)?;
+    let interface = args.required(2)?;
+    let wwid = args.required(3)?;
+    if wwid.value.encode_utf16().count() > 64 {
+        return Err(DevicePathError::new(wwid.offset, "WWID cannot exceed 64 UTF-16 code units"));
+    }
+
+    let mut writer = NodeWriter::new(node, 3, 16);
+    writer.u16(u16::from(parse_u8(&interface.value, interface.offset, "InterfaceNumber")?));
+    writer.u16(parse_u16(&vid.value, vid.offset, "VID")?);
+    writer.u16(parse_u16(&pid.value, pid.offset, "PID")?);
+    writer.utf16(&wwid.value, false);
+    writer.finish()
+}
+
+fn encode_unit(node: &ParsedNode, arguments: &[ParsedArgument]) -> Result<Vec<u8>, DevicePathError> {
+    let args = ResolvedArgs::new(node, arguments, &["LUN"])?;
+    let lun = args.required(0)?;
+    let mut writer = NodeWriter::new(node, 3, 17);
+    writer.byte(parse_u8(&lun.value, lun.offset, "LUN")?);
+    writer.finish()
+}
+
+fn encode_sata(node: &ParsedNode, arguments: &[ParsedArgument]) -> Result<Vec<u8>, DevicePathError> {
+    let args = ResolvedArgs::new(node, arguments, &["HPN", "PMPN", "LUN"])?;
+    let hpn = args.required(0)?;
+    let hpn = parse_u16(&hpn.value, hpn.offset, "HPN")?;
+    if hpn == u16::MAX {
+        return Err(DevicePathError::new(args.offset(0), "HPN must be between 0 and 65534"));
+    }
+    let lun = args.required(2)?;
+    let mut writer = NodeWriter::new(node, 3, 18);
+    writer.u16(hpn);
+    writer.u16(args.optional(1).map_or(Ok(u16::MAX), |argument| parse_u16(&argument.value, argument.offset, "PMPN"))?);
+    writer.u16(parse_u16(&lun.value, lun.offset, "LUN")?);
+    writer.finish()
+}
+
+fn encode_iscsi(node: &ParsedNode, arguments: &[ParsedArgument]) -> Result<Vec<u8>, DevicePathError> {
+    let args = ResolvedArgs::new(
+        node,
+        arguments,
+        &["TargetName", "PortalGroup", "LUN", "HeaderDigest", "DataDigest", "Authentication", "Protocol"],
+    )?;
+    let target = args.required(0)?;
+    if !target.value.is_ascii() || target.value.len() > 223 {
+        return Err(DevicePathError::new(target.offset, "TargetName must be ASCII and cannot exceed 223 bytes"));
+    }
+    let portal_group = args.required(1)?;
+    let lun = args.required(2)?;
+    let header_digest = match args.text(3, "None") {
+        "None" => 0,
+        "CRC32C" => 2,
+        _ => return Err(DevicePathError::new(args.offset(3), "HeaderDigest must be None or CRC32C")),
+    };
+    let data_digest = match args.text(4, "None") {
+        "None" => 0,
+        "CRC32C" => 2 << 2,
+        _ => return Err(DevicePathError::new(args.offset(4), "DataDigest must be None or CRC32C")),
+    };
+    let authentication = match args.text(5, "None") {
+        "CHAP_BI" => 0,
+        "CHAP_UNI" => 1 << 12,
+        "None" => 2 << 10,
+        _ => return Err(DevicePathError::new(args.offset(5), "Authentication must be None, CHAP_BI, or CHAP_UNI")),
+    };
+    if args.text(6, "TCP") != "TCP" {
+        return Err(DevicePathError::new(args.offset(6), "Protocol must be TCP"));
+    }
+
+    let mut writer = NodeWriter::new(node, 3, 19);
+    writer.u16(0);
+    writer.u16(header_digest | data_digest | authentication);
+    writer.bytes(&parse_fixed_hex::<8>(&lun.value, lun.offset, "LUN")?);
+    writer.u16(parse_u16(&portal_group.value, portal_group.offset, "PortalGroup")?);
+    writer.ascii_nul(&target.value, "TargetName")?;
+    writer.finish()
+}
+
+fn encode_vlan(node: &ParsedNode, arguments: &[ParsedArgument]) -> Result<Vec<u8>, DevicePathError> {
+    let args = ResolvedArgs::new(node, arguments, &["VlanId"])?;
+    let vlan_argument = args.required(0)?;
+    let vlan = parse_u16(&vlan_argument.value, vlan_argument.offset, "VlanId")?;
+    if vlan > 4094 {
+        return Err(DevicePathError::new(vlan_argument.offset, "VlanId must be between 0 and 4094"));
+    }
+    let mut writer = NodeWriter::new(node, 3, 20);
+    writer.u16(vlan);
+    writer.finish()
+}
+
+fn encode_sas_ex(node: &ParsedNode, arguments: &[ParsedArgument]) -> Result<Vec<u8>, DevicePathError> {
+    let args =
+        ResolvedArgs::new(node, arguments, &["Address", "LUN", "RTP", "SASSATA", "Location", "Connect", "DriveBay"])?;
+    let address = args.required(0)?;
+    let topology = encode_sas_topology(&args, 3, 4, 5, 6)?;
+    let mut writer = NodeWriter::new(node, 3, 22);
+    writer.bytes(&parse_fixed_hex::<8>(&address.value, address.offset, "Address")?);
+    writer.bytes(
+        &args
+            .optional(1)
+            .map_or(Ok([0; 8]), |argument| parse_fixed_hex::<8>(&argument.value, argument.offset, "LUN"))?,
+    );
+    writer.u16(topology);
+    writer.u16(args.optional(2).map_or(Ok(0), |argument| parse_u16(&argument.value, argument.offset, "RTP"))?);
+    writer.finish()
+}
+
+fn encode_nvme(node: &ParsedNode, arguments: &[ParsedArgument]) -> Result<Vec<u8>, DevicePathError> {
+    let args = ResolvedArgs::new(node, arguments, &["NSID", "EUI"])?;
+    let namespace = args.required(0)?;
+    let namespace = parse_u32(&namespace.value, namespace.offset, "NSID")?;
+    if matches!(namespace, 0 | u32::MAX) {
+        return Err(DevicePathError::new(args.offset(0), "NSID cannot be 0 or 0xffffffff"));
+    }
+    let eui = args.required(1)?;
+    let eui = u64::from_be_bytes(parse_fixed_hex::<8>(&eui.value, eui.offset, "EUI")?);
+    let mut writer = NodeWriter::new(node, 3, 23);
+    writer.u32(namespace);
+    writer.u64(eui);
+    writer.finish()
+}
+
+fn encode_uri(node: &ParsedNode, arguments: &[ParsedArgument]) -> Result<Vec<u8>, DevicePathError> {
+    let args = ResolvedArgs::new(node, arguments, &["Uri"])?;
+    let uri = args.text(0, "");
+    if !uri.is_ascii() {
+        return Err(DevicePathError::new(args.offset(0), "Uri must contain only ASCII characters"));
+    }
+    let mut writer = NodeWriter::new(node, 3, 24);
+    writer.bytes(uri.as_bytes());
+    writer.finish()
+}
+
+fn encode_ufs(node: &ParsedNode, arguments: &[ParsedArgument]) -> Result<Vec<u8>, DevicePathError> {
+    let args = ResolvedArgs::new(node, arguments, &["PUN", "LUN"])?;
+    let pun = args.required(0)?;
+    if parse_u8(&pun.value, pun.offset, "PUN")? != 0 {
+        return Err(DevicePathError::new(pun.offset, "PUN must be 0"));
+    }
+    let lun = args.required(1)?;
+    let lun = parse_u8(&lun.value, lun.offset, "LUN")?;
+    if !matches!(lun, 0..=7 | 0x81 | 0xd0 | 0xb0 | 0xc4) {
+        return Err(DevicePathError::new(args.offset(1), "LUN is not a valid UFS logical unit"));
+    }
+    let mut writer = NodeWriter::new(node, 3, 25);
+    writer.byte(0);
+    writer.byte(lun);
+    writer.finish()
+}
+
+fn encode_sd_emmc(node: &ParsedNode, arguments: &[ParsedArgument], subtype: u8) -> Result<Vec<u8>, DevicePathError> {
+    let args = ResolvedArgs::new(node, arguments, &["SlotNumber"])?;
+    let slot = args.optional(0).map_or(Ok(0), |argument| parse_u8(&argument.value, argument.offset, "SlotNumber"))?;
+    let mut writer = NodeWriter::new(node, 3, subtype);
+    writer.byte(slot);
+    writer.finish()
+}
+
+fn encode_bluetooth(node: &ParsedNode, arguments: &[ParsedArgument]) -> Result<Vec<u8>, DevicePathError> {
+    let args = ResolvedArgs::new(node, arguments, &["BD_ADDR"])?;
+    let address = args.required(0)?;
+    let mut writer = NodeWriter::new(node, 3, 27);
+    writer.bytes(&parse_fixed_hex::<6>(&address.value, address.offset, "BD_ADDR")?);
+    writer.finish()
+}
+
+fn encode_wifi(node: &ParsedNode, arguments: &[ParsedArgument]) -> Result<Vec<u8>, DevicePathError> {
+    let args = ResolvedArgs::new(node, arguments, &["SSID"])?;
+    let ssid = args.required(0)?;
+    if ssid.value.len() > 32 {
+        return Err(DevicePathError::new(ssid.offset, "SSID cannot exceed 32 UTF-8 bytes"));
+    }
+    let mut writer = NodeWriter::new(node, 3, 28);
+    writer.bytes(ssid.value.as_bytes());
+    writer.bytes(&vec![0; 32 - ssid.value.len()]);
+    writer.finish()
+}
+
+fn encode_bluetooth_le(node: &ParsedNode, arguments: &[ParsedArgument]) -> Result<Vec<u8>, DevicePathError> {
+    let args = ResolvedArgs::new(node, arguments, &["BD_ADDR", "AddressType"])?;
+    let address = args.required(0)?;
+    let address_type = args.required(1)?;
+    let address_type = parse_u8(&address_type.value, address_type.offset, "AddressType")?;
+    if address_type > 1 {
+        return Err(DevicePathError::new(args.offset(1), "AddressType must be 0 (public) or 1 (random)"));
+    }
+    let mut writer = NodeWriter::new(node, 3, 30);
+    writer.bytes(&parse_fixed_hex::<6>(&address.value, address.offset, "BD_ADDR")?);
+    writer.byte(address_type);
+    writer.finish()
+}
+
+fn encode_dns(node: &ParsedNode, arguments: &[ParsedArgument]) -> Result<Vec<u8>, DevicePathError> {
+    if arguments.is_empty() {
+        return Err(DevicePathError::new(node.offset, "at least one DnsServerIp is required"));
+    }
+    if let Some(argument) = arguments.iter().find(|argument| argument.name.is_some()) {
+        return Err(DevicePathError::new(argument.offset, "Dns does not accept named parameters"));
+    }
+
+    let first_is_ipv6 = arguments
+        .first()
+        .expect("an empty DNS argument list is rejected above")
+        .value
+        .parse::<std::net::Ipv6Addr>()
+        .is_ok();
+    let mut writer = NodeWriter::new(node, 3, 31);
+    writer.byte(u8::from(first_is_ipv6));
+    for argument in arguments {
+        if first_is_ipv6 {
+            writer.bytes(&parse_ipv6(&argument.value, argument.offset, "DnsServerIp")?);
+        } else {
+            writer.bytes(&parse_ipv4(&argument.value, argument.offset, "DnsServerIp")?);
+            writer.bytes(&[0; 12]);
+        }
+    }
+    writer.finish()
+}
+
+fn encode_nvdimm(node: &ParsedNode, arguments: &[ParsedArgument]) -> Result<Vec<u8>, DevicePathError> {
+    let args = ResolvedArgs::new(node, arguments, &["UUID"])?;
+    let uuid = args.required(0)?;
+    let mut writer = NodeWriter::new(node, 3, 32);
+    writer.bytes(&parse_efi_guid(&uuid.value, uuid.offset, "UUID")?);
+    writer.finish()
+}
+
+fn encode_rest_service(node: &ParsedNode, arguments: &[ParsedArgument]) -> Result<Vec<u8>, DevicePathError> {
+    if let Some(argument) = arguments.iter().find(|argument| argument.name.is_some()) {
+        return Err(DevicePathError::new(argument.offset, "RestService does not accept named parameters"));
+    }
+    if arguments.len() < 2 {
+        return Err(DevicePathError::new(node.offset, "RestExServiceType and AccessMode are required"));
+    }
+    let service_argument = arguments.first().expect("fewer than two REST arguments are rejected above");
+    let access_argument = arguments.get(1).expect("fewer than two REST arguments are rejected above");
+    let service = parse_u8(&service_argument.value, service_argument.offset, "RestExServiceType")?;
+    let access = parse_u8(&access_argument.value, access_argument.offset, "AccessMode")?;
+    if !matches!(access, 1 | 2) {
+        return Err(DevicePathError::new(access_argument.offset, "AccessMode must be 1 or 2"));
+    }
+
+    let mut writer = NodeWriter::new(node, 3, 33);
+    writer.byte(service);
+    writer.byte(access);
+    match service {
+        1 | 2 => {
+            if arguments.len() != 2 {
+                return Err(DevicePathError::new(
+                    arguments.get(2).expect("the argument list has more than two entries").offset,
+                    "standard REST services accept exactly two parameters",
+                ));
+            }
+        }
+        0xff => {
+            let guid = arguments
+                .get(2)
+                .filter(|argument| !argument.value.is_empty())
+                .ok_or_else(|| DevicePathError::new(node.offset, "VendorRestServiceGuid is required"))?;
+            writer.bytes(&parse_efi_guid(&guid.value, guid.offset, "VendorRestServiceGuid")?);
+            for argument in arguments.get(3..).expect("a vendor REST service has a GUID argument") {
+                writer.byte(parse_u8(&argument.value, argument.offset, "VendorDefinedData")?);
+            }
+        }
+        _ => return Err(DevicePathError::new(service_argument.offset, "RestExServiceType must be 1, 2, or 0xff")),
+    }
+    writer.finish()
+}
+
+fn encode_nvme_of(node: &ParsedNode, arguments: &[ParsedArgument]) -> Result<Vec<u8>, DevicePathError> {
+    let args = ResolvedArgs::new(node, arguments, &["SubsystemNQN", "NID"])?;
+    let nqn = args.required(0)?;
+    if nqn.value.as_bytes().contains(&0) || nqn.value.len() + 1 > 224 {
+        return Err(DevicePathError::new(nqn.offset, "SubsystemNQN must be at most 223 UTF-8 bytes"));
+    }
+    let nid = args.required(1)?;
+    let (nidt, nid_bytes) = parse_nvme_of_nid(&nid.value, nid.offset)?;
+    let mut writer = NodeWriter::new(node, 3, 34);
+    writer.byte(nidt);
+    writer.bytes(&nid_bytes);
+    writer.bytes(nqn.value.as_bytes());
+    writer.byte(0);
+    writer.finish()
+}
+
+fn encode_hard_drive(node: &ParsedNode, arguments: &[ParsedArgument]) -> Result<Vec<u8>, DevicePathError> {
+    let args = ResolvedArgs::new(node, arguments, &["Partition", "Type", "Signature", "Start", "Size"])?;
+    let partition =
+        args.optional(0).map_or(Ok(0), |argument| parse_u32(&argument.value, argument.offset, "Partition"))?;
+    let type_text = args.text(1, "GPT");
+    let signature = args.required(2)?;
+    let (format, signature_type, signature_bytes) = match type_text {
+        "MBR" | "1" | "0x1" | "0X1" => {
+            let mut bytes = [0; 16];
+            bytes[..4].copy_from_slice(&parse_u32(&signature.value, signature.offset, "Signature")?.to_le_bytes());
+            (1, 1, bytes)
+        }
+        "GPT" | "2" | "0x2" | "0X2" => (2, 2, parse_efi_guid(&signature.value, signature.offset, "Signature")?),
+        _ => {
+            let signature_type = parse_u8(type_text, args.offset(1), "Type")?;
+            if signature.value != "0" {
+                return Err(DevicePathError::new(signature.offset, "Signature must be 0 when Type is not MBR or GPT"));
+            }
+            (0, signature_type, [0; 16])
+        }
+    };
+    let (start, size) = if partition == 0 {
+        if args.optional(3).is_some() || args.optional(4).is_some() {
+            return Err(DevicePathError::new(args.offset(3), "Start and Size are prohibited when Partition is 0"));
+        }
+        (0, 0)
+    } else {
+        let start = args.required(3)?;
+        let size = args.required(4)?;
+        (parse_u64(&start.value, start.offset, "Start")?, parse_u64(&size.value, size.offset, "Size")?)
+    };
+
+    let mut writer = NodeWriter::new(node, 4, 1);
+    writer.u32(partition);
+    writer.u64(start);
+    writer.u64(size);
+    writer.bytes(&signature_bytes);
+    writer.byte(format);
+    writer.byte(signature_type);
+    writer.finish()
+}
+
+fn encode_cdrom(node: &ParsedNode, arguments: &[ParsedArgument]) -> Result<Vec<u8>, DevicePathError> {
+    let args = ResolvedArgs::new(node, arguments, &["Entry", "Start", "Size"])?;
+    let start = args.required(1)?;
+    let size = args.required(2)?;
+    let mut writer = NodeWriter::new(node, 4, 2);
+    writer.u32(args.optional(0).map_or(Ok(0), |argument| parse_u32(&argument.value, argument.offset, "Entry"))?);
+    writer.u64(parse_u64(&start.value, start.offset, "Start")?);
+    writer.u64(parse_u64(&size.value, size.offset, "Size")?);
+    writer.finish()
+}
+
+fn encode_media(node: &ParsedNode, arguments: &[ParsedArgument]) -> Result<Vec<u8>, DevicePathError> {
+    let args = ResolvedArgs::new(node, arguments, &["Guid"])?;
+    let guid = args.required(0)?;
+    let mut writer = NodeWriter::new(node, 4, 5);
+    writer.bytes(&parse_efi_guid(&guid.value, guid.offset, "Guid")?);
+    writer.finish()
+}
+
+fn encode_fv(node: &ParsedNode, arguments: &[ParsedArgument], subtype: u8) -> Result<Vec<u8>, DevicePathError> {
+    let args = ResolvedArgs::new(node, arguments, &["Guid"])?;
+    let guid = args.required(0)?;
+    let mut writer = NodeWriter::new(node, 4, subtype);
+    writer.bytes(&parse_efi_guid(&guid.value, guid.offset, "Guid")?);
+    writer.finish()
+}
+
+fn encode_offset(node: &ParsedNode, arguments: &[ParsedArgument]) -> Result<Vec<u8>, DevicePathError> {
+    let args = ResolvedArgs::new(node, arguments, &["StartingOffset", "EndingOffset"])?;
+    let start = args.required(0)?;
+    let end = args.required(1)?;
+    let mut writer = NodeWriter::new(node, 4, 8);
+    writer.u32(0);
+    writer.u64(parse_u64(&start.value, start.offset, "StartingOffset")?);
+    writer.u64(parse_u64(&end.value, end.offset, "EndingOffset")?);
+    writer.finish()
+}
+
+fn encode_ram_disk(
+    node: &ParsedNode,
+    arguments: &[ParsedArgument],
+    fixed_guid: Option<&str>,
+) -> Result<Vec<u8>, DevicePathError> {
+    let names: &'static [&'static str] = if fixed_guid.is_some() {
+        &["StartingAddress", "EndingAddress", "DiskInstance"]
+    } else {
+        &["StartingAddress", "EndingAddress", "DiskInstance", "DiskTypeGuid"]
+    };
+    let args = ResolvedArgs::new(node, arguments, names)?;
+    let start = args.required(0)?;
+    let end = args.required(1)?;
+    let instance =
+        args.optional(2).map_or(Ok(0), |argument| parse_u16(&argument.value, argument.offset, "DiskInstance"))?;
+    let guid = if let Some(guid) = fixed_guid {
+        parse_efi_guid(guid, node.offset, "DiskTypeGuid")?
+    } else {
+        let guid = args.required(3)?;
+        parse_efi_guid(&guid.value, guid.offset, "DiskTypeGuid")?
+    };
+    let mut writer = NodeWriter::new(node, 4, 9);
+    writer.u64(parse_u64(&start.value, start.offset, "StartingAddress")?);
+    writer.u64(parse_u64(&end.value, end.offset, "EndingAddress")?);
+    writer.bytes(&guid);
+    writer.u16(instance);
+    writer.finish()
+}
+
+fn encode_bbs(node: &ParsedNode, arguments: &[ParsedArgument]) -> Result<Vec<u8>, DevicePathError> {
+    let args = ResolvedArgs::new(node, arguments, &["Type", "Id", "Flags"])?;
+    let device_type = args.required(0)?;
+    let description = args.required(1)?;
+    let device_type = parse_u16_keyword(
+        &device_type.value,
+        device_type.offset,
+        "Type",
+        &[("Floppy", 1), ("HD", 2), ("CDROM", 3), ("PCMCIA", 4), ("USB", 5), ("Network", 6)],
+    )?;
+    let mut writer = NodeWriter::new(node, 5, 1);
+    writer.u16(device_type);
+    writer.u16(args.optional(2).map_or(Ok(0), |argument| parse_u16(&argument.value, argument.offset, "Flags"))?);
+    writer.ascii_nul(&description.value, "Id")?;
+    writer.finish()
+}
+
+fn parse_u8_keyword(value: &str, offset: usize, field: &str, keywords: &[(&str, u8)]) -> Result<u8, DevicePathError> {
+    keywords
+        .iter()
+        .find_map(|(keyword, value_for_keyword)| (*keyword == value).then_some(*value_for_keyword))
+        .map_or_else(|| parse_u8(value, offset, field), Ok)
+}
+
+fn parse_u16_keyword(
+    value: &str,
+    offset: usize,
+    field: &str,
+    keywords: &[(&str, u16)],
+) -> Result<u16, DevicePathError> {
+    keywords
+        .iter()
+        .find_map(|(keyword, value_for_keyword)| (*keyword == value).then_some(*value_for_keyword))
+        .map_or_else(|| parse_u16(value, offset, field), Ok)
+}
+
+fn parse_network_protocol(argument: Option<&ParsedArgument>, field: &str) -> Result<u8, DevicePathError> {
+    argument.map_or(Ok(17), |argument| {
+        parse_u8_keyword(&argument.value, argument.offset, field, &[("UDP", 17), ("TCP", 6)])
+    })
+}
+
+fn encode_sas_topology(
+    args: &ResolvedArgs<'_>,
+    sassata_index: usize,
+    location_index: usize,
+    connect_index: usize,
+    drive_bay_index: usize,
+) -> Result<u16, DevicePathError> {
+    let sassata = args.text(sassata_index, "NoTopology");
+    if sassata == "NoTopology" {
+        reject_present(args, &[location_index, connect_index, drive_bay_index], "topology details")?;
+        return Ok(0);
+    }
+    if let Ok(topology) = parse_u16(sassata, args.offset(sassata_index), "SASSATA") {
+        reject_present(args, &[location_index, connect_index, drive_bay_index], "topology details")?;
+        return Ok(topology);
+    }
+    if !matches!(sassata, "SAS" | "SATA") {
+        return Err(DevicePathError::new(
+            args.offset(sassata_index),
+            "SASSATA must be SAS, SATA, NoTopology, or a 16-bit integer",
+        ));
+    }
+
+    let location = args.required(location_index)?;
+    let connect = args.required(connect_index)?;
+    let location = parse_u8_keyword(&location.value, location.offset, "Location", &[("Internal", 0), ("External", 1)])?;
+    if location > 1 {
+        return Err(DevicePathError::new(args.offset(location_index), "Location must be Internal, External, 0, or 1"));
+    }
+    let connect = parse_u8_keyword(&connect.value, connect.offset, "Connect", &[("Direct", 0), ("Expanded", 1)])?;
+    if connect > 3 {
+        return Err(DevicePathError::new(args.offset(connect_index), "Connect must be between 0 and 3"));
+    }
+    let drive_bay = args.optional(drive_bay_index).map(|argument| {
+        let drive_bay = parse_unsigned(&argument.value, 16, argument.offset, "DriveBay")?;
+        if !(1..=256).contains(&drive_bay) {
+            return Err(DevicePathError::new(argument.offset, "DriveBay must be between 1 and 256"));
+        }
+        Ok((drive_bay - 1) as u8)
+    });
+    let information = if drive_bay.is_some() { 2 } else { 1 };
+    let device_type = u16::from(sassata == "SATA") | (u16::from(location) << 1);
+    Ok(information
+        | (device_type << 4)
+        | (u16::from(connect) << 6)
+        | (u16::from(drive_bay.transpose()?.unwrap_or(0)) << 8))
+}
+
+fn reject_present(args: &ResolvedArgs<'_>, indices: &[usize], description: &str) -> Result<(), DevicePathError> {
+    if let Some(index) = indices.iter().copied().find(|index| args.optional(*index).is_some()) {
+        return Err(DevicePathError::new(
+            args.offset(index),
+            format!("{description} are prohibited for this SASSATA value"),
+        ));
+    }
+    Ok(())
+}
+
+fn parse_nvme_of_nid(value: &str, offset: usize) -> Result<(u8, [u8; 16]), DevicePathError> {
+    if let Some(value) = value.strip_prefix("eui.") {
+        let eui = parse_fixed_hex::<8>(value, offset + 4, "NID")?;
+        let mut bytes = [0; 16];
+        bytes[..8].copy_from_slice(&eui);
+        return Ok((1, bytes));
+    }
+    if let Some(value) = value.strip_prefix("nguid.") {
+        return Ok((2, parse_fixed_hex::<16>(value, offset + 6, "NID")?));
+    }
+    if let Some(value) = value.strip_prefix("urn:uuid:") {
+        return Ok((3, parse_uuid_bytes(value, offset + 9, "NID")?));
+    }
+    Err(DevicePathError::new(offset, "NID must use eui., nguid., or urn:uuid: namespace identifier syntax"))
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::device_path_encoder::encode_device_path;
+
+    #[test]
+    fn test_encode_every_node_spelling() {
+        for path in [
+            "Path(1,1,00)",
+            "HardwarePath(1,00)",
+            "Pci(1,0)",
+            "PcCard(0)",
+            "MemoryMapped(0,0,0)",
+            "VenHw(00112233-4455-6677-8899-aabbccddeeff)",
+            "Ctrl(0)",
+            "BMC(0,0)",
+            "AcpiPath(1,0000000000000000)",
+            "Acpi(PNP0A03,0)",
+            "PciRoot()",
+            "PcieRoot()",
+            "Floppy()",
+            "Keyboard()",
+            "Serial()",
+            "ParallelPort()",
+            "AcpiEx(PNP0A03,,,,,)",
+            "AcpiExp(PNP0A03,,Root)",
+            "AcpiAdr(0)",
+            "NvdimmAcpiAdr(0)",
+            "Msg(1,00)",
+            "Ata(Primary,Master,0)",
+            "Scsi(0,0)",
+            "Fibre(0,0)",
+            "FibreEx(0000000000000000,0000000000000000)",
+            "I1394(0)",
+            "USB(0,0)",
+            "I2O(0)",
+            "Infiniband(0,00112233-4455-6677-8899-aabbccddeeff,0,0,0)",
+            "VenMsg(00112233-4455-6677-8899-aabbccddeeff)",
+            "VenPcAnsi()",
+            "VenVt100()",
+            "VenVt100Plus()",
+            "VenUtf8()",
+            "UartFlowCtrl(None)",
+            "SAS(0)",
+            "DebugPort()",
+            "MAC(001122334455,1)",
+            "IPv4(192.0.2.1)",
+            "IPv6(2001:db8::1,TCP,Static,2001:db8::2,64,2001:db8::ffff)",
+            "Uart()",
+            "UsbClass()",
+            "UsbAudio()",
+            "UsbCDCControl()",
+            "UsbHID()",
+            "UsbImage()",
+            "UsbPrinter()",
+            "UsbMassStorage()",
+            "UsbHub()",
+            "UsbCDCData()",
+            "UsbSmartCard()",
+            "UsbVideo()",
+            "UsbDiagnostic()",
+            "UsbWireless()",
+            "UsbDeviceFirmwareUpdate()",
+            "UsbIrdaBridge()",
+            "UsbTestAndMeasurement()",
+            "UsbWwid(0,0,0,WWID)",
+            "Unit(0)",
+            "Sata(0,,0)",
+            "iSCSI(iqn.test,0,0000000000000000)",
+            "Vlan(0)",
+            "SasEx(0000000000000000)",
+            "NVMe(1,00-00-00-00-00-00-00-00)",
+            "Uri(https://example.com/)",
+            "UFS(0,0)",
+            "SD()",
+            "Bluetooth(001122334455)",
+            "Wi-Fi(SSID)",
+            "eMMC()",
+            "BluetoothLE(001122334455,0)",
+            "Dns(192.0.2.53)",
+            "NVDIMM(00112233-4455-6677-8899-aabbccddeeff)",
+            "RestService(1,1)",
+            "NVMEoF(nqn.2014-08.org.nvmexpress:test,urn:uuid:00112233-4455-6677-8899-aabbccddeeff)",
+            "MediaPath(5,00000000000000000000000000000000)",
+            "HD(0,GPT,00112233-4455-6677-8899-aabbccddeeff)",
+            "CDROM(0,0,0)",
+            "VenMedia(00112233-4455-6677-8899-aabbccddeeff)",
+            "EFI",
+            "Media(00112233-4455-6677-8899-aabbccddeeff)",
+            "FvFile(00112233-4455-6677-8899-aabbccddeeff)",
+            "Fv(00112233-4455-6677-8899-aabbccddeeff)",
+            "Offset(0,0)",
+            "RamDisk(0,0,0,00112233-4455-6677-8899-aabbccddeeff)",
+            "VirtualDisk(0,0)",
+            "VirtualCD(0,0)",
+            "PersistentVirtualDisk(0,0)",
+            "PersistentVirtualCD(0,0)",
+            "BbsPath(1,00000000)",
+            "BBS(USB,Device)",
+        ] {
+            encode_device_path(path).unwrap_or_else(|error| panic!("{path}: {error}"));
+        }
+    }
+
+    #[test]
+    fn test_encode_messaging_media_and_bbs_nodes() {
+        for path in [
+            "Ata(Primary,Master,0)",
+            "IPv4(192.0.2.1,TCP,Static,192.0.2.2,192.0.2.254,255.255.255.0)",
+            "SasEx(0102030405060708)",
+            "NVDIMM(00112233-4455-6677-8899-aabbccddeeff)",
+            "RestService(0xff,1,00112233-4455-6677-8899-aabbccddeeff,0xaa,0x55)",
+            "NVMEoF(nqn.2014-08.org.nvmexpress:uuid:test,urn:uuid:00112233-4455-6677-8899-aabbccddeeff)",
+            "HD(1,GPT,00112233-4455-6677-8899-aabbccddeeff,0x800,0x1000)",
+            "BBS(USB,\"USB Device\",0)",
+        ] {
+            encode_device_path(path).unwrap_or_else(|error| panic!("{path}: {error}"));
+        }
+    }
+
+    #[test]
+    fn test_nvdimm_uses_efi_guid_byte_order() {
+        let encoded = encode_device_path("NVDIMM(00112233-4455-6677-8899-aabbccddeeff)").expect("path should encode");
+        assert_eq!(
+            &encoded[4..20],
+            &[0x33, 0x22, 0x11, 0x00, 0x55, 0x44, 0x77, 0x66, 0x88, 0x99, 0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff]
+        );
+    }
+
+    #[test]
+    fn test_nvme_of_uuid_uses_rfc_byte_order() {
+        let encoded = encode_device_path(
+            "NVMEoF(nqn.2014-08.org.nvmexpress:uuid:test,urn:uuid:00112233-4455-6677-8899-aabbccddeeff)",
+        )
+        .expect("path should encode");
+        assert_eq!(
+            &encoded[5..21],
+            &[0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99, 0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff]
+        );
+    }
+
+    #[test]
+    fn test_defaults_named_arguments_and_numeric_bases_are_equivalent() {
+        assert_eq!(
+            encode_device_path("PciRoot()").expect("shortcut should encode"),
+            encode_device_path("Acpi(PNP0A03,0)").expect("canonical form should encode")
+        );
+        assert_eq!(
+            encode_device_path("Pci(Function=0,Device=0x11)").expect("named form should encode"),
+            encode_device_path("Pci(17,0)").expect("positional form should encode")
+        );
+        assert_eq!(
+            encode_device_path("Uart()").expect("default form should encode"),
+            encode_device_path("Uart(115200,8,0,0)").expect("explicit form should encode")
+        );
+        assert_eq!(
+            encode_device_path("UsbClass()").expect("default form should encode"),
+            encode_device_path("UsbClass(0xffff,65535,0xff,255,0xff)").expect("explicit form should encode")
+        );
+    }
+
+    #[test]
+    fn test_vendor_usb_and_ram_disk_aliases_match_canonical_forms() {
+        assert_eq!(
+            encode_device_path("VenPcAnsi()").expect("shortcut should encode"),
+            encode_device_path("VenMsg(e0c14753-f9be-11d2-9a0c-0090273fc14d)").expect("canonical form should encode")
+        );
+        assert_eq!(
+            encode_device_path("UsbAudio()").expect("shortcut should encode"),
+            encode_device_path("UsbClass(0xffff,0xffff,1,0xff,0xff)").expect("canonical form should encode")
+        );
+        assert_eq!(
+            encode_device_path("VirtualDisk(1,2)").expect("shortcut should encode"),
+            encode_device_path("RamDisk(1,2,0,77ab535a-45fc-624b-5560-f7b281d1f96e)")
+                .expect("canonical form should encode")
+        );
+    }
+
+    #[test]
+    fn test_encode_vendor_rest_service_golden_vector() {
+        assert_eq!(
+            encode_device_path("RestService(0xff,1,00112233-4455-6677-8899-aabbccddeeff,0xaa,0x55)")
+                .expect("path should encode"),
+            [
+                0x03, 0x21, 0x18, 0x00, 0xff, 0x01, 0x33, 0x22, 0x11, 0x00, 0x55, 0x44, 0x77, 0x66, 0x88, 0x99, 0xaa,
+                0xbb, 0xcc, 0xdd, 0xee, 0xff, 0xaa, 0x55, 0x7f, 0xff, 0x04, 0x00,
+            ]
+        );
+    }
+
+    #[test]
+    fn test_encode_sas_ex_topology_golden_vector() {
+        assert_eq!(
+            encode_device_path("SasEx(0102030405060708,0001020304050607,0x1234,SATA,External,Expanded,256)")
+                .expect("path should encode"),
+            [
+                0x03, 0x16, 0x18, 0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x00, 0x01, 0x02, 0x03, 0x04,
+                0x05, 0x06, 0x07, 0x72, 0xff, 0x34, 0x12, 0x7f, 0xff, 0x04, 0x00,
+            ]
+        );
+    }
+
+    #[test]
+    fn test_nvme_of_identifier_forms() {
+        let eui = encode_device_path("NVMEoF(nqn.test,eui.0011223344556677)").expect("EUI should encode");
+        assert_eq!(
+            eui.get(4..21).expect("NVMe-oF node contains NIDT and NID"),
+            &[0x01, 0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00]
+        );
+
+        let nguid =
+            encode_device_path("NVMEoF(nqn.test,nguid.00112233445566778899aabbccddeeff)").expect("NGUID should encode");
+        assert_eq!(
+            nguid.get(4..21).expect("NVMe-oF node contains NIDT and NID"),
+            &[0x02, 0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99, 0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff]
+        );
+    }
+
+    #[test]
+    fn test_rejects_cross_field_constraint_violations() {
+        assert!(encode_device_path("Dns(192.0.2.1,2001:db8::1)").is_err());
+        assert!(encode_device_path("Uart(115200,8,N,0)").is_err());
+        assert!(encode_device_path("HD(0,GPT,00112233-4455-6677-8899-aabbccddeeff,1,1)").is_err());
+        assert!(encode_device_path("Sata(65535,,0)").is_err());
+        assert!(encode_device_path("SAS(1,0,0,NoTopology,Internal,Direct)").is_err());
+    }
+}

--- a/sdk/patina_macro/src/device_path_nodes.rs
+++ b/sdk/patina_macro/src/device_path_nodes.rs
@@ -15,6 +15,8 @@
 //!
 //! SPDX-License-Identifier: Apache-2.0
 
+// cspell:ignore UIDSTR SASSATA nvmexpress nguid
+
 use crate::{
     device_path_encoder::{
         NodeWriter, parse_efi_guid, parse_eisa_id, parse_fixed_hex, parse_hex_bytes, parse_ipv4, parse_ipv6, parse_u8,
@@ -35,15 +37,164 @@ const VIRTUAL_CD_GUID: &str = "3d5abd30-4175-87ce-6d64-d2ade523c4bb";
 const PERSISTENT_VIRTUAL_DISK_GUID: &str = "5cea02c9-4d07-69d3-269f-4496fbe096f9";
 const PERSISTENT_VIRTUAL_CD_GUID: &str = "08018188-42cd-bb48-100f-5387d53ded3d";
 
-/// Encode one parsed node.
-pub(crate) fn encode_node(node: &ParsedNode) -> Result<Vec<u8>, DevicePathError> {
-    match &node.kind {
-        ParsedNodeKind::FilePath(path) => encode_file_path(node, path),
-        ParsedNodeKind::Canonical { name, arguments } => encode_canonical(node, name, arguments),
+/// Encoding of one custom vendor hardware payload field.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum VendorHardwareFieldType {
+    U8,
+    U16Le,
+    U32Le,
+    U64Le,
+    Guid,
+    Uuid,
+    Bytes,
+}
+
+impl VendorHardwareFieldType {
+    pub(crate) fn from_name(name: &str) -> Option<Self> {
+        match name {
+            "u8" => Some(Self::U8),
+            "u16le" => Some(Self::U16Le),
+            "u32le" => Some(Self::U32Le),
+            "u64le" => Some(Self::U64Le),
+            "guid" => Some(Self::Guid),
+            "uuid" => Some(Self::Uuid),
+            "bytes" => Some(Self::Bytes),
+            _ => None,
+        }
     }
 }
 
-fn encode_canonical(node: &ParsedNode, name: &str, arguments: &[ParsedArgument]) -> Result<Vec<u8>, DevicePathError> {
+/// One named field in a custom vendor hardware payload.
+#[derive(Debug, Eq, PartialEq)]
+pub(crate) struct VendorHardwareField {
+    pub(crate) name: String,
+    pub(crate) field_type: VendorHardwareFieldType,
+}
+
+/// A user-declared shortcut for a vendor hardware device path node.
+#[derive(Debug, Eq, PartialEq)]
+pub(crate) struct VendorHardwareSchema {
+    pub(crate) name: String,
+    pub(crate) guid: [u8; 16],
+    pub(crate) fields: Vec<VendorHardwareField>,
+}
+
+/// Return whether a name is reserved by a built-in UEFI node or shortcut.
+pub(crate) fn is_builtin_node_name(name: &str) -> bool {
+    matches!(
+        name,
+        "Path"
+            | "HardwarePath"
+            | "Pci"
+            | "PcCard"
+            | "MemoryMapped"
+            | "VenHw"
+            | "Ctrl"
+            | "BMC"
+            | "AcpiPath"
+            | "Acpi"
+            | "PciRoot"
+            | "PcieRoot"
+            | "Floppy"
+            | "Keyboard"
+            | "Serial"
+            | "ParallelPort"
+            | "AcpiEx"
+            | "AcpiExp"
+            | "AcpiAdr"
+            | "NvdimmAcpiAdr"
+            | "Msg"
+            | "Ata"
+            | "Scsi"
+            | "Fibre"
+            | "FibreEx"
+            | "I1394"
+            | "USB"
+            | "I2O"
+            | "Infiniband"
+            | "VenMsg"
+            | "VenPcAnsi"
+            | "VenVt100"
+            | "VenVt100Plus"
+            | "VenUtf8"
+            | "UartFlowCtrl"
+            | "SAS"
+            | "DebugPort"
+            | "MAC"
+            | "IPv4"
+            | "IPv6"
+            | "Uart"
+            | "UsbClass"
+            | "UsbAudio"
+            | "UsbCDCControl"
+            | "UsbHID"
+            | "UsbImage"
+            | "UsbPrinter"
+            | "UsbMassStorage"
+            | "UsbHub"
+            | "UsbCDCData"
+            | "UsbSmartCard"
+            | "UsbVideo"
+            | "UsbDiagnostic"
+            | "UsbWireless"
+            | "UsbDeviceFirmwareUpdate"
+            | "UsbIrdaBridge"
+            | "UsbTestAndMeasurement"
+            | "UsbWwid"
+            | "Unit"
+            | "Sata"
+            | "iSCSI"
+            | "Vlan"
+            | "SasEx"
+            | "NVMe"
+            | "Uri"
+            | "UFS"
+            | "SD"
+            | "Bluetooth"
+            | "Wi-Fi"
+            | "eMMC"
+            | "BluetoothLE"
+            | "Dns"
+            | "NVDIMM"
+            | "RestService"
+            | "NVMEoF"
+            | "MediaPath"
+            | "HD"
+            | "CDROM"
+            | "VenMedia"
+            | "Media"
+            | "FvFile"
+            | "Fv"
+            | "Offset"
+            | "RamDisk"
+            | "VirtualDisk"
+            | "VirtualCD"
+            | "PersistentVirtualDisk"
+            | "PersistentVirtualCD"
+            | "BbsPath"
+            | "BBS"
+    )
+}
+
+/// Encode one parsed node.
+pub(crate) fn encode_node(
+    node: &ParsedNode,
+    vendor_hardware_schemas: &[VendorHardwareSchema],
+) -> Result<Vec<u8>, DevicePathError> {
+    match &node.kind {
+        ParsedNodeKind::FilePath(path) => encode_file_path(node, path),
+        ParsedNodeKind::Canonical { name, arguments } => {
+            encode_canonical(node, name, arguments, vendor_hardware_schemas)
+        }
+    }
+}
+
+fn encode_canonical(
+    node: &ParsedNode,
+    name: &str,
+    arguments: &[ParsedArgument],
+    vendor_hardware_schemas: &[VendorHardwareSchema],
+) -> Result<Vec<u8>, DevicePathError> {
     match name {
         "Path" => encode_generic(node, arguments, None),
         "HardwarePath" => encode_generic(node, arguments, Some(1)),
@@ -135,22 +286,21 @@ fn encode_canonical(node: &ParsedNode, name: &str, arguments: &[ParsedArgument])
         "PersistentVirtualCD" => encode_ram_disk(node, arguments, Some(PERSISTENT_VIRTUAL_CD_GUID)),
         "BbsPath" => encode_generic(node, arguments, Some(5)),
         "BBS" => encode_bbs(node, arguments),
-        _ => Err(DevicePathError::new(node.offset, format!("unknown device path node `{name}`"))),
+        _ => vendor_hardware_schemas.iter().find(|schema| schema.name == name).map_or_else(
+            || Err(DevicePathError::new(node.offset, format!("unknown device path node `{name}`"))),
+            |schema| encode_vendor_hardware(node, arguments, schema),
+        ),
     }
 }
 
-struct ResolvedArgs<'a> {
+struct ResolvedArgs<'a, 'n> {
     node_offset: usize,
-    names: &'static [&'static str],
+    names: &'n [&'n str],
     values: Vec<Option<&'a ParsedArgument>>,
 }
 
-impl<'a> ResolvedArgs<'a> {
-    fn new(
-        node: &ParsedNode,
-        arguments: &'a [ParsedArgument],
-        names: &'static [&'static str],
-    ) -> Result<Self, DevicePathError> {
+impl<'a, 'n> ResolvedArgs<'a, 'n> {
+    fn new(node: &ParsedNode, arguments: &'a [ParsedArgument], names: &'n [&'n str]) -> Result<Self, DevicePathError> {
         let mut values = vec![None; names.len()];
         let mut positional_index = 0;
 
@@ -296,6 +446,46 @@ fn encode_vendor(
     let mut writer = NodeWriter::new(node, r#type, subtype);
     writer.bytes(&parse_efi_guid(&guid.value, guid.offset, "Guid")?);
     writer.bytes(&data);
+    writer.finish()
+}
+
+fn encode_vendor_hardware(
+    node: &ParsedNode,
+    arguments: &[ParsedArgument],
+    schema: &VendorHardwareSchema,
+) -> Result<Vec<u8>, DevicePathError> {
+    let names: Vec<&str> = schema.fields.iter().map(|field| field.name.as_str()).collect();
+    let args = ResolvedArgs::new(node, arguments, &names)?;
+    let mut writer = NodeWriter::new(node, 1, 4);
+    writer.bytes(&schema.guid);
+
+    for (index, field) in schema.fields.iter().enumerate() {
+        let argument = args.required(index)?;
+        match field.field_type {
+            VendorHardwareFieldType::U8 => {
+                writer.byte(parse_u8(&argument.value, argument.offset, &field.name)?);
+            }
+            VendorHardwareFieldType::U16Le => {
+                writer.u16(parse_u16(&argument.value, argument.offset, &field.name)?);
+            }
+            VendorHardwareFieldType::U32Le => {
+                writer.u32(parse_u32(&argument.value, argument.offset, &field.name)?);
+            }
+            VendorHardwareFieldType::U64Le => {
+                writer.u64(parse_u64(&argument.value, argument.offset, &field.name)?);
+            }
+            VendorHardwareFieldType::Guid => {
+                writer.bytes(&parse_efi_guid(&argument.value, argument.offset, &field.name)?);
+            }
+            VendorHardwareFieldType::Uuid => {
+                writer.bytes(&parse_uuid_bytes(&argument.value, argument.offset, &field.name)?);
+            }
+            VendorHardwareFieldType::Bytes => {
+                writer.bytes(&parse_hex_bytes(&argument.value, argument.offset, &field.name)?);
+            }
+        }
+    }
+
     writer.finish()
 }
 
@@ -1167,7 +1357,7 @@ fn parse_network_protocol(argument: Option<&ParsedArgument>, field: &str) -> Res
 }
 
 fn encode_sas_topology(
-    args: &ResolvedArgs<'_>,
+    args: &ResolvedArgs<'_, '_>,
     sassata_index: usize,
     location_index: usize,
     connect_index: usize,
@@ -1214,7 +1404,7 @@ fn encode_sas_topology(
         | (u16::from(drive_bay.transpose()?.unwrap_or(0)) << 8))
 }
 
-fn reject_present(args: &ResolvedArgs<'_>, indices: &[usize], description: &str) -> Result<(), DevicePathError> {
+fn reject_present(args: &ResolvedArgs<'_, '_>, indices: &[usize], description: &str) -> Result<(), DevicePathError> {
     if let Some(index) = indices.iter().copied().find(|index| args.optional(*index).is_some()) {
         return Err(DevicePathError::new(
             args.offset(index),

--- a/sdk/patina_macro/src/device_path_parser.rs
+++ b/sdk/patina_macro/src/device_path_parser.rs
@@ -6,6 +6,8 @@
 //!
 //! SPDX-License-Identifier: Apache-2.0
 
+// cspell:ignore UIDSTR
+
 use core::fmt;
 
 /// A device path parsing or encoding error.

--- a/sdk/patina_macro/src/device_path_parser.rs
+++ b/sdk/patina_macro/src/device_path_parser.rs
@@ -68,7 +68,7 @@ pub(crate) fn parse_device_path(input: &str) -> Result<ParsedDevicePath, DeviceP
     let mut offset = 0;
     let mut instances = vec![Vec::new()];
 
-    if matches!(byte_at(input, offset), Some(b'/' | b'\\')) {
+    if byte_at(input, offset) == Some(b'/') {
         offset += 1;
         if offset == input.len() {
             return Err(DevicePathError::new(offset - 1, "device path cannot end with a separator"));
@@ -91,7 +91,7 @@ pub(crate) fn parse_device_path(input: &str) -> Result<ParsedDevicePath, DeviceP
         offset = node_end;
         match separator {
             None => break,
-            Some(b'/') | Some(b'\\') => {
+            Some(b'/') => {
                 offset += 1;
                 if offset == input.len() {
                     return Err(DevicePathError::new(offset - 1, "device path cannot end with a separator"));
@@ -141,7 +141,7 @@ fn find_node_end(input: &str, start: usize) -> Result<(usize, Option<u8>), Devic
                     }
                     depth -= 1;
                 }
-                b'/' | b'\\' | b',' if depth == 0 => return Ok((offset, Some(byte))),
+                b'/' | b',' if depth == 0 => return Ok((offset, Some(byte))),
                 b'|' | b'<' | b'>' => {
                     return Err(DevicePathError::new(offset, "shell-reserved character is not allowed"));
                 }
@@ -329,6 +329,16 @@ mod tests {
 
         assert_eq!(arguments[0].name.as_deref(), Some("Device"));
         assert_eq!(arguments[1].name, None);
+    }
+
+    #[test]
+    fn test_parse_preserves_backslashes_in_file_path() {
+        let parsed = parse_device_path(r"\EFI\BOOT\BOOTX64.EFI").expect("path should parse");
+        let ParsedNodeKind::FilePath(path) = &parsed.instances[0][0].kind else {
+            panic!("expected file path node");
+        };
+
+        assert_eq!(path, r"\EFI\BOOT\BOOTX64.EFI");
     }
 
     #[test]

--- a/sdk/patina_macro/src/device_path_parser.rs
+++ b/sdk/patina_macro/src/device_path_parser.rs
@@ -1,0 +1,338 @@
+//! Parser for the UEFI device path text representation.
+//!
+//! ## License
+//!
+//! Copyright (c) Microsoft Corporation.
+//!
+//! SPDX-License-Identifier: Apache-2.0
+
+use core::fmt;
+
+/// A device path parsing or encoding error.
+#[derive(Debug, Eq, PartialEq)]
+pub(crate) struct DevicePathError {
+    pub(crate) offset: usize,
+    pub(crate) message: String,
+}
+
+impl DevicePathError {
+    pub(crate) fn new(offset: usize, message: impl Into<String>) -> Self {
+        Self { offset, message: message.into() }
+    }
+}
+
+impl fmt::Display for DevicePathError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(formatter, "{} at character {}", self.message, self.offset)
+    }
+}
+
+impl std::error::Error for DevicePathError {}
+
+/// A parsed device path containing one or more instances.
+#[derive(Debug, Eq, PartialEq)]
+pub(crate) struct ParsedDevicePath {
+    pub(crate) instances: Vec<Vec<ParsedNode>>,
+}
+
+/// A parsed canonical node or file path segment.
+#[derive(Debug, Eq, PartialEq)]
+pub(crate) struct ParsedNode {
+    pub(crate) offset: usize,
+    pub(crate) kind: ParsedNodeKind,
+}
+
+/// The two UEFI text node forms.
+#[derive(Debug, Eq, PartialEq)]
+pub(crate) enum ParsedNodeKind {
+    Canonical { name: String, arguments: Vec<ParsedArgument> },
+    FilePath(String),
+}
+
+/// A positional or named node argument.
+#[derive(Debug, Eq, PartialEq)]
+pub(crate) struct ParsedArgument {
+    pub(crate) name: Option<String>,
+    pub(crate) value: String,
+    pub(crate) offset: usize,
+}
+
+/// Parse a complete UEFI text device path.
+pub(crate) fn parse_device_path(input: &str) -> Result<ParsedDevicePath, DevicePathError> {
+    if input.is_empty() {
+        return Err(DevicePathError::new(0, "device path cannot be empty"));
+    }
+
+    let mut offset = 0;
+    let mut instances = vec![Vec::new()];
+
+    if matches!(byte_at(input, offset), Some(b'/' | b'\\')) {
+        offset += 1;
+        if offset == input.len() {
+            return Err(DevicePathError::new(offset - 1, "device path cannot end with a separator"));
+        }
+    }
+
+    while offset < input.len() {
+        let node_start = offset;
+        let (node_end, separator) = find_node_end(input, node_start)?;
+        if node_end == node_start {
+            return Err(DevicePathError::new(node_start, "empty device path node"));
+        }
+
+        let node_text = input
+            .get(node_start..node_end)
+            .ok_or_else(|| DevicePathError::new(node_start, "device path contains an invalid UTF-8 boundary"))?;
+        let node = parse_node(node_text, node_start)?;
+        instances.last_mut().expect("at least one instance exists").push(node);
+
+        offset = node_end;
+        match separator {
+            None => break,
+            Some(b'/') | Some(b'\\') => {
+                offset += 1;
+                if offset == input.len() {
+                    return Err(DevicePathError::new(offset - 1, "device path cannot end with a separator"));
+                }
+            }
+            Some(b',') => {
+                offset += 1;
+                if offset == input.len() {
+                    return Err(DevicePathError::new(offset - 1, "device path cannot end with an instance separator"));
+                }
+                instances.push(Vec::new());
+            }
+            Some(_) => unreachable!("find_node_end only returns recognized separators"),
+        }
+    }
+
+    if instances.iter().any(Vec::is_empty) {
+        return Err(DevicePathError::new(offset, "device path instance cannot be empty"));
+    }
+
+    Ok(ParsedDevicePath { instances })
+}
+
+fn find_node_end(input: &str, start: usize) -> Result<(usize, Option<u8>), DevicePathError> {
+    let bytes = input.as_bytes();
+    let mut offset = start;
+    let mut depth = 0usize;
+    let mut quote_start = None;
+
+    while offset < bytes.len() {
+        let byte = *bytes.get(offset).expect("offset is checked against the input length");
+        if byte == b'"' {
+            quote_start = if quote_start.is_some() { None } else { Some(offset) };
+            offset += 1;
+            continue;
+        }
+
+        if quote_start.is_none() {
+            if byte.is_ascii_whitespace() {
+                return Err(DevicePathError::new(offset, "unquoted whitespace is not allowed"));
+            }
+            match byte {
+                b'(' => depth += 1,
+                b')' => {
+                    if depth == 0 {
+                        return Err(DevicePathError::new(offset, "unmatched closing parenthesis"));
+                    }
+                    depth -= 1;
+                }
+                b'/' | b'\\' | b',' if depth == 0 => return Ok((offset, Some(byte))),
+                b'|' | b'<' | b'>' => {
+                    return Err(DevicePathError::new(offset, "shell-reserved character is not allowed"));
+                }
+                _ => {}
+            }
+        }
+        offset += 1;
+    }
+
+    if let Some(quote_offset) = quote_start {
+        return Err(DevicePathError::new(quote_offset, "unterminated quoted string"));
+    }
+    if depth != 0 {
+        return Err(DevicePathError::new(start, "unmatched opening parenthesis"));
+    }
+
+    Ok((offset, None))
+}
+
+fn parse_node(text: &str, base_offset: usize) -> Result<ParsedNode, DevicePathError> {
+    let Some(open) = text.find('(') else {
+        return Ok(ParsedNode { offset: base_offset, kind: ParsedNodeKind::FilePath(text.to_owned()) });
+    };
+
+    if !text.ends_with(')') {
+        return Err(DevicePathError::new(base_offset + open, "canonical node must end with a closing parenthesis"));
+    }
+
+    let name = text.get(..open).expect("find returned a valid UTF-8 boundary");
+    if name.is_empty() || !name.bytes().all(|byte| byte.is_ascii_alphanumeric() || byte == b'-') {
+        return Err(DevicePathError::new(
+            base_offset,
+            "device path node name must contain only alphanumeric characters or `-`",
+        ));
+    }
+
+    let argument_text = text
+        .get(open + 1..text.len() - 1)
+        .ok_or_else(|| DevicePathError::new(base_offset + open, "invalid canonical node boundary"))?;
+    let arguments = parse_arguments(argument_text, base_offset + open + 1)?;
+
+    Ok(ParsedNode { offset: base_offset, kind: ParsedNodeKind::Canonical { name: name.to_owned(), arguments } })
+}
+
+fn parse_arguments(text: &str, base_offset: usize) -> Result<Vec<ParsedArgument>, DevicePathError> {
+    if text.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    let bytes = text.as_bytes();
+    let mut arguments = Vec::new();
+    let mut argument_start = 0;
+    let mut quote_start = None;
+
+    for offset in 0..=bytes.len() {
+        let at_end = offset == bytes.len();
+        let byte = bytes.get(offset).copied();
+
+        if byte == Some(b'"') {
+            quote_start = if quote_start.is_some() { None } else { Some(offset) };
+        }
+
+        if at_end || (byte == Some(b',') && quote_start.is_none()) {
+            let value = text
+                .get(argument_start..offset)
+                .ok_or_else(|| DevicePathError::new(base_offset + argument_start, "invalid argument boundary"))?;
+            arguments.push(parse_argument(value, base_offset + argument_start)?);
+            argument_start = offset + 1;
+        }
+    }
+
+    if let Some(offset) = quote_start {
+        return Err(DevicePathError::new(base_offset + offset, "unterminated quoted argument"));
+    }
+
+    Ok(arguments)
+}
+
+fn parse_argument(text: &str, offset: usize) -> Result<ParsedArgument, DevicePathError> {
+    let mut quoted = false;
+    let equals = text.char_indices().find_map(|(index, character)| match character {
+        '"' => {
+            quoted = !quoted;
+            None
+        }
+        '=' if !quoted => Some(index),
+        _ => None,
+    });
+    let (name, value, value_offset) = if let Some(equals) = equals {
+        let name = text.get(..equals).expect("find returned a valid UTF-8 boundary");
+        if name.is_empty() || !name.bytes().all(|byte| byte.is_ascii_alphanumeric()) {
+            return Err(DevicePathError::new(offset, "parameter identifier must be alphanumeric"));
+        }
+        (
+            Some(name.to_owned()),
+            text.get(equals + 1..).expect("find returned a valid UTF-8 boundary"),
+            offset + equals + 1,
+        )
+    } else {
+        (None, text, offset)
+    };
+
+    let value = if value.starts_with('"') || value.ends_with('"') {
+        if value.len() < 2 || !value.starts_with('"') || !value.ends_with('"') {
+            return Err(DevicePathError::new(value_offset, "quoted argument must have matching double quotes"));
+        }
+        value
+            .get(1..value.len() - 1)
+            .ok_or_else(|| DevicePathError::new(value_offset, "invalid quoted argument boundary"))?
+            .to_owned()
+    } else {
+        value.to_owned()
+    };
+
+    Ok(ParsedArgument { name, value, offset: value_offset })
+}
+
+fn byte_at(input: &str, offset: usize) -> Option<u8> {
+    input.as_bytes().get(offset).copied()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_device_path_nodes_and_instances() {
+        let parsed = parse_device_path("PciRoot(0)/Pci(0x11,0),USB(1,0)").expect("path should parse");
+
+        assert_eq!(parsed.instances.len(), 2);
+        assert_eq!(parsed.instances[0].len(), 2);
+        assert_eq!(parsed.instances[1].len(), 1);
+    }
+
+    #[test]
+    fn test_parse_named_and_quoted_arguments() {
+        let parsed = parse_device_path("AcpiEx(HID=HWP0002,UIDSTR=\"Root Bridge\")").expect("path should parse");
+        let ParsedNodeKind::Canonical { arguments, .. } = &parsed.instances[0][0].kind else {
+            panic!("expected canonical node");
+        };
+
+        assert_eq!(arguments[0].name.as_deref(), Some("HID"));
+        assert_eq!(arguments[1].value, "Root Bridge");
+    }
+
+    #[test]
+    fn test_parse_rejects_unquoted_whitespace() {
+        let error = parse_device_path("Pci(1, 0)").expect_err("path should fail");
+        assert_eq!(error.offset, 6);
+    }
+
+    #[test]
+    fn test_parse_allows_equals_inside_quoted_value() {
+        let parsed = parse_device_path("Uri(\"https://example.com/?a=b\")").expect("path should parse");
+        let ParsedNodeKind::Canonical { arguments, .. } = &parsed.instances[0][0].kind else {
+            panic!("expected canonical node");
+        };
+
+        assert_eq!(arguments[0].name, None);
+        assert_eq!(arguments[0].value, "https://example.com/?a=b");
+    }
+
+    #[test]
+    fn test_parse_allows_hyphenated_node_name() {
+        parse_device_path("Wi-Fi(Test)").expect("path should parse");
+    }
+
+    #[test]
+    fn test_parse_keeps_quoted_commas_inside_one_argument() {
+        let parsed = parse_device_path("Uri(\"https://example.com/a,b\")").expect("path should parse");
+        let ParsedNodeKind::Canonical { arguments, .. } = &parsed.instances[0][0].kind else {
+            panic!("expected canonical node");
+        };
+
+        assert_eq!(arguments.len(), 1);
+        assert_eq!(arguments[0].value, "https://example.com/a,b");
+    }
+
+    #[test]
+    fn test_parse_accepts_leading_separator_and_named_then_positional_arguments() {
+        let parsed = parse_device_path("/Pci(Device=17,0)").expect("path should parse");
+        let ParsedNodeKind::Canonical { arguments, .. } = &parsed.instances[0][0].kind else {
+            panic!("expected canonical node");
+        };
+
+        assert_eq!(arguments[0].name.as_deref(), Some("Device"));
+        assert_eq!(arguments[1].name, None);
+    }
+
+    #[test]
+    fn test_parse_rejects_reserved_shell_characters() {
+        let error = parse_device_path("Uri(http://example.com/<bad>)").expect_err("path should fail");
+
+        assert_eq!(error.message, "shell-reserved character is not allowed");
+    }
+}

--- a/sdk/patina_macro/src/lib.rs
+++ b/sdk/patina_macro/src/lib.rs
@@ -27,10 +27,12 @@ mod validate_params_macro;
 /// macro inserts an End Instance node between instances and an End Entire node
 /// after the final instance.
 ///
-/// An optional `vendors { ... };` registry may precede the literal to define
-/// invocation-local vendor hardware shortcuts. Each schema supplies an
-/// [`VenHw`](https://uefi.org/specs/UEFI/2.11/10_Protocols_Device_Path_Protocol.html#vendor-device-path)
-/// GUID and a list of required payload fields. Supported field types are `u8`,
+/// An optional `vendor-defined { ... };` registry may precede the literal to
+/// define invocation-local vendor hardware, messaging, or media shortcuts. Each schema
+/// selects `type: hardware` ([`VenHw`](https://uefi.org/specs/UEFI/2.11/10_Protocols_Device_Path_Protocol.html#vendor-device-path))
+/// or `type: messaging` ([`VenMsg`](https://uefi.org/specs/UEFI/2.11/10_Protocols_Device_Path_Protocol.html#vendor-defined-messaging-device-path))
+/// or `type: media` ([`VenMedia`](https://uefi.org/specs/UEFI/2.11/10_Protocols_Device_Path_Protocol.html#vendor-defined-media-device-path))
+/// and supplies a GUID and a list of required payload fields. Supported field types are `u8`,
 /// `u16le`, `u32le`, `u64le`, `guid` (EFI byte order), `uuid` (RFC byte
 /// order), and `bytes` (hexadecimal byte data). Schema and field names are
 /// case-sensitive and must contain only alphanumeric characters. Built-in node
@@ -68,14 +70,15 @@ mod validate_params_macro;
 /// assert_eq!(&path[16..20], &[0x7f, 0xff, 0x04, 0x00]);
 /// ```
 ///
-/// Vendor hardware shortcuts encode their fields after the vendor GUID:
+/// Vendor-defined shortcuts encode their fields after the vendor GUID:
 ///
 /// ```
 /// use patina::devpath;
 ///
 /// let path = devpath!(
-///     vendors {
+///     vendor-defined {
 ///         AcmeController {
+///             type: hardware,
 ///             guid: "00112233-4455-6677-8899-aabbccddeeff",
 ///             fields: [port: u8, flags: u16le],
 ///         },

--- a/sdk/patina_macro/src/lib.rs
+++ b/sdk/patina_macro/src/lib.rs
@@ -9,11 +9,58 @@
 
 #![cfg_attr(coverage, feature(coverage_attribute))]
 
+mod device_path_encoder;
+mod device_path_macro;
+mod device_path_nodes;
+mod device_path_parser;
 mod hob_macro;
 mod service_macro;
 mod smbios_record_macro;
 mod test_macro;
 mod validate_params_macro;
+
+/// Encodes a UEFI text device path as an owned byte array at compile time.
+///
+/// The input must be exactly one string literal using the UEFI 2.11 Device Path
+/// From Text syntax. Nodes are separated by `/` or `\`. A top-level comma
+/// separates device path instances. The macro inserts an End Instance node
+/// between instances and an End Entire node after the final instance.
+///
+/// The expanded expression has type `[u8; N]` and requires no runtime parser,
+/// allocation, or device-path feature.
+///
+/// Compilation fails when the input is not one string literal or when the
+/// device path contains invalid syntax, an unknown node, an invalid field, or
+/// a value that cannot be represented by the UEFI binary format.
+///
+/// ## Examples
+///
+/// ```
+/// use patina::devpath;
+///
+/// let path: [u8; 22] = devpath!("PciRoot(0)/Pci(0x11,0)");
+/// assert_eq!(
+///     path,
+///     [
+///         0x02, 0x01, 0x0c, 0x00, 0xd0, 0x41, 0x03, 0x0a, 0x00, 0x00, 0x00,
+///         0x00, 0x01, 0x01, 0x06, 0x00, 0x00, 0x11, 0x7f, 0xff, 0x04, 0x00,
+///     ],
+/// );
+/// ```
+///
+/// A top-level comma creates multiple device path instances:
+///
+/// ```
+/// use patina::devpath;
+///
+/// let path: [u8; 20] = devpath!("Pci(1,0),USB(2,1)");
+/// assert_eq!(&path[6..10], &[0x7f, 0x01, 0x04, 0x00]);
+/// assert_eq!(&path[16..20], &[0x7f, 0xff, 0x04, 0x00]);
+/// ```
+#[proc_macro]
+pub fn devpath(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
+    device_path_macro::devpath2(input.into()).into()
+}
 
 /// Derive Macro for implementing the `IntoService` trait for a type.
 ///

--- a/sdk/patina_macro/src/lib.rs
+++ b/sdk/patina_macro/src/lib.rs
@@ -21,17 +21,26 @@ mod validate_params_macro;
 
 /// Encodes a UEFI text device path as an owned byte array at compile time.
 ///
-/// The input must be exactly one string literal using the UEFI 2.11 Device Path
+/// The input is normally one string literal using the UEFI 2.11 Device Path
 /// From Text syntax. Nodes are separated by `/` or `\`. A top-level comma
 /// separates device path instances. The macro inserts an End Instance node
 /// between instances and an End Entire node after the final instance.
 ///
+/// An optional `vendors { ... };` registry may precede the literal to define
+/// invocation-local vendor hardware shortcuts. Each schema supplies an
+/// [`VenHw`](https://uefi.org/specs/UEFI/2.11/10_Protocols_Device_Path_Protocol.html#vendor-device-path)
+/// GUID and a list of required payload fields. Supported field types are `u8`,
+/// `u16le`, `u32le`, `u64le`, `guid` (EFI byte order), `uuid` (RFC byte
+/// order), and `bytes` (hexadecimal byte data). Schema and field names are
+/// case-sensitive and must contain only alphanumeric characters. Built-in node
+/// names cannot be redefined.
+///
 /// The expanded expression has type `[u8; N]` and requires no runtime parser,
 /// allocation, or device-path feature.
 ///
-/// Compilation fails when the input is not one string literal or when the
-/// device path contains invalid syntax, an unknown node, an invalid field, or
-/// a value that cannot be represented by the UEFI binary format.
+/// Compilation fails when the input shape or vendor schema is invalid, or when
+/// the device path contains invalid syntax, an unknown node, an invalid field,
+/// or a value that cannot be represented by the UEFI binary format.
 ///
 /// ## Examples
 ///
@@ -56,6 +65,26 @@ mod validate_params_macro;
 /// let path: [u8; 20] = devpath!("Pci(1,0),USB(2,1)");
 /// assert_eq!(&path[6..10], &[0x7f, 0x01, 0x04, 0x00]);
 /// assert_eq!(&path[16..20], &[0x7f, 0xff, 0x04, 0x00]);
+/// ```
+///
+/// Vendor hardware shortcuts encode their fields after the vendor GUID:
+///
+/// ```
+/// use patina::devpath;
+///
+/// let path = devpath!(
+///     vendors {
+///         AcmeController {
+///             guid: "00112233-4455-6677-8899-aabbccddeeff",
+///             fields: [port: u8, flags: u16le],
+///         },
+///     };
+///     "AcmeController(port=3,flags=0x1234)"
+/// );
+/// assert_eq!(
+///     path,
+///     devpath!("VenHw(00112233-4455-6677-8899-aabbccddeeff,033412)")
+/// );
 /// ```
 #[proc_macro]
 pub fn devpath(input: proc_macro::TokenStream) -> proc_macro::TokenStream {

--- a/sdk/patina_macro/src/lib.rs
+++ b/sdk/patina_macro/src/lib.rs
@@ -22,9 +22,10 @@ mod validate_params_macro;
 /// Encodes a UEFI text device path as an owned byte array at compile time.
 ///
 /// The input is normally one string literal using the UEFI 2.11 Device Path
-/// From Text syntax. Nodes are separated by `/` or `\`. A top-level comma
-/// separates device path instances. The macro inserts an End Instance node
-/// between instances and an End Entire node after the final instance.
+/// From Text syntax. Nodes are separated by `/`; backslashes are preserved in
+/// file path nodes. A top-level comma separates device path instances. The
+/// macro inserts an End Instance node between instances and an End Entire node
+/// after the final instance.
 ///
 /// An optional `vendors { ... };` registry may precede the literal to define
 /// invocation-local vendor hardware shortcuts. Each schema supplies an


### PR DESCRIPTION
## Description

Adds macros for build-time construction of device path byte arrays from string literals. This is an ergonomic change, but it helps change this:
```rust

   let mut path = [0u8; DEVICE_PATH_LENGTH];

    // ACPI(PNP0A03,0): PCI root bridge for segment 0.
    path[0] = 0x02;
    path[1] = 0x01;
    path[2] = ACPI_PCI_ROOT_NODE_LENGTH as u8;
    let pci_root_hid = 0x0A03_41D0u32.to_le_bytes();
    let mut index = 0;
    while index < pci_root_hid.len() {
        path[4 + index] = pci_root_hid[index];
        index += 1;
    }

    // Pci(0x11,0) on bus 0.
    let pci_offset = ACPI_PCI_ROOT_NODE_LENGTH;
    path[pci_offset] = 0x01;
    path[pci_offset + 1] = 0x01;
    path[pci_offset + 2] = PCI_NODE_LENGTH as u8;
    path[pci_offset + 4] = 0;
    path[pci_offset + 5] = 0x11;
```
into 
```rust
const path: &[u8] =  &devpath!("PciRoot(0)/Pci(0x11,0)");
```

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [x] Includes tests?
- [x] Includes documentation?

## How This Was Tested

New macro includes unit tests and compilation tests. 


## Integration Instructions

N/A - usage is documented in the readme and rustdocs. 