### PR TITLE
[feature/supv] Cleanup redundant error handling when writing/reading MSRs

### DIFF
--- a/patina_mm_supervisor/Cargo.toml
+++ b/patina_mm_supervisor/Cargo.toml
@@ -16,7 +16,7 @@ workspace = true
 
 [dependencies]
 log = { workspace = true }
-patina = { version = "22.0.1", path = "../sdk/patina", default-features = false }
+patina = { workspace = true }
 patina_internal_cpu = { workspace = true }
 patina_paging = { workspace = true, features = [
     "supervisor"

--- a/patina_mm_supervisor/src/cpu.rs
+++ b/patina_mm_supervisor/src/cpu.rs
@@ -435,7 +435,7 @@ pub fn get_current_cpu_id() -> u32 {
 ///
 /// The caller must ensure the MSR index is valid and readable on the current platform.
 #[cfg(target_arch = "x86_64")]
-pub unsafe fn read_msr(msr: u32) -> Result<u64, &'static str> {
+pub unsafe fn read_msr(msr: u32) -> u64 {
     let lo: u32;
     let hi: u32;
     // SAFETY: Reading the MSR is memory safe as long as the caller ensures the MSR index is valid.
@@ -450,13 +450,13 @@ pub unsafe fn read_msr(msr: u32) -> Result<u64, &'static str> {
             options(nomem, nostack),
         );
     }
-    Ok(((hi as u64) << 32) | (lo as u64))
+    ((hi as u64) << 32) | (lo as u64)
 }
 
 /// Reads a Model-Specific Register (stub for non-x86_64).
 #[cfg(not(target_arch = "x86_64"))]
-pub unsafe fn read_msr(_msr: u32) -> Result<u64, &'static str> {
-    Err("rdmsr not supported on this architecture")
+pub unsafe fn read_msr(_msr: u32) -> u64 {
+    0
 }
 
 /// Writes a 64-bit value to a Model-Specific Register (MSR).
@@ -465,7 +465,7 @@ pub unsafe fn read_msr(_msr: u32) -> Result<u64, &'static str> {
 ///
 /// The caller must ensure the MSR index is valid and writable on the current platform.
 #[cfg(target_arch = "x86_64")]
-pub unsafe fn write_msr(msr: u32, value: u64) -> Result<(), &'static str> {
+pub unsafe fn write_msr(msr: u32, value: u64) {
     let lo = value as u32;
     let hi = (value >> 32) as u32;
     // SAFETY: Writing the MSR is memory safe as long as the caller ensures the MSR index is valid
@@ -480,13 +480,12 @@ pub unsafe fn write_msr(msr: u32, value: u64) -> Result<(), &'static str> {
             options(nomem, nostack),
         );
     }
-    Ok(())
 }
 
 /// Writes a Model-Specific Register (stub for non-x86_64).
 #[cfg(not(target_arch = "x86_64"))]
-pub unsafe fn write_msr(_msr: u32, _value: u64) -> Result<(), &'static str> {
-    Err("wrmsr not supported on this architecture")
+pub unsafe fn write_msr(_msr: u32, _value: u64) {
+    // No-op on non-x86_64 architectures
 }
 
 /// Checks if the current processor is the Bootstrap Processor (BSP).
@@ -497,7 +496,7 @@ pub unsafe fn write_msr(_msr: u32, _value: u64) -> Result<(), &'static str> {
 #[cfg(target_arch = "x86_64")]
 pub fn is_bsp() -> bool {
     // SAFETY: The IA32_APIC_BASE MSR is safe to read on x86_64.
-    let apic_base = unsafe { read_msr(IA32_APIC_BASE_MSR_INDEX) }.expect("IA32_APIC_BASE is always readable on x86_64");
+    let apic_base = unsafe { read_msr(IA32_APIC_BASE_MSR_INDEX) };
     (apic_base & IA32_APIC_BSP) != 0
 }
 

--- a/patina_mm_supervisor/src/cpu.rs
+++ b/patina_mm_supervisor/src/cpu.rs
@@ -16,9 +16,11 @@
 //!
 
 use core::{
-    arch::{x86_64, x86_64::CpuidResult},
+    arch::x86_64::{__cpuid, CpuidResult},
     sync::atomic::{AtomicU8, AtomicU32, Ordering},
 };
