### PR TITLE
Remove stale cargo dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,6 @@ linked_list_allocator = { version = "0.10" }
 linkme = { version = "0.3.36" }
 log = { version = "0.4", default-features = false }
 memoffset = {version = "0.9.1" }
-mu_rust_helpers = { version = "4.1" }
 num-traits = { version = "0.2", default-features = false }
 patina = { version = "22.2.2", path = "sdk/patina" }
 patina_debugger = { version = "22.2.2", path = "core/patina_debugger" }
@@ -52,7 +51,6 @@ r-efi = { version = "7", default-features = false }
 scroll = { version = "0.13", default-features = false, features = ["derive"]}
 spin = { version = "0.12" }
 syn = { version = "2" }
-time = { version = "0.3.49" }
 uart_16550 = { version = "0.3.2" }
 corosensei = { version = "0.3.4", default-features = false }
 uuid = { version = "1.23", default-features = false }
@@ -68,7 +66,6 @@ rand = { version = "0.10" }
 # This can be updated when the Patina MSRV is updated to 1.90+.
 ruint = { version = "~1.17" }
 serial_test = { version = "3.5" }
-winapi = { version = "0.3" }
 serde = { version = "1.0", default-features = false, features = ["derive"] }
 serde_yaml = { version = "0.9" }
 serde_json = { version = "1.0", default-features = false, features = ["alloc"] }

--- a/components/patina_acpi/Cargo.toml
+++ b/components/patina_acpi/Cargo.toml
@@ -14,8 +14,6 @@ log = { workspace = true }
 memoffset = { workspace = true }
 mockall = { workspace = true, optional = true }
 r-efi = { workspace = true }
-scroll = { workspace = true }
-spin = { workspace = true }
 zerocopy = { workspace = true }
 zerocopy-derive = { workspace = true }
 

--- a/components/patina_performance/Cargo.toml
+++ b/components/patina_performance/Cargo.toml
@@ -13,7 +13,6 @@ workspace = true
 [dependencies]
 r-efi = { workspace = true }
 log = { workspace = true }
-uuid = { workspace = true }
 
 patina = { workspace = true }
 patina_mm = { workspace = true }
@@ -23,7 +22,6 @@ zerocopy-derive = { workspace = true }
 [dev-dependencies]
 patina = { path = "../../sdk/patina", features = ["mockall"] }
 patina_dxe_core = { path = "../../patina_dxe_core"}
-mockall = { workspace = true }
 
 [features]
 # All non-std features to test in CI

--- a/components/patina_smbios/Cargo.toml
+++ b/components/patina_smbios/Cargo.toml
@@ -13,7 +13,6 @@ mockall = { workspace = true, optional = true }
 patina = { workspace = true }
 patina_macro = { workspace = true }
 r-efi = { workspace = true }
-spin = { workspace = true }
 zerocopy = { workspace = true }
 zerocopy-derive = { workspace = true }
 bitfield-struct = { workspace = true }

--- a/core/patina_stacktrace/Cargo.toml
+++ b/core/patina_stacktrace/Cargo.toml
@@ -14,18 +14,6 @@ workspace = true
 cfg-if = { workspace = true }
 log = { workspace = true }
 
-[dev-dependencies]
-winapi = { workspace = true, features = [
-    "psapi",
-    "libloaderapi",
-    "minwinbase",
-    "errhandlingapi",
-    "processthreadsapi",
-    "winbase",
-    "synchapi",
-    "debugapi",
-] }
-
 [features]
 std = []
 doc = []

--- a/patina_dxe_core/Cargo.toml
+++ b/patina_dxe_core/Cargo.toml
@@ -32,7 +32,6 @@ patina_ffs = { workspace = true }
 patina_internal_core = { workspace = true }
 patina_internal_cpu = { workspace = true }
 patina_debugger = { workspace = true, features = ["alloc"] }
-patina_performance = { workspace = true }
 patina_test = { workspace = true }
 
 [dev-dependencies]

--- a/sdk/patina/Cargo.toml
+++ b/sdk/patina/Cargo.toml
@@ -40,7 +40,6 @@ num-traits = { workspace = true }
 indoc = { workspace = true }
 fallible-streaming-iterator = { workspace = true }
 safe-mmio = { workspace = true }
-linkme = { workspace = true }
 scroll = { workspace = true }
 uuid = { workspace = true }
 serde = { workspace = true, optional = true }

--- a/sdk/patina_ffs_extractors/Cargo.toml
+++ b/sdk/patina_ffs_extractors/Cargo.toml
@@ -11,10 +11,8 @@ description = "UEFI section extractor implementations."
 workspace = true
 
 [dependencies]
-log = { workspace = true }
 patina = { workspace = true }
 patina_ffs = { workspace = true }
-r-efi = {workspace = true}
 brotli-decompressor = { workspace = true, optional = true }
 alloc-no-stdlib = { workspace = true, optional = true }
 crc32fast = { workspace = true, optional = true }


### PR DESCRIPTION
## Description

Remove stale dependencies

Found by running `cargo machete --fix` and filtered some false positives.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

`cargo make all`

## Integration Instructions

NA