### PR TITLE
[Rebase & FF] Memory Protection Policy: Default System Memory to WB

### DIFF
--- a/docs/src/dxe_core/memory_management.md
+++ b/docs/src/dxe_core/memory_management.md
@@ -298,7 +298,8 @@ auditability and ensuring consistency.
 > **Note:** This section primarily deals with access attributes. Caching attributes are platform and driver driven and
 > outside the scope of this document. The core gets the initial platform specified caching attributes via the Resource
 > Descriptor HOB v2 and persists whatever the GCD entry has on every other call. After this point, drivers (such as
-> the PCI Host Bridge driver) may update memory regions with different caching attributes.
+> the PCI Host Bridge driver) may update memory regions with different caching attributes. The one place Patina
+> is opinionated in caching is that the default caching attribute for system memory is write back.
 
 ### General Flow
 
@@ -344,6 +345,17 @@ update the attributes.
 
 When pages are freed, Patina will unmap the pages in the page table so that any further accesses to them cause page
 faults. This helps to catch use-after-free bugs as well as meeting the cleanliness requirements of Patina.
+
+System memory page allocations will also have the write back caching attribute applied to maintain a consistent state.
+Patina expects that consumers may update system memory attributes and as such it will reset the memory attributes of
+system memory to writeback on free.
+
+### Added Memory
+
+The DXE_SERVICES.ADD_MEMORY_SPACE() PI spec defined API allows for adding new memory to Patina's GCD. Callers are
+expected to call DXE_SERVICES.SET_MEMORY_SPACE_ATTRIBUTES() to set caching and/or protection attributes.
+
+Patina will default system memory to writeback cached upon addition, but it will not be mapped until allocated.
 
 ### Image Memory Protections
 

--- a/patina_dxe_core/src/allocator.rs
+++ b/patina_dxe_core/src/allocator.rs
@@ -362,7 +362,7 @@ fn memory_type_to_str(f: &mut core::fmt::Formatter<'_>, memory_type: efi::Memory
 
 pub struct MemoryDescriptorSlice<'a>(pub &'a [efi::MemoryDescriptor]);
 