+
+const CPUID_VERSION_INFO: u32 = 0x01;
 
 /// MSR index for IA32_APIC_BASE.
 const IA32_APIC_BASE_MSR_INDEX: u32 = 0x1B;
@@ -412,21 +414,14 @@ impl<const MAX_CPUS: usize> Default for CpuManager<MAX_CPUS> {
 /// Gets the current CPU's APIC ID.
 ///
 /// On x86_64, this reads the APIC ID from the Local APIC or CPUID.
-#[cfg(target_arch = "x86_64")]
 pub fn get_current_cpu_id() -> u32 {
     // Use CPUID to get the initial APIC ID
     // CPUID function 0x01, EBX[31:24] contains the initial APIC ID
 
     // CPUID is always available on x86_64 and `__cpuid` is a safe intrinsic.
-    let CpuidResult { ebx, .. } = x86_64::__cpuid(0x01);
+    let CpuidResult { ebx, .. } = __cpuid(CPUID_VERSION_INFO);
 
     (ebx >> 24) & 0xff
-}
-
-/// Gets the current CPU's APIC ID (stub for non-x86_64).
-#[cfg(not(target_arch = "x86_64"))]
-pub fn get_current_cpu_id() -> u32 {
-    0
 }
 
 /// Reads a Model-Specific Register (MSR) by index.
@@ -434,7 +429,6 @@ pub fn get_current_cpu_id() -> u32 {
 /// ## Safety
 ///
 /// The caller must ensure the MSR index is valid and readable on the current platform.
-#[cfg(target_arch = "x86_64")]
 pub unsafe fn read_msr(msr: u32) -> u64 {
     let lo: u32;
     let hi: u32;
@@ -453,18 +447,11 @@ pub unsafe fn read_msr(msr: u32) -> u64 {
     ((hi as u64) << 32) | (lo as u64)
 }
 
-/// Reads a Model-Specific Register (stub for non-x86_64).
-#[cfg(not(target_arch = "x86_64"))]
-pub unsafe fn read_msr(_msr: u32) -> u64 {
-    0
-}
-
 /// Writes a 64-bit value to a Model-Specific Register (MSR).
 ///
 /// ## Safety
 ///
 /// The caller must ensure the MSR index is valid and writable on the current platform.
-#[cfg(target_arch = "x86_64")]
 pub unsafe fn write_msr(msr: u32, value: u64) {
     let lo = value as u32;
     let hi = (value >> 32) as u32;
@@ -482,28 +469,15 @@ pub unsafe fn write_msr(msr: u32, value: u64) {
     }
 }
 
-/// Writes a Model-Specific Register (stub for non-x86_64).
-#[cfg(not(target_arch = "x86_64"))]
-pub unsafe fn write_msr(_msr: u32, _value: u64) {
-    // No-op on non-x86_64 architectures
-}
-
 /// Checks if the current processor is the Bootstrap Processor (BSP).
 ///
 /// This reads the IA32_APIC_BASE MSR and checks the BSP flag (bit 8).
 /// The BSP flag is set by hardware during reset and indicates which
 /// processor is the bootstrap processor.
-#[cfg(target_arch = "x86_64")]
 pub fn is_bsp() -> bool {
     // SAFETY: The IA32_APIC_BASE MSR is safe to read on x86_64.
     let apic_base = unsafe { read_msr(IA32_APIC_BASE_MSR_INDEX) };
     (apic_base & IA32_APIC_BSP) != 0
-}
-
-/// Checks if the current processor is the BSP (stub for non-x86_64).
-#[cfg(not(target_arch = "x86_64"))]
-pub fn is_bsp() -> bool {
-    true // Assume BSP on non-x86_64 platforms
 }
 
 #[cfg(test)]

--- a/patina_mm_supervisor/src/init.rs
+++ b/patina_mm_supervisor/src/init.rs
@@ -187,7 +187,7 @@ fn read_idtr() -> DescriptorTablePointer {
     // On the real firmware target, populate it via `SIDT`. The asm-free builds
     // (tests / non-x86_64) keep the zero-initialized value, so no mutable binding
     // is introduced where it would go unused.
-    #[cfg(all(not(test), target_arch = "x86_64"))]
+    #[cfg(not(test))]
     let rt_descriptor = {
         let mut descriptor = rt_descriptor;
         // SAFETY: SIDT stores the 10-byte IDTR pseudo-descriptor to the specified

--- a/patina_mm_supervisor/src/lib.rs
+++ b/patina_mm_supervisor/src/lib.rs
@@ -327,7 +327,7 @@ pub(crate) fn is_buffer_inside_mmram(base: u64, size: u64) -> bool {
 pub(crate) fn read_cr3() -> u64 {
     let mut _value = 0u64;
 
-    #[cfg(all(not(test), target_arch = "x86_64"))]
+    #[cfg(not(test))]
     {
         // SAFETY: inline asm is inherently unsafe because Rust can't reason about it.
         // In this case we are reading the CR3 register, which is a safe operation.

--- a/patina_mm_supervisor/src/perf_timer.rs
+++ b/patina_mm_supervisor/src/perf_timer.rs
@@ -11,8 +11,12 @@
 //!
 
 use core::arch::x86_64;
+use core::arch::x86_64::{__cpuid, CpuidResult};
 
 use crate::CpuInfo;
+
+const CPUID_TIME_STAMP_COUNTER: u32 = 0x15;
+const CPUID_PROCESSOR_FREQUENCY: u32 = 0x16;
 
 // TODO: This is copied from perf_timer.rs in patina_dxe_core
 /// Returns the current CPU count using architecture-specific methods.
@@ -46,41 +50,24 @@ pub fn us_to_ticks<C: CpuInfo>(us: u64) -> Option<u64> {
 
 pub(crate) fn arch_perf_frequency() -> u64 {
     // Try to get TSC frequency from CPUID (most Intel and AMD platforms).
-    #[cfg(target_arch = "x86_64")]
-    {
-        // `#[allow(unused_unsafe)]` is used here to simultaneously support Rust <= 1.93 toolchains
-        // that consider __cpuid unsafe and Rust >= 1.94 (or >= nightly-2025-12-27) toolchains that
-        // consider __cpuid safe.
-        #[allow(unused_unsafe)]
-        // SAFETY: Calling cpuid does not violate memory safety
-        let core::arch::x86_64::CpuidResult { eax, ebx, ecx, .. } = unsafe { core::arch::x86_64::__cpuid(0x15) };
-        if eax != 0 && ebx != 0 && ecx != 0 {
-            // CPUID 0x15 gives TSC_frequency = (ECX * EBX) / EAX.
-            // Most modern x86 platforms support this leaf.
-            return (ecx as u64 * ebx as u64) / eax as u64;
-        }
+    let CpuidResult { eax, ebx, ecx, .. } = __cpuid(CPUID_TIME_STAMP_COUNTER);
+    if eax != 0 && ebx != 0 && ecx != 0 {
+        // CPUID 0x15 gives TSC_frequency = (ECX * EBX) / EAX.
+        // Most modern x86 platforms support this leaf.
+        return (ecx as u64 * ebx as u64) / eax as u64;
+    }
 
+    // CPUID 0x16 gives base frequency in MHz in EAX.
+    // This is supported on some older x86 platforms.
+    // This is a nominal frequency and is less accurate for reflecting actual operating conditions.
+    let CpuidResult { eax, .. } = __cpuid(CPUID_PROCESSOR_FREQUENCY);
+    if eax != 0 {
         // CPUID 0x16 gives base frequency in MHz in EAX.
         // This is supported on some older x86 platforms.
         // This is a nominal frequency and is less accurate for reflecting actual operating conditions.
-        //
-        // `#[allow(unused_unsafe)]` is used here to simultaneously support Rust <= 1.93 toolchains
-        // that consider __cpuid unsafe and Rust >= 1.94 (or >= nightly-2025-12-27) toolchains that
-        // consider __cpuid safe.
-        #[allow(unused_unsafe)]
-        // SAFETY: Calling cpuid does not violate memory safety
-        let core::arch::x86_64::CpuidResult { eax, .. } = unsafe { core::arch::x86_64::__cpuid(0x16) };
-        if eax != 0 {
-            // CPUID 0x16 gives base frequency in MHz in EAX.
-            // This is supported on some older x86 platforms.
-            // This is a nominal frequency and is less accurate for reflecting actual operating conditions.
-            return (eax * 1_000_000) as u64;
-        }
-
-        0
+        return (eax * 1_000_000) as u64;
     }
 
-    #[cfg(not(any(target_arch = "x86_64", target_arch = "aarch64")))]
     0
 }
 

--- a/patina_mm_supervisor/src/privilege_mgmt/call_gate.rs
+++ b/patina_mm_supervisor/src/privilege_mgmt/call_gate.rs
@@ -161,7 +161,6 @@ pub struct TaskStateSegment {
 /// Gets the current GDT base address by reading the GDTR register.
 /// ## Safety
 /// This function is safe to call as it only reads the GDTR register.
-#[cfg(target_arch = "x86_64")]
 pub unsafe fn get_current_gdt_base() -> u64 {
     // Get current GDT base
     let mut gdtr = GdtRegister::default();
@@ -185,7 +184,6 @@ pub unsafe fn get_current_gdt_base() -> u64 {
 ///
 /// This modifies the GDT.
 #[unsafe(no_mangle)]
-#[cfg(target_arch = "x86_64")]
 pub unsafe extern "efiapi" fn setup_call_gate(return_pointer: u64, cpl0_stack_ptr: u64) {
     // Get current GDT base
     // SAFETY: Reads the current GDTR register; see `get_current_gdt_base`.

--- a/patina_mm_supervisor/src/privilege_mgmt/syscall_dispatcher.rs
+++ b/patina_mm_supervisor/src/privilege_mgmt/syscall_dispatcher.rs
@@ -277,10 +277,7 @@ impl SyscallDispatcher {
         // Policy allows - execute the MSR read
         // SAFETY: the policy gate authorized reading this MSR above; `read_msr` only issues
         // `rdmsr` for `msr_index` and returns its value.
-        let value = unsafe { crate::cpu::read_msr(msr_index) }.unwrap_or_else(|e| {
-            log::error!("RDMSR: rdmsr failed: {}", e);
-            0
-        });
+        let value = unsafe { crate::cpu::read_msr(msr_index) };
         log::debug!("RDMSR: MSR 0x{:x} = 0x{:x}", msr_index, value);
         Ok(value)
     }
@@ -312,10 +309,7 @@ impl SyscallDispatcher {
         // Policy allows - execute the MSR write
         // SAFETY: the policy gate authorized writing this MSR above; `write_msr` only issues
         // `wrmsr` for `msr_index` with the requested value.
-        if let Err(e) = unsafe { crate::cpu::write_msr(msr_index, value) } {
-            log::error!("WRMSR: wrmsr failed: {}", e);
-            return Err(Status::UNSUPPORTED);
-        }
+        unsafe { crate::cpu::write_msr(msr_index, value) };
         log::debug!("WRMSR: MSR 0x{:x} written with 0x{:x}", msr_index, value);
         Ok(0)
     }

--- a/patina_mm_supervisor/src/runtime.rs
+++ b/patina_mm_supervisor/src/runtime.rs
@@ -39,7 +39,7 @@ unsafe fn disable_smap() {
     // SAFETY: `stac` only sets the AC flag in EFLAGS; it touches no memory and clobbers
     // no registers (hence `nostack, preserves_flags`). It is a privileged instruction that
     // is valid in the Ring 0 supervisor context this code always runs in.
-    #[cfg(all(not(test), target_arch = "x86_64"))]
+    #[cfg(not(test))]
     unsafe {
         core::arch::asm!(
             "stac", // Set AC flag to enable access to user memory
@@ -60,7 +60,7 @@ unsafe fn enable_smap() {
     // SAFETY: `clac` only clears the AC flag in EFLAGS; it touches no memory and clobbers
     // no registers (hence `nostack, preserves_flags`). It is a privileged instruction that
     // is valid in the Ring 0 supervisor context this code always runs in.
-    #[cfg(all(not(test), target_arch = "x86_64"))]
+    #[cfg(not(test))]
     unsafe {
         core::arch::asm!(
             "clac", // Clear AC flag to re-enable SMAP protections


### PR DESCRIPTION
## Description

- Remove redundant error handling when writing and reading MSRs. 
- Crate explicitly compiles only for `x86_64` arch, hence also removing redundant `target_arch=x86_64` config attributes.
- Other minor cleanups
---

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

cargo make all

## Integration Instructions

NA