### PR TITLE
smbios: use upstream table GUID

### DIFF
--- a/components/patina_smbios/src/manager.rs
+++ b/components/patina_smbios/src/manager.rs
@@ -21,7 +21,7 @@ mod protocol;
 mod record;
 
 // Re-export main types and functions
-pub use core::{SMBIOS_3_X_TABLE_GUID, SmbiosManager};
+pub use core::SmbiosManager;
 pub(crate) use record::SmbiosRecord;
 
 use alloc::boxed::Box;

--- a/components/patina_smbios/src/manager/core.rs
+++ b/components/patina_smbios/src/manager/core.rs
@@ -30,14 +30,6 @@ use crate::{
 
 use super::record::SmbiosRecord;
 
-/// SMBIOS 3.x Configuration Table GUID: F2FD1544-9794-4A2C-992E-E5BBCF20E394
-///
-/// This GUID identifies the SMBIOS 3.0+ entry point structure in the UEFI Configuration Table.
-/// Used for SMBIOS 3.0 and later versions which support 64-bit table addresses and remove
-/// the 4GB table size limitation of SMBIOS 2.x.
-pub const SMBIOS_3_X_TABLE_GUID: patina::BinaryGuid =
-    patina::BinaryGuid::from_string("F2FD1544-9794-4A2C-992E-E5BBCF20E394");
-
 /// SMBIOS 3.0 entry point structure (64-bit)
 /// Per SMBIOS 3.0+ specification section 5.2.2
 #[repr(C, packed)]

--- a/components/patina_smbios/src/service.rs
+++ b/components/patina_smbios/src/service.rs
@@ -14,7 +14,7 @@ extern crate alloc;
 use alloc::vec::Vec;
 use core::cell::Ref;
 use patina::boot_services::{BootServices, StandardBootServices};
-use r_efi::efi::Handle;
+use r_efi::{efi::Handle, system::SMBIOS3_TABLE_GUID};
 use zerocopy_derive::*;
 
 #[cfg(any(test, feature = "mockall"))]
@@ -244,10 +244,7 @@ impl<B: BootServices> Smbios for SmbiosImpl<B> {
         // SAFETY: We pass a valid GUID and a pointer to ACPI_RECLAIM_MEMORY that remains valid
         unsafe {
             self.boot_services
-                .install_configuration_table(
-                    &crate::manager::SMBIOS_3_X_TABLE_GUID.into_inner(),
-                    ep_addr as *mut core::ffi::c_void,
-                )
+                .install_configuration_table(&SMBIOS3_TABLE_GUID, ep_addr as *mut core::ffi::c_void)
                 .map_err(|_| crate::error::SmbiosError::AllocationFailed)?;
         }
 


### PR DESCRIPTION
## Description

Use `r_efi::system::SMBIOS3_TABLE_GUID` when publishing the SMBIOS 3 configuration table, removing Patina's duplicate private definition. This keeps the component aligned with the canonical UEFI constant provided by r-efi.

Tracking: #1457

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

- `cargo make fmt` 
- `cargo make test -p patina_smbios` 

## Integration Instructions

N/A