-pub struct MemoryDescriptorRef<'a>(&'a efi::MemoryDescriptor);
+pub struct MemoryDescriptorRef<'a>(pub &'a efi::MemoryDescriptor);
 
 impl Debug for MemoryDescriptorRef<'_> {
     fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {

--- a/patina_dxe_core/src/dxe_services.rs
+++ b/patina_dxe_core/src/dxe_services.rs
@@ -1612,8 +1612,9 @@ mod tests {
                 efi::Status::SUCCESS
             );
 
-            // Set a combination of reasonable capabilities
-            let caps = efi::MEMORY_RP | efi::MEMORY_RO | efi::MEMORY_XP;
+            // Set a combination of reasonable capabilities. SystemMemory blocks carry a WB attribute by default, so
+            // the new capabilities must continue to support WB.
+            let caps = efi::MEMORY_RP | efi::MEMORY_RO | efi::MEMORY_XP | efi::MEMORY_WB;
             let s = set_memory_space_capabilities(base, length, caps);
             assert_eq!(s, efi::Status::SUCCESS);
 

--- a/patina_dxe_core/src/gcd.rs
+++ b/patina_dxe_core/src/gcd.rs
@@ -15,7 +15,7 @@ use goblin::pe::section_table;
 use alloc::boxed::Box;
 use core::{cell::Cell, ffi::c_void, ops::Range};
 use patina::{
-    base::{align_down, align_up},
+    base::{DEFAULT_CACHE_ATTR, align_down, align_up},
     error::EfiError,
     pi::{
         dxe_services::{GcdIoType, GcdMemoryType, MemorySpaceDescriptor},
@@ -51,16 +51,26 @@ impl MemoryProtectionPolicy {
         Self { memory_allocation_default_attributes: Cell::new(efi::MEMORY_XP) }
     }
 
-    /// Rule: All memory allocations will be marked as the set cache type with NX applied. If compatibility mode
+    /// Rule: All memory allocations will have EFI_MEMORY_NX applied. If compatibility mode
     /// has been activated, no protections will be applied.
+    /// System memory allocations will have EFI_MEMORY_WB applied. All other memory types
+    /// will preserve the cache attributes.
     ///
     /// Arguments
     /// * `attributes` - The cache attributes to apply to the allocated memory
+    /// * `gcd_memory_type` - The GCD memory type being allocated
     ///
     /// Use Case: This is called whenever memory is allocated via the GCD to ensure
     /// allocated memory is NX by default.
-    pub(crate) const fn apply_allocated_memory_protection_policy(&self, attributes: u64) -> u64 {
-        (attributes & efi::CACHE_ATTRIBUTE_MASK) | self.memory_allocation_default_attributes.get()
+    pub(crate) const fn apply_allocated_memory_protection_policy(
+        &self,
+        attributes: u64,
+        gcd_memory_type: GcdMemoryType,
+    ) -> u64 {
+        match gcd_memory_type {
+            GcdMemoryType::SystemMemory => DEFAULT_CACHE_ATTR | self.memory_allocation_default_attributes.get(),
+            _ => (attributes & efi::CACHE_ATTRIBUTE_MASK) | self.memory_allocation_default_attributes.get(),
+        }
     }
 
     /// Rule: All resource descriptor HOBs are initially mapped as the supplied cache attribute
@@ -212,28 +222,44 @@ impl MemoryProtectionPolicy {
     /// Rule: All new memory should support all access capabilities and runtime. These are generally applicable, not
     /// specific to any memory. All new memory is marked as EFI_MEMORY_RP to start with and will not be mapped until
     /// SetMemorySpaceAttributes() is called to set the attributes. EFI_MEMORY_XP is also set to allow merging with
-    /// other free memory blocks.
+    /// other free memory blocks. System memory is marked as EFI_MEMORY_WB by default. Other memory types are expected
+    /// to have their cache attributes set by set_memory_space_attributes().
     ///
     /// Arguments
     /// - * `capabilities` - The existing capabilities for the memory region
+    /// - * `memory_type` - The GCD memory type being added
     ///
     /// Returns the updated capabilities and the attributes to set
     ///
     /// Use Case: This is called whenever new memory is added to the GCD
-    pub(crate) const fn apply_add_memory_policy(capabilities: u64) -> (u64, u64) {
-        (capabilities | efi::MEMORY_ACCESS_MASK | efi::MEMORY_RUNTIME, efi::MEMORY_RP | efi::MEMORY_XP)
+    pub(crate) const fn apply_add_memory_policy(capabilities: u64, memory_type: GcdMemoryType) -> (u64, u64) {
+        let new_capabilities = efi::MEMORY_ACCESS_MASK | efi::MEMORY_RUNTIME | capabilities;
+
+        match memory_type {
+            // System memory defaults to EFI_MEMORY_WB, so it must also advertise WB as a capability; otherwise the
+            // WB attribute cannot be applied to the block.
+            GcdMemoryType::SystemMemory => {
+                (new_capabilities | DEFAULT_CACHE_ATTR, efi::MEMORY_RP | efi::MEMORY_XP | DEFAULT_CACHE_ATTR)
+            }
+            _ => (new_capabilities, efi::MEMORY_RP | efi::MEMORY_XP),
+        }
     }
 
-    /// Rule: All free memory should be marked as EFI_MEMORY_RP, EFI_MEMORY_XP, and the preserved cache attributes.
+    /// Rule: All free memory should be marked as EFI_MEMORY_RP and EFI_MEMORY_XP. System memory should be reset back
+    /// to EFI_MEMORY_WB as the default. Other memory types should preserve the existing cache attributes.
     /// EFI_MEMORY_RP will cause the memory to be unmapped in the page table, but we still set EFI_MEMORY_XP to align
     /// with the originally added memory so that free memory can be coalesced into fewer blocks.
     ///
     /// Arguments
     /// - * `attributes` - The existing attributes for the memory region
+    /// - * `gcd_memory_type` - The GCD memory type being freed
     ///
     /// Use Case: This is called whenever memory is freed in the GCD
-    pub(crate) const fn apply_free_memory_policy(attributes: u64) -> u64 {
-        (attributes & efi::CACHE_ATTRIBUTE_MASK) | efi::MEMORY_RP | efi::MEMORY_XP
+    pub(crate) const fn apply_free_memory_policy(attributes: u64, gcd_memory_type: GcdMemoryType) -> u64 {
+        match gcd_memory_type {
+            GcdMemoryType::SystemMemory => DEFAULT_CACHE_ATTR | efi::MEMORY_RP | efi::MEMORY_XP,
+            _ => (attributes & efi::CACHE_ATTRIBUTE_MASK) | efi::MEMORY_RP | efi::MEMORY_XP,
+        }
     }
 
     /// Rule: Page 0 should be unmapped to catch null pointer dereferences. Cache attributes should be preserved.
@@ -465,7 +491,7 @@ pub fn init_gcd(physical_hob_list: *const c_void) {
                     && res_desc.physical_start.saturating_add(res_desc.resource_length)
                         >= free_memory_start.saturating_add(free_memory_size)
                 {
-                    free_memory_attributes = cache_attributes.unwrap_or(0);
+                    free_memory_attributes = cache_attributes.unwrap_or(DEFAULT_CACHE_ATTR);
                     free_memory_capabilities = spin_locked_gcd::get_capabilities(
                         GcdMemoryType::SystemMemory,
                         res_desc.resource_attribute as u64,
@@ -553,8 +579,11 @@ pub fn add_hob_resource_descriptors_to_gcd(hob_list: &HobList) {
 
         let mut resource_attributes: u32 = 0;
         // Only process Resource Descriptor HOBs according to the selected version
+        // If we have resc desc HOB v2s, we will take the cache attributes from there. If we don't,
+        // we will default to EFI_MEMORY_WB for system memory and 0 for all other types.
         let (res_desc, cache_attributes) = match parse_resource_descriptor_hob(hob) {
             Some((desc, Some(attrs))) => (desc, attrs),
+            Some((desc, None)) if desc.resource_type == hob::EFI_RESOURCE_SYSTEM_MEMORY => (desc, DEFAULT_CACHE_ATTR),
             Some((desc, None)) => (desc, 0u64),
             None => continue, // Not a resource descriptor HOB or unsupported version for this build
         };
@@ -860,9 +889,13 @@ mod tests {
     #[test]
     fn test_memory_protection_policy_apply_allocated_memory_protection_policy() {
         let policy = MemoryProtectionPolicy::new();
-        let attributes = efi::MEMORY_WB;
-        let result = policy.apply_allocated_memory_protection_policy(attributes);
+        let attributes = efi::MEMORY_UC;
+        let result = policy.apply_allocated_memory_protection_policy(attributes, GcdMemoryType::Reserved);
         // Should preserve cache attributes and add default XP
+        assert_eq!(result, efi::MEMORY_UC | efi::MEMORY_XP);
+
+        let result = policy.apply_allocated_memory_protection_policy(attributes, GcdMemoryType::SystemMemory);
+        // Should default to WB and XP
         assert_eq!(result, efi::MEMORY_WB | efi::MEMORY_XP);
     }
 
@@ -991,15 +1024,25 @@ mod tests {
     #[test]
     fn test_memory_protection_policy_apply_add_memory_policy() {
         let capabilities = efi::MEMORY_WB | efi::MEMORY_UC;
-        let (new_capabilities, attributes) = MemoryProtectionPolicy::apply_add_memory_policy(capabilities);
+        let (new_capabilities, attributes) =
+            MemoryProtectionPolicy::apply_add_memory_policy(capabilities, GcdMemoryType::Reserved);
         assert_eq!(new_capabilities, efi::MEMORY_ACCESS_MASK | efi::MEMORY_RUNTIME | efi::MEMORY_WB | efi::MEMORY_UC);
         assert_eq!(attributes, efi::MEMORY_RP | efi::MEMORY_XP);
+
+        let (new_capabilities, attributes) =
+            MemoryProtectionPolicy::apply_add_memory_policy(capabilities, GcdMemoryType::SystemMemory);
+        assert_eq!(new_capabilities, efi::MEMORY_ACCESS_MASK | efi::MEMORY_RUNTIME | efi::MEMORY_WB | efi::MEMORY_UC);
+        assert_eq!(attributes, efi::MEMORY_RP | efi::MEMORY_XP | efi::MEMORY_WB);
     }
 
     #[test]
     fn test_memory_protection_policy_apply_free_memory_policy() {
-        let attributes = efi::MEMORY_WB | efi::MEMORY_RO | efi::MEMORY_RUNTIME;
-        let result = MemoryProtectionPolicy::apply_free_memory_policy(attributes);
+        let attributes = efi::MEMORY_UC | efi::MEMORY_RO | efi::MEMORY_RUNTIME;
+        let result = MemoryProtectionPolicy::apply_free_memory_policy(attributes, GcdMemoryType::Reserved);
+        assert_eq!(result, efi::MEMORY_RP | efi::MEMORY_XP | efi::MEMORY_UC);
+
+        let attributes = efi::MEMORY_UC | efi::MEMORY_RO | efi::MEMORY_RUNTIME;
+        let result = MemoryProtectionPolicy::apply_free_memory_policy(attributes, GcdMemoryType::SystemMemory);
         assert_eq!(result, efi::MEMORY_RP | efi::MEMORY_XP | efi::MEMORY_WB);
     }
 

--- a/patina_dxe_core/src/gcd/spin_locked_gcd.rs
+++ b/patina_dxe_core/src/gcd/spin_locked_gcd.rs
@@ -396,7 +396,8 @@ impl GCD {
         match self.set_memory_space_attributes(
             base_address,
             len,
-            GCD.memory_protection_policy.apply_allocated_memory_protection_policy(attributes),
+            GCD.memory_protection_policy
+                .apply_allocated_memory_protection_policy(attributes, GcdMemoryType::SystemMemory),
         ) {
             Ok(_) | Err(EfiError::NotReady) => Ok(()),
             Err(err) => Err(err),
@@ -417,7 +418,7 @@ impl GCD {
             match self.set_memory_space_attributes(
                 base_address + MEMORY_BLOCK_SLICE_SIZE,
                 len - MEMORY_BLOCK_SLICE_SIZE,
-                MemoryProtectionPolicy::apply_free_memory_policy(attributes),
+                MemoryProtectionPolicy::apply_free_memory_policy(attributes, GcdMemoryType::SystemMemory),
             ) {
                 Ok(_) | Err(EfiError::NotReady) => Ok(()),
                 Err(err) => Err(err),
@@ -453,7 +454,7 @@ impl GCD {
         log::trace!(target: "allocations", "[{}]   Capabilities: {:#x}\n", function!(), capabilities);
 
         // All software capabilities are supported for system memory
-        let (capabilities, attributes) = MemoryProtectionPolicy::apply_add_memory_policy(capabilities);
+        let (capabilities, attributes) = MemoryProtectionPolicy::apply_add_memory_policy(capabilities, memory_type);
 
         let memory_blocks = &mut self.memory_blocks;
 
@@ -1022,7 +1023,7 @@ impl GCD {
     /// * `filter` - A closure invoked with the descriptor and a boolean indicating whether the
     ///   descriptor's block is allocated. Returns `true` if the descriptor should be included.
     pub fn get_memory_descriptor_for_address(
-        &mut self,
+        &self,
         address: efi::PhysicalAddress,
         mut filter: impl FnMut(&dxe_services::MemorySpaceDescriptor, bool) -> bool,
     ) -> Result<dxe_services::MemorySpaceDescriptor, EfiError> {
@@ -1138,7 +1139,7 @@ impl GCD {
     ///
     /// Returns
     /// * `usize` - The new count of descriptors after merging.
-    fn merge_blocks_in_place(descriptors: &mut [efi::MemoryDescriptor]) -> usize {
+    fn merge_blocks_in_place(&self, descriptors: &mut [efi::MemoryDescriptor]) -> usize {
         if descriptors.is_empty() {
             return 0;
         }
@@ -1160,14 +1161,14 @@ impl GCD {
                     // If this fails to be true it can cause odd behavior if applications try to allocate blocks of free
                     // memory by address, which is a common pattern for OS loaders.
                     if prev.r#type == efi::CONVENTIONAL_MEMORY {
+                        let prev_gcd = self.get_memory_descriptor_for_address(prev.physical_start, |_, _| true);
+                        let curr_gcd = self.get_memory_descriptor_for_address(current.physical_start, |_, _| true);
                         log::error!(
-                            "Free memory is fragmented in memory descriptors! prev: {:#x}-{:#x} (attr: {:#x}), current: {:#x}-{:#x} (attr: {:#x})",
-                            prev.physical_start,
-                            prev.physical_start + uefi_pages_to_size!(prev.number_of_pages as usize) as u64,
-                            prev.attribute,
-                            current.physical_start,
-                            current.physical_start + uefi_pages_to_size!(current.number_of_pages as usize) as u64,
-                            current.attribute,
+                            "Free memory is fragmented in memory descriptors!\r\nprev: {:?}\r\ncurr: {:?}\r\nprev_gcd: {:?}\r\ncurr_gcd: {:?}",
+                            crate::allocator::MemoryDescriptorRef(prev),
+                            crate::allocator::MemoryDescriptorRef(&current),
+                            prev_gcd.unwrap_or_default(),
+                            curr_gcd.unwrap_or_default()
                         );
                         debug_assert!(false);
                     }
@@ -1360,7 +1361,7 @@ impl GCD {
         }
 
         // Merge consecutive descriptors with the same type and attributes
-        Ok(Self::merge_blocks_in_place(buffer.get_mut(..write_idx).ok_or(EfiError::BufferTooSmall)?))
+        Ok(self.merge_blocks_in_place(buffer.get_mut(..write_idx).ok_or(EfiError::BufferTooSmall)?))
     }
 
     //Note: truncated strings here are expected and are for alignment with EDK2 reference prints.
@@ -2306,7 +2307,8 @@ impl SpinLockedGcd {
             if let Err(err) = self.set_memory_space_attributes(
                 desc.base_address as usize,
                 desc.length as usize,
-                GCD.memory_protection_policy.apply_allocated_memory_protection_policy(desc.attributes),
+                GCD.memory_protection_policy
+                    .apply_allocated_memory_protection_policy(desc.attributes, desc.memory_type),
             ) {
                 // if we fail to set these attributes (which should just be XP at this point), we should try to
                 // continue
@@ -2351,7 +2353,8 @@ impl SpinLockedGcd {
         self.set_memory_space_attributes(
             dxe_core_hob.alloc_descriptor.memory_base_address as usize,
             dxe_core_hob.alloc_descriptor.memory_length as usize,
-            GCD.memory_protection_policy.apply_allocated_memory_protection_policy(dxe_core_desc.attributes),
+            GCD.memory_protection_policy
+                .apply_allocated_memory_protection_policy(dxe_core_desc.attributes, dxe_core_desc.memory_type),
         )
         .unwrap_or_else(|_| {
             panic!(
@@ -2402,7 +2405,9 @@ impl SpinLockedGcd {
             // table
             let base_address = desc.base_address as usize & !UEFI_PAGE_MASK;
             let len = (desc.length as usize + UEFI_PAGE_MASK) & !UEFI_PAGE_MASK;
-            let new_attributes = GCD.memory_protection_policy.apply_allocated_memory_protection_policy(desc.attributes);
+            let new_attributes = GCD
+                .memory_protection_policy
+                .apply_allocated_memory_protection_policy(desc.attributes, desc.memory_type);
 
             log::trace!(
                 target: "paging",
@@ -2455,8 +2460,9 @@ impl SpinLockedGcd {
             {
                 // Set Stack region to execute protect. We use the allocated memory protection policy here because
                 // that matches our standard policy
-                let attributes =
-                    self.memory_protection_policy.apply_allocated_memory_protection_policy(gcd_desc.attributes);
+                let attributes = self
+                    .memory_protection_policy
+                    .apply_allocated_memory_protection_policy(gcd_desc.attributes, gcd_desc.memory_type);
                 match self.set_memory_space_attributes(stack_address as usize, stack_length as usize, attributes) {
                     Ok(_) | Err(EfiError::NotReady) => (),
                     Err(e) => {
@@ -2607,7 +2613,8 @@ impl SpinLockedGcd {
                 // because we set efi::MEMORY_XP as a capability on all memory ranges we add to the GCD. A driver could
                 // call set_memory_space_capabilities to remove the XP capability, but that is something that should
                 // be caught and fixed.
-                attributes = self.memory_protection_policy.apply_allocated_memory_protection_policy(attributes);
+                attributes =
+                    self.memory_protection_policy.apply_allocated_memory_protection_policy(attributes, memory_type);
                 match self.set_memory_space_attributes(*base_address, len, attributes) {
                     Ok(_) => (),
                     Err(EfiError::NotReady) => {
@@ -2667,7 +2674,7 @@ impl SpinLockedGcd {
             if let Err(e) = self.set_memory_space_attributes_worker(
                 current_range.start as usize,
                 (current_range.end - current_range.start) as usize,
-                MemoryProtectionPolicy::apply_free_memory_policy(desc.attributes),
+                MemoryProtectionPolicy::apply_free_memory_policy(desc.attributes, desc.memory_type),
                 desc.attributes,
             ) && e != EfiError::NotReady
             {
@@ -4323,8 +4330,13 @@ mod tests {
             .unwrap();
             // Trying to set capabilities where the range falls outside a block should return unsupported
             assert_eq!(Err(EfiError::Unsupported), gcd.set_memory_space_capabilities(0x1000, 0x3000, 0b1111));
-            gcd.set_memory_space_capabilities(0x1000, 0x2000, efi::MEMORY_RP | efi::MEMORY_RO | efi::MEMORY_XP)
-                .unwrap();
+            // System memory is added with a default WB attribute, so the new capabilities must continue to support it.
+            gcd.set_memory_space_capabilities(
+                0x1000,
+                0x2000,
+                efi::MEMORY_RP | efi::MEMORY_RO | efi::MEMORY_XP | efi::MEMORY_WB,
+            )
+            .unwrap();
             gcd.set_gcd_memory_attributes(0x1000, 0x2000, efi::MEMORY_RO).unwrap();
         });
     }
@@ -6129,7 +6141,8 @@ mod tests {
     fn test_merge_blocks_in_place_empty() {
         with_locked_state(|| {
             let mut descriptors: [efi::MemoryDescriptor; 0] = [];
-            let result = GCD::merge_blocks_in_place(&mut descriptors);
+            let gcd = GCD::new(48);
+            let result = gcd.merge_blocks_in_place(&mut descriptors);
             assert_eq!(result, 0);
         });
     }
@@ -6145,7 +6158,8 @@ mod tests {
                 attribute: efi::MEMORY_WB,
             }];
 
-            let result = GCD::merge_blocks_in_place(&mut descriptors);
+            let gcd = GCD::new(48);
+            let result = gcd.merge_blocks_in_place(&mut descriptors);
             assert_eq!(result, 1);
             assert_eq!(descriptors[0].physical_start, 0x1000);
             assert_eq!(descriptors[0].number_of_pages, 4);
@@ -6172,7 +6186,8 @@ mod tests {
                 },
             ];
 
-            let result = GCD::merge_blocks_in_place(&mut descriptors);
+            let gcd = GCD::new(48);
+            let result = gcd.merge_blocks_in_place(&mut descriptors);
             assert_eq!(result, 1);
             assert_eq!(descriptors[0].physical_start, 0x1000);
             assert_eq!(descriptors[0].number_of_pages, 6);
@@ -6201,7 +6216,8 @@ mod tests {
                 },
             ];
 
-            let result = GCD::merge_blocks_in_place(&mut descriptors);
+            let gcd = GCD::new(48);
+            let result = gcd.merge_blocks_in_place(&mut descriptors);
             assert_eq!(result, 2);
             assert_eq!(descriptors[0].physical_start, 0x1000);
             assert_eq!(descriptors[0].number_of_pages, 4);
@@ -6232,7 +6248,8 @@ mod tests {
                 },
             ];
 
-            let result = GCD::merge_blocks_in_place(&mut descriptors);
+            let gcd = GCD::new(48);
+            let result = gcd.merge_blocks_in_place(&mut descriptors);
             assert_eq!(result, 2);
             assert_eq!(descriptors[0].attribute, efi::MEMORY_WB);
             assert_eq!(descriptors[1].attribute, efi::MEMORY_WT);
@@ -6259,7 +6276,8 @@ mod tests {
                 },
             ];
 
-            let result = GCD::merge_blocks_in_place(&mut descriptors);
+            let gcd = GCD::new(48);
+            let result = gcd.merge_blocks_in_place(&mut descriptors);
             assert_eq!(result, 2);
             assert_eq!(descriptors[0].physical_start, 0x1000);
             assert_eq!(descriptors[0].number_of_pages, 4);
@@ -6295,7 +6313,8 @@ mod tests {
                 },
             ];
 
-            let result = GCD::merge_blocks_in_place(&mut descriptors);
+            let gcd = GCD::new(48);
+            let result = gcd.merge_blocks_in_place(&mut descriptors);
             assert_eq!(result, 1);
             assert_eq!(descriptors[0].physical_start, 0x1000);
             assert_eq!(descriptors[0].number_of_pages, 6);
@@ -6343,7 +6362,8 @@ mod tests {
                 },
             ];
 
-            let result = GCD::merge_blocks_in_place(&mut descriptors);
+            let gcd = GCD::new(48);
+            let result = gcd.merge_blocks_in_place(&mut descriptors);
             assert_eq!(result, 3);
             // First two should merge
             assert_eq!(descriptors[0].physical_start, 0x1000);
@@ -6387,7 +6407,8 @@ mod tests {
                 },
             ];
 
-            let result = GCD::merge_blocks_in_place(&mut descriptors);
+            let gcd = GCD::new(48);
+            let result = gcd.merge_blocks_in_place(&mut descriptors);
             assert_eq!(result, 3);
             assert_eq!(descriptors[0].physical_start, 0x1000);
             assert_eq!(descriptors[1].physical_start, 0x3000);

--- a/patina_dxe_core/src/gcd/spin_locked_gcd.rs
+++ b/patina_dxe_core/src/gcd/spin_locked_gcd.rs
@@ -175,7 +175,7 @@ const ATTRIBUTE_CONVERSION_TABLE: [GcdAttributeConversionEntry; 15] = [
     GcdAttributeConversionEntry { attribute: 0, capability: 0, memory: false },
 ];
 
-pub fn get_capabilities(gcd_mem_type: dxe_services::GcdMemoryType, attributes: u64) -> u64 {
+pub fn get_capabilities(gcd_mem_type: GcdMemoryType, attributes: u64) -> u64 {
     let mut capabilities = 0;
 
     for conversion in ATTRIBUTE_CONVERSION_TABLE.iter() {
@@ -184,8 +184,7 @@ pub fn get_capabilities(gcd_mem_type: dxe_services::GcdMemoryType, attributes: u
         }
 
         if (conversion.memory
-            || (gcd_mem_type != dxe_services::GcdMemoryType::SystemMemory
-                && gcd_mem_type != dxe_services::GcdMemoryType::MoreReliable))
+            || (gcd_mem_type != GcdMemoryType::SystemMemory && gcd_mem_type != GcdMemoryType::MoreReliable))
             && (attributes & (conversion.attribute as u64) != 0)
         {
             capabilities |= conversion.capability;
@@ -198,7 +197,7 @@ pub fn get_capabilities(gcd_mem_type: dxe_services::GcdMemoryType, attributes: u
 type GcdAllocateFn = fn(
     gcd: &mut GCD,
     allocate_type: AllocateType,
-    memory_type: dxe_services::GcdMemoryType,
+    memory_type: GcdMemoryType,
     alignment: usize,
     len: usize,
     image_handle: efi::Handle,
@@ -241,7 +240,7 @@ impl PageAllocator for PagingAllocator<'_> {
 
             let res = self.gcd.memory.lock().allocate_memory_space(
                 AllocateType::BottomUp(Some(addr as usize)),
-                dxe_services::GcdMemoryType::SystemMemory,
+                GcdMemoryType::SystemMemory,
                 UEFI_PAGE_SHIFT,
                 uefi_pages_to_size!(len),
                 protocol_db::EFI_BOOT_SERVICES_DATA_ALLOCATOR_HANDLE,
@@ -257,7 +256,7 @@ impl PageAllocator for PagingAllocator<'_> {
 
                     match self.gcd.memory.lock().allocate_memory_space(
                         DEFAULT_ALLOCATION_STRATEGY,
-                        dxe_services::GcdMemoryType::SystemMemory,
+                        GcdMemoryType::SystemMemory,
                         UEFI_PAGE_SHIFT,
                         uefi_pages_to_size!(len),
                         protocol_db::EFI_BOOT_SERVICES_DATA_ALLOCATOR_HANDLE,
@@ -282,7 +281,7 @@ impl PageAllocator for PagingAllocator<'_> {
                     // map them. This function is called with the page table lock held, so we cannot do that
                     match self.gcd.memory.lock().allocate_memory_space(
                         DEFAULT_ALLOCATION_STRATEGY,
-                        dxe_services::GcdMemoryType::SystemMemory,
+                        GcdMemoryType::SystemMemory,
                         UEFI_PAGE_SHIFT,
                         uefi_pages_to_size!(len),
                         protocol_db::EFI_BOOT_SERVICES_DATA_ALLOCATOR_HANDLE,
@@ -362,17 +361,14 @@ impl GCD {
 
     pub(crate) unsafe fn init_memory_blocks(
         &mut self,
-        memory_type: dxe_services::GcdMemoryType,
+        memory_type: GcdMemoryType,
         base_address: usize,
         len: usize,
         attributes: u64,
         capabilities: u64,
     ) -> Result<usize, EfiError> {
         ensure!(self.maximum_address != 0, EfiError::NotReady);
-        ensure!(
-            memory_type == dxe_services::GcdMemoryType::SystemMemory && len >= MEMORY_BLOCK_SLICE_SIZE,
-            EfiError::OutOfResources
-        );
+        ensure!(memory_type == GcdMemoryType::SystemMemory && len >= MEMORY_BLOCK_SLICE_SIZE, EfiError::OutOfResources);
 
         log::trace!(target: "allocations", "[{}] Initializing memory blocks at {:#x}", function!(), base_address);
         log::trace!(target: "allocations", "[{}]   Length: {:#x}", function!(), len);
@@ -381,7 +377,7 @@ impl GCD {
         log::trace!(target: "allocations", "[{}]   Capabilities: {:#x}", function!(), capabilities);
 
         let unallocated_memory_space = MemoryBlock::Unallocated(dxe_services::MemorySpaceDescriptor {
-            memory_type: dxe_services::GcdMemoryType::NonExistent,
+            memory_type: GcdMemoryType::NonExistent,
             base_address: 0,
             length: self.maximum_address as u64,
             ..Default::default()
@@ -409,7 +405,7 @@ impl GCD {
         // Allocate a chunk of the block to hold the actual first GCD slice
         self.allocate_memory_space(
             AllocateType::Address(base_address),
-            dxe_services::GcdMemoryType::SystemMemory,
+            GcdMemoryType::SystemMemory,
             UEFI_PAGE_SHIFT,
             MEMORY_BLOCK_SLICE_SIZE,
             protocol_db::EFI_BOOT_SERVICES_DATA_ALLOCATOR_HANDLE,
@@ -441,7 +437,7 @@ impl GCD {
     /// UEFI Platform Initialization Specification, Release 1.8, Section II-7.2.4.1
     pub unsafe fn add_memory_space(
         &mut self,
-        memory_type: dxe_services::GcdMemoryType,
+        memory_type: GcdMemoryType,
         base_address: usize,
         len: usize,
         capabilities: u64,
@@ -465,7 +461,7 @@ impl GCD {
         let idx = memory_blocks.get_closest_idx(&(base_address as u64)).ok_or(EfiError::NotFound)?;
         let block = memory_blocks.get_with_idx(idx).ok_or(EfiError::NotFound)?;
 
-        ensure!(block.as_ref().memory_type == dxe_services::GcdMemoryType::NonExistent, EfiError::AccessDenied);
+        ensure!(block.as_ref().memory_type == GcdMemoryType::NonExistent, EfiError::AccessDenied);
 
         // all newly added memory is marked as RP
         match Self::split_state_transition_at_idx(
@@ -518,7 +514,7 @@ impl GCD {
     fn allocate_memory_space(
         &mut self,
         allocate_type: AllocateType,
-        memory_type: dxe_services::GcdMemoryType,
+        memory_type: GcdMemoryType,
         alignment: usize,
         len: usize,
         image_handle: efi::Handle,
@@ -534,7 +530,7 @@ impl GCD {
     fn allocate_memory_space_internal(
         gcd: &mut GCD,
         allocate_type: AllocateType,
-        memory_type: dxe_services::GcdMemoryType,
+        memory_type: GcdMemoryType,
         alignment: usize,
         len: usize,
         image_handle: efi::Handle,
@@ -542,7 +538,7 @@ impl GCD {
     ) -> Result<usize, EfiError> {
         ensure!(gcd.maximum_address != 0, EfiError::NotReady);
         ensure!(
-            len > 0 && image_handle > ptr::null_mut() && memory_type != dxe_services::GcdMemoryType::Unaccepted,
+            len > 0 && image_handle > ptr::null_mut() && memory_type != GcdMemoryType::Unaccepted,
             EfiError::InvalidParameter
         );
 
@@ -581,7 +577,7 @@ impl GCD {
     fn allocate_memory_space_null(
         _gcd: &mut GCD,
         _allocate_type: AllocateType,
-        _memory_type: dxe_services::GcdMemoryType,
+        _memory_type: GcdMemoryType,
         _alignment: usize,
         _len: usize,
         _image_handle: efi::Handle,
@@ -675,7 +671,7 @@ impl GCD {
 
     fn allocate_bottom_up(
         &mut self,
-        memory_type: dxe_services::GcdMemoryType,
+        memory_type: GcdMemoryType,
         align_shift: usize,
         len: usize,
         image_handle: efi::Handle,
@@ -749,7 +745,7 @@ impl GCD {
 
     fn allocate_top_down(
         &mut self,
-        memory_type: dxe_services::GcdMemoryType,
+        memory_type: GcdMemoryType,
         align_shift: usize,
         len: usize,
         image_handle: efi::Handle,
@@ -832,7 +828,7 @@ impl GCD {
 
     fn allocate_address(
         &mut self,
-        memory_type: dxe_services::GcdMemoryType,
+        memory_type: GcdMemoryType,
         align_shift: usize,
         len: usize,
         image_handle: efi::Handle,
@@ -1478,31 +1474,6 @@ impl IoGCD {
             .map_err(|_| EfiError::OutOfResources)?;
 
         Ok(())
-        /*
-        ensure!(memory_type == dxe_services::GcdMemoryType::SystemMemory && len >= MEMORY_BLOCK_SLICE_SIZE, EfiError::OutOfResources);
-
-        let unallocated_memory_space = MemoryBlock::Unallocated(dxe_services::MemorySpaceDescriptor {
-          memory_type: dxe_services::GcdMemoryType::NonExistent,
-          base_address: 0,
-          length: self.maximum_address as u64,
-          ..Default::default()
-        });
-
-        let mut memory_blocks =
-          SortedSlice::new(slice::from_raw_parts_mut::<'static>(base_address as *mut u8, MEMORY_BLOCK_SLICE_SIZE));
-        memory_blocks.add(unallocated_memory_space).map_err(|_| EfiError::OutOfResources)?;
-        self.memory_blocks.replace(memory_blocks);
-
-        self.add_memory_space(memory_type, base_address, len, capabilities)?;
-
-        self.allocate_memory_space(
-          AllocateType::Address(base_address),
-          dxe_services::GcdMemoryType::SystemMemory,
-          0,
-          MEMORY_BLOCK_SLICE_SIZE,
-          1 as _,
-          None,
-        ) */
     }
 
     /// This service adds reserved I/O, or system I/O resources to the global coherency domain of the processor.
@@ -2061,7 +2032,7 @@ impl SpinLockedGcd {
     #[cfg_attr(coverage, coverage(off))]
     pub(crate) unsafe fn init_memory_blocks(
         &self,
-        memory_type: dxe_services::GcdMemoryType,
+        memory_type: GcdMemoryType,
         base_address: usize,
         len: usize,
         attributes: u64,
@@ -2300,10 +2271,7 @@ impl SpinLockedGcd {
         self.memory
             .lock()
             .get_memory_descriptors(mmio_res_descs.as_mut(), |d, _| {
-                matches!(
-                    d.memory_type,
-                    dxe_services::GcdMemoryType::MemoryMappedIo | dxe_services::GcdMemoryType::Reserved
-                )
+                matches!(d.memory_type, GcdMemoryType::MemoryMappedIo | GcdMemoryType::Reserved)
             })
             .expect("Failed to get MMIO descriptors!");
 
@@ -2317,9 +2285,7 @@ impl SpinLockedGcd {
         self.memory
             .lock()
             .get_memory_descriptors(&mut descriptors, |d, allocated| {
-                if d.memory_type == dxe_services::GcdMemoryType::MemoryMappedIo
-                    || d.memory_type == dxe_services::GcdMemoryType::Reserved
-                {
+                if d.memory_type == GcdMemoryType::MemoryMappedIo || d.memory_type == GcdMemoryType::Reserved {
                     // we've already handled MMIO and reserved memory, so skip these
                     return false;
                 }
@@ -2375,7 +2341,7 @@ impl SpinLockedGcd {
 
         let dxe_core_desc = match self
             .get_memory_descriptor_for_address(dxe_core_hob.alloc_descriptor.memory_base_address, |d, _| {
-                d.memory_type != dxe_services::GcdMemoryType::NonExistent
+                d.memory_type != GcdMemoryType::NonExistent
             }) {
             Ok(desc) => desc,
             Err(e) => panic!("DXE Core not mapped in GCD {e:?}"),
@@ -2484,9 +2450,9 @@ impl SpinLockedGcd {
                 "Invalid Stack Configuration: Stack base address {stack_address:#X} for len {stack_length:#X}"
             );
 
-            if let Ok(gcd_desc) = self.get_memory_descriptor_for_address(stack_address, |d, _| {
-                d.memory_type != dxe_services::GcdMemoryType::NonExistent
-            }) {
+            if let Ok(gcd_desc) = self
+                .get_memory_descriptor_for_address(stack_address, |d, _| d.memory_type != GcdMemoryType::NonExistent)
+            {
                 // Set Stack region to execute protect. We use the allocated memory protection policy here because
                 // that matches our standard policy
                 let attributes =
@@ -2533,7 +2499,7 @@ impl SpinLockedGcd {
         // make sure we didn't map page 0 if it was reserved or MMIO, we are using this for null pointer detection
         // only do this if page 0 actually exists
         if let Ok(descriptor) =
-            self.get_memory_descriptor_for_address(0, |d, _| d.memory_type != dxe_services::GcdMemoryType::NonExistent)
+            self.get_memory_descriptor_for_address(0, |d, _| d.memory_type != GcdMemoryType::NonExistent)
             && let Err(err) = self.set_memory_space_attributes(
                 0,
                 UEFI_PAGE_SIZE,
@@ -2561,7 +2527,7 @@ impl SpinLockedGcd {
     /// UEFI Platform Initialization Specification, Release 1.8, Section II-7.2.4.1
     pub unsafe fn add_memory_space(
         &self,
-        memory_type: dxe_services::GcdMemoryType,
+        memory_type: GcdMemoryType,
         base_address: usize,
         len: usize,
         capabilities: u64,
@@ -2610,7 +2576,7 @@ impl SpinLockedGcd {
     pub fn allocate_memory_space(
         &self,
         allocate_type: AllocateType,
-        memory_type: dxe_services::GcdMemoryType,
+        memory_type: GcdMemoryType,
         alignment: usize,
         len: usize,
         image_handle: efi::Handle,
@@ -2632,7 +2598,7 @@ impl SpinLockedGcd {
             if let Ok(base_address) = result.as_ref() {
                 let mut attributes = match self
                     .get_memory_descriptor_for_address(*base_address as efi::PhysicalAddress, |d, _| {
-                        d.memory_type != dxe_services::GcdMemoryType::NonExistent
+                        d.memory_type != GcdMemoryType::NonExistent
                     }) {
                     Ok(descriptor) => descriptor.attributes,
                     Err(_) => DEFAULT_CACHE_ATTR,
@@ -3111,7 +3077,6 @@ mod tests {
 
     use super::*;
     use alloc::vec::Vec;
-    use patina::pi::dxe_services::GcdMemoryType;
     use r_efi::efi;
     use std::{alloc::GlobalAlloc, cell::RefCell, rc::Rc};
 
@@ -3216,9 +3181,7 @@ mod tests {
             assert_eq!(
                 Err(EfiError::NotReady),
                 // SAFETY: Test-controlled addresses and sizes are used with the GCD initialized by create_gcd or get_memory.
-                unsafe {
-                    gcd.add_memory_space(dxe_services::GcdMemoryType::Reserved, address, MEMORY_BLOCK_SLICE_SIZE, 0)
-                },
+                unsafe { gcd.add_memory_space(GcdMemoryType::Reserved, address, MEMORY_BLOCK_SLICE_SIZE, 0) },
                 "First add memory space should be a system memory."
             );
             assert_eq!(0, gcd.memory_descriptor_count());
@@ -3229,7 +3192,7 @@ mod tests {
                 // SAFETY: address/size come from the test buffer and are valid to initialize memory blocks.
                 unsafe {
                     gcd.init_memory_blocks(
-                        dxe_services::GcdMemoryType::SystemMemory,
+                        GcdMemoryType::SystemMemory,
                         address,
                         MEMORY_BLOCK_SLICE_SIZE - 1,
                         efi::MEMORY_WB,
@@ -3248,24 +3211,24 @@ mod tests {
             // SAFETY: Test-controlled addresses and sizes are used with the GCD initialized by create_gcd or get_memory.
             let (mut gcd, _) = create_gcd();
             // SAFETY: Test-controlled addresses and sizes are used with the GCD initialized by create_gcd or get_memory.
-            assert_eq!(Ok(0), unsafe { gcd.add_memory_space(dxe_services::GcdMemoryType::Reserved, 0, 1, 0) });
+            assert_eq!(Ok(0), unsafe { gcd.add_memory_space(GcdMemoryType::Reserved, 0, 1, 0) });
             // SAFETY: Test-controlled addresses and sizes are used with the GCD initialized by create_gcd or get_memory.
-            assert_eq!(Ok(3), unsafe { gcd.add_memory_space(dxe_services::GcdMemoryType::SystemMemory, 1, 1, 0) });
+            assert_eq!(Ok(3), unsafe { gcd.add_memory_space(GcdMemoryType::SystemMemory, 1, 1, 0) });
             // SAFETY: Test-controlled addresses and sizes are used with the GCD initialized by create_gcd or get_memory.
-            assert_eq!(Ok(4), unsafe { gcd.add_memory_space(dxe_services::GcdMemoryType::Persistent, 2, 1, 0) });
+            assert_eq!(Ok(4), unsafe { gcd.add_memory_space(GcdMemoryType::Persistent, 2, 1, 0) });
             // SAFETY: Test-controlled addresses and sizes are used with the GCD initialized by create_gcd or get_memory.
-            assert_eq!(Ok(5), unsafe { gcd.add_memory_space(dxe_services::GcdMemoryType::MoreReliable, 3, 1, 0) });
+            assert_eq!(Ok(5), unsafe { gcd.add_memory_space(GcdMemoryType::MoreReliable, 3, 1, 0) });
             // SAFETY: Test-controlled addresses and sizes are used with the GCD initialized by create_gcd or get_memory.
-            assert_eq!(Ok(6), unsafe { gcd.add_memory_space(dxe_services::GcdMemoryType::Unaccepted, 4, 1, 0) });
+            assert_eq!(Ok(6), unsafe { gcd.add_memory_space(GcdMemoryType::Unaccepted, 4, 1, 0) });
             // SAFETY: Test-controlled addresses and sizes are used with the GCD initialized by create_gcd or get_memory.
-            assert_eq!(Ok(7), unsafe { gcd.add_memory_space(dxe_services::GcdMemoryType::MemoryMappedIo, 5, 1, 0) });
+            assert_eq!(Ok(7), unsafe { gcd.add_memory_space(GcdMemoryType::MemoryMappedIo, 5, 1, 0) });
 
             let snapshot = copy_memory_block(&gcd);
 
             assert_eq!(
                 Err(EfiError::InvalidParameter),
                 // SAFETY: Test-controlled addresses and sizes are used with the GCD initialized by create_gcd or get_memory.
-                unsafe { gcd.add_memory_space(dxe_services::GcdMemoryType::NonExistent, 10, 1, 0) },
+                unsafe { gcd.add_memory_space(GcdMemoryType::NonExistent, 10, 1, 0) },
                 "Can't manually add NonExistent memory space manually."
             );
 
@@ -3282,7 +3245,7 @@ mod tests {
             let snapshot = copy_memory_block(&gcd);
             // SAFETY: Test-controlled addresses and sizes are used with the GCD initialized by create_gcd or get_memory.
             assert_eq!(Err(EfiError::InvalidParameter), unsafe {
-                gcd.add_memory_space(dxe_services::GcdMemoryType::SystemMemory, 0, 0, 0)
+                gcd.add_memory_space(GcdMemoryType::SystemMemory, 0, 0, 0)
             });
             assert_eq!(snapshot, copy_memory_block(&gcd));
         });
@@ -3300,8 +3263,7 @@ mod tests {
                 // SAFETY: Test-controlled addresses and sizes are used with the GCD initialized by create_gcd or get_memory.
                 assert!(
                     // SAFETY: Test-controlled addresses and sizes are used with the GCD initialized by create_gcd or get_memory.
-                    unsafe { gcd.add_memory_space(dxe_services::GcdMemoryType::SystemMemory, addr + n, 1, n as u64) }
-                        .is_ok()
+                    unsafe { gcd.add_memory_space(GcdMemoryType::SystemMemory, addr + n, 1, n as u64) }.is_ok()
                 );
                 n += 1;
             }
@@ -3310,7 +3272,7 @@ mod tests {
             let memory_blocks_snapshot = copy_memory_block(&gcd);
 
             // SAFETY: Test-controlled addresses and sizes are used with the GCD initialized by create_gcd or get_memory.
-            let res = unsafe { gcd.add_memory_space(dxe_services::GcdMemoryType::SystemMemory, addr + n, 1, n as u64) };
+            let res = unsafe { gcd.add_memory_space(GcdMemoryType::SystemMemory, addr + n, 1, n as u64) };
             assert_eq!(
                 Err(EfiError::OutOfResources),
                 res,
@@ -3333,16 +3295,16 @@ mod tests {
 
             // SAFETY: Test-controlled addresses and sizes are used with the GCD initialized by create_gcd or get_memory.
             assert_eq!(Err(EfiError::Unsupported), unsafe {
-                gcd.add_memory_space(dxe_services::GcdMemoryType::SystemMemory, gcd.maximum_address + 1, 1, 0)
+                gcd.add_memory_space(GcdMemoryType::SystemMemory, gcd.maximum_address + 1, 1, 0)
             });
             // SAFETY: Test-controlled addresses and sizes are used with the GCD initialized by create_gcd or get_memory.
             assert_eq!(Err(EfiError::Unsupported), unsafe {
-                gcd.add_memory_space(dxe_services::GcdMemoryType::SystemMemory, gcd.maximum_address, 1, 0)
+                gcd.add_memory_space(GcdMemoryType::SystemMemory, gcd.maximum_address, 1, 0)
                 // SAFETY: Test-controlled addresses and sizes are used with the GCD initialized by create_gcd or get_memory.
             });
             // SAFETY: Test-controlled addresses and sizes are used with the GCD initialized by create_gcd or get_memory.
             assert_eq!(Err(EfiError::Unsupported), unsafe {
-                gcd.add_memory_space(dxe_services::GcdMemoryType::SystemMemory, gcd.maximum_address - 1, 2, 0)
+                gcd.add_memory_space(GcdMemoryType::SystemMemory, gcd.maximum_address - 1, 2, 0)
             });
 
             // SAFETY: Test-controlled addresses and sizes are used with the GCD initialized by create_gcd or get_memory.
@@ -3357,26 +3319,26 @@ mod tests {
             let (mut gcd, _) = create_gcd();
             // Add block to test the boundary on.
             // SAFETY: Test-controlled addresses and sizes are used with the GCD initialized by create_gcd or get_memory.
-            unsafe { gcd.add_memory_space(dxe_services::GcdMemoryType::SystemMemory, 1000, 10, 0) }.unwrap();
+            unsafe { gcd.add_memory_space(GcdMemoryType::SystemMemory, 1000, 10, 0) }.unwrap();
 
             let snapshot = copy_memory_block(&gcd);
 
             assert_eq!(
                 Err(EfiError::AccessDenied),
                 // SAFETY: Test-controlled addresses and sizes are used with the GCD initialized by create_gcd or get_memory.
-                unsafe { gcd.add_memory_space(dxe_services::GcdMemoryType::Reserved, 1002, 5, 0) },
+                unsafe { gcd.add_memory_space(GcdMemoryType::Reserved, 1002, 5, 0) },
                 "Can't add inside a range previously added."
             );
             assert_eq!(
                 Err(EfiError::AccessDenied),
                 // SAFETY: Test-controlled addresses and sizes are used with the GCD initialized by create_gcd or get_memory.
-                unsafe { gcd.add_memory_space(dxe_services::GcdMemoryType::Reserved, 998, 5, 0) },
+                unsafe { gcd.add_memory_space(GcdMemoryType::Reserved, 998, 5, 0) },
                 "Can't add partially inside a range previously added (Start)."
             );
             assert_eq!(
                 Err(EfiError::AccessDenied),
                 // SAFETY: Test-controlled addresses and sizes are used with the GCD initialized by create_gcd or get_memory.
-                unsafe { gcd.add_memory_space(dxe_services::GcdMemoryType::Reserved, 1009, 5, 0) },
+                unsafe { gcd.add_memory_space(GcdMemoryType::Reserved, 1009, 5, 0) },
                 "Can't add partially inside a range previously added (End)."
             );
 
@@ -3391,7 +3353,7 @@ mod tests {
             let (mut gcd, address) = create_gcd();
             // Add unallocated block after allocated one.
             // SAFETY: Test-controlled addresses and sizes are used with the GCD initialized by create_gcd or get_memory.
-            unsafe { gcd.add_memory_space(dxe_services::GcdMemoryType::SystemMemory, address - 100, 100, 0) }.unwrap();
+            unsafe { gcd.add_memory_space(GcdMemoryType::SystemMemory, address - 100, 100, 0) }.unwrap();
 
             let snapshot = copy_memory_block(&gcd);
 
@@ -3399,14 +3361,14 @@ mod tests {
             assert_eq!(
                 Err(EfiError::AccessDenied),
                 // SAFETY: Test-controlled addresses and sizes are used with the GCD initialized by create_gcd or get_memory.
-                unsafe { gcd.add_memory_space(dxe_services::GcdMemoryType::SystemMemory, address, 5, 0) },
+                unsafe { gcd.add_memory_space(GcdMemoryType::SystemMemory, address, 5, 0) },
                 // SAFETY: Test-controlled addresses and sizes are used with the GCD initialized by create_gcd or get_memory.
                 "Can't add inside a range previously allocated."
             );
             assert_eq!(
                 Err(EfiError::AccessDenied),
                 // SAFETY: Test-controlled addresses and sizes are used with the GCD initialized by create_gcd or get_memory.
-                unsafe { gcd.add_memory_space(dxe_services::GcdMemoryType::Reserved, address - 100, 200, 0) },
+                unsafe { gcd.add_memory_space(GcdMemoryType::Reserved, address - 100, 200, 0) },
                 "Can't add partially inside a range previously allocated."
             );
 
@@ -3421,13 +3383,13 @@ mod tests {
             let (mut gcd, _) = create_gcd();
 
             // SAFETY: Test-controlled addresses and sizes are used with the GCD initialized by create_gcd or get_memory.
-            assert_eq!(Ok(4), unsafe { gcd.add_memory_space(dxe_services::GcdMemoryType::SystemMemory, 1000, 10, 0) });
+            assert_eq!(Ok(4), unsafe { gcd.add_memory_space(GcdMemoryType::SystemMemory, 1000, 10, 0) });
             let block_count = gcd.memory_descriptor_count();
 
             // SAFETY: Test-controlled addresses and sizes are used with the GCD initialized by create_gcd or get_memory.
             // Test merging when added after
             // SAFETY: Test-controlled addresses and sizes are used with the GCD initialized by create_gcd or get_memory.
-            match unsafe { gcd.add_memory_space(dxe_services::GcdMemoryType::SystemMemory, 1010, 10, 0) } {
+            match unsafe { gcd.add_memory_space(GcdMemoryType::SystemMemory, 1010, 10, 0) } {
                 Ok(idx) => {
                     let mb = gcd.memory_blocks.get_with_idx(idx).unwrap();
                     // SAFETY: Test-controlled addresses and sizes are used with the GCD initialized by create_gcd or get_memory.
@@ -3440,7 +3402,7 @@ mod tests {
 
             // Test merging when added before
             // SAFETY: Test-controlled addresses and sizes are used with the GCD initialized by create_gcd or get_memory.
-            match unsafe { gcd.add_memory_space(dxe_services::GcdMemoryType::SystemMemory, 990, 10, 0) } {
+            match unsafe { gcd.add_memory_space(GcdMemoryType::SystemMemory, 990, 10, 0) } {
                 Ok(idx) => {
                     let mb = gcd.memory_blocks.get_with_idx(idx).unwrap();
                     assert_eq!(990, mb.as_ref().base_address);
@@ -3453,13 +3415,13 @@ mod tests {
 
             assert!(
                 // SAFETY: Test-controlled addresses and sizes are used with the GCD initialized by create_gcd or get_memory.
-                unsafe { gcd.add_memory_space(dxe_services::GcdMemoryType::Reserved, 1020, 10, 0) }.is_ok(),
+                unsafe { gcd.add_memory_space(GcdMemoryType::Reserved, 1020, 10, 0) }.is_ok(),
                 "A different memory type should note result in a merge."
             );
             assert_eq!(block_count + 1, gcd.memory_descriptor_count());
             assert!(
                 // SAFETY: Test-controlled addresses and sizes are used with the GCD initialized by create_gcd or get_memory.
-                unsafe { gcd.add_memory_space(dxe_services::GcdMemoryType::Reserved, 1030, 10, 1) }.is_ok(),
+                unsafe { gcd.add_memory_space(GcdMemoryType::Reserved, 1030, 10, 1) }.is_ok(),
                 "A different capabilities should note result in a merge."
             );
             assert_eq!(block_count + 2, gcd.memory_descriptor_count());
@@ -3474,7 +3436,7 @@ mod tests {
         with_locked_state(|| {
             let (mut gcd, _) = create_gcd();
             // SAFETY: Test-controlled addresses and sizes are used with the GCD initialized by create_gcd or get_memory.
-            match unsafe { gcd.add_memory_space(dxe_services::GcdMemoryType::SystemMemory, 100, 10, 123) } {
+            match unsafe { gcd.add_memory_space(GcdMemoryType::SystemMemory, 100, 10, 123) } {
                 Ok(idx) => {
                     let mb = *gcd.memory_blocks.get_with_idx(idx).unwrap();
                     match mb {
@@ -3514,7 +3476,7 @@ mod tests {
 
             // Add memory space to remove in a valid area.
             // SAFETY: Test-controlled addresses and sizes are used with the GCD initialized by create_gcd or get_memory.
-            assert!(unsafe { gcd.add_memory_space(dxe_services::GcdMemoryType::SystemMemory, 0, 10, 0) }.is_ok());
+            assert!(unsafe { gcd.add_memory_space(GcdMemoryType::SystemMemory, 0, 10, 0) }.is_ok());
 
             let snapshot = copy_memory_block(&gcd);
             assert_eq!(Err(EfiError::InvalidParameter), gcd.remove_memory_space(5, 0));
@@ -3537,10 +3499,7 @@ mod tests {
             // Add memory space to remove in a valid area.
             assert!(
                 // SAFETY: Test-controlled addresses and sizes are used with the GCD initialized by create_gcd or get_memory.
-                unsafe {
-                    gcd.add_memory_space(dxe_services::GcdMemoryType::SystemMemory, gcd.maximum_address - 10, 10, 0)
-                }
-                .is_ok()
+                unsafe { gcd.add_memory_space(GcdMemoryType::SystemMemory, gcd.maximum_address - 10, 10, 0) }.is_ok()
             );
 
             let snapshot = copy_memory_block(&gcd);
@@ -3566,7 +3525,7 @@ mod tests {
             let (mut gcd, _) = create_gcd();
             // Add memory space to remove in a valid area.
             // SAFETY: Test-controlled addresses and sizes are used with the GCD initialized by create_gcd or get_memory.
-            assert!(unsafe { gcd.add_memory_space(dxe_services::GcdMemoryType::SystemMemory, 100, 10, 0) }.is_ok());
+            assert!(unsafe { gcd.add_memory_space(GcdMemoryType::SystemMemory, 100, 10, 0) }.is_ok());
 
             let snapshot = copy_memory_block(&gcd);
 
@@ -3629,7 +3588,7 @@ mod tests {
 
             assert!(
                 // SAFETY: Test-controlled addresses and sizes are used with the GCD initialized by create_gcd or get_memory.
-                unsafe { gcd.add_memory_space(dxe_services::GcdMemoryType::SystemMemory, addr, 10, 0_u64) }.is_ok()
+                unsafe { gcd.add_memory_space(GcdMemoryType::SystemMemory, addr, 10, 0_u64) }.is_ok()
             );
             let mut n = 1;
             while gcd.memory_descriptor_count() < MEMORY_BLOCK_SLICE_LEN {
@@ -3637,7 +3596,7 @@ mod tests {
                     // SAFETY: Test-controlled addresses and sizes are used with the GCD initialized by create_gcd or get_memory.
                     unsafe {
                         // SAFETY: Test-controlled addresses and sizes are used with the GCD initialized by create_gcd or get_memory.
-                        gcd.add_memory_space(dxe_services::GcdMemoryType::SystemMemory, addr + 10 + n, 1, n as u64)
+                        gcd.add_memory_space(GcdMemoryType::SystemMemory, addr + 10 + n, 1, n as u64)
                     }
                     .is_ok()
                 );
@@ -3673,10 +3632,8 @@ mod tests {
 
             assert!(
                 // SAFETY: Test-controlled addresses and sizes are used with the GCD initialized by create_gcd or get_memory.
-                unsafe {
-                    gcd.add_memory_space(dxe_services::GcdMemoryType::SystemMemory, aligned_address, aligned_length, 0)
-                }
-                .is_ok()
+                unsafe { gcd.add_memory_space(GcdMemoryType::SystemMemory, aligned_address, aligned_length, 0) }
+                    .is_ok()
             );
 
             let block_count = gcd.memory_descriptor_count();
@@ -3704,7 +3661,7 @@ mod tests {
             let (mut gcd, address) = create_gcd();
             assert!(
                 // SAFETY: Test-controlled addresses and sizes are used with the GCD initialized by create_gcd or get_memory.
-                unsafe { gcd.add_memory_space(dxe_services::GcdMemoryType::SystemMemory, 0, address, 123) }.is_ok()
+                unsafe { gcd.add_memory_space(GcdMemoryType::SystemMemory, 0, address, 123) }.is_ok()
             );
 
             match gcd.remove_memory_space(0, 10) {
@@ -3734,7 +3691,7 @@ mod tests {
                 Err(EfiError::NotFound),
                 gcd.allocate_memory_space(
                     AllocateType::Address(0),
-                    dxe_services::GcdMemoryType::SystemMemory,
+                    GcdMemoryType::SystemMemory,
                     UEFI_PAGE_SHIFT,
                     10,
                     1 as _,
@@ -3753,7 +3710,7 @@ mod tests {
                 Err(EfiError::InvalidParameter),
                 gcd.allocate_memory_space(
                     AllocateType::BottomUp(None),
-                    dxe_services::GcdMemoryType::Reserved,
+                    GcdMemoryType::Reserved,
                     UEFI_PAGE_SHIFT,
                     0,
                     1 as _,
@@ -3773,7 +3730,7 @@ mod tests {
                 Err(EfiError::InvalidParameter),
                 gcd.allocate_memory_space(
                     AllocateType::BottomUp(None),
-                    dxe_services::GcdMemoryType::Reserved,
+                    GcdMemoryType::Reserved,
                     0,
                     10,
                     ptr::null_mut(),
@@ -3794,7 +3751,7 @@ mod tests {
                 Err(EfiError::NotFound),
                 gcd.allocate_memory_space(
                     AllocateType::Address(gcd.maximum_address - 100),
-                    dxe_services::GcdMemoryType::Reserved,
+                    GcdMemoryType::Reserved,
                     0,
                     // SAFETY: Test-controlled addresses and sizes are used with the GCD initialized by create_gcd or get_memory.
                     1000,
@@ -3806,7 +3763,7 @@ mod tests {
                 Err(EfiError::NotFound),
                 gcd.allocate_memory_space(
                     AllocateType::Address(gcd.maximum_address + 100),
-                    dxe_services::GcdMemoryType::Reserved,
+                    GcdMemoryType::Reserved,
                     0,
                     1000,
                     1 as _,
@@ -3826,12 +3783,12 @@ mod tests {
         with_locked_state(|| {
             let (mut gcd, _) = create_gcd();
             for (i, memory_type) in [
-                dxe_services::GcdMemoryType::Reserved,
-                dxe_services::GcdMemoryType::SystemMemory,
-                dxe_services::GcdMemoryType::Persistent,
-                dxe_services::GcdMemoryType::MemoryMappedIo,
-                dxe_services::GcdMemoryType::MoreReliable,
-                dxe_services::GcdMemoryType::Unaccepted,
+                GcdMemoryType::Reserved,
+                GcdMemoryType::SystemMemory,
+                GcdMemoryType::Persistent,
+                GcdMemoryType::MemoryMappedIo,
+                GcdMemoryType::MoreReliable,
+                GcdMemoryType::Unaccepted,
             ]
             .into_iter()
             .enumerate()
@@ -3841,7 +3798,7 @@ mod tests {
                 let res =
                     gcd.allocate_memory_space(AllocateType::Address((i + 1) * 10), memory_type, 0, 10, 1 as _, None);
                 match memory_type {
-                    dxe_services::GcdMemoryType::Unaccepted => assert_eq!(Err(EfiError::InvalidParameter), res),
+                    GcdMemoryType::Unaccepted => assert_eq!(Err(EfiError::InvalidParameter), res),
                     _ => assert!(res.is_ok()),
                 }
             }
@@ -3855,14 +3812,11 @@ mod tests {
 
             // Add memory space of len 100 to multiple space.
             // SAFETY: Test-controlled addresses and sizes are used with the GCD initialized by create_gcd or get_memory.
-            unsafe { gcd.add_memory_space(dxe_services::GcdMemoryType::SystemMemory, 0, 100, 0) }.unwrap();
+            unsafe { gcd.add_memory_space(GcdMemoryType::SystemMemory, 0, 100, 0) }.unwrap();
             // SAFETY: Test-controlled addresses and sizes are used with the GCD initialized by create_gcd or get_memory.
-            unsafe { gcd.add_memory_space(dxe_services::GcdMemoryType::SystemMemory, 1000, 100, 0) }.unwrap();
+            unsafe { gcd.add_memory_space(GcdMemoryType::SystemMemory, 1000, 100, 0) }.unwrap();
             // SAFETY: Test-controlled addresses and sizes are used with the GCD initialized by create_gcd or get_memory.
-            unsafe {
-                gcd.add_memory_space(dxe_services::GcdMemoryType::SystemMemory, gcd.maximum_address - 100, 100, 0)
-            }
-            .unwrap();
+            unsafe { gcd.add_memory_space(GcdMemoryType::SystemMemory, gcd.maximum_address - 100, 100, 0) }.unwrap();
 
             let memory_blocks_snapshot = copy_memory_block(&gcd);
 
@@ -3871,14 +3825,7 @@ mod tests {
                 assert_eq!(
                     // SAFETY: Test-controlled addresses and sizes are used with the GCD initialized by create_gcd or get_memory.
                     Err(EfiError::OutOfResources),
-                    gcd.allocate_memory_space(
-                        allocate_type,
-                        dxe_services::GcdMemoryType::SystemMemory,
-                        0,
-                        1000,
-                        1 as _,
-                        None
-                    ),
+                    gcd.allocate_memory_space(allocate_type, GcdMemoryType::SystemMemory, 0, 1000, 1 as _, None),
                     "Assert fail with allocate type: {allocate_type:?}"
                 );
             }
@@ -3890,14 +3837,7 @@ mod tests {
             ] {
                 assert_eq!(
                     Err(EfiError::NotFound),
-                    gcd.allocate_memory_space(
-                        allocate_type,
-                        dxe_services::GcdMemoryType::SystemMemory,
-                        0,
-                        1000,
-                        1 as _,
-                        None
-                    ),
+                    gcd.allocate_memory_space(allocate_type, GcdMemoryType::SystemMemory, 0, 1000, 1 as _, None),
                     "Assert fail with allocate type: {allocate_type:?}"
                 );
             }
@@ -3911,13 +3851,13 @@ mod tests {
         with_locked_state(|| {
             let (mut gcd, _) = create_gcd();
             // SAFETY: Test-controlled addresses and sizes are used with the GCD initialized by create_gcd or get_memory.
-            unsafe { gcd.add_memory_space(dxe_services::GcdMemoryType::SystemMemory, 0x1000, 0x1000, 0) }.unwrap();
+            unsafe { gcd.add_memory_space(GcdMemoryType::SystemMemory, 0x1000, 0x1000, 0) }.unwrap();
 
             assert_eq!(
                 Ok(0x1000),
                 gcd.allocate_memory_space(
                     AllocateType::BottomUp(None),
-                    dxe_services::GcdMemoryType::SystemMemory,
+                    GcdMemoryType::SystemMemory,
                     0,
                     0x0f,
                     1 as _,
@@ -3929,7 +3869,7 @@ mod tests {
                 Ok(0x1010),
                 gcd.allocate_memory_space(
                     AllocateType::BottomUp(None),
-                    dxe_services::GcdMemoryType::SystemMemory,
+                    GcdMemoryType::SystemMemory,
                     4,
                     0x10,
                     1 as _,
@@ -3941,7 +3881,7 @@ mod tests {
                 Ok(0x1020),
                 gcd.allocate_memory_space(
                     AllocateType::BottomUp(None),
-                    dxe_services::GcdMemoryType::SystemMemory,
+                    GcdMemoryType::SystemMemory,
                     4,
                     100,
                     1 as _,
@@ -3953,7 +3893,7 @@ mod tests {
                 Ok(0x1ff1),
                 gcd.allocate_memory_space(
                     AllocateType::TopDown(None),
-                    dxe_services::GcdMemoryType::SystemMemory,
+                    GcdMemoryType::SystemMemory,
                     0,
                     0x0f,
                     1 as _,
@@ -3965,7 +3905,7 @@ mod tests {
                 Ok(0x1fe0),
                 gcd.allocate_memory_space(
                     AllocateType::TopDown(None),
-                    dxe_services::GcdMemoryType::SystemMemory,
+                    GcdMemoryType::SystemMemory,
                     4,
                     0x0f,
                     1 as _,
@@ -3977,7 +3917,7 @@ mod tests {
                 Ok(0x1f00),
                 gcd.allocate_memory_space(
                     AllocateType::TopDown(None),
-                    dxe_services::GcdMemoryType::SystemMemory,
+                    GcdMemoryType::SystemMemory,
                     4,
                     0xe0,
                     // SAFETY: Test-controlled addresses and sizes are used with the GCD initialized by create_gcd or get_memory.
@@ -3990,7 +3930,7 @@ mod tests {
                 Ok(0x1a00),
                 gcd.allocate_memory_space(
                     AllocateType::Address(0x1a00),
-                    dxe_services::GcdMemoryType::SystemMemory,
+                    GcdMemoryType::SystemMemory,
                     4,
                     100,
                     1 as _,
@@ -4006,7 +3946,7 @@ mod tests {
                 Err(EfiError::NotFound),
                 gcd.allocate_memory_space(
                     AllocateType::Address(0x1a0f),
-                    dxe_services::GcdMemoryType::SystemMemory,
+                    GcdMemoryType::SystemMemory,
                     4,
                     100,
                     1 as _,
@@ -4023,60 +3963,29 @@ mod tests {
         with_locked_state(|| {
             let (mut gcd, _) = create_gcd();
             // SAFETY: Test-controlled addresses and sizes are used with the GCD initialized by create_gcd or get_memory.
-            unsafe { gcd.add_memory_space(dxe_services::GcdMemoryType::SystemMemory, 0x1000, 0x1000, 0) }.unwrap();
+            unsafe { gcd.add_memory_space(GcdMemoryType::SystemMemory, 0x1000, 0x1000, 0) }.unwrap();
 
             for allocate_type in [AllocateType::BottomUp(None), AllocateType::TopDown(None)] {
                 let block_count = gcd.memory_descriptor_count();
                 assert!(
-                    gcd.allocate_memory_space(
-                        allocate_type,
-                        dxe_services::GcdMemoryType::SystemMemory,
-                        0,
-                        1,
-                        1 as _,
-                        None
-                    )
-                    .is_ok(),
+                    gcd.allocate_memory_space(allocate_type, GcdMemoryType::SystemMemory, 0, 1, 1 as _, None).is_ok(),
                     "{allocate_type:?}"
                 );
                 assert_eq!(block_count + 1, gcd.memory_descriptor_count());
                 assert!(
-                    gcd.allocate_memory_space(
-                        allocate_type,
-                        dxe_services::GcdMemoryType::SystemMemory,
-                        0,
-                        1,
-                        1 as _,
-                        None
-                    )
-                    .is_ok(),
+                    gcd.allocate_memory_space(allocate_type, GcdMemoryType::SystemMemory, 0, 1, 1 as _, None).is_ok(),
                     "{allocate_type:?}"
                 );
                 assert_eq!(block_count + 1, gcd.memory_descriptor_count());
                 assert!(
-                    gcd.allocate_memory_space(
-                        allocate_type,
-                        dxe_services::GcdMemoryType::SystemMemory,
-                        0,
-                        1,
-                        2 as _,
-                        None
-                    )
-                    .is_ok(),
+                    gcd.allocate_memory_space(allocate_type, GcdMemoryType::SystemMemory, 0, 1, 2 as _, None).is_ok(),
                     // SAFETY: Test-controlled addresses and sizes are used with the GCD initialized by create_gcd or get_memory.
                     "{allocate_type:?}: A different image handle should not result in a merge."
                 );
                 assert_eq!(block_count + 2, gcd.memory_descriptor_count());
                 assert!(
-                    gcd.allocate_memory_space(
-                        allocate_type,
-                        dxe_services::GcdMemoryType::SystemMemory,
-                        0,
-                        1,
-                        2 as _,
-                        Some(1 as _)
-                    )
-                    .is_ok(),
+                    gcd.allocate_memory_space(allocate_type, GcdMemoryType::SystemMemory, 0, 1, 2 as _, Some(1 as _))
+                        .is_ok(),
                     "{allocate_type:?}: A different device handle should not result in a merge."
                 );
                 assert_eq!(block_count + 3, gcd.memory_descriptor_count());
@@ -4087,7 +3996,7 @@ mod tests {
                 Ok(0x1000 + 4),
                 gcd.allocate_memory_space(
                     AllocateType::Address(0x1000 + 4),
-                    dxe_services::GcdMemoryType::SystemMemory,
+                    GcdMemoryType::SystemMemory,
                     0,
                     1,
                     2 as _,
@@ -4107,7 +4016,7 @@ mod tests {
             let (mut gcd, _) = create_gcd();
 
             // SAFETY: Test-controlled addresses and sizes are used with the GCD initialized by create_gcd or get_memory.
-            unsafe { gcd.add_memory_space(dxe_services::GcdMemoryType::SystemMemory, 0x100, 10, 0) }.unwrap();
+            unsafe { gcd.add_memory_space(GcdMemoryType::SystemMemory, 0x100, 10, 0) }.unwrap();
 
             let snapshot = copy_memory_block(&gcd);
 
@@ -4115,7 +4024,7 @@ mod tests {
                 Err(EfiError::NotFound),
                 gcd.allocate_memory_space(
                     AllocateType::Address(0x100),
-                    dxe_services::GcdMemoryType::SystemMemory,
+                    GcdMemoryType::SystemMemory,
                     0,
                     11,
                     1 as _,
@@ -4126,7 +4035,7 @@ mod tests {
                 Err(EfiError::NotFound),
                 gcd.allocate_memory_space(
                     AllocateType::Address(0x95),
-                    dxe_services::GcdMemoryType::SystemMemory,
+                    GcdMemoryType::SystemMemory,
                     0,
                     10,
                     1 as _,
@@ -4135,25 +4044,11 @@ mod tests {
             );
             assert_eq!(
                 Err(EfiError::NotFound),
-                gcd.allocate_memory_space(
-                    AllocateType::Address(110),
-                    dxe_services::GcdMemoryType::SystemMemory,
-                    0,
-                    5,
-                    1 as _,
-                    None
-                ),
+                gcd.allocate_memory_space(AllocateType::Address(110), GcdMemoryType::SystemMemory, 0, 5, 1 as _, None),
             );
             assert_eq!(
                 Err(EfiError::NotFound),
-                gcd.allocate_memory_space(
-                    AllocateType::Address(0),
-                    dxe_services::GcdMemoryType::SystemMemory,
-                    0,
-                    5,
-                    1 as _,
-                    None
-                ),
+                gcd.allocate_memory_space(AllocateType::Address(0), GcdMemoryType::SystemMemory, 0, 5, 1 as _, None),
             );
 
             assert_eq!(snapshot, copy_memory_block(&gcd));
@@ -4169,7 +4064,7 @@ mod tests {
                 Err(EfiError::NotFound),
                 gcd.allocate_memory_space(
                     AllocateType::Address(address),
-                    dxe_services::GcdMemoryType::SystemMemory,
+                    GcdMemoryType::SystemMemory,
                     0,
                     5,
                     1 as _,
@@ -4204,13 +4099,10 @@ mod tests {
             let (mut gcd, _) = create_gcd();
 
             // SAFETY: Test-controlled addresses and sizes are used with the GCD initialized by create_gcd or get_memory.
-            unsafe {
-                gcd.add_memory_space(dxe_services::GcdMemoryType::SystemMemory, gcd.maximum_address - 100, 100, 0)
-            }
-            .unwrap();
+            unsafe { gcd.add_memory_space(GcdMemoryType::SystemMemory, gcd.maximum_address - 100, 100, 0) }.unwrap();
             gcd.allocate_memory_space(
                 AllocateType::Address(gcd.maximum_address - 100),
-                dxe_services::GcdMemoryType::SystemMemory,
+                GcdMemoryType::SystemMemory,
                 0,
                 100,
                 1 as _,
@@ -4244,10 +4136,10 @@ mod tests {
         with_locked_state(|| {
             let (mut gcd, _) = create_gcd();
             // SAFETY: Test-controlled addresses and sizes are used with the GCD initialized by create_gcd or get_memory.
-            unsafe { gcd.add_memory_space(dxe_services::GcdMemoryType::SystemMemory, 0x3000, 0x3000, 0) }.unwrap();
+            unsafe { gcd.add_memory_space(GcdMemoryType::SystemMemory, 0x3000, 0x3000, 0) }.unwrap();
             gcd.allocate_memory_space(
                 AllocateType::Address(0x3000),
-                dxe_services::GcdMemoryType::SystemMemory,
+                GcdMemoryType::SystemMemory,
                 0,
                 0x1000,
                 1 as _,
@@ -4268,13 +4160,10 @@ mod tests {
             let (mut gcd, _) = create_gcd();
 
             // SAFETY: Test-controlled addresses and sizes are used with the GCD initialized by create_gcd or get_memory.
-            unsafe {
-                gcd.add_memory_space(dxe_services::GcdMemoryType::SystemMemory, 0x1000000, UEFI_PAGE_SIZE * 2, 0)
-            }
-            .unwrap();
+            unsafe { gcd.add_memory_space(GcdMemoryType::SystemMemory, 0x1000000, UEFI_PAGE_SIZE * 2, 0) }.unwrap();
             gcd.allocate_memory_space(
                 AllocateType::Address(0x1000000),
-                dxe_services::GcdMemoryType::SystemMemory,
+                GcdMemoryType::SystemMemory,
                 0,
                 UEFI_PAGE_SIZE * 2,
                 1 as _,
@@ -4286,10 +4175,7 @@ mod tests {
             while gcd.memory_descriptor_count() < MEMORY_BLOCK_SLICE_LEN {
                 let addr = 0x2000000 + (n * UEFI_PAGE_SIZE);
                 // SAFETY: Test-controlled addresses and sizes are used with the GCD initialized by create_gcd or get_memory.
-                unsafe {
-                    gcd.add_memory_space(dxe_services::GcdMemoryType::SystemMemory, addr, UEFI_PAGE_SIZE, n as u64)
-                }
-                .unwrap();
+                unsafe { gcd.add_memory_space(GcdMemoryType::SystemMemory, addr, UEFI_PAGE_SIZE, n as u64) }.unwrap();
                 n += 1;
             }
             let memory_blocks_snapshot = copy_memory_block(&gcd);
@@ -4307,10 +4193,10 @@ mod tests {
             let (mut gcd, _) = create_gcd();
 
             // SAFETY: Test-controlled addresses and sizes are used with the GCD initialized by create_gcd or get_memory.
-            unsafe { gcd.add_memory_space(dxe_services::GcdMemoryType::SystemMemory, 0x1000, 0x10000, 0) }.unwrap();
+            unsafe { gcd.add_memory_space(GcdMemoryType::SystemMemory, 0x1000, 0x10000, 0) }.unwrap();
             gcd.allocate_memory_space(
                 AllocateType::Address(0x1000),
-                dxe_services::GcdMemoryType::SystemMemory,
+                GcdMemoryType::SystemMemory,
                 0,
                 0x10000,
                 1 as _,
@@ -4424,12 +4310,11 @@ mod tests {
         with_locked_state(|| {
             let (mut gcd, address) = create_gcd();
             // SAFETY: Test-controlled addresses and sizes are used with the GCD initialized by create_gcd or get_memory.
-            unsafe { gcd.add_memory_space(dxe_services::GcdMemoryType::SystemMemory, 0x1000, address - 0x1000, 0) }
-                .unwrap();
+            unsafe { gcd.add_memory_space(GcdMemoryType::SystemMemory, 0x1000, address - 0x1000, 0) }.unwrap();
 
             gcd.allocate_memory_space(
                 AllocateType::BottomUp(None),
-                dxe_services::GcdMemoryType::SystemMemory,
+                GcdMemoryType::SystemMemory,
                 0,
                 0x2000,
                 1 as _,
@@ -4450,11 +4335,11 @@ mod tests {
         with_locked_state(|| {
             let (mut gcd, address) = create_gcd();
             // SAFETY: Test-controlled addresses and sizes are used with the GCD initialized by create_gcd or get_memory.
-            unsafe { gcd.add_memory_space(dxe_services::GcdMemoryType::SystemMemory, 0, address, 0) }.unwrap();
+            unsafe { gcd.add_memory_space(GcdMemoryType::SystemMemory, 0, address, 0) }.unwrap();
 
             gcd.allocate_memory_space(
                 AllocateType::BottomUp(None),
-                dxe_services::GcdMemoryType::SystemMemory,
+                GcdMemoryType::SystemMemory,
                 0,
                 0x2000,
                 1 as _,
@@ -4474,7 +4359,7 @@ mod tests {
             // SAFETY: Test-controlled addresses and sizes are used with the GCD initialized by create_gcd or get_memory.
             unsafe {
                 gcd.add_memory_space(
-                    dxe_services::GcdMemoryType::SystemMemory,
+                    GcdMemoryType::SystemMemory,
                     0,
                     address,
                     efi::MEMORY_RP | efi::MEMORY_RO | efi::MEMORY_XP | efi::MEMORY_WB,
@@ -4488,7 +4373,7 @@ mod tests {
                 let addr = gcd
                     .allocate_memory_space(
                         AllocateType::BottomUp(None),
-                        dxe_services::GcdMemoryType::SystemMemory,
+                        GcdMemoryType::SystemMemory,
                         0,
                         0x2000,
                         n as _,
@@ -4507,7 +4392,7 @@ mod tests {
                 Err(EfiError::OutOfResources),
                 gcd.allocate_memory_space(
                     AllocateType::BottomUp(None),
-                    dxe_services::GcdMemoryType::SystemMemory,
+                    GcdMemoryType::SystemMemory,
                     0,
                     0x1000,
                     1 as _,
@@ -4807,7 +4692,7 @@ mod tests {
         // SAFETY: address/size come from the test buffer and are valid to initialize memory blocks.
         unsafe {
             gcd.init_memory_blocks(
-                dxe_services::GcdMemoryType::SystemMemory,
+                GcdMemoryType::SystemMemory,
                 address,
                 MEMORY_BLOCK_SLICE_SIZE,
                 efi::MEMORY_WB,
@@ -4859,17 +4744,11 @@ mod tests {
             assert_eq!(GCD.memory.lock().maximum_address, 0);
 
             // SAFETY: The GCD is intentionally uninitialized to validate error handling paths.
-            let add_result = unsafe { GCD.add_memory_space(dxe_services::GcdMemoryType::SystemMemory, 0, 100, 0) };
+            let add_result = unsafe { GCD.add_memory_space(GcdMemoryType::SystemMemory, 0, 100, 0) };
             assert_eq!(add_result, Err(EfiError::NotReady));
 
-            let allocate_result = GCD.allocate_memory_space(
-                AllocateType::Address(0),
-                dxe_services::GcdMemoryType::SystemMemory,
-                0,
-                10,
-                1 as _,
-                None,
-            );
+            let allocate_result =
+                GCD.allocate_memory_space(AllocateType::Address(0), GcdMemoryType::SystemMemory, 0, 10, 1 as _, None);
             assert_eq!(allocate_result, Err(EfiError::NotReady));
 
             let free_result = GCD.free_memory_space(0, 10);
@@ -4894,7 +4773,7 @@ mod tests {
             // SAFETY: address/size come from the test buffer and are valid to initialize memory blocks.
             unsafe {
                 GCD.init_memory_blocks(
-                    dxe_services::GcdMemoryType::SystemMemory,
+                    GcdMemoryType::SystemMemory,
                     address,
                     MEMORY_BLOCK_SLICE_SIZE,
                     efi::MEMORY_WB,
@@ -4929,7 +4808,7 @@ mod tests {
             // SAFETY: address/size come from the test buffer and are valid to initialize memory blocks.
             unsafe {
                 GCD.init_memory_blocks(
-                    dxe_services::GcdMemoryType::SystemMemory,
+                    GcdMemoryType::SystemMemory,
                     address,
                     MEMORY_BLOCK_SLICE_SIZE,
                     efi::MEMORY_WB,
@@ -4940,8 +4819,7 @@ mod tests {
 
             // SAFETY: Adds a small test range to trigger the map-change callback.
             unsafe {
-                GCD.add_memory_space(dxe_services::GcdMemoryType::SystemMemory, 0x1000, 0x1000, efi::MEMORY_WB)
-                    .unwrap();
+                GCD.add_memory_space(GcdMemoryType::SystemMemory, 0x1000, 0x1000, efi::MEMORY_WB).unwrap();
             }
 
             assert!(CALLBACK_INVOKED.load(core::sync::atomic::Ordering::SeqCst));
@@ -4969,7 +4847,7 @@ mod tests {
             // SAFETY: address/size come from the test buffer and are valid to initialize memory blocks.
             unsafe {
                 GCD.init_memory_blocks(
-                    dxe_services::GcdMemoryType::SystemMemory,
+                    GcdMemoryType::SystemMemory,
                     address,
                     MEMORY_BLOCK_SLICE_SIZE,
                     efi::MEMORY_WB,
@@ -5001,7 +4879,7 @@ mod tests {
             // SAFETY: base/size come from the test allocation and are valid for initializing memory blocks.
             unsafe {
                 GCD.init_memory_blocks(
-                    dxe_services::GcdMemoryType::SystemMemory,
+                    GcdMemoryType::SystemMemory,
                     base as usize,
                     GCD_SIZE,
                     efi::MEMORY_WB,
@@ -5014,7 +4892,7 @@ mod tests {
             loop {
                 let allocate_result = GCD.allocate_memory_space(
                     AllocateType::BottomUp(None),
-                    dxe_services::GcdMemoryType::SystemMemory,
+                    GcdMemoryType::SystemMemory,
                     12,
                     0x1000,
                     1 as _,
@@ -5048,7 +4926,7 @@ mod tests {
             // SAFETY: base/size come from the test allocation and are valid for initializing memory blocks.
             unsafe {
                 GCD.init_memory_blocks(
-                    dxe_services::GcdMemoryType::SystemMemory,
+                    GcdMemoryType::SystemMemory,
                     base as usize,
                     GCD_SIZE,
                     efi::MEMORY_WB,
@@ -5061,7 +4939,7 @@ mod tests {
             loop {
                 let allocate_result = GCD.allocate_memory_space(
                     AllocateType::TopDown(None),
-                    dxe_services::GcdMemoryType::SystemMemory,
+                    GcdMemoryType::SystemMemory,
                     // SAFETY: Test-controlled addresses and sizes are used with the GCD initialized by create_gcd or get_memory.
                     12,
                     0x1000,
@@ -5089,13 +4967,13 @@ mod tests {
             // Increase the memory block size so allocation at 0x1000 is possible after skipping page 0
             // SAFETY: Test-controlled addresses and sizes are used with the GCD initialized by create_gcd or get_memory.
             unsafe {
-                gcd.add_memory_space(dxe_services::GcdMemoryType::SystemMemory, 0, 0x2000, efi::MEMORY_WB).unwrap();
+                gcd.add_memory_space(GcdMemoryType::SystemMemory, 0, 0x2000, efi::MEMORY_WB).unwrap();
             }
 
             // Try to allocate page 0 implicitly bottom up, we should get bumped to the next available page
             let res = gcd.allocate_memory_space(
                 AllocateType::BottomUp(None),
-                dxe_services::GcdMemoryType::SystemMemory,
+                GcdMemoryType::SystemMemory,
                 0,
                 0x1000,
                 1 as _,
@@ -5107,7 +4985,7 @@ mod tests {
             // Try to allocate page 0 implicitly top down, we should fail with out of resources
             let res = gcd.allocate_memory_space(
                 AllocateType::TopDown(None),
-                dxe_services::GcdMemoryType::SystemMemory,
+                GcdMemoryType::SystemMemory,
                 0,
                 0x1000,
                 1 as _,
@@ -5118,14 +4996,13 @@ mod tests {
             // add a new block to ensure block skipping logic works
             // SAFETY: Test-controlled addresses and sizes are used with the GCD initialized by create_gcd or get_memory.
             unsafe {
-                gcd.add_memory_space(dxe_services::GcdMemoryType::SystemMemory, 0x2000, 0x2000, efi::MEMORY_WB)
-                    .unwrap();
+                gcd.add_memory_space(GcdMemoryType::SystemMemory, 0x2000, 0x2000, efi::MEMORY_WB).unwrap();
             }
 
             // now allocate bottom up, we should be able to allocate page 0x2000
             let res = gcd.allocate_memory_space(
                 AllocateType::BottomUp(None),
-                dxe_services::GcdMemoryType::SystemMemory,
+                GcdMemoryType::SystemMemory,
                 0,
                 0x2000,
                 1 as _,
@@ -5136,7 +5013,7 @@ mod tests {
             // Try to allocate page 0 explicitly. This should pass as Patina DXE Core needs to allocate by address
             let res = gcd.allocate_memory_space(
                 AllocateType::Address(0),
-                dxe_services::GcdMemoryType::SystemMemory,
+                GcdMemoryType::SystemMemory,
                 0,
                 UEFI_PAGE_SIZE,
                 1 as _,
@@ -5154,12 +5031,12 @@ mod tests {
 
             // Test with a contiguous 8gb without a gap.
             // SAFETY: Test-controlled addresses and sizes are used with the GCD initialized by create_gcd or get_memory.
-            unsafe { gcd.add_memory_space(dxe_services::GcdMemoryType::SystemMemory, 0, 2 * SIZE_4GB, 0) }.unwrap();
+            unsafe { gcd.add_memory_space(GcdMemoryType::SystemMemory, 0, 2 * SIZE_4GB, 0) }.unwrap();
 
             // make sure it prioritizes 32 bit addresses.
             let res = gcd.allocate_memory_space(
                 AllocateType::TopDown(None),
-                dxe_services::GcdMemoryType::SystemMemory,
+                GcdMemoryType::SystemMemory,
                 UEFI_PAGE_SHIFT,
                 0x10000,
                 1 as _,
@@ -5170,7 +5047,7 @@ mod tests {
             // check that it will fall back to >32 bits.
             let res = gcd.allocate_memory_space(
                 AllocateType::TopDown(None),
-                dxe_services::GcdMemoryType::SystemMemory,
+                GcdMemoryType::SystemMemory,
                 UEFI_PAGE_SHIFT,
                 SIZE_4GB,
                 1 as _,
@@ -5185,7 +5062,7 @@ mod tests {
             // Check that a sufficiently large allocation will straddle the boundary.
             let res = gcd.allocate_memory_space(
                 AllocateType::TopDown(None),
-                dxe_services::GcdMemoryType::SystemMemory,
+                GcdMemoryType::SystemMemory,
                 UEFI_PAGE_SHIFT,
                 SIZE_4GB + 0x1000,
                 1 as _,
@@ -5209,7 +5086,7 @@ mod tests {
             // SAFETY: address/size come from the test allocation and are used to initialize the GCD memory blocks.
             unsafe {
                 GCD.init_memory_blocks(
-                    dxe_services::GcdMemoryType::SystemMemory,
+                    GcdMemoryType::SystemMemory,
                     address,
                     MEMORY_BLOCK_SLICE_SIZE,
                     efi::MEMORY_WB,
@@ -5254,7 +5131,7 @@ mod tests {
             // SAFETY: base points to the test allocation and GCD_SIZE defines the initialized range.
             unsafe {
                 GCD.init_memory_blocks(
-                    dxe_services::GcdMemoryType::SystemMemory,
+                    GcdMemoryType::SystemMemory,
                     base as usize,
                     GCD_SIZE,
                     efi::MEMORY_WB,
@@ -5308,7 +5185,7 @@ mod tests {
             // SAFETY: base/size correspond to the test allocation and are safe to register with the GCD.
             unsafe {
                 GCD.init_memory_blocks(
-                    dxe_services::GcdMemoryType::SystemMemory,
+                    GcdMemoryType::SystemMemory,
                     base as usize,
                     GCD_SIZE,
                     efi::MEMORY_WB,
@@ -5335,11 +5212,11 @@ mod tests {
             let (mut gcd, _address) = create_gcd();
 
             // SAFETY: Test-controlled addresses and sizes are used with the GCD initialized by create_gcd or get_memory.
-            unsafe { gcd.add_memory_space(dxe_services::GcdMemoryType::SystemMemory, 0, 2 * SIZE_4GB, 0) }.unwrap();
+            unsafe { gcd.add_memory_space(GcdMemoryType::SystemMemory, 0, 2 * SIZE_4GB, 0) }.unwrap();
 
             gcd.allocate_memory_space(
                 AllocateType::Address(0x5000),
-                dxe_services::GcdMemoryType::SystemMemory,
+                GcdMemoryType::SystemMemory,
                 UEFI_PAGE_SHIFT,
                 0x4000,
                 1 as _,
@@ -5348,7 +5225,7 @@ mod tests {
             .unwrap();
             gcd.allocate_memory_space(
                 AllocateType::Address(0x9000),
-                dxe_services::GcdMemoryType::SystemMemory,
+                GcdMemoryType::SystemMemory,
                 UEFI_PAGE_SHIFT,
                 0x2000,
                 2 as _,
@@ -5379,30 +5256,27 @@ mod tests {
             // Add MMIO and Reserved blocks
             // SAFETY: Test-controlled addresses and sizes are used with the GCD initialized by create_gcd or get_memory.
             unsafe {
-                gcd.add_memory_space(dxe_services::GcdMemoryType::MemoryMappedIo, 0x2000, 0x1000, 0).unwrap();
+                gcd.add_memory_space(GcdMemoryType::MemoryMappedIo, 0x2000, 0x1000, 0).unwrap();
             }
             // SAFETY: Test-controlled addresses and sizes are used with the GCD initialized by create_gcd or get_memory.
             unsafe {
-                gcd.add_memory_space(dxe_services::GcdMemoryType::Reserved, 0x3000, 0x10000, 0).unwrap();
+                gcd.add_memory_space(GcdMemoryType::Reserved, 0x3000, 0x10000, 0).unwrap();
             }
             // SAFETY: Test-controlled addresses and sizes are used with the GCD initialized by create_gcd or get_memory.
             unsafe {
-                gcd.add_memory_space(dxe_services::GcdMemoryType::SystemMemory, 0x14000, 0x6000, 0).unwrap();
+                gcd.add_memory_space(GcdMemoryType::SystemMemory, 0x14000, 0x6000, 0).unwrap();
             }
 
             let mut buffer = Vec::with_capacity(gcd.memory_descriptor_count());
             gcd.get_memory_descriptors(&mut buffer, |d, _| {
-                matches!(
-                    d.memory_type,
-                    dxe_services::GcdMemoryType::MemoryMappedIo | dxe_services::GcdMemoryType::Reserved
-                )
+                matches!(d.memory_type, GcdMemoryType::MemoryMappedIo | GcdMemoryType::Reserved)
             })
             .unwrap();
             assert!(buffer.len() == 2);
-            assert!(buffer.iter().any(|desc| desc.memory_type == dxe_services::GcdMemoryType::MemoryMappedIo
+            assert!(buffer.iter().any(|desc| desc.memory_type == GcdMemoryType::MemoryMappedIo
                 && desc.base_address == 0x2000
                 && desc.length == 0x1000));
-            assert!(buffer.iter().any(|desc| desc.memory_type == dxe_services::GcdMemoryType::Reserved
+            assert!(buffer.iter().any(|desc| desc.memory_type == GcdMemoryType::Reserved
                 && desc.base_address == 0x3000
                 && desc.length == 0x10000));
         });
@@ -5414,9 +5288,9 @@ mod tests {
             let (mut gcd, _address) = create_gcd();
             // SAFETY: Test-controlled addresses and sizes are used with the GCD initialized by create_gcd.
             unsafe {
-                gcd.add_memory_space(dxe_services::GcdMemoryType::MemoryMappedIo, 0x2000, 0x1000, 0).unwrap();
-                gcd.add_memory_space(dxe_services::GcdMemoryType::Reserved, 0x3000, 0x1000, 0).unwrap();
-                gcd.add_memory_space(dxe_services::GcdMemoryType::SystemMemory, 0x14000, 0x6000, 0).unwrap();
+                gcd.add_memory_space(GcdMemoryType::MemoryMappedIo, 0x2000, 0x1000, 0).unwrap();
+                gcd.add_memory_space(GcdMemoryType::Reserved, 0x3000, 0x1000, 0).unwrap();
+                gcd.add_memory_space(GcdMemoryType::SystemMemory, 0x14000, 0x6000, 0).unwrap();
             }
 
             let mut buffer = Vec::with_capacity(gcd.memory_descriptor_count());
@@ -5425,19 +5299,19 @@ mod tests {
             // The `All` filter returns every block, including NonExistent regions.
             assert_eq!(buffer.len(), gcd.memory_descriptor_count());
             assert!(
-                buffer.iter().any(|desc| desc.memory_type == dxe_services::GcdMemoryType::MemoryMappedIo
-                    && desc.base_address == 0x2000)
+                buffer
+                    .iter()
+                    .any(|desc| desc.memory_type == GcdMemoryType::MemoryMappedIo && desc.base_address == 0x2000)
             );
             assert!(
-                buffer.iter().any(
-                    |desc| desc.memory_type == dxe_services::GcdMemoryType::Reserved && desc.base_address == 0x3000
-                )
+                buffer.iter().any(|desc| desc.memory_type == GcdMemoryType::Reserved && desc.base_address == 0x3000)
             );
             assert!(
-                buffer.iter().any(|desc| desc.memory_type == dxe_services::GcdMemoryType::SystemMemory
-                    && desc.base_address == 0x14000)
+                buffer
+                    .iter()
+                    .any(|desc| desc.memory_type == GcdMemoryType::SystemMemory && desc.base_address == 0x14000)
             );
-            assert!(buffer.iter().any(|desc| desc.memory_type == dxe_services::GcdMemoryType::NonExistent));
+            assert!(buffer.iter().any(|desc| desc.memory_type == GcdMemoryType::NonExistent));
         });
     }
 
@@ -5447,14 +5321,14 @@ mod tests {
             let (mut gcd, _address) = create_gcd();
             // SAFETY: Test-controlled addresses and sizes are used with the GCD initialized by create_gcd.
             unsafe {
-                gcd.add_memory_space(dxe_services::GcdMemoryType::MemoryMappedIo, 0x2000, 0x1000, 0).unwrap();
-                gcd.add_memory_space(dxe_services::GcdMemoryType::Reserved, 0x3000, 0x1000, 0).unwrap();
-                gcd.add_memory_space(dxe_services::GcdMemoryType::SystemMemory, 0x14000, 0x6000, 0).unwrap();
+                gcd.add_memory_space(GcdMemoryType::MemoryMappedIo, 0x2000, 0x1000, 0).unwrap();
+                gcd.add_memory_space(GcdMemoryType::Reserved, 0x3000, 0x1000, 0).unwrap();
+                gcd.add_memory_space(GcdMemoryType::SystemMemory, 0x14000, 0x6000, 0).unwrap();
             }
             // Allocate part of the system memory so that an allocated block is present to exclude.
             gcd.allocate_memory_space(
                 AllocateType::Address(0x14000),
-                dxe_services::GcdMemoryType::SystemMemory,
+                GcdMemoryType::SystemMemory,
                 UEFI_PAGE_SHIFT,
                 0x1000,
                 1 as _,
@@ -5464,13 +5338,13 @@ mod tests {
 
             let mut buffer = Vec::with_capacity(gcd.memory_descriptor_count());
             gcd.get_memory_descriptors(&mut buffer, |d, allocated| {
-                !allocated && d.memory_type == dxe_services::GcdMemoryType::SystemMemory
+                !allocated && d.memory_type == GcdMemoryType::SystemMemory
             })
             .unwrap();
 
             // Only unallocated system memory is returned.
             assert!(!buffer.is_empty());
-            assert!(buffer.iter().all(|desc| desc.memory_type == dxe_services::GcdMemoryType::SystemMemory));
+            assert!(buffer.iter().all(|desc| desc.memory_type == GcdMemoryType::SystemMemory));
             assert!(buffer.iter().all(|desc| desc.image_handle == INVALID_HANDLE));
             // The remaining free portion of the added system memory is present, the allocated portion is not.
             assert!(buffer.iter().any(|desc| desc.base_address == 0x15000 && desc.length == 0x5000));
@@ -5486,29 +5360,28 @@ mod tests {
             let (mut gcd, _address) = create_gcd();
             // SAFETY: Test-controlled addresses and sizes are used with the GCD initialized by create_gcd.
             unsafe {
-                gcd.add_memory_space(dxe_services::GcdMemoryType::MemoryMappedIo, 0x2000, 0x1000, 0).unwrap();
-                gcd.add_memory_space(dxe_services::GcdMemoryType::Reserved, 0x3000, 0x1000, 0).unwrap();
-                gcd.add_memory_space(dxe_services::GcdMemoryType::SystemMemory, 0x14000, 0x6000, 0).unwrap();
+                gcd.add_memory_space(GcdMemoryType::MemoryMappedIo, 0x2000, 0x1000, 0).unwrap();
+                gcd.add_memory_space(GcdMemoryType::Reserved, 0x3000, 0x1000, 0).unwrap();
+                gcd.add_memory_space(GcdMemoryType::SystemMemory, 0x14000, 0x6000, 0).unwrap();
             }
 
             let mut buffer = Vec::with_capacity(gcd.memory_descriptor_count());
-            gcd.get_memory_descriptors(&mut buffer, |d, _| d.memory_type != dxe_services::GcdMemoryType::NonExistent)
-                .unwrap();
+            gcd.get_memory_descriptors(&mut buffer, |d, _| d.memory_type != GcdMemoryType::NonExistent).unwrap();
 
             // Every existent (non-NonExistent) block is returned, regardless of allocation state or type.
-            assert!(buffer.iter().all(|desc| desc.memory_type != dxe_services::GcdMemoryType::NonExistent));
+            assert!(buffer.iter().all(|desc| desc.memory_type != GcdMemoryType::NonExistent));
             assert!(
-                buffer.iter().any(|desc| desc.memory_type == dxe_services::GcdMemoryType::MemoryMappedIo
-                    && desc.base_address == 0x2000)
+                buffer
+                    .iter()
+                    .any(|desc| desc.memory_type == GcdMemoryType::MemoryMappedIo && desc.base_address == 0x2000)
             );
             assert!(
-                buffer.iter().any(
-                    |desc| desc.memory_type == dxe_services::GcdMemoryType::Reserved && desc.base_address == 0x3000
-                )
+                buffer.iter().any(|desc| desc.memory_type == GcdMemoryType::Reserved && desc.base_address == 0x3000)
             );
             assert!(
-                buffer.iter().any(|desc| desc.memory_type == dxe_services::GcdMemoryType::SystemMemory
-                    && desc.base_address == 0x14000)
+                buffer
+                    .iter()
+                    .any(|desc| desc.memory_type == GcdMemoryType::SystemMemory && desc.base_address == 0x14000)
             );
         });
     }
@@ -5519,14 +5392,14 @@ mod tests {
             let (mut gcd, _address) = create_gcd();
             // SAFETY: Test-controlled addresses and sizes are used with the GCD initialized by create_gcd.
             unsafe {
-                gcd.add_memory_space(dxe_services::GcdMemoryType::MemoryMappedIo, 0x2000, 0x1000, 0).unwrap();
-                gcd.add_memory_space(dxe_services::GcdMemoryType::Reserved, 0x3000, 0x1000, 0).unwrap();
-                gcd.add_memory_space(dxe_services::GcdMemoryType::SystemMemory, 0x14000, 0x6000, 0).unwrap();
+                gcd.add_memory_space(GcdMemoryType::MemoryMappedIo, 0x2000, 0x1000, 0).unwrap();
+                gcd.add_memory_space(GcdMemoryType::Reserved, 0x3000, 0x1000, 0).unwrap();
+                gcd.add_memory_space(GcdMemoryType::SystemMemory, 0x14000, 0x6000, 0).unwrap();
             }
             // Allocate part of the system memory so that an allocated block is present to exclude.
             gcd.allocate_memory_space(
                 AllocateType::Address(0x14000),
-                dxe_services::GcdMemoryType::SystemMemory,
+                GcdMemoryType::SystemMemory,
                 UEFI_PAGE_SHIFT,
                 0x1000,
                 1 as _,
@@ -5540,13 +5413,12 @@ mod tests {
             // Unallocated blocks of any type are returned; unlike `Free`, MMIO and Reserved are included.
             assert!(buffer.iter().all(|desc| desc.image_handle == INVALID_HANDLE));
             assert!(
-                buffer.iter().any(|desc| desc.memory_type == dxe_services::GcdMemoryType::MemoryMappedIo
-                    && desc.base_address == 0x2000)
+                buffer
+                    .iter()
+                    .any(|desc| desc.memory_type == GcdMemoryType::MemoryMappedIo && desc.base_address == 0x2000)
             );
             assert!(
-                buffer.iter().any(
-                    |desc| desc.memory_type == dxe_services::GcdMemoryType::Reserved && desc.base_address == 0x3000
-                )
+                buffer.iter().any(|desc| desc.memory_type == GcdMemoryType::Reserved && desc.base_address == 0x3000)
             );
             assert!(buffer.iter().any(|desc| desc.base_address == 0x15000 && desc.length == 0x5000));
             // The allocated portion is excluded.
@@ -5560,12 +5432,12 @@ mod tests {
             let (mut gcd, _address) = create_gcd();
             // SAFETY: Test-controlled addresses and sizes are used with the GCD initialized by create_gcd.
             unsafe {
-                gcd.add_memory_space(dxe_services::GcdMemoryType::MemoryMappedIo, 0x2000, 0x2000, 0).unwrap();
+                gcd.add_memory_space(GcdMemoryType::MemoryMappedIo, 0x2000, 0x2000, 0).unwrap();
             }
             // Allocate part of the MMIO region so both an allocated and unallocated MMIO block exist.
             gcd.allocate_memory_space(
                 AllocateType::Address(0x2000),
-                dxe_services::GcdMemoryType::MemoryMappedIo,
+                GcdMemoryType::MemoryMappedIo,
                 UEFI_PAGE_SHIFT,
                 0x1000,
                 1 as _,
@@ -5575,19 +5447,16 @@ mod tests {
 
             let mut buffer = Vec::with_capacity(gcd.memory_descriptor_count());
             gcd.get_memory_descriptors(&mut buffer, |d, _| {
-                matches!(
-                    d.memory_type,
-                    dxe_services::GcdMemoryType::MemoryMappedIo | dxe_services::GcdMemoryType::Reserved
-                )
+                matches!(d.memory_type, GcdMemoryType::MemoryMappedIo | GcdMemoryType::Reserved)
             })
             .unwrap();
 
             // The `MmioAndReserved` filter returns both allocated and unallocated MMIO/Reserved blocks.
-            assert!(buffer.iter().any(|desc| desc.memory_type == dxe_services::GcdMemoryType::MemoryMappedIo
+            assert!(buffer.iter().any(|desc| desc.memory_type == GcdMemoryType::MemoryMappedIo
                 && desc.base_address == 0x2000
                 && desc.length == 0x1000
                 && desc.image_handle == 1 as _));
-            assert!(buffer.iter().any(|desc| desc.memory_type == dxe_services::GcdMemoryType::MemoryMappedIo
+            assert!(buffer.iter().any(|desc| desc.memory_type == GcdMemoryType::MemoryMappedIo
                 && desc.base_address == 0x3000
                 && desc.length == 0x1000
                 && desc.image_handle == INVALID_HANDLE));
@@ -5607,7 +5476,7 @@ mod tests {
             // SAFETY: address/length are derived from the test buffer so the ranges are valid for GCD initialization.
             unsafe {
                 GCD.init_memory_blocks(
-                    dxe_services::GcdMemoryType::SystemMemory,
+                    GcdMemoryType::SystemMemory,
                     address,
                     MEMORY_BLOCK_SLICE_SIZE * 99,
                     efi::MEMORY_WB,
@@ -5615,14 +5484,14 @@ mod tests {
                 )
                 .unwrap();
                 GCD.add_memory_space(
-                    dxe_services::GcdMemoryType::MemoryMappedIo,
+                    GcdMemoryType::MemoryMappedIo,
                     0x1000,
                     0x1000,
                     efi::CACHE_ATTRIBUTE_MASK | efi::MEMORY_ACCESS_MASK,
                 )
                 .unwrap();
                 GCD.add_memory_space(
-                    dxe_services::GcdMemoryType::SystemMemory,
+                    GcdMemoryType::SystemMemory,
                     0x2000,
                     0x40000,
                     efi::CACHE_ATTRIBUTE_MASK | efi::MEMORY_ACCESS_MASK,
@@ -5748,7 +5617,7 @@ mod tests {
             // Check Guard Page.
             let mut stack_desc =
                 GCD.get_memory_descriptor_for_address(stack_hob.memory_base_address, |_, _| true).unwrap();
-            assert_eq!(stack_desc.memory_type, dxe_services::GcdMemoryType::SystemMemory);
+            assert_eq!(stack_desc.memory_type, GcdMemoryType::SystemMemory);
             assert_eq!((stack_desc.attributes & efi::MEMORY_RP), efi::MEMORY_RP);
 
             // Check rest of the stack.
@@ -5756,7 +5625,7 @@ mod tests {
                 .get_memory_descriptor_for_address(stack_hob.memory_base_address + UEFI_PAGE_SIZE as u64, |_, _| true)
                 .unwrap();
             assert_eq!((stack_desc.attributes & efi::MEMORY_XP), efi::MEMORY_XP);
-            assert_eq!(stack_desc.memory_type, dxe_services::GcdMemoryType::SystemMemory);
+            assert_eq!(stack_desc.memory_type, GcdMemoryType::SystemMemory);
         });
     }
 
@@ -5773,7 +5642,7 @@ mod tests {
             // SAFETY: The address/length come from the test allocation and are valid to register with the GCD.
             unsafe {
                 GCD.init_memory_blocks(
-                    dxe_services::GcdMemoryType::SystemMemory,
+                    GcdMemoryType::SystemMemory,
                     address,
                     MEMORY_BLOCK_SLICE_SIZE,
                     efi::MEMORY_WB,
@@ -5826,7 +5695,7 @@ mod tests {
             // SAFETY: The buffer range is owned by this test and can be registered as system memory.
             unsafe {
                 GCD.init_memory_blocks(
-                    dxe_services::GcdMemoryType::SystemMemory,
+                    GcdMemoryType::SystemMemory,
                     address,
                     MEMORY_BLOCK_SLICE_SIZE,
                     efi::MEMORY_WB,
@@ -6089,7 +5958,7 @@ mod tests {
             // SAFETY: We just allocated this memory to use in the test
             unsafe {
                 GCD.init_memory_blocks(
-                    dxe_services::GcdMemoryType::SystemMemory,
+                    GcdMemoryType::SystemMemory,
                     address,
                     MEMORY_BLOCK_SLICE_SIZE,
                     efi::MEMORY_WB,
@@ -6136,7 +6005,7 @@ mod tests {
             // SAFETY: We just allocated this memory to use in the test
             unsafe {
                 GCD.init_memory_blocks(
-                    dxe_services::GcdMemoryType::SystemMemory,
+                    GcdMemoryType::SystemMemory,
                     address,
                     MEMORY_BLOCK_SLICE_SIZE,
                     efi::MEMORY_WB,
@@ -6178,7 +6047,7 @@ mod tests {
             // SAFETY: We just allocated this memory to use in the test
             unsafe {
                 GCD.init_memory_blocks(
-                    dxe_services::GcdMemoryType::SystemMemory,
+                    GcdMemoryType::SystemMemory,
                     address,
                     MEMORY_BLOCK_SLICE_SIZE,
                     efi::MEMORY_WB,
@@ -6530,7 +6399,7 @@ mod tests {
     fn test_adjust_efi_memory_map_descriptor_active_attributes_true() {
         with_locked_state(|| {
             let descriptor = dxe_services::MemorySpaceDescriptor {
-                memory_type: dxe_services::GcdMemoryType::SystemMemory,
+                memory_type: GcdMemoryType::SystemMemory,
                 base_address: 0x1000,
                 length: UEFI_PAGE_SIZE as u64,
                 capabilities: efi::MEMORY_WB | efi::MEMORY_WT,
@@ -6551,7 +6420,7 @@ mod tests {
     fn test_adjust_efi_memory_map_descriptor_active_attributes_false() {
         with_locked_state(|| {
             let descriptor = dxe_services::MemorySpaceDescriptor {
-                memory_type: dxe_services::GcdMemoryType::SystemMemory,
+                memory_type: GcdMemoryType::SystemMemory,
                 base_address: 0x1000,
                 length: UEFI_PAGE_SIZE as u64,
                 capabilities: efi::MEMORY_WB | efi::MEMORY_WT | efi::MEMORY_UC,
@@ -6578,7 +6447,7 @@ mod tests {
     fn test_adjust_efi_memory_map_descriptor_runtime_memory_type() {
         with_locked_state(|| {
             let descriptor = dxe_services::MemorySpaceDescriptor {
-                memory_type: dxe_services::GcdMemoryType::SystemMemory,
+                memory_type: GcdMemoryType::SystemMemory,
                 base_address: 0x1000,
                 length: UEFI_PAGE_SIZE as u64,
                 capabilities: efi::MEMORY_WB | efi::MEMORY_RUNTIME,
@@ -6604,7 +6473,7 @@ mod tests {
     fn test_adjust_efi_memory_map_descriptor_mmio_type() {
         with_locked_state(|| {
             let descriptor = dxe_services::MemorySpaceDescriptor {
-                memory_type: dxe_services::GcdMemoryType::MemoryMappedIo,
+                memory_type: GcdMemoryType::MemoryMappedIo,
                 base_address: 0xF0000000,
                 length: UEFI_PAGE_SIZE as u64,
                 capabilities: efi::MEMORY_UC | efi::MEMORY_RUNTIME,
@@ -6643,7 +6512,7 @@ mod tests {
 
             for (attributes, capabilities) in test_cases {
                 let descriptor = dxe_services::MemorySpaceDescriptor {
-                    memory_type: dxe_services::GcdMemoryType::SystemMemory,
+                    memory_type: GcdMemoryType::SystemMemory,
                     base_address: 0x1000,
                     length: UEFI_PAGE_SIZE as u64,
                     capabilities,
@@ -6660,7 +6529,7 @@ mod tests {
                 let expected = MemoryProtectionPolicy::apply_efi_memory_map_policy(
                     attributes,
                     capabilities,
-                    dxe_services::GcdMemoryType::SystemMemory,
+                    GcdMemoryType::SystemMemory,
                     efi::CONVENTIONAL_MEMORY,
                 );
                 assert_eq!(result_capabilities, expected, "Failed for capabilities={:#x}", capabilities);
@@ -6876,7 +6745,7 @@ mod tests {
             // SAFETY: This is a synthetic MMIO range used for test coverage only.
             unsafe {
                 gcd.add_memory_space(
-                    dxe_services::GcdMemoryType::MemoryMappedIo,
+                    GcdMemoryType::MemoryMappedIo,
                     0x80000000,
                     UEFI_PAGE_SIZE * 10,
                     efi::MEMORY_UC | efi::MEMORY_RUNTIME,
@@ -6902,7 +6771,7 @@ mod tests {
             // SAFETY: This is a synthetic MMIO range for test bookkeeping only.
             unsafe {
                 gcd.add_memory_space(
-                    dxe_services::GcdMemoryType::MemoryMappedIo,
+                    GcdMemoryType::MemoryMappedIo,
                     0x80000000,
                     UEFI_PAGE_SIZE * 10,
                     efi::MEMORY_UC | efi::MEMORY_RUNTIME,
@@ -6914,29 +6783,15 @@ mod tests {
 
             // Add Persistent memory
             // SAFETY: This is a synthetic persistent memory range used only for test coverage.
-            unsafe {
-                gcd.add_memory_space(
-                    dxe_services::GcdMemoryType::Persistent,
-                    0x90000000,
-                    UEFI_PAGE_SIZE * 10,
-                    efi::MEMORY_WB,
-                )
-            }
-            .expect("Failed to add Persistent memory");
+            unsafe { gcd.add_memory_space(GcdMemoryType::Persistent, 0x90000000, UEFI_PAGE_SIZE * 10, efi::MEMORY_WB) }
+                .expect("Failed to add Persistent memory");
             gcd.set_memory_space_attributes(0x90000000, UEFI_PAGE_SIZE * 10, efi::MEMORY_WB)
                 .expect("Failed to set Persistent memory attributes");
 
             // Add Reserved memory
             // SAFETY: This is a synthetic reserved range used only for test coverage.
-            unsafe {
-                gcd.add_memory_space(
-                    dxe_services::GcdMemoryType::Reserved,
-                    0xA0000000,
-                    UEFI_PAGE_SIZE * 10,
-                    efi::MEMORY_WB,
-                )
-            }
-            .expect("Failed to add Reserved memory");
+            unsafe { gcd.add_memory_space(GcdMemoryType::Reserved, 0xA0000000, UEFI_PAGE_SIZE * 10, efi::MEMORY_WB) }
+                .expect("Failed to add Reserved memory");
             gcd.set_memory_space_attributes(0xA0000000, UEFI_PAGE_SIZE * 10, efi::MEMORY_WB)
                 .expect("Failed to set Reserved memory attributes");
 
@@ -6954,12 +6809,7 @@ mod tests {
             // Add non-runtime MMIO - should not be counted
             // SAFETY: This is a synthetic MMIO range used only for test bookkeeping.
             unsafe {
-                gcd.add_memory_space(
-                    dxe_services::GcdMemoryType::MemoryMappedIo,
-                    0x80000000,
-                    UEFI_PAGE_SIZE * 10,
-                    efi::MEMORY_UC,
-                )
+                gcd.add_memory_space(GcdMemoryType::MemoryMappedIo, 0x80000000, UEFI_PAGE_SIZE * 10, efi::MEMORY_UC)
             }
             .expect("Failed to add non-runtime MMIO");
 
@@ -6978,7 +6828,7 @@ mod tests {
             // SAFETY: This is a synthetic persistent memory range used only for test coverage.
             unsafe {
                 gcd.add_memory_space(
-                    dxe_services::GcdMemoryType::Persistent,
+                    GcdMemoryType::Persistent,
                     // SAFETY: get_memory returns a test-owned buffer of the requested size.
                     0x100000000,
                     UEFI_PAGE_SIZE * 100,
@@ -7003,12 +6853,7 @@ mod tests {
             // Add Unaccepted memory - should be counted
             // SAFETY: This is a synthetic unaccepted memory range used only for test coverage.
             unsafe {
-                gcd.add_memory_space(
-                    dxe_services::GcdMemoryType::Unaccepted,
-                    0x200000000,
-                    UEFI_PAGE_SIZE * 50,
-                    efi::MEMORY_WB,
-                )
+                gcd.add_memory_space(GcdMemoryType::Unaccepted, 0x200000000, UEFI_PAGE_SIZE * 50, efi::MEMORY_WB)
             }
             .expect("Failed to add Unaccepted memory");
 
@@ -7025,7 +6870,7 @@ mod tests {
 
             // Add Reserved memory - should be counted
             // SAFETY: This is a synthetic reserved range used only for test coverage.
-            unsafe { gcd.add_memory_space(dxe_services::GcdMemoryType::Reserved, 0x90000000, UEFI_PAGE_SIZE * 20, 0) }
+            unsafe { gcd.add_memory_space(GcdMemoryType::Reserved, 0x90000000, UEFI_PAGE_SIZE * 20, 0) }
                 .expect("Failed to add Reserved memory");
 
             let count = gcd.memory_descriptor_count_for_efi_memory_map();
@@ -7046,7 +6891,7 @@ mod tests {
             // SAFETY: address/size come from the test buffer and are valid to initialize memory blocks.
             unsafe {
                 GCD.init_memory_blocks(
-                    dxe_services::GcdMemoryType::SystemMemory,
+                    GcdMemoryType::SystemMemory,
                     address,
                     MEMORY_BLOCK_SLICE_SIZE,
                     efi::MEMORY_WB,
@@ -7060,67 +6905,58 @@ mod tests {
             // SAFETY: Test-controlled addresses and sizes are used with the GCD initialized by create_gcd or get_memory.
             unsafe {
                 // SAFETY: address/size come from the test buffer and are valid to initialize memory blocks.
-                GCD.add_memory_space(dxe_services::GcdMemoryType::SystemMemory, 0x1000, 0x2000, efi::MEMORY_WB)
-                    .unwrap();
-                GCD.add_memory_space(dxe_services::GcdMemoryType::MemoryMappedIo, 0x5000, 0x1000, efi::MEMORY_UC)
-                    .unwrap();
-                GCD.add_memory_space(dxe_services::GcdMemoryType::Reserved, 0x8000, 0x1000, 0).unwrap();
+                GCD.add_memory_space(GcdMemoryType::SystemMemory, 0x1000, 0x2000, efi::MEMORY_WB).unwrap();
+                GCD.add_memory_space(GcdMemoryType::MemoryMappedIo, 0x5000, 0x1000, efi::MEMORY_UC).unwrap();
+                GCD.add_memory_space(GcdMemoryType::Reserved, 0x8000, 0x1000, 0).unwrap();
             }
 
             // Test: Address at the start of a SystemMemory block
-            let result = GCD.get_memory_descriptor_for_address(0x1000, |d, _| {
-                d.memory_type != dxe_services::GcdMemoryType::NonExistent
-            });
+            let result =
+                GCD.get_memory_descriptor_for_address(0x1000, |d, _| d.memory_type != GcdMemoryType::NonExistent);
             assert!(result.is_ok());
             let desc = result.unwrap();
             assert_eq!(desc.base_address, 0x1000);
             assert_eq!(desc.length, 0x2000);
-            assert_eq!(desc.memory_type, dxe_services::GcdMemoryType::SystemMemory);
+            assert_eq!(desc.memory_type, GcdMemoryType::SystemMemory);
 
             // Test: Address in the middle of a SystemMemory block
-            let result = GCD.get_memory_descriptor_for_address(0x2000, |d, _| {
-                d.memory_type != dxe_services::GcdMemoryType::NonExistent
-            });
+            let result =
+                GCD.get_memory_descriptor_for_address(0x2000, |d, _| d.memory_type != GcdMemoryType::NonExistent);
             assert!(result.is_ok());
             let desc = result.unwrap();
             assert_eq!(desc.base_address, 0x1000);
-            assert_eq!(desc.memory_type, dxe_services::GcdMemoryType::SystemMemory);
+            assert_eq!(desc.memory_type, GcdMemoryType::SystemMemory);
 
             // Test: Address at the start of MMIO block
-            let result = GCD.get_memory_descriptor_for_address(0x5000, |d, _| {
-                d.memory_type != dxe_services::GcdMemoryType::NonExistent
-            });
+            let result =
+                GCD.get_memory_descriptor_for_address(0x5000, |d, _| d.memory_type != GcdMemoryType::NonExistent);
             assert!(result.is_ok());
             let desc = result.unwrap();
             assert_eq!(desc.base_address, 0x5000);
             assert_eq!(desc.length, 0x1000);
-            assert_eq!(desc.memory_type, dxe_services::GcdMemoryType::MemoryMappedIo);
+            assert_eq!(desc.memory_type, GcdMemoryType::MemoryMappedIo);
 
             // Test: Address at the start of Reserved block
-            let result = GCD.get_memory_descriptor_for_address(0x8000, |d, _| {
-                d.memory_type != dxe_services::GcdMemoryType::NonExistent
-            });
+            let result =
+                GCD.get_memory_descriptor_for_address(0x8000, |d, _| d.memory_type != GcdMemoryType::NonExistent);
             assert!(result.is_ok());
             let desc = result.unwrap();
             assert_eq!(desc.base_address, 0x8000);
-            assert_eq!(desc.memory_type, dxe_services::GcdMemoryType::Reserved);
+            assert_eq!(desc.memory_type, GcdMemoryType::Reserved);
 
             // Test: Address in a NonExistent region (between added blocks)
-            let result = GCD.get_memory_descriptor_for_address(0x4000, |d, _| {
-                d.memory_type != dxe_services::GcdMemoryType::NonExistent
-            });
+            let result =
+                GCD.get_memory_descriptor_for_address(0x4000, |d, _| d.memory_type != GcdMemoryType::NonExistent);
             assert_eq!(result, Err(EfiError::NotFound));
 
             // Test: Address before any added memory space (in NonExistent region)
-            let result = GCD.get_memory_descriptor_for_address(0x500, |d, _| {
-                d.memory_type != dxe_services::GcdMemoryType::NonExistent
-            });
+            let result =
+                GCD.get_memory_descriptor_for_address(0x500, |d, _| d.memory_type != GcdMemoryType::NonExistent);
             assert_eq!(result, Err(EfiError::NotFound));
 
             // Test: Address way outside any added memory space
-            let result = GCD.get_memory_descriptor_for_address(0xFFFF0000, |d, _| {
-                d.memory_type != dxe_services::GcdMemoryType::NonExistent
-            });
+            let result =
+                GCD.get_memory_descriptor_for_address(0xFFFF0000, |d, _| d.memory_type != GcdMemoryType::NonExistent);
             assert_eq!(result, Err(EfiError::NotFound));
         });
     }
@@ -7131,17 +6967,17 @@ mod tests {
             let (mut gcd, _address) = create_gcd();
             // SAFETY: Test-controlled addresses and sizes are used with the GCD initialized by create_gcd.
             unsafe {
-                gcd.add_memory_space(dxe_services::GcdMemoryType::SystemMemory, 0x1000, 0x2000, 0).unwrap();
+                gcd.add_memory_space(GcdMemoryType::SystemMemory, 0x1000, 0x2000, 0).unwrap();
             }
 
             // An existent address returns its descriptor.
             let desc = gcd.get_memory_descriptor_for_address(0x1000, |_, _| true).unwrap();
             assert_eq!(desc.base_address, 0x1000);
-            assert_eq!(desc.memory_type, dxe_services::GcdMemoryType::SystemMemory);
+            assert_eq!(desc.memory_type, GcdMemoryType::SystemMemory);
 
             // The `All` filter also returns NonExistent regions rather than failing.
             let desc = gcd.get_memory_descriptor_for_address(0x500, |_, _| true).unwrap();
-            assert_eq!(desc.memory_type, dxe_services::GcdMemoryType::NonExistent);
+            assert_eq!(desc.memory_type, GcdMemoryType::NonExistent);
         });
     }
 
@@ -7151,11 +6987,11 @@ mod tests {
             let (mut gcd, _address) = create_gcd();
             // SAFETY: Test-controlled addresses and sizes are used with the GCD initialized by create_gcd.
             unsafe {
-                gcd.add_memory_space(dxe_services::GcdMemoryType::SystemMemory, 0x1000, 0x2000, 0).unwrap();
+                gcd.add_memory_space(GcdMemoryType::SystemMemory, 0x1000, 0x2000, 0).unwrap();
             }
             gcd.allocate_memory_space(
                 AllocateType::Address(0x1000),
-                dxe_services::GcdMemoryType::SystemMemory,
+                GcdMemoryType::SystemMemory,
                 UEFI_PAGE_SHIFT,
                 0x1000,
                 1 as _,
@@ -7181,12 +7017,12 @@ mod tests {
             let (mut gcd, _address) = create_gcd();
             // SAFETY: Test-controlled addresses and sizes are used with the GCD initialized by create_gcd.
             unsafe {
-                gcd.add_memory_space(dxe_services::GcdMemoryType::SystemMemory, 0x1000, 0x2000, 0).unwrap();
-                gcd.add_memory_space(dxe_services::GcdMemoryType::MemoryMappedIo, 0x5000, 0x1000, 0).unwrap();
+                gcd.add_memory_space(GcdMemoryType::SystemMemory, 0x1000, 0x2000, 0).unwrap();
+                gcd.add_memory_space(GcdMemoryType::MemoryMappedIo, 0x5000, 0x1000, 0).unwrap();
             }
             gcd.allocate_memory_space(
                 AllocateType::Address(0x1000),
-                dxe_services::GcdMemoryType::SystemMemory,
+                GcdMemoryType::SystemMemory,
                 UEFI_PAGE_SHIFT,
                 0x1000,
                 1 as _,
@@ -7197,22 +7033,22 @@ mod tests {
             // Free system memory is returned.
             let desc = gcd
                 .get_memory_descriptor_for_address(0x2000, |d, allocated| {
-                    !allocated && d.memory_type == dxe_services::GcdMemoryType::SystemMemory
+                    !allocated && d.memory_type == GcdMemoryType::SystemMemory
                 })
                 .unwrap();
             assert_eq!(desc.base_address, 0x2000);
-            assert_eq!(desc.memory_type, dxe_services::GcdMemoryType::SystemMemory);
+            assert_eq!(desc.memory_type, GcdMemoryType::SystemMemory);
             assert_eq!(desc.image_handle, INVALID_HANDLE);
 
             // Allocated system memory is not free.
             let result = gcd.get_memory_descriptor_for_address(0x1000, |d, allocated| {
-                !allocated && d.memory_type == dxe_services::GcdMemoryType::SystemMemory
+                !allocated && d.memory_type == GcdMemoryType::SystemMemory
             });
             assert_eq!(result, Err(EfiError::NotFound));
 
             // Unallocated MMIO is not system memory, so it is not matched by the `Free` filter.
             let result = gcd.get_memory_descriptor_for_address(0x5000, |d, allocated| {
-                !allocated && d.memory_type == dxe_services::GcdMemoryType::SystemMemory
+                !allocated && d.memory_type == GcdMemoryType::SystemMemory
             });
             assert_eq!(result, Err(EfiError::NotFound));
         });
@@ -7224,47 +7060,35 @@ mod tests {
             let (mut gcd, _address) = create_gcd();
             // SAFETY: Test-controlled addresses and sizes are used with the GCD initialized by create_gcd.
             unsafe {
-                gcd.add_memory_space(dxe_services::GcdMemoryType::SystemMemory, 0x1000, 0x2000, 0).unwrap();
-                gcd.add_memory_space(dxe_services::GcdMemoryType::MemoryMappedIo, 0x5000, 0x2000, 0).unwrap();
-                gcd.add_memory_space(dxe_services::GcdMemoryType::Reserved, 0x8000, 0x1000, 0).unwrap();
+                gcd.add_memory_space(GcdMemoryType::SystemMemory, 0x1000, 0x2000, 0).unwrap();
+                gcd.add_memory_space(GcdMemoryType::MemoryMappedIo, 0x5000, 0x2000, 0).unwrap();
+                gcd.add_memory_space(GcdMemoryType::Reserved, 0x8000, 0x1000, 0).unwrap();
             }
 
             // Unallocated MMIO and Reserved are returned.
             let desc = gcd
                 .get_memory_descriptor_for_address(0x5000, |d, allocated| {
-                    !allocated
-                        && matches!(
-                            d.memory_type,
-                            dxe_services::GcdMemoryType::MemoryMappedIo | dxe_services::GcdMemoryType::Reserved
-                        )
+                    !allocated && matches!(d.memory_type, GcdMemoryType::MemoryMappedIo | GcdMemoryType::Reserved)
                 })
                 .unwrap();
-            assert_eq!(desc.memory_type, dxe_services::GcdMemoryType::MemoryMappedIo);
+            assert_eq!(desc.memory_type, GcdMemoryType::MemoryMappedIo);
             let desc = gcd
                 .get_memory_descriptor_for_address(0x8000, |d, allocated| {
-                    !allocated
-                        && matches!(
-                            d.memory_type,
-                            dxe_services::GcdMemoryType::MemoryMappedIo | dxe_services::GcdMemoryType::Reserved
-                        )
+                    !allocated && matches!(d.memory_type, GcdMemoryType::MemoryMappedIo | GcdMemoryType::Reserved)
                 })
                 .unwrap();
-            assert_eq!(desc.memory_type, dxe_services::GcdMemoryType::Reserved);
+            assert_eq!(desc.memory_type, GcdMemoryType::Reserved);
 
             // System memory is not matched.
             let result = gcd.get_memory_descriptor_for_address(0x1000, |d, allocated| {
-                !allocated
-                    && matches!(
-                        d.memory_type,
-                        dxe_services::GcdMemoryType::MemoryMappedIo | dxe_services::GcdMemoryType::Reserved
-                    )
+                !allocated && matches!(d.memory_type, GcdMemoryType::MemoryMappedIo | GcdMemoryType::Reserved)
             });
             assert_eq!(result, Err(EfiError::NotFound));
 
             // Allocated MMIO is not matched (this filter only returns unallocated MMIO/Reserved for a single address).
             gcd.allocate_memory_space(
                 AllocateType::Address(0x5000),
-                dxe_services::GcdMemoryType::MemoryMappedIo,
+                GcdMemoryType::MemoryMappedIo,
                 UEFI_PAGE_SHIFT,
                 0x1000,
                 1 as _,
@@ -7272,11 +7096,7 @@ mod tests {
             )
             .unwrap();
             let result = gcd.get_memory_descriptor_for_address(0x5000, |d, allocated| {
-                !allocated
-                    && matches!(
-                        d.memory_type,
-                        dxe_services::GcdMemoryType::MemoryMappedIo | dxe_services::GcdMemoryType::Reserved
-                    )
+                !allocated && matches!(d.memory_type, GcdMemoryType::MemoryMappedIo | GcdMemoryType::Reserved)
             });
             assert_eq!(result, Err(EfiError::NotFound));
         });
@@ -7288,23 +7108,23 @@ mod tests {
             let (mut gcd, _address) = create_gcd();
             // SAFETY: Test-controlled addresses and sizes are used with the GCD initialized by create_gcd.
             unsafe {
-                gcd.add_memory_space(dxe_services::GcdMemoryType::SystemMemory, 0x1000, 0x2000, 0).unwrap();
-                gcd.add_memory_space(dxe_services::GcdMemoryType::MemoryMappedIo, 0x5000, 0x1000, 0).unwrap();
+                gcd.add_memory_space(GcdMemoryType::SystemMemory, 0x1000, 0x2000, 0).unwrap();
+                gcd.add_memory_space(GcdMemoryType::MemoryMappedIo, 0x5000, 0x1000, 0).unwrap();
             }
 
             // Unlike `Free`, unallocated MMIO is matched by `FreeAnyType`.
             let desc = gcd.get_memory_descriptor_for_address(0x5000, |_, allocated| !allocated).unwrap();
-            assert_eq!(desc.memory_type, dxe_services::GcdMemoryType::MemoryMappedIo);
+            assert_eq!(desc.memory_type, GcdMemoryType::MemoryMappedIo);
             assert_eq!(desc.image_handle, INVALID_HANDLE);
 
             // Unallocated system memory is also matched.
             let desc = gcd.get_memory_descriptor_for_address(0x1000, |_, allocated| !allocated).unwrap();
-            assert_eq!(desc.memory_type, dxe_services::GcdMemoryType::SystemMemory);
+            assert_eq!(desc.memory_type, GcdMemoryType::SystemMemory);
 
             // Allocated regions are not matched.
             gcd.allocate_memory_space(
                 AllocateType::Address(0x5000),
-                dxe_services::GcdMemoryType::MemoryMappedIo,
+                GcdMemoryType::MemoryMappedIo,
                 UEFI_PAGE_SHIFT,
                 0x1000,
                 1 as _,
@@ -7331,7 +7151,7 @@ mod tests {
             // SAFETY: address/size come from the test buffer and are valid to initialize memory blocks.
             unsafe {
                 GCD.init_memory_blocks(
-                    dxe_services::GcdMemoryType::SystemMemory,
+                    GcdMemoryType::SystemMemory,
                     address,
                     MEMORY_BLOCK_SLICE_SIZE * 99,
                     efi::MEMORY_WB,
@@ -7394,7 +7214,7 @@ mod tests {
             // SAFETY: address/size come from the test buffer and are valid to initialize memory blocks.
             unsafe {
                 GCD.init_memory_blocks(
-                    dxe_services::GcdMemoryType::SystemMemory,
+                    GcdMemoryType::SystemMemory,
                     address,
                     MEMORY_BLOCK_SLICE_SIZE * 99,
                     efi::MEMORY_WB,
@@ -7476,7 +7296,7 @@ mod tests {
             // SAFETY: address/size come from the test buffer and are valid to initialize memory blocks.
             unsafe {
                 GCD.init_memory_blocks(
-                    dxe_services::GcdMemoryType::SystemMemory,
+                    GcdMemoryType::SystemMemory,
                     address,
                     MEMORY_BLOCK_SLICE_SIZE * 99,
                     efi::MEMORY_WB,


### PR DESCRIPTION
## Description
Currently, the add/allocate/free memory protection policies preserve the cache attributes of the memory. However, the entity consuming this memory may have changed the cache attributes. And added memory may have 0, which is invalid.

In order to maintain a consistent state for system memory, Patina is taking the stance that system memory should be writeback by default. It will be allocated and returned as free as such. This allows a new allocation to have WB and allows free system memory blocks to coalesce correctly.

Other memory types Patina preserves the cache attribute for because Patina doesn't know what the right attribute should be.

This also contains a commit to clean up the includes in the GCD to be less verbose.

Closes #1418 

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Booting Q35/ArmVirt to Windows, booting a physical Intel system to Windows.

## Integration Instructions

N/A.
