### PR TITLE
Add Patina SDK UEFI String Types [Rebase & FF]

### DIFF
--- a/components/patina_performance/src/component/protocol.rs
+++ b/components/patina_performance/src/component/protocol.rs
@@ -10,12 +10,13 @@
 //!
 
 use core::{
-    ffi::{CStr, c_char, c_void},
+    ffi::{c_char, c_void},
     sync::atomic::{AtomicBool, Ordering},
 };
 
 use alloc::string::ToString;
 use patina::{
+    Char8Str,
     performance::{
         error::Error,
         measurement::{CallerIdentifier, create_performance_measurement},
@@ -42,8 +43,8 @@ pub(crate) unsafe extern "efiapi" fn create_performance_measurement_efiapi(
     identifier: u32,
     attribute: PerfAttribute,
 ) -> efi::Status {
-    // SAFETY: The caller ensures that string is a valid C string pointer (or NULL).
-    let string = unsafe { string.as_ref().map(|s| CStr::from_ptr(s).to_string_lossy().to_string()) };
+    // SAFETY: The caller ensures that `string` is a valid, NUL-terminated CHAR8 pointer (or NULL).
+    let string = unsafe { string.as_ref().map(|s| Char8Str::from_ptr((s as *const c_char).cast()).to_string()) };
 
     // To conform with UEFI spec, `identifier` must be a u32 when passed in.
     // However, FPDT performance measurement IDs are always u16.

--- a/components/patina_smbios/src/manager/protocol.rs
+++ b/components/patina_smbios/src/manager/protocol.rs
@@ -13,9 +13,12 @@
 //! SPDX-License-Identifier: Apache-2.0
 //!
 
+extern crate alloc;
+
 use core::ffi::c_char;
 
-use patina::{tpl_mutex::TplMutex, uefi_protocol::ProtocolInterface};
+use alloc::string::ToString;
+use patina::{Char8Str, tpl_mutex::TplMutex, uefi_protocol::ProtocolInterface};
 use r_efi::efi;
 
 use crate::service::{SMBIOS_HANDLE_PI_RESERVED, SmbiosHandle, SmbiosTableHeader, SmbiosType};
@@ -226,17 +229,13 @@ impl SmbiosProtocol {
             let handle = smbios_handle.read_unaligned();
             let str_num = string_number.read_unaligned();
 
-            // Convert C string to Rust str
-            let c_str = core::ffi::CStr::from_ptr(string);
-            let rust_str = match c_str.to_str() {
-                Ok(s) => s,
-                Err(_) => return efi::Status::INVALID_PARAMETER,
-            };
+            // `string` is a NUL-terminated CHAR8 string, per the SMBIOS Protocol's `UpdateString()` interface.
+            let rust_str = Char8Str::from_ptr(string.cast()).to_string();
 
             (handle, str_num, rust_str)
         };
 
-        match manager.update_string(handle, str_num, rust_str) {
+        match manager.update_string(handle, str_num, &rust_str) {
             Ok(()) => {
                 if manager.republish_table().is_err() {
                     log::error!("[SMBIOS UpdateString] Failed to rebuild table");

--- a/cspell.yml
+++ b/cspell.yml
@@ -186,6 +186,7 @@ words:
   - regsvr
   - relia
   - reloc
+  - reowned
   - riscv
   - rlibs
   - rposition

--- a/docs/book.toml
+++ b/docs/book.toml
@@ -8,6 +8,9 @@ title = "Developing UEFI with Rust"
 additional-js = ["cdn-assets.js", "mermaid.min.js", "mermaid-init.js"]
 additional-css = ["./mdbook-admonish.css"]
 
+[rust]
+edition = "2021"
+
 [output.html.playground]
 editable = true
 editor = "ace"

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -20,6 +20,7 @@
 - [Dependency Management](dev/principles/dependency-management.md)
 - [Error Handling](dev/principles/error-handling.md)
 - [FFI Authoring](dev/principles/ffi.md)
+- [UEFI Strings](dev/principles/strings.md)
 - [Unsafe Guidance](dev/principles/unsafe.md)
 
 # Developer Guides

--- a/docs/src/dev/principles/strings.md
+++ b/docs/src/dev/principles/strings.md
@@ -1,0 +1,229 @@
+# UEFI Strings
+
+The UEFI Specification defines two string encodings, and Patina provides a native and idiomatic type for each of them
+in the `patina` SDK.
+
+Use these types instead of passing raw `&[u16]`, `&[u8]`, or bare pointers around, so that encoding and NUL-termination
+rules are enforced by the type system.
+
+These types do not need to be used for every string in the codebase. Use them only for strings that are passed to or
+received from UEFI interfaces, or for fixed-size fields in `#[repr(C)]` structures that mirror UEFI binary layouts. For
+all other strings, use Rust's built-in `str` and `String`.
+
+## Encodings
+
+| UEFI type | Width          | Character set                       | Patina types                                  |
+|-----------|----------------|-------------------------------------|-----------------------------------------------|
+| `CHAR8`   | 1 byte (8-bit) | ASCII / ISO-Latin-1 (ISO-8859-1)    | `Char8Str`, `Char8String`, `Char8Array<N>`    |
+| `CHAR16`  | 2 bytes        | UCS-2 (Unicode 2.1 / ISO/IEC 10646) | `Char16Str`, `Char16String`, `Char16Array<N>` |
+
+`CHAR8` covers the ASCII characters and the ISO-Latin-1 character set, where every byte in `0x01..=0xFF` maps directly
+to a Unicode scalar in `U+0001..=U+00FF`. `CHAR16` is used for all other characters and strings. UCS-2 is a fixed-width
+encoding covering the Basic Multilingual Plane. Code points above `U+FFFF` (which would require a UTF-16 surrogate
+pair) and lone surrogate code units are not valid UCS-2 and are rejected during conversion.
+
+## Type families
+
+Each encoding provides three types that mirror the roles of `str`, `String`, and a fixed-size array:
+
+| Role                                       | CHAR8           | CHAR16           |
+|--------------------------------------------|-----------------|------------------|
+| Borrowed, unsized view                     | `Char8Str`      | `Char16Str`      |
+| Owned, heap-backed (requires `alloc`)      | `Char8String`   | `Char16String`   |
+| Owned, fixed capacity (usable in `const`)  | `Char8Array<N>` | `Char16Array<N>` |
+
+The borrowed types are the CHAR8/CHAR16 analogues of [`core::ffi::CStr`], and the owned types are the analogues of
+[`alloc::ffi::CString`]. All of them guarantee a single trailing NUL with no interior NUL, so a pointer obtained from
+one is always valid to hand to an `extern "efiapi"` interface that expects a NUL-terminated string.
+
+## Choosing a type
+
+- Use `Char16Str` / `Char8Str` to borrow an existing NUL-terminated buffer, such as a value received across an FFI
+  boundary, or to accept a string as a function parameter.
+- Use `Char16String` / `Char8String` to build or own a string, typically by converting from a Rust `str`. These require
+  the `alloc` feature.
+- Use `Char16Array<N>` / `Char8Array<N>` for compile-time string constants and for `#[repr(C)]` structure fields that
+  hold a fixed-size character array, which is a common UEFI layout.
+
+Prefer `CHAR16` for anything that is passed to the UEFI interfaces that expect wide strings (variable names, load
+options, file paths, text output). Reserve `CHAR8` for the interfaces and data structures that are specified in terms
+of ASCII/Latin-1 bytes, such as SMBIOS strings and ACPI signatures.
+
+```admonish note
+The trailing NUL is part of the value's invariant, not something callers manage. `as_ptr()` always returns a pointer to
+a NUL-terminated sequence, and the length accessors (`len`) never count the terminator.
+```
+
+## Borrowing a string from FFI
+
+When a UEFI interface hands back a `*const CHAR16`, wrap it in a `Char16Str` to read it safely. The constructor scans
+for the terminator and validates the encoding.
+
+```rust
+# extern crate patina;
+use patina::Char16Str;
+
+// A NUL-terminated CHAR16 buffer, as might be received across an FFI boundary.
+let raw: [u16; 4] = [0x0045, 0x0046, 0x0049, 0x0000]; // "EFI\0"
+
+// SAFETY: `raw` is NUL-terminated and remains valid for the duration of the borrow.
+let name = unsafe { Char16Str::from_ptr(raw.as_ptr()) }.expect("valid UCS-2");
+
+assert_eq!(name.len(), 3);
+assert!(name == "EFI");
+assert_eq!(name.chars().collect::<String>(), "EFI");
+```
+
+Use `from_ptr_bounded` when a maximum length is known, so the scan cannot read past the end of a
+buffer that is missing its terminator.
+
+## Building an owned string for an FFI call
+
+To pass a Rust string to a UEFI interface, encode it into an owned string and use its pointer. The
+conversion is fallible and returns a [`Result`], so invalid input never panics.
+
+```rust
+# extern crate patina;
+use patina::Char16String;
+
+// Encode a Rust string as UCS-2 for a call that expects `*const CHAR16`.
+let variable_name = Char16String::try_from_str("BootOrder").expect("valid UCS-2");
+
+// `as_ptr()` is always NUL-terminated and ready for `extern "efiapi"`.
+let name_ptr = variable_name.as_ptr();
+# let _ = name_ptr;
+
+assert_eq!(variable_name.len(), 9);
+```
+
+## Compile-time string literals
+
+The `char16!` and `char8!` macros build a `&'static` string from a string literal and validate the encoding at compile
+time. An invalid literal is a compilation error (not a runtime panic).
+
+```rust
+# extern crate patina;
+use patina::{char8, char16};
+
+let ascii = char8!("EFI"); // &'static Char8Str  (CHAR8 / Latin-1)
+let wide = char16!("EFI"); // &'static Char16Str (CHAR16 / UCS-2)
+
+assert_eq!(ascii.len(), 3);
+assert_eq!(wide.len(), 3);
+assert!(wide == "EFI");
+```
+
+## Fixed-size fields in binary structures
+
+`Char16Array<N>` and `Char8Array<N>` are `#[repr(transparent)]` over `[u16; N]` and `[u8; N]`, so they can be embedded
+directly in `#[repr(C)]` structures that mirror UEFI binary layouts. `N` includes the trailing NUL, and unused trailing
+slots are NUL-padded. `from_str` is a `const fn`, so these fields can be initialized in `const` contexts with
+compile-time validation.
+
+```rust
+# extern crate patina;
+use patina::Char16Array;
+
+#[repr(C)]
+struct DriverRecord {
+    version: u32,
+    // A fixed CHAR16[16] field, matching a UEFI binary layout.
+    name: Char16Array<16>,
+}
+
+const RECORD: DriverRecord = DriverRecord { version: 1, name: Char16Array::from_str("Disk") };
+
+assert_eq!(RECORD.name.as_char16_str().len(), 4);
+assert!(RECORD.name.as_char16_str() == "Disk");
+```
+
+## Zero-copy parsing and serialization
+
+`Char16Array<N>` and `Char8Array<N>` implement `zerocopy::FromBytes` and `zerocopy::IntoBytes`. A structure that embeds
+them as fields can derive those traits too, to parse the structure directly from a raw byte buffer or view it as bytes
+without a manual copy.
+
+```rust
+# extern crate patina;
+# extern crate zerocopy;
+use patina::Char8Array;
+use zerocopy::{FromBytes, Immutable, IntoBytes, KnownLayout};
+
+#[derive(Clone, Copy, FromBytes, IntoBytes, Immutable, KnownLayout)]
+#[repr(C, packed)]
+struct EntryPoint {
+    anchor_string: Char8Array<6>,
+    revision: u8,
+}
+
+let entry = EntryPoint { anchor_string: Char8Array::from_str("_SM3_"), revision: 3 };
+let bytes = entry.as_bytes();
+
+let parsed = EntryPoint::read_from_bytes(bytes).expect("buffer is large enough");
+assert!(parsed.anchor_string.as_char8_str() == "_SM3_");
+```
+
+`FromBytes` allows a value to be constructed from any bit pattern, including one with no NUL byte anywhere in the
+array. That can't happen through `from_str`, `try_from_str`, or `Default`, but it can happen when parsing untrusted or
+malformed data this way. In that case `as_char16_str` / `as_char8_str` (and the `Deref` impl) return an empty string
+rather than panicking or reading out of bounds.
+
+## Latin-1 (CHAR8) strings
+
+`Char8Str` and its owned forms cover the ASCII and ISO-Latin-1 character set. Every byte in `0x01..=0xFF` is a valid
+character, so bytes read from an interface are always valid Latin-1.
+
+```rust
+# extern crate patina;
+use patina::{Char8Str, Char8String};
+
+// Borrow a NUL-terminated Latin-1 buffer.
+let borrowed = Char8Str::from_bytes_with_nul(b"ACPI\0").expect("valid Latin-1");
+assert_eq!(borrowed.len(), 4);
+
+// Build an owned Latin-1 string from a Rust `str`.
+let owned = Char8String::try_from_str("Firmware").expect("valid Latin-1");
+assert_eq!(owned.len(), 8);
+assert!(owned == "Firmware");
+```
+
+## Validation and error handling
+
+All conversions from a Rust `str` return a `Result` with a `StringError` describing why the input was rejected, rather
+than panicking. This is the "safe runtime path" and should be preferred over the `const` `from_str` constructors
+anywhere the input is not a fixed literal.
+
+```rust
+# extern crate patina;
+use patina::{Char16String, Char8String, StringError};
+
+// UCS-2 cannot represent code points above U+FFFF; the conversion fails instead of panicking.
+let non_bmp = Char16String::try_from_str("emoji \u{1F600}");
+assert!(matches!(non_bmp, Err(StringError::NotUcs2 { .. })));
+
+// Latin-1 cannot represent code points above U+00FF.
+let non_latin1 = Char8String::try_from_str("\u{0100}");
+assert!(matches!(non_latin1, Err(StringError::NotLatin1 { .. })));
+
+// Interior NUL characters are rejected by every conversion.
+let interior_nul = Char16String::try_from_str("a\0b");
+assert!(matches!(interior_nul, Err(StringError::InteriorNul { position: 1 })));
+```
+
+## Avoiding panics
+
+Panics can halt firmware boot, so the string API avoids them during runtime:
+
+- The `try_from_str` constructors return `Result` and never panic. Use them whenever the input is not a fixed literal.
+- The `const fn` `from_str` constructors and the `char16!` / `char8!` macros do panic on invalid input, but only in
+  `const`/`static` contexts, where the panic manifests as a compile-time error. Do not call `from_str` at runtime with
+  untrusted input.
+- Reading a string built through an unchecked constructor never panics. An invalid CHAR16 code unit is mapped to the
+  Unicode replacement character (`U+FFFD`) rather than aborting.
+- `Char16Array` / `Char8Array` values built by casting from arbitrary bytes (through their `zerocopy::FromBytes`
+  implementation) are not guaranteed to contain a NUL terminator. Reading such a value returns an empty string rather
+  than panicking.
+
+[`core::ffi::CStr`]: https://doc.rust-lang.org/core/ffi/struct.CStr.html
+[`alloc::ffi::CString`]: https://doc.rust-lang.org/alloc/ffi/struct.CString.html
+[`Result`]: https://doc.rust-lang.org/core/result/enum.Result.html

--- a/patina_dxe_core/src/pi_dispatcher.rs
+++ b/patina_dxe_core/src/pi_dispatcher.rs
@@ -17,12 +17,12 @@ mod section_decompress;
 use alloc::{
     boxed::Box,
     collections::{BTreeMap, BTreeSet},
-    string::{String, ToString},
+    string::String,
     vec::Vec,
 };
 use core::{cmp::Ordering, ffi::c_void};
 use patina::{
-    BinaryGuid, OwnedGuid,
+    BinaryGuid, Char16Str, OwnedGuid,
     device_path::walker::concat_device_path_to_boxed_slice,
     error::EfiError,
     pi::{
@@ -731,14 +731,14 @@ impl DispatcherContext {
                             .iter()
                             .find(|x| x.section_type() == Some(ffs::section::Type::UserInterface))
                             .and_then(|x| x.try_content_as_slice().ok())
-                            .map(|data| {
-                                let chars: Vec<u16> = data
+                            .and_then(|data| {
+                                let units: Vec<u16> = data
                                     .chunks_exact(2)
                                     .map(|c| {
                                         u16::from_le_bytes(c.try_into().expect("chunks_exact(2) guarantees length"))
                                     })
                                     .collect();
-                                String::from_utf16_lossy(&chars).trim_end_matches('\0').to_string()
+                                Char16Str::from_units_until_nul(&units).ok().map(|s| s.chars().collect())
                             });
 
                         if let Some(pe32_section) =

--- a/patina_dxe_core/src/pi_dispatcher/image.rs
+++ b/patina_dxe_core/src/pi_dispatcher/image.rs
@@ -16,6 +16,7 @@ use core::{
     slice::from_raw_parts,
 };
 use patina::{
+    Char16Str,
     base::{DEFAULT_CACHE_ATTR, UEFI_PAGE_SIZE, align_up},
     component::service::memory::{AllocationOptions, MemoryManager, PageFree},
     device_path::walker::{DevicePathWalker, copy_device_path_to_boxed_slice, device_path_node_count},
@@ -1415,7 +1416,8 @@ fn get_file_buffer_from_sfs(file_path: NonNull<Protocol>) -> Result<(Vec<u8>, ef
             efi::protocols::device_path::TYPE_END => break,
             _ => Err(EfiError::Unsupported)?,
         }
-        //For MEDIA_FILE_PATH_DP, file name is in the node data, but it needs to be converted to Vec<u16> for call to open.
+        // For MEDIA_FILE_PATH_DP, file name is in the node data, but it needs to be converted to u16 code units for
+        // the call to open, since the raw device path bytes are not guaranteed to be aligned.
         let filename: Vec<u16> = node
             .data()
             .chunks_exact(2)
@@ -1427,8 +1429,9 @@ fn get_file_buffer_from_sfs(file_path: NonNull<Protocol>) -> Result<(Vec<u8>, ef
                 }
             })
             .collect::<Result<Vec<_>, _>>()?;
+        let filename = Char16Str::from_units_until_nul(&filename)?;
 
-        file = file.open(filename, efi::protocols::file::MODE_READ, 0)?;
+        file = file.open(filename.as_units_with_nul().to_vec(), efi::protocols::file::MODE_READ, 0)?;
     }
 
     // if execution comes here, the above loop was successfully able to open all the files on the remaining device path,

--- a/sdk/patina/src/base.rs
+++ b/sdk/patina/src/base.rs
@@ -16,6 +16,7 @@ use crate::error::EfiError;
 pub mod guid;
 #[cfg(any(test, feature = "alloc"))]
 pub mod memory_map;
+pub mod string;
 
 /// EFI memory allocation functions work in units of EFI_PAGEs that are 4KB.
 /// This should in no way be confused with the page size of the processor.

--- a/sdk/patina/src/base/string.rs
+++ b/sdk/patina/src/base/string.rs
@@ -1,0 +1,275 @@
+//! Patina UEFI string types
+//!
+//! Idiomatic, safe wrappers for the two string encodings defined by the UEFI Specification:
+//!
+//! - **CHAR8** ([`Char8Str`] / [`Char8String`] / [`Char8Array`]): A one byte (exactly 8-bit)
+//!   character string using the ASCII / ISO-Latin-1 (ISO-8859-1) character set. Every byte in the
+//!   range `0x01..=0xFF` is a valid character, so any byte value maps directly to a Unicode scalar
+//!   in `U+0001..=U+00FF`.
+//! - **CHAR16** ([`Char16Str`] / [`Char16String`] / [`Char16Array`]): A two byte character string
+//!   using the UCS-2 encoding (as defined by Unicode 2.1 and ISO/IEC 10646). UCS-2 is a fixed width
+//!   encoding. Characters that would require a UTF-16 surrogate pair (code points above `U+FFFF`)
+//!   and lone surrogate code units (`U+D800..=U+DFFF`) are not valid UCS-2 and are rejected.
+//!
+//! ## NUL termination
+//!
+//! All string types in this module follow the same model as [`core::ffi::CStr`] and
+//! [`alloc::ffi::CString`]: the value is guaranteed to be terminated by a single NUL and to contain
+//! no interior NUL. This makes [`Char8Str::as_ptr`] and [`Char16Str::as_ptr`] always safe to hand to
+//! `extern "efiapi"` interfaces that expect a NUL-terminated string.
+//!
+//! ## Type overview
+//!
+//! Each encoding provides three types that mirror the roles of [`str`], [`alloc::string::String`],
+//! and a fixed size array:
+//!
+//! | Role                                       | CHAR8           | CHAR16           |
+//! |--------------------------------------------|-----------------|------------------|
+//! | Borrowed, unsized view (works in `no_std`) | [`Char8Str`]    | [`Char16Str`]    |
+//! | Owned, heap-backed (requires `alloc`)      | [`Char8String`] | [`Char16String`] |
+//! | Owned, fixed capacity (usable in `const`)  | [`Char8Array`]  | [`Char16Array`]  |
+//!
+//! ## When to use which type
+//!
+//! - Use [`Char16Str`] / [`Char8Str`] to borrow an existing NUL-terminated buffer (for example, a
+//!   value received across an FFI boundary) or to accept a string in a function parameter.
+//! - Use [`Char16String`] / [`Char8String`] to build or own a string on the heap, typically by
+//!   converting from a Rust [`str`].
+//! - Use [`Char16Array`] / [`Char8Array`] for compile-time string constants and for `#[repr(C)]`
+//!   structure fields that hold a fixed size character array (a common UEFI layout).
+//!
+//! ## Compile-time literals
+//!
+//! The [`char16!`](crate::char16) and [`char8!`](crate::char8) macros build a `&'static` string from
+//! a string literal, validating the encoding at compile time:
+//!
+//! ```rust
+//! use patina::{char16, char8};
+//!
+//! let ascii = char8!("Firmware");
+//! let wide = char16!("Firmware");
+//!
+//! assert_eq!(ascii.len(), 8);
+//! assert_eq!(wide.len(), 8);
+//! assert!(wide == "Firmware");
+//! ```
+//!
+//! ## License
+//!
+//! Copyright (C) Microsoft Corporation.
+//!
+//! SPDX-License-Identifier: Apache-2.0
+
+use crate::error::EfiError;
+
+pub mod char16;
+pub mod char8;
+
+pub use char8::{Char8Array, Char8Str, Char8String};
+pub use char16::{Char16Array, Char16Str, Char16String};
+
+#[doc(hidden)]
+pub use char8::latin1_capacity;
+#[doc(hidden)]
+pub use char16::ucs2_capacity;
+
+/// Decodes the UTF-8 sequence starting at `bytes[index]`, returning the code point and its length in
+/// bytes.
+///
+/// This assumes the input is valid UTF-8, which is guaranteed for the bytes of a Rust [`str`].
+///
+/// # Note
+///
+/// This function is provided because [`str::chars()`] and [`str::char_indices()`] are not `const fn`s
+/// and return iterators. [`core::iter::Iterator`] is not a `const` trait on stable Rust, so this function
+/// provides UTF-8 decoding in `const` context.
+#[allow(clippy::indexing_slicing)] // Input is valid UTF-8, so continuation bytes are always present.
+const fn decode_utf8(bytes: &[u8], index: usize) -> (u32, usize) {
+    let b0 = bytes[index];
+    if b0 < 0x80 {
+        (b0 as u32, 1)
+    } else if b0 >> 5 == 0b110 {
+        let b1 = bytes[index + 1];
+        (((b0 as u32 & 0x1F) << 6) | (b1 as u32 & 0x3F), 2)
+    } else if b0 >> 4 == 0b1110 {
+        let b1 = bytes[index + 1];
+        let b2 = bytes[index + 2];
+        (((b0 as u32 & 0x0F) << 12) | ((b1 as u32 & 0x3F) << 6) | (b2 as u32 & 0x3F), 3)
+    } else {
+        let b1 = bytes[index + 1];
+        let b2 = bytes[index + 2];
+        let b3 = bytes[index + 3];
+        (((b0 as u32 & 0x07) << 18) | ((b1 as u32 & 0x3F) << 12) | ((b2 as u32 & 0x3F) << 6) | (b3 as u32 & 0x3F), 4)
+    }
+}
+
+/// Returns the number of [`char`]s in `s`.
+const fn char_count(s: &str) -> usize {
+    let bytes = s.as_bytes();
+    let mut index = 0;
+    let mut count = 0;
+    while index < bytes.len() {
+        let (_, len) = decode_utf8(bytes, index);
+        index += len;
+        count += 1;
+    }
+    count
+}
+
+/// Error returned when constructing or validating a UEFI string.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum StringError {
+    /// A NUL character was found before the end of the string, at the given index.
+    InteriorNul {
+        /// Index of the interior NUL, counted in characters (CHAR8) or code units (CHAR16).
+        position: usize,
+    },
+    /// The provided data did not end with a NUL terminator.
+    MissingNulTerminator,
+    /// A byte buffer holding little-endian CHAR16 code units did not contain a whole number of
+    /// `u16` values (its length was not a multiple of two).
+    OddByteLength {
+        /// The length of the offending byte buffer.
+        len: usize,
+    },
+    /// A character could not be represented in UCS-2.
+    ///
+    /// This occurs for code points above `U+FFFF` (which would require a UTF-16 surrogate pair) and
+    /// for lone surrogate code units in the range `U+D800..=U+DFFF`.
+    NotUcs2 {
+        /// Index of the offending character, counted in characters or code units.
+        position: usize,
+        /// The offending Unicode code point or surrogate code unit.
+        value: u32,
+    },
+    /// A character could not be represented in Latin-1 (CHAR8).
+    ///
+    /// This occurs for code points above `U+00FF`.
+    NotLatin1 {
+        /// Index of the offending character, counted in characters.
+        position: usize,
+        /// The offending Unicode code point.
+        value: u32,
+    },
+    /// The string does not fit within the capacity of a fixed size buffer.
+    TooLong {
+        /// The number of characters or code units the buffer can hold, excluding the NUL terminator.
+        capacity: usize,
+        /// The number of characters or code units the string requires, including the NUL terminator.
+        required: usize,
+    },
+}
+
+impl core::fmt::Display for StringError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            StringError::InteriorNul { position } => {
+                write!(f, "interior NUL found at position {position}")
+            }
+            StringError::MissingNulTerminator => write!(f, "string is not NUL-terminated"),
+            StringError::OddByteLength { len } => {
+                write!(f, "byte buffer length {len} is not a multiple of two CHAR16 code units")
+            }
+            StringError::NotUcs2 { position, value } => {
+                write!(f, "code point U+{value:04X} at position {position} is not valid UCS-2")
+            }
+            StringError::NotLatin1 { position, value } => {
+                write!(f, "code point U+{value:04X} at position {position} is not valid Latin-1 (CHAR8)")
+            }
+            StringError::TooLong { capacity, required } => {
+                write!(f, "string requires {required} code units but the buffer capacity is {capacity}")
+            }
+        }
+    }
+}
+
+impl core::error::Error for StringError {}
+
+impl From<StringError> for EfiError {
+    fn from(_: StringError) -> Self {
+        EfiError::InvalidParameter
+    }
+}
+
+/// Builds a `&'static` [`Char16Str`] from a string literal, validated as UCS-2 at compile time.
+///
+/// The literal must not contain interior NUL characters or code points above `U+FFFF`; violating
+/// either condition is a compile-time error.
+///
+/// # Examples
+///
+/// ```rust
+/// use patina::char16;
+///
+/// let name = char16!("EFI");
+/// assert_eq!(name.len(), 3);
+/// assert!(name == "EFI");
+/// ```
+#[macro_export]
+macro_rules! char16 {
+    ($s:literal) => {{
+        static CHAR16_LITERAL: $crate::base::string::Char16Array<{ $crate::base::string::ucs2_capacity($s) }> =
+            $crate::base::string::Char16Array::from_str($s);
+        CHAR16_LITERAL.as_char16_str()
+    }};
+}
+
+/// Builds a `&'static` [`Char8Str`] from a string literal, validated as Latin-1 at compile time.
+///
+/// The literal must not contain interior NUL characters or code points above `U+00FF`; violating
+/// either condition is a compile-time error.
+///
+/// # Examples
+///
+/// ```rust
+/// use patina::char8;
+///
+/// let name = char8!("EFI");
+/// assert_eq!(name.len(), 3);
+/// assert!(name == "EFI");
+/// ```
+#[macro_export]
+macro_rules! char8 {
+    ($s:literal) => {{
+        static CHAR8_LITERAL: $crate::base::string::Char8Array<{ $crate::base::string::latin1_capacity($s) }> =
+            $crate::base::string::Char8Array::from_str($s);
+        CHAR8_LITERAL.as_char8_str()
+    }};
+}
+
+#[cfg(test)]
+#[cfg_attr(coverage, coverage(off))]
+mod tests {
+    use super::*;
+    use alloc::string::ToString;
+
+    #[test]
+    fn test_string_error_display() {
+        assert_eq!(StringError::InteriorNul { position: 3 }.to_string(), "interior NUL found at position 3");
+        assert_eq!(StringError::MissingNulTerminator.to_string(), "string is not NUL-terminated");
+        assert_eq!(
+            StringError::NotUcs2 { position: 1, value: 0x1F600 }.to_string(),
+            "code point U+1F600 at position 1 is not valid UCS-2"
+        );
+        assert_eq!(
+            StringError::NotLatin1 { position: 2, value: 0x0100 }.to_string(),
+            "code point U+0100 at position 2 is not valid Latin-1 (CHAR8)"
+        );
+        assert_eq!(
+            StringError::TooLong { capacity: 2, required: 4 }.to_string(),
+            "string requires 4 code units but the buffer capacity is 2"
+        );
+    }
+
+    #[test]
+    fn test_string_error_into_efi_error() {
+        let error: EfiError = StringError::MissingNulTerminator.into();
+        assert_eq!(error, EfiError::InvalidParameter);
+    }
+
+    #[test]
+    fn test_string_error_is_error_trait() {
+        fn assert_error<T: core::error::Error>(_: &T) {}
+        assert_error(&StringError::MissingNulTerminator);
+    }
+}

--- a/sdk/patina/src/base/string/char16.rs
+++ b/sdk/patina/src/base/string/char16.rs
@@ -11,8 +11,13 @@
 use super::{StringError, char_count, decode_utf8};
 use zerocopy_derive::{FromBytes, Immutable, IntoBytes, KnownLayout};
 
+use super::char8::Char8Array;
+
 #[cfg(any(test, feature = "alloc"))]
-use alloc::vec::Vec;
+use alloc::{string::String, vec::Vec};
+
+#[cfg(any(test, feature = "alloc"))]
+use super::char8::{Char8Str, Char8String};
 
 /// The inclusive range of UTF-16 surrogate code units, which are not valid UCS-2.
 const SURROGATE_RANGE: core::ops::RangeInclusive<u16> = 0xD800..=0xDFFF;
@@ -463,6 +468,36 @@ impl<'a> TryFrom<&'a str> for Char16String {
 }
 
 #[cfg(any(test, feature = "alloc"))]
+impl From<&Char8Str> for Char16String {
+    /// Converts Latin-1 to UCS-2.
+    ///
+    /// Always succeeds since every Latin-1 byte maps directly onto an identically-valued, non-surrogate
+    /// UCS-2 code unit.
+    fn from(value: &Char8Str) -> Self {
+        let mut units = Vec::with_capacity(value.len() + 1);
+        for &byte in value.iter() {
+            units.push(byte as u16);
+        }
+        units.push(0);
+        Self(units)
+    }
+}
+
+#[cfg(any(test, feature = "alloc"))]
+impl From<&Char8String> for Char16String {
+    fn from(value: &Char8String) -> Self {
+        Self::from(value.as_char8_str())
+    }
+}
+
+#[cfg(any(test, feature = "alloc"))]
+impl From<Char8String> for Char16String {
+    fn from(value: Char8String) -> Self {
+        Self::from(&value)
+    }
+}
+
+#[cfg(any(test, feature = "alloc"))]
 impl core::fmt::Display for Char16String {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         core::fmt::Display::fmt(self.as_char16_str(), f)
@@ -666,6 +701,57 @@ impl<const N: usize> Default for Char16Array<N> {
     /// [`Char16Array::try_from_str`], a capacity of `0` cannot represent a valid string.
     fn default() -> Self {
         Self([0; N])
+    }
+}
+
+impl<'a, const N: usize> TryFrom<&'a str> for Char16Array<N> {
+    type Error = StringError;
+
+    /// Equivalent to [`Char16Array::try_from_str`], provided for generic code written against the
+    /// standard [`TryFrom`] trait.
+    fn try_from(s: &'a str) -> Result<Self, StringError> {
+        Self::try_from_str(s)
+    }
+}
+
+impl<const N: usize> From<Char8Array<N>> for Char16Array<N> {
+    /// Converts Latin-1 to UCS-2.
+    ///
+    /// Always succeeds since every Latin-1 byte maps directly onto an identically-valued, non-surrogate
+    /// UCS-2 code unit, and a `Char8Array<N>`'s logical content (at most `N - 1` characters) always
+    /// fits within `Char16Array<N>`'s equal capacity.
+    // Note: `out[position]` is safe because `position < src.len() < N`, except when `N == 0`, where `src`
+    // is empty and the loop never runs.
+    #[allow(clippy::indexing_slicing)]
+    fn from(value: Char8Array<N>) -> Self {
+        let src = value.as_char8_str();
+        // Note: The terminator and any trailing padding are already present due to zero-initialization.
+        let mut out = [0u16; N];
+        for (position, &byte) in src.iter().enumerate() {
+            out[position] = byte as u16;
+        }
+        Self(out)
+    }
+}
+
+#[cfg(any(test, feature = "alloc"))]
+impl<const N: usize> From<Char16Array<N>> for Char16String {
+    /// Converts a fixed-capacity array to a heap-owned string, dropping the const capacity `N`.
+    fn from(value: Char16Array<N>) -> Self {
+        use alloc::borrow::ToOwned;
+        value.as_char16_str().to_owned()
+    }
+}
+
+#[cfg(any(test, feature = "alloc"))]
+impl<const N: usize> From<Char16Array<N>> for String {
+    /// Converts to a native Rust string.
+    ///
+    /// Always succeeds. Lossless for arrays built through a safe constructor; a surrogate code unit
+    /// reachable only via an unchecked constructor is replaced with [`char::REPLACEMENT_CHARACTER`]
+    /// rather than causing a panic.
+    fn from(value: Char16Array<N>) -> Self {
+        value.as_char16_str().chars().collect()
     }
 }
 
@@ -1086,5 +1172,62 @@ mod tests {
     fn test_char16_capacity_helper_runtime() {
         assert_eq!(ucs2_capacity("EFI"), 4);
         assert_eq!(ucs2_capacity(""), 1);
+    }
+
+    #[test]
+    fn test_char16_array_try_from_str_trait() {
+        let array = Char16Array::<9>::try_from("Firmware").unwrap();
+        assert!(array.as_char16_str() == "Firmware");
+    }
+
+    #[test]
+    fn test_char16_array_from_char8_array() {
+        let narrow = Char8Array::<9>::from_str("Firmware");
+        let wide: Char16Array<9> = narrow.into();
+        assert!(wide.as_char16_str() == "Firmware");
+    }
+
+    #[test]
+    fn test_char16_array_from_char8_array_high_latin1() {
+        let narrow = Char8Array::<2>::from_str("\u{00E9}"); // 'é'
+        let wide: Char16Array<2> = narrow.into();
+        assert!(wide.as_char16_str() == "\u{00E9}");
+    }
+
+    #[test]
+    fn test_char16_array_from_char8_array_empty_capacity() {
+        let narrow = Char8Array::<0>::default();
+        let wide: Char16Array<0> = narrow.into();
+        assert!(wide.as_char16_str().is_empty());
+    }
+
+    #[test]
+    fn test_char16_array_to_char16string() {
+        let array = Char16Array::<9>::from_str("Firmware");
+        let owned: Char16String = array.into();
+        assert!(owned == "Firmware");
+    }
+
+    #[test]
+    fn test_char16_array_to_string() {
+        let array = Char16Array::<9>::from_str("Firmware");
+        let owned: alloc::string::String = array.into();
+        assert_eq!(owned, "Firmware");
+    }
+
+    #[test]
+    fn test_char16string_from_char8str() {
+        let narrow = Char8Array::<4>::from_str("EFI");
+        let wide = Char16String::from(narrow.as_char8_str());
+        assert!(wide == "EFI");
+    }
+
+    #[test]
+    fn test_char16string_from_char8string() {
+        let narrow = Char8String::try_from_str("EFI").unwrap();
+        let wide = Char16String::from(&narrow);
+        assert!(wide == "EFI");
+        let wide_owned = Char16String::from(narrow);
+        assert!(wide_owned == "EFI");
     }
 }

--- a/sdk/patina/src/base/string/char16.rs
+++ b/sdk/patina/src/base/string/char16.rs
@@ -1,0 +1,1090 @@
+//! CHAR16 (UCS-2) string types
+//!
+//! See the [module documentation](crate::base::string) for an overview of the UEFI string types.
+//!
+//! ## License
+//!
+//! Copyright (C) Microsoft Corporation.
+//!
+//! SPDX-License-Identifier: Apache-2.0
+
+use super::{StringError, char_count, decode_utf8};
+use zerocopy_derive::{FromBytes, Immutable, IntoBytes, KnownLayout};
+
+#[cfg(any(test, feature = "alloc"))]
+use alloc::vec::Vec;
+
+/// The inclusive range of UTF-16 surrogate code units, which are not valid UCS-2.
+const SURROGATE_RANGE: core::ops::RangeInclusive<u16> = 0xD800..=0xDFFF;
+
+/// A borrowed, NUL-terminated UCS-2 (UEFI CHAR16) string.
+///
+/// This is the CHAR16 analogue of [`core::ffi::CStr`]. It is an unsized type that is always accessed
+/// behind a reference (`&Char16Str`). The referenced data is guaranteed to:
+///
+/// - End with a single NUL (`0x0000`) terminator,
+/// - Contain no interior NUL, and
+/// - Contain only valid UCS-2 code units (no surrogates in `0xD800..=0xDFFF`).
+///
+/// Because the terminator is guaranteed, [`Char16Str::as_ptr`] can be passed directly to
+/// `extern "efiapi"` interfaces expecting a `*const CHAR16`.
+///
+/// # Examples
+///
+/// ```rust
+/// use patina::base::string::Char16Str;
+///
+/// let units = [0x0045u16, 0x0046, 0x0049, 0x0000]; // "EFI\0"
+/// let s = Char16Str::from_units_with_nul(&units).unwrap();
+/// assert_eq!(s.len(), 3);
+/// assert!(s == "EFI");
+/// ```
+#[repr(transparent)]
+pub struct Char16Str([u16]);
+
+impl Char16Str {
+    /// An empty, NUL-terminated CHAR16 string.
+    // SAFETY: `&[0]` is a single NUL code unit that is trivially NUL-terminated with no interior NUL.
+    pub const EMPTY: &'static Char16Str = unsafe { Self::from_units_with_nul_unchecked(&[0]) };
+
+    /// Creates a `&Char16Str` from a slice of code units that ends with a NUL terminator.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`StringError::MissingNulTerminator`] if `units` does not end with a NUL,
+    /// [`StringError::InteriorNul`] if a NUL appears before the end, or [`StringError::NotUcs2`] if a
+    /// surrogate code unit is present.
+    pub fn from_units_with_nul(units: &[u16]) -> Result<&Char16Str, StringError> {
+        let body = match units.split_last() {
+            Some((0, body)) => body,
+            _ => return Err(StringError::MissingNulTerminator),
+        };
+
+        for (position, &unit) in body.iter().enumerate() {
+            if unit == 0 {
+                return Err(StringError::InteriorNul { position });
+            }
+            if SURROGATE_RANGE.contains(&unit) {
+                return Err(StringError::NotUcs2 { position, value: unit as u32 });
+            }
+        }
+
+        // SAFETY: The loop above verified that `units` is NUL-terminated, has no interior NUL, and
+        // contains no surrogate code units, which are exactly the invariants of `Char16Str`.
+        Ok(unsafe { Self::from_units_with_nul_unchecked(units) })
+    }
+
+    /// Creates a `&Char16Str` from a NUL-terminated slice without validating its contents.
+    ///
+    /// # Safety
+    ///
+    /// The caller must ensure that `units` ends with a single NUL terminator, contains no interior
+    /// NUL, and contains only valid UCS-2 code units.
+    pub const unsafe fn from_units_with_nul_unchecked(units: &[u16]) -> &Char16Str {
+        // SAFETY: `Char16Str` is `#[repr(transparent)]` over `[u16]`, so `&[u16]` and `&Char16Str`
+        // share the same layout. The caller upholds the value invariants.
+        unsafe { &*(units as *const [u16] as *const Char16Str) }
+    }
+
+    /// Creates a `&Char16Str` from the code units up to and including the first NUL, ignoring
+    /// anything after it.
+    ///
+    /// This mirrors [`core::ffi::CStr::from_bytes_until_nul`]. It is useful for fixed-size or
+    /// over-allocated buffers that may carry trailing NUL padding (or other data) after the logical
+    /// end of the string, where [`Char16Str::from_units_with_nul`] would reject anything after the
+    /// first NUL as an interior NUL.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`StringError::MissingNulTerminator`] if `units` contains no NUL at all, or
+    /// [`StringError::NotUcs2`] if a surrogate code unit appears before the first NUL.
+    // `end` is a valid index into `units` because it came from `position`, so the slice can't panic.
+    #[allow(clippy::indexing_slicing)]
+    pub fn from_units_until_nul(units: &[u16]) -> Result<&Char16Str, StringError> {
+        let end = units.iter().position(|&unit| unit == 0).ok_or(StringError::MissingNulTerminator)?;
+        Self::from_units_with_nul(&units[..=end])
+    }
+
+    /// Creates a `&Char16Str` by scanning a raw pointer for a NUL terminator.
+    ///
+    /// # Safety
+    ///
+    /// The caller must ensure that:
+    ///
+    /// - `ptr` is non-null and aligned, even for a zero-length string.
+    /// - The memory pointed to by `ptr` contains a sequence of `u16` values that is valid for
+    ///   reads up to and including a NUL terminator.
+    ///   - The entire memory range of this `Char16Str`, from `ptr` through the terminator, must be
+    ///     contained within a single allocation.
+    ///   - The entire memory range must remain valid and unmodified for the lifetime `'a`.
+    ///   - The NUL terminator must be within `isize::MAX` bytes of `ptr`.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`StringError::NotUcs2`] if the scanned data contains a surrogate code unit.
+    pub unsafe fn from_ptr<'a>(ptr: *const u16) -> Result<&'a Char16Str, StringError> {
+        let mut len = 0usize;
+        // SAFETY: The caller guarantees `ptr` points to a NUL-terminated sequence valid for reads.
+        while unsafe { *ptr.add(len) } != 0 {
+            len += 1;
+        }
+        // SAFETY: `len + 1` code units up to and including the terminator are valid for reads.
+        let units = unsafe { core::slice::from_raw_parts(ptr, len + 1) };
+        Self::from_units_with_nul(units)
+    }
+
+    /// Creates a `&Char16Str` by scanning at most `max_units` code units for a NUL terminator.
+    ///
+    /// # Safety
+    ///
+    /// The caller must ensure that:
+    ///
+    /// - `ptr` is non-null and aligned, even for a zero-length string.
+    /// - `max_units * size_of::<u16>()` must not exceed `isize::MAX` bytes.
+    /// - The memory pointed to by `ptr` contains a sequence of `u16` values that is valid for
+    ///   reads up to and including a NUL terminator.
+    ///   - The entire memory range of this `Char16Str`, from `ptr` through the terminator, must be
+    ///     contained within a single allocation.
+    ///   - The entire memory range must remain valid and unmodified for the lifetime `'a`.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`StringError::MissingNulTerminator`] if no NUL is found within `max_units` code units,
+    /// or [`StringError::NotUcs2`] if a surrogate code unit is present.
+    pub unsafe fn from_ptr_bounded<'a>(ptr: *const u16, max_units: usize) -> Result<&'a Char16Str, StringError> {
+        let mut len = 0usize;
+        // SAFETY: The caller guarantees `max_units` code units are valid for reads.
+        while len < max_units && unsafe { *ptr.add(len) } != 0 {
+            len += 1;
+        }
+        if len == max_units {
+            return Err(StringError::MissingNulTerminator);
+        }
+        // SAFETY: `len + 1 <= max_units` code units up to and including the terminator are valid.
+        let units = unsafe { core::slice::from_raw_parts(ptr, len + 1) };
+        Self::from_units_with_nul(units)
+    }
+
+    /// Returns a pointer to the first code unit, suitable for passing to `extern "efiapi"` interfaces.
+    ///
+    /// The pointed-to sequence is always NUL-terminated.
+    pub const fn as_ptr(&self) -> *const u16 {
+        self.0.as_ptr()
+    }
+
+    /// Returns the code units including the trailing NUL terminator.
+    pub const fn as_units_with_nul(&self) -> &[u16] {
+        &self.0
+    }
+
+    /// Returns the code units excluding the trailing NUL terminator.
+    pub fn as_units(&self) -> &[u16] {
+        match self.0.split_last() {
+            Some((_, body)) => body,
+            None => &[],
+        }
+    }
+
+    /// Returns the number of code units, excluding the trailing NUL terminator.
+    pub fn len(&self) -> usize {
+        self.as_units().len()
+    }
+
+    /// Returns `true` if the string contains no characters (only the NUL terminator).
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    /// Returns an iterator over the code units, excluding the terminator.
+    ///
+    /// This borrows each code unit rather than copying it. Call [`Iterator::copied`] on the result if
+    /// owned `u16` values are needed.
+    pub fn iter(&self) -> core::slice::Iter<'_, u16> {
+        self.as_units().iter()
+    }
+
+    /// Returns an iterator over the characters as [`char`] values.
+    ///
+    /// Every valid UCS-2 code unit is a Unicode scalar value in the Basic Multilingual Plane, so this
+    /// conversion is lossless for any string built through a checked constructor. If the string was
+    /// built through an unchecked constructor and contains a surrogate code unit, that unit is mapped
+    /// to [`char::REPLACEMENT_CHARACTER`] rather than panicking.
+    pub fn chars(&self) -> impl Iterator<Item = char> + '_ {
+        self.iter().map(|&unit| char::from_u32(unit as u32).unwrap_or(char::REPLACEMENT_CHARACTER))
+    }
+}
+
+impl PartialEq for Char16Str {
+    fn eq(&self, other: &Self) -> bool {
+        self.0 == other.0
+    }
+}
+
+impl Eq for Char16Str {}
+
+impl PartialOrd for Char16Str {
+    fn partial_cmp(&self, other: &Self) -> Option<core::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for Char16Str {
+    fn cmp(&self, other: &Self) -> core::cmp::Ordering {
+        self.0.cmp(&other.0)
+    }
+}
+
+impl core::hash::Hash for Char16Str {
+    fn hash<H: core::hash::Hasher>(&self, state: &mut H) {
+        self.0.hash(state);
+    }
+}
+
+impl PartialEq<str> for Char16Str {
+    fn eq(&self, other: &str) -> bool {
+        self.chars().eq(other.chars())
+    }
+}
+
+impl PartialEq<&str> for Char16Str {
+    fn eq(&self, other: &&str) -> bool {
+        self == *other
+    }
+}
+
+impl PartialEq<Char16Str> for str {
+    fn eq(&self, other: &Char16Str) -> bool {
+        other == self
+    }
+}
+
+impl core::fmt::Display for Char16Str {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        for c in self.chars() {
+            write!(f, "{c}")?;
+        }
+        Ok(())
+    }
+}
+
+impl core::fmt::Debug for Char16Str {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.write_str("\"")?;
+        for c in self.chars() {
+            write!(f, "{}", c.escape_debug())?;
+        }
+        f.write_str("\"")
+    }
+}
+
+/// Decodes a little-endian CHAR16 byte buffer into `u16` code units.
+///
+/// # Errors
+///
+/// Returns [`StringError::OddByteLength`] if `bytes` is not a whole number of `u16` code units.
+#[cfg(any(test, feature = "alloc"))]
+fn decode_le_units(bytes: &[u8]) -> Result<Vec<u16>, StringError> {
+    if !bytes.len().is_multiple_of(2) {
+        return Err(StringError::OddByteLength { len: bytes.len() });
+    }
+    Ok(bytes
+        .chunks_exact(2)
+        .map(|pair| u16::from_le_bytes(pair.try_into().expect("chunks_exact(2) yields 2-byte slices")))
+        .collect())
+}
+
+/// An owned, heap-backed, NUL-terminated UCS-2 (UEFI CHAR16) string.
+///
+/// This is the CHAR16 analogue of [`alloc::string::String`]. It dereferences to [`Char16Str`], so all
+/// borrowed operations are available on an owned value.
+///
+/// # Examples
+///
+/// ```rust
+/// use patina::base::string::Char16String;
+///
+/// let s = Char16String::try_from_str("Boot0001").unwrap();
+/// assert_eq!(s.len(), 8);
+/// assert!(s == "Boot0001");
+/// ```
+#[cfg(any(test, feature = "alloc"))]
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct Char16String(Vec<u16>);
+
+#[cfg(any(test, feature = "alloc"))]
+impl Char16String {
+    /// Creates an empty string containing only the NUL terminator.
+    pub fn new() -> Self {
+        Self(alloc::vec![0])
+    }
+
+    /// Creates a `Char16String` by encoding a Rust [`str`] as UCS-2.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`StringError::InteriorNul`] if the input contains a NUL character, or
+    /// [`StringError::NotUcs2`] if it contains a code point above `U+FFFF` (which cannot be
+    /// represented in UCS-2 without a surrogate pair).
+    pub fn try_from_str(s: &str) -> Result<Self, StringError> {
+        let mut units = Vec::with_capacity(s.len() + 1);
+        for (position, c) in s.chars().enumerate() {
+            let value = c as u32;
+            if value == 0 {
+                return Err(StringError::InteriorNul { position });
+            }
+            if value > 0xFFFF {
+                return Err(StringError::NotUcs2 { position, value });
+            }
+            units.push(value as u16);
+        }
+        units.push(0);
+        Ok(Self(units))
+    }
+
+    /// Creates a `Char16String` from a `Vec<u16>` that ends with a NUL terminator.
+    ///
+    /// This validates `units` the same way [`Char16Str::from_units_with_nul`] does, then takes
+    /// ownership of the buffer directly instead of cloning it.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`StringError::MissingNulTerminator`] if `units` does not end with a NUL,
+    /// [`StringError::InteriorNul`] if a NUL appears before the end, or [`StringError::NotUcs2`] if a
+    /// surrogate code unit is present.
+    pub fn from_units_with_nul(units: Vec<u16>) -> Result<Self, StringError> {
+        Char16Str::from_units_with_nul(&units)?;
+        Ok(Self(units))
+    }
+
+    /// Creates a `Char16String` by decoding a little-endian CHAR16 byte buffer that ends with a NUL
+    /// terminator.
+    ///
+    /// This is the byte-oriented companion to [`Char16Str::from_units_with_nul`]. UEFI stores CHAR16
+    /// strings as little-endian byte sequences, so this pairs each two bytes into a `u16` before
+    /// applying the same NUL and UCS-2 validation.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`StringError::OddByteLength`] if `bytes` is not a whole number of `u16` code units,
+    /// [`StringError::MissingNulTerminator`] if `bytes` does not end with a NUL,
+    /// [`StringError::InteriorNul`] if a NUL appears before the end, or [`StringError::NotUcs2`] if a
+    /// surrogate code unit is present.
+    pub fn from_le_bytes_with_nul(bytes: &[u8]) -> Result<Self, StringError> {
+        Self::from_units_with_nul(decode_le_units(bytes)?)
+    }
+
+    /// Creates a `Char16String` by decoding a little-endian CHAR16 byte buffer up to and including
+    /// the first NUL, ignoring anything after it.
+    ///
+    /// This is the byte-oriented companion to [`Char16Str::from_units_until_nul`]. It is useful for
+    /// fixed-size or over-allocated buffers that may carry trailing padding after the logical end of
+    /// the string, such as the `UserInterface` section of a firmware file.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`StringError::OddByteLength`] if `bytes` is not a whole number of `u16` code units,
+    /// [`StringError::MissingNulTerminator`] if no NUL code unit is present, or
+    /// [`StringError::NotUcs2`] if a surrogate code unit appears before the first NUL.
+    pub fn from_le_bytes_until_nul(bytes: &[u8]) -> Result<Self, StringError> {
+        use alloc::borrow::ToOwned;
+        let units = decode_le_units(bytes)?;
+        Ok(Char16Str::from_units_until_nul(&units)?.to_owned())
+    }
+
+    /// Creates a `Char16String` from a NUL-terminated `Vec<u16>` without validating its contents.
+    ///
+    /// # Safety
+    ///
+    /// The caller must ensure that `units` ends with a single NUL terminator, contains no interior
+    /// NUL, and contains only valid UCS-2 code units.
+    pub unsafe fn from_units_with_nul_unchecked(units: Vec<u16>) -> Self {
+        Self(units)
+    }
+
+    /// Borrows this owned string as a [`Char16Str`].
+    pub fn as_char16_str(&self) -> &Char16Str {
+        // SAFETY: The type invariant guarantees `self.0` is a valid NUL-terminated UCS-2 sequence.
+        unsafe { Char16Str::from_units_with_nul_unchecked(&self.0) }
+    }
+
+    /// Consumes the string and returns the backing code units, including the trailing NUL.
+    pub fn into_units_with_nul(self) -> Vec<u16> {
+        self.0
+    }
+}
+
+#[cfg(any(test, feature = "alloc"))]
+impl Default for Char16String {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(any(test, feature = "alloc"))]
+impl core::ops::Deref for Char16String {
+    type Target = Char16Str;
+
+    fn deref(&self) -> &Char16Str {
+        self.as_char16_str()
+    }
+}
+
+#[cfg(any(test, feature = "alloc"))]
+impl core::borrow::Borrow<Char16Str> for Char16String {
+    fn borrow(&self) -> &Char16Str {
+        self.as_char16_str()
+    }
+}
+
+#[cfg(any(test, feature = "alloc"))]
+impl alloc::borrow::ToOwned for Char16Str {
+    type Owned = Char16String;
+
+    fn to_owned(&self) -> Char16String {
+        Char16String(self.0.to_vec())
+    }
+}
+
+#[cfg(any(test, feature = "alloc"))]
+impl From<&Char16Str> for Char16String {
+    fn from(s: &Char16Str) -> Self {
+        use alloc::borrow::ToOwned;
+        s.to_owned()
+    }
+}
+
+#[cfg(any(test, feature = "alloc"))]
+impl<'a> TryFrom<&'a str> for Char16String {
+    type Error = StringError;
+
+    fn try_from(s: &'a str) -> Result<Self, Self::Error> {
+        Self::try_from_str(s)
+    }
+}
+
+#[cfg(any(test, feature = "alloc"))]
+impl core::fmt::Display for Char16String {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        core::fmt::Display::fmt(self.as_char16_str(), f)
+    }
+}
+
+#[cfg(any(test, feature = "alloc"))]
+impl core::fmt::Debug for Char16String {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        core::fmt::Debug::fmt(self.as_char16_str(), f)
+    }
+}
+
+#[cfg(any(test, feature = "alloc"))]
+impl PartialEq<str> for Char16String {
+    fn eq(&self, other: &str) -> bool {
+        self.as_char16_str() == other
+    }
+}
+
+#[cfg(any(test, feature = "alloc"))]
+impl PartialEq<&str> for Char16String {
+    fn eq(&self, other: &&str) -> bool {
+        self.as_char16_str() == *other
+    }
+}
+
+#[cfg(any(test, feature = "alloc"))]
+impl PartialEq<Char16String> for str {
+    fn eq(&self, other: &Char16String) -> bool {
+        other.as_char16_str() == self
+    }
+}
+
+#[cfg(any(test, feature = "alloc"))]
+impl PartialEq<Char16Str> for Char16String {
+    fn eq(&self, other: &Char16Str) -> bool {
+        self.as_char16_str() == other
+    }
+}
+
+#[cfg(any(test, feature = "alloc"))]
+impl PartialEq<&Char16Str> for Char16String {
+    fn eq(&self, other: &&Char16Str) -> bool {
+        self.as_char16_str() == *other
+    }
+}
+
+#[cfg(any(test, feature = "alloc"))]
+impl PartialEq<Char16String> for Char16Str {
+    fn eq(&self, other: &Char16String) -> bool {
+        self == other.as_char16_str()
+    }
+}
+
+/// Returns the [`Char16Array`] capacity needed to hold `s` plus a NUL terminator.
+///
+/// This is an implementation detail of the [`char16!`](crate::char16) macro.
+#[doc(hidden)]
+pub const fn ucs2_capacity(s: &str) -> usize {
+    // Every accepted UCS-2 character occupies a single code unit, plus one for the terminator.
+    char_count(s) + 1
+}
+
+/// A fixed capacity, NUL-terminated UCS-2 (UEFI CHAR16) string of `N` code units.
+///
+/// The capacity `N` includes the trailing NUL terminator, so the array can hold up to `N - 1`
+/// characters. Unused trailing slots are filled with NUL. This type is `#[repr(transparent)]` over
+/// `[u16; N]`, making it suitable for `#[repr(C)]` structure fields.
+///
+/// Values can be built in `const` contexts using [`Char16Array::from_str`] and
+/// [`Char16Array::try_from_str`], which is how the [`char16!`](crate::char16) macro validates literals
+/// at compile time.
+///
+/// This type also implements [`zerocopy::FromBytes`] and [`zerocopy::IntoBytes`], so it can be used
+/// directly as a field of a `#[repr(C)]`/`#[repr(C, packed)]` structure that derives those traits for
+/// zero-copy parsing and serialization. Because `FromBytes` allows constructing a value from arbitrary
+/// code units, a value built that way is not guaranteed to contain a NUL terminator. In that case,
+/// [`Char16Array::as_char16_str`] (and [`Deref`](core::ops::Deref)) return an empty string rather than
+/// panicking.
+///
+/// # Examples
+///
+/// ```rust
+/// use patina::base::string::Char16Array;
+///
+/// const NAME: Char16Array<4> = Char16Array::from_str("EFI");
+/// assert_eq!(NAME.as_char16_str().len(), 3);
+/// assert!(NAME.as_char16_str() == "EFI");
+/// ```
+#[repr(transparent)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, FromBytes, IntoBytes, Immutable, KnownLayout)]
+pub struct Char16Array<const N: usize>([u16; N]);
+
+impl<const N: usize> Char16Array<N> {
+    /// Creates a `Char16Array` by encoding a Rust [`str`] as UCS-2.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`StringError::InteriorNul`] if the input contains a NUL character,
+    /// [`StringError::NotUcs2`] if it contains a code point above `U+FFFF`, or
+    /// [`StringError::TooLong`] if the encoded string plus its NUL terminator does not fit in `N` code
+    /// units.
+    // `out[out_index]` is guarded by the `out_index + 1 >= N` check, so `out_index < N`.
+    #[allow(clippy::indexing_slicing)]
+    pub const fn try_from_str(s: &str) -> Result<Self, StringError> {
+        let bytes = s.as_bytes();
+        let mut out = [0u16; N];
+        let mut index = 0;
+        let mut out_index = 0;
+        let mut position = 0;
+
+        while index < bytes.len() {
+            let (value, len) = decode_utf8(bytes, index);
+            if value == 0 {
+                return Err(StringError::InteriorNul { position });
+            }
+            if value > 0xFFFF {
+                return Err(StringError::NotUcs2 { position, value });
+            }
+            // Require room for this code unit and a trailing NUL terminator.
+            if out_index + 1 >= N {
+                return Err(StringError::TooLong { capacity: N.saturating_sub(1), required: out_index + 2 });
+            }
+            out[out_index] = value as u16;
+            out_index += 1;
+            index += len;
+            position += 1;
+        }
+
+        // Guard against `N == 0`, where there is no room for even a terminator.
+        if out_index >= N {
+            return Err(StringError::TooLong { capacity: 0, required: 1 });
+        }
+
+        Ok(Self(out))
+    }
+
+    /// Creates a `Char16Array`, panicking on invalid input.
+    ///
+    /// This is intended for compile-time string literals: because it is a `const fn`, an invalid
+    /// literal in a `const`/`static` context (including through the [`char16!`](crate::char16) macro)
+    /// is reported as a compile-time error, not a runtime panic. Runtime callers that cannot
+    /// guarantee valid input should use [`Char16Array::try_from_str`] instead, which returns a
+    /// [`Result`] rather than panicking.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the input is not valid UCS-2 or does not fit in `N` code units. In a `const` context
+    /// this manifests as a compile-time error.
+    pub const fn from_str(s: &str) -> Self {
+        match Self::try_from_str(s) {
+            Ok(array) => array,
+            Err(_) => panic!("invalid UCS-2 string literal"),
+        }
+    }
+
+    /// Borrows the populated portion of the array as a [`Char16Str`].
+    ///
+    /// Every value produced by a safe constructor (`try_from_str`, `from_str`, `Default`) contains a
+    /// NUL terminator by construction. A value materialized from arbitrary code units via `FromBytes`
+    /// is not guaranteed to, so this returns [`Char16Str::EMPTY`] in that case rather than panicking.
+    #[allow(clippy::indexing_slicing)]
+    pub fn as_char16_str(&self) -> &Char16Str {
+        let mut len = 0;
+        while len < N && self.0[len] != 0 {
+            len += 1;
+        }
+        if len == N {
+            return Char16Str::EMPTY;
+        }
+        // SAFETY: `self.0[..=len]` ends at the first NUL (found above) and contains only validated
+        // UCS-2 code units.
+        unsafe { Char16Str::from_units_with_nul_unchecked(&self.0[..=len]) }
+    }
+
+    /// Returns the full backing array, including trailing NUL padding.
+    pub const fn as_array(&self) -> &[u16; N] {
+        &self.0
+    }
+}
+
+impl<const N: usize> core::ops::Deref for Char16Array<N> {
+    type Target = Char16Str;
+
+    fn deref(&self) -> &Char16Str {
+        self.as_char16_str()
+    }
+}
+
+impl<const N: usize> core::fmt::Display for Char16Array<N> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        core::fmt::Display::fmt(self.as_char16_str(), f)
+    }
+}
+
+impl<const N: usize> Default for Char16Array<N> {
+    /// Returns an empty string backed by an all-zero array.
+    ///
+    /// `N` must be at least `1` to hold the mandatory NUL terminator; as with
+    /// [`Char16Array::try_from_str`], a capacity of `0` cannot represent a valid string.
+    fn default() -> Self {
+        Self([0; N])
+    }
+}
+
+#[cfg(test)]
+#[cfg_attr(coverage, coverage(off))]
+mod tests {
+    use super::*;
+    use crate::char16;
+    use alloc::string::ToString;
+
+    #[test]
+    fn test_char16_from_units_with_nul_valid() {
+        let units = [0x0045u16, 0x0046, 0x0049, 0x0000];
+        let s = Char16Str::from_units_with_nul(&units).unwrap();
+        assert_eq!(s.len(), 3);
+        assert!(!s.is_empty());
+        assert_eq!(s.as_units(), &[0x0045, 0x0046, 0x0049]);
+        assert_eq!(s.as_units_with_nul(), &units);
+    }
+
+    #[test]
+    fn test_char16_empty_string() {
+        let units = [0x0000u16];
+        let s = Char16Str::from_units_with_nul(&units).unwrap();
+        assert_eq!(s.len(), 0);
+        assert!(s.is_empty());
+    }
+
+    #[test]
+    fn test_char16_missing_nul_terminator() {
+        let units = [0x0045u16, 0x0046];
+        assert_eq!(Char16Str::from_units_with_nul(&units), Err(StringError::MissingNulTerminator));
+        assert_eq!(Char16Str::from_units_with_nul(&[]), Err(StringError::MissingNulTerminator));
+    }
+
+    #[test]
+    fn test_char16_interior_nul() {
+        let units = [0x0045u16, 0x0000, 0x0049, 0x0000];
+        assert_eq!(Char16Str::from_units_with_nul(&units), Err(StringError::InteriorNul { position: 1 }));
+    }
+
+    #[test]
+    fn test_char16_surrogate_rejected() {
+        let units = [0x0045u16, 0xD800, 0x0000];
+        assert_eq!(Char16Str::from_units_with_nul(&units), Err(StringError::NotUcs2 { position: 1, value: 0xD800 }));
+    }
+
+    #[test]
+    fn test_char16_chars_and_iter() {
+        let units = [0x0041u16, 0x00E9, 0x20AC, 0x0000]; // "Aé€"
+        let s = Char16Str::from_units_with_nul(&units).unwrap();
+        let chars: alloc::vec::Vec<char> = s.chars().collect();
+        assert_eq!(chars, ['A', 'é', '€']);
+        let code_units: alloc::vec::Vec<u16> = s.iter().copied().collect();
+        assert_eq!(code_units, [0x0041, 0x00E9, 0x20AC]);
+    }
+
+    #[test]
+    fn test_char16_chars_lossy_on_unchecked_surrogate() {
+        // A surrogate can only reach `chars()` via the unchecked constructor. Rather than panicking,
+        // it is mapped to the Unicode replacement character.
+        let units = [0x0041u16, 0xD800, 0x0000];
+        // SAFETY: This deliberately bypasses validation to exercise the lossy fallback path.
+        let s = unsafe { Char16Str::from_units_with_nul_unchecked(&units) };
+        let chars: alloc::vec::Vec<char> = s.chars().collect();
+        assert_eq!(chars, ['A', char::REPLACEMENT_CHARACTER]);
+    }
+
+    #[test]
+    fn test_char16_from_ptr() {
+        let units = [0x0045u16, 0x0046, 0x0049, 0x0000];
+        // SAFETY: `units` is a valid NUL-terminated buffer that outlives the borrow.
+        let s = unsafe { Char16Str::from_ptr(units.as_ptr()) }.unwrap();
+        assert!(s == "EFI");
+    }
+
+    #[test]
+    fn test_char16_from_ptr_bounded_finds_nul() {
+        let units = [0x0045u16, 0x0046, 0x0000, 0x0049];
+        // SAFETY: `units` has at least 4 readable code units.
+        let s = unsafe { Char16Str::from_ptr_bounded(units.as_ptr(), 4) }.unwrap();
+        assert_eq!(s.len(), 2);
+    }
+
+    #[test]
+    fn test_char16_from_ptr_bounded_no_nul() {
+        let units = [0x0045u16, 0x0046, 0x0049];
+        // SAFETY: `units` has at least 3 readable code units.
+        let result = unsafe { Char16Str::from_ptr_bounded(units.as_ptr(), 3) };
+        assert_eq!(result, Err(StringError::MissingNulTerminator));
+    }
+
+    #[test]
+    fn test_char16_as_ptr_points_to_first_unit() {
+        let units = [0x0045u16, 0x0046, 0x0049, 0x0000];
+        let s = Char16Str::from_units_with_nul(&units).unwrap();
+        assert_eq!(s.as_ptr(), units.as_ptr());
+    }
+
+    #[test]
+    fn test_char16_display_and_debug() {
+        let units = [0x0045u16, 0x0046, 0x0049, 0x0000];
+        let s = Char16Str::from_units_with_nul(&units).unwrap();
+        assert_eq!(s.to_string(), "EFI");
+        assert_eq!(alloc::format!("{s:?}"), "\"EFI\"");
+    }
+
+    #[test]
+    fn test_char16_equality_and_ordering() {
+        let a = [0x0041u16, 0x0000];
+        let b = [0x0042u16, 0x0000];
+        let a = Char16Str::from_units_with_nul(&a).unwrap();
+        let b = Char16Str::from_units_with_nul(&b).unwrap();
+        assert!(a < b);
+        assert_ne!(a, b);
+        assert!(a == "A");
+        assert!(*"A" == *a);
+    }
+
+    #[test]
+    fn test_char16string_try_from_str() {
+        let s = Char16String::try_from_str("Boot0001").unwrap();
+        assert_eq!(s.len(), 8);
+        assert!(*s == *"Boot0001");
+        assert_eq!(s.to_string(), "Boot0001");
+    }
+
+    #[test]
+    fn test_char16string_partial_eq_str() {
+        let s = Char16String::try_from_str("EFI").unwrap();
+        assert!(s == "EFI");
+        assert!(s == *"EFI");
+        assert!(*"EFI" == s);
+        assert!(s != "NOPE");
+        assert!(*"NOPE" != s);
+    }
+
+    #[test]
+    fn test_char16string_partial_eq_char16str() {
+        let s = Char16String::try_from_str("EFI").unwrap();
+        let same = Char16String::try_from_str("EFI").unwrap();
+        let different = Char16String::try_from_str("NOPE").unwrap();
+        let same_str: &Char16Str = same.as_char16_str();
+        let different_str: &Char16Str = different.as_char16_str();
+        assert!(s == *same_str);
+        assert!(s == same_str);
+        assert!(*same_str == s);
+        assert!(s != *different_str);
+        assert!(*different_str != s);
+    }
+
+    #[test]
+    fn test_char16string_from_le_bytes_with_nul() {
+        // "EFI\0" as little-endian CHAR16 bytes.
+        let bytes = [0x45, 0x00, 0x46, 0x00, 0x49, 0x00, 0x00, 0x00];
+        let s = Char16String::from_le_bytes_with_nul(&bytes).unwrap();
+        assert_eq!(s.len(), 3);
+        assert_eq!(s.to_string(), "EFI");
+    }
+
+    #[test]
+    fn test_char16string_from_le_bytes_with_nul_rejects_trailing_padding() {
+        // A trailing code unit after the terminator is an interior NUL for the with_nul constructor.
+        let bytes = [0x45, 0x00, 0x00, 0x00, 0x49, 0x00, 0x00, 0x00];
+        assert_eq!(Char16String::from_le_bytes_with_nul(&bytes), Err(StringError::InteriorNul { position: 1 }));
+    }
+
+    #[test]
+    fn test_char16string_from_le_bytes_until_nul_ignores_padding() {
+        // "EFI\0" followed by trailing padding that must be ignored.
+        let bytes = [0x45, 0x00, 0x46, 0x00, 0x49, 0x00, 0x00, 0x00, 0xFF, 0xFF];
+        let s = Char16String::from_le_bytes_until_nul(&bytes).unwrap();
+        assert_eq!(s.to_string(), "EFI");
+        // The owned buffer is trimmed to exactly "EFI\0".
+        assert_eq!(s.into_units_with_nul(), alloc::vec![0x0045, 0x0046, 0x0049, 0x0000]);
+    }
+
+    #[test]
+    fn test_char16string_from_le_bytes_odd_length() {
+        let bytes = [0x45, 0x00, 0x46];
+        assert_eq!(Char16String::from_le_bytes_with_nul(&bytes), Err(StringError::OddByteLength { len: 3 }));
+        assert_eq!(Char16String::from_le_bytes_until_nul(&bytes), Err(StringError::OddByteLength { len: 3 }));
+    }
+
+    #[test]
+    fn test_char16string_from_le_bytes_until_nul_missing_terminator() {
+        let bytes = [0x45, 0x00, 0x46, 0x00];
+        assert_eq!(Char16String::from_le_bytes_until_nul(&bytes), Err(StringError::MissingNulTerminator));
+    }
+
+    #[test]
+    fn test_char16string_from_le_bytes_surrogate_rejected() {
+        // 0xD800 is a lone surrogate and is not valid UCS-2.
+        let bytes = [0x45, 0x00, 0x00, 0xD8, 0x00, 0x00];
+        assert_eq!(
+            Char16String::from_le_bytes_until_nul(&bytes),
+            Err(StringError::NotUcs2 { position: 1, value: 0xD800 })
+        );
+    }
+
+    #[test]
+    fn test_char16string_rejects_non_bmp() {
+        // U+1F600 requires a surrogate pair in UTF-16 and is not valid UCS-2.
+        let result = Char16String::try_from_str("A\u{1F600}");
+        assert_eq!(result, Err(StringError::NotUcs2 { position: 1, value: 0x1F600 }));
+    }
+
+    #[test]
+    fn test_char16string_rejects_interior_nul() {
+        let result = Char16String::try_from_str("A\0B");
+        assert_eq!(result, Err(StringError::InteriorNul { position: 1 }));
+    }
+
+    #[test]
+    fn test_char16string_new_and_default() {
+        let a = Char16String::new();
+        let b = Char16String::default();
+        assert!(a.is_empty());
+        assert_eq!(a, b);
+        assert_eq!(a.clone().into_units_with_nul(), alloc::vec![0]);
+    }
+
+    #[test]
+    fn test_char16string_to_owned_roundtrip() {
+        use alloc::borrow::ToOwned;
+        let owned = Char16String::try_from_str("Test").unwrap();
+        let borrowed: &Char16Str = &owned;
+        let reowned = borrowed.to_owned();
+        assert_eq!(owned, reowned);
+    }
+
+    #[test]
+    fn test_char16string_from_ref_char16str() {
+        let owned = Char16String::try_from_str("Test").unwrap();
+        let borrowed: &Char16Str = &owned;
+        let converted = Char16String::from(borrowed);
+        assert_eq!(owned, converted);
+        let via_into: Char16String = borrowed.into();
+        assert_eq!(owned, via_into);
+    }
+
+    #[test]
+    fn test_char16_from_ptr_surrogate_error() {
+        let units = [0x0041u16, 0xD800, 0x0000];
+        // SAFETY: `units` is a NUL-terminated buffer that outlives the borrow.
+        let result = unsafe { Char16Str::from_ptr(units.as_ptr()) };
+        assert_eq!(result, Err(StringError::NotUcs2 { position: 1, value: 0xD800 }));
+    }
+
+    #[test]
+    fn test_char16str_partial_eq_ref_str() {
+        let units = [0x0045u16, 0x0046, 0x0049, 0x0000];
+        let s = Char16Str::from_units_with_nul(&units).unwrap();
+        let other: &str = "EFI";
+        assert!(s == other);
+        assert!(s != "NOPE");
+    }
+
+    #[test]
+    fn test_char16str_hash() {
+        use core::hash::{Hash, Hasher};
+        use std::collections::hash_map::DefaultHasher;
+        let units = [0x0045u16, 0x0000];
+        let s = Char16Str::from_units_with_nul(&units).unwrap();
+        let mut hasher = DefaultHasher::new();
+        s.hash(&mut hasher);
+        let _ = hasher.finish();
+    }
+
+    #[test]
+    fn test_char16string_debug_borrow_and_display() {
+        use core::borrow::Borrow;
+        let s = Char16String::try_from_str("EFI").unwrap();
+        assert_eq!(alloc::format!("{s:?}"), "\"EFI\"");
+        assert_eq!(s.to_string(), "EFI");
+        let borrowed: &Char16Str = s.borrow();
+        assert_eq!(borrowed.len(), 3);
+    }
+
+    #[test]
+    fn test_char16_from_units_until_nul_exact() {
+        let units = [0x0045u16, 0x0046, 0x0049, 0x0000];
+        let s = Char16Str::from_units_until_nul(&units).unwrap();
+        assert!(s == "EFI");
+    }
+
+    #[test]
+    fn test_char16_from_units_until_nul_trailing_padding() {
+        // Extra trailing NUL padding after the terminator is ignored rather than rejected.
+        let units = [0x0045u16, 0x0046, 0x0049, 0x0000, 0x0000, 0x0000];
+        let s = Char16Str::from_units_until_nul(&units).unwrap();
+        assert_eq!(s.len(), 3);
+        assert!(s == "EFI");
+    }
+
+    #[test]
+    fn test_char16_from_units_until_nul_trailing_garbage() {
+        // Anything after the first NUL is ignored, matching core::ffi::CStr::from_bytes_until_nul.
+        let units = [0x0045u16, 0x0000, 0x1234];
+        let s = Char16Str::from_units_until_nul(&units).unwrap();
+        assert_eq!(s.len(), 1);
+        assert!(s == "E");
+    }
+
+    #[test]
+    fn test_char16_from_units_until_nul_missing_nul() {
+        let units = [0x0045u16, 0x0046];
+        assert_eq!(Char16Str::from_units_until_nul(&units), Err(StringError::MissingNulTerminator));
+        assert_eq!(Char16Str::from_units_until_nul(&[]), Err(StringError::MissingNulTerminator));
+    }
+
+    #[test]
+    fn test_char16_from_units_until_nul_surrogate_rejected() {
+        let units = [0x0045u16, 0xD800, 0x0000];
+        assert_eq!(Char16Str::from_units_until_nul(&units), Err(StringError::NotUcs2 { position: 1, value: 0xD800 }));
+    }
+
+    #[test]
+    fn test_char16string_from_units_with_nul() {
+        let units = alloc::vec![0x0045u16, 0x0046, 0x0049, 0x0000];
+        let s = Char16String::from_units_with_nul(units).unwrap();
+        assert_eq!(s.len(), 3);
+        assert!(*s == *"EFI");
+    }
+
+    #[test]
+    fn test_char16string_from_units_with_nul_missing_terminator() {
+        let units = alloc::vec![0x0045u16, 0x0046];
+        assert_eq!(Char16String::from_units_with_nul(units), Err(StringError::MissingNulTerminator));
+    }
+
+    #[test]
+    fn test_char16string_from_units_with_nul_interior_nul() {
+        let units = alloc::vec![0x0045u16, 0x0000, 0x0049, 0x0000];
+        assert_eq!(Char16String::from_units_with_nul(units), Err(StringError::InteriorNul { position: 1 }));
+    }
+
+    #[test]
+    fn test_char16string_from_units_with_nul_surrogate_rejected() {
+        let units = alloc::vec![0x0045u16, 0xD800, 0x0000];
+        assert_eq!(Char16String::from_units_with_nul(units), Err(StringError::NotUcs2 { position: 1, value: 0xD800 }));
+    }
+
+    #[test]
+    fn test_char16string_from_units_with_nul_unchecked() {
+        let units = alloc::vec![0x0045u16, 0x0046, 0x0049, 0x0000];
+        // SAFETY: `units` is a valid NUL-terminated UCS-2 sequence.
+        let s = unsafe { Char16String::from_units_with_nul_unchecked(units) };
+        assert!(*s == *"EFI");
+    }
+
+    #[test]
+    fn test_char16_array_from_str_exact_fit() {
+        const NAME: Char16Array<4> = Char16Array::from_str("EFI");
+        assert_eq!(NAME.as_char16_str().len(), 3);
+        assert!(NAME.as_char16_str() == "EFI");
+        assert_eq!(NAME.to_string(), "EFI");
+    }
+
+    #[test]
+    fn test_char16_array_with_padding() {
+        let array = Char16Array::<8>::from_str("EFI");
+        assert_eq!(array.as_char16_str().len(), 3);
+        // The backing array is NUL-padded to its full capacity.
+        assert_eq!(array.as_array(), &[0x45, 0x46, 0x49, 0, 0, 0, 0, 0]);
+    }
+
+    #[test]
+    fn test_char16_array_too_long() {
+        assert_eq!(Char16Array::<3>::try_from_str("EFI"), Err(StringError::TooLong { capacity: 2, required: 4 }));
+    }
+
+    #[test]
+    fn test_char16_array_rejects_non_bmp() {
+        assert_eq!(
+            Char16Array::<8>::try_from_str("A\u{1F600}"),
+            Err(StringError::NotUcs2 { position: 1, value: 0x1F600 })
+        );
+    }
+
+    #[test]
+    fn test_char16_array_zero_capacity() {
+        assert_eq!(Char16Array::<0>::try_from_str(""), Err(StringError::TooLong { capacity: 0, required: 1 }));
+    }
+
+    #[test]
+    fn test_char16_macro() {
+        let name = char16!("Firmware");
+        assert_eq!(name.len(), 8);
+        assert!(name == "Firmware");
+    }
+
+    #[test]
+    fn test_char16_macro_multibyte_utf8() {
+        // "café" is 4 characters but 5 UTF-8 bytes; capacity must be counted in characters.
+        let name = char16!("café");
+        assert_eq!(name.len(), 4);
+        assert!(name == "café");
+    }
+
+    #[test]
+    fn test_char16_array_binary_layout() {
+        assert_eq!(core::mem::size_of::<Char16Array<8>>(), 16);
+    }
+
+    #[test]
+    fn test_char16_array_runtime_multibyte_decode() {
+        // Exercise the multi-byte UTF-8 decode branches at runtime (not just at const time).
+        let two_byte = Char16Array::<8>::try_from_str("café").unwrap(); // 'é' is 2 UTF-8 bytes
+        assert!(two_byte.as_char16_str() == "café");
+        let three_byte = Char16Array::<8>::try_from_str("€").unwrap(); // '€' is 3 UTF-8 bytes
+        assert_eq!(three_byte.as_char16_str().len(), 1);
+        // A 4-byte sequence decodes to a non-BMP code point, which is rejected as non-UCS-2.
+        assert!(matches!(Char16Array::<8>::try_from_str("\u{1F600}"), Err(StringError::NotUcs2 { .. })));
+    }
+
+    #[test]
+    fn test_char16_capacity_helper_runtime() {
+        assert_eq!(ucs2_capacity("EFI"), 4);
+        assert_eq!(ucs2_capacity(""), 1);
+    }
+}

--- a/sdk/patina/src/base/string/char8.rs
+++ b/sdk/patina/src/base/string/char8.rs
@@ -1,0 +1,913 @@
+//! CHAR8 (ASCII / ISO-Latin-1) string types
+//!
+//! See the [module documentation](crate::base::string) for an overview of the UEFI string types.
+//!
+//! ## License
+//!
+//! Copyright (C) Microsoft Corporation.
+//!
+//! SPDX-License-Identifier: Apache-2.0
+
+use super::{StringError, char_count, decode_utf8};
+use zerocopy_derive::{FromBytes, Immutable, IntoBytes, KnownLayout};
+
+#[cfg(any(test, feature = "alloc"))]
+use alloc::vec::Vec;
+
+/// A borrowed, NUL-terminated CHAR8 (ASCII / ISO-Latin-1) string.
+///
+/// This is the CHAR8 analogue of [`core::ffi::CStr`]. It is an unsized type that is always accessed
+/// behind a reference (`&Char8Str`). The referenced data is guaranteed to:
+///
+/// - end with a single NUL (`0x00`) terminator, and
+/// - contain no interior NUL.
+///
+/// Every byte in `0x01..=0xFF` is a valid ISO-Latin-1 (ISO-8859-1) character, mapping directly onto
+/// the Unicode scalar values `U+0001..=U+00FF`. Because the terminator is guaranteed,
+/// [`Char8Str::as_ptr`] can be passed directly to `extern "efiapi"` interfaces expecting a
+/// `*const CHAR8`.
+///
+/// # Examples
+///
+/// ```rust
+/// use patina::base::string::Char8Str;
+///
+/// let bytes = *b"EFI\0";
+/// let s = Char8Str::from_bytes_with_nul(&bytes).unwrap();
+/// assert_eq!(s.len(), 3);
+/// assert!(s == "EFI");
+/// ```
+#[repr(transparent)]
+pub struct Char8Str([u8]);
+
+impl Char8Str {
+    /// An empty, NUL-terminated CHAR8 string.
+    // SAFETY: `&[0]` is a single NUL byte that is trivially NUL-terminated with no interior NUL.
+    pub const EMPTY: &'static Char8Str = unsafe { Self::from_bytes_with_nul_unchecked(&[0]) };
+
+    /// Creates a `&Char8Str` from a slice of bytes that ends with a NUL terminator.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`StringError::MissingNulTerminator`] if `bytes` does not end with a NUL, or
+    /// [`StringError::InteriorNul`] if a NUL appears before the end.
+    pub fn from_bytes_with_nul(bytes: &[u8]) -> Result<&Char8Str, StringError> {
+        let body = match bytes.split_last() {
+            Some((0, body)) => body,
+            _ => return Err(StringError::MissingNulTerminator),
+        };
+
+        for (position, &byte) in body.iter().enumerate() {
+            if byte == 0 {
+                return Err(StringError::InteriorNul { position });
+            }
+        }
+
+        // SAFETY: The loop above verified that `bytes` is NUL-terminated with no interior NUL, which
+        // are exactly the invariants of `Char8Str`. Every remaining byte is valid Latin-1.
+        Ok(unsafe { Self::from_bytes_with_nul_unchecked(bytes) })
+    }
+
+    /// Creates a `&Char8Str` from a NUL-terminated slice without validating its contents.
+    ///
+    /// # Safety
+    ///
+    /// The caller must ensure that `bytes` ends with a single NUL terminator and contains no interior
+    /// NUL.
+    pub const unsafe fn from_bytes_with_nul_unchecked(bytes: &[u8]) -> &Char8Str {
+        // SAFETY: `Char8Str` is `#[repr(transparent)]` over `[u8]`, so `&[u8]` and `&Char8Str` share
+        // the same layout. The caller upholds the value invariants.
+        unsafe { &*(bytes as *const [u8] as *const Char8Str) }
+    }
+
+    /// Creates a `&Char8Str` from the bytes up to and including the first NUL, ignoring anything
+    /// after it.
+    ///
+    /// This mirrors [`core::ffi::CStr::from_bytes_until_nul`]. It is useful for fixed-size or
+    /// over-allocated buffers that may carry trailing NUL padding (or other data) after the logical
+    /// end of the string, where [`Char8Str::from_bytes_with_nul`] would reject anything after the
+    /// first NUL as an interior NUL.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`StringError::MissingNulTerminator`] if `bytes` contains no NUL at all.
+    // `end` is a valid index into `bytes` because it came from `position`, so the slice can't panic.
+    #[allow(clippy::indexing_slicing)]
+    pub fn from_bytes_until_nul(bytes: &[u8]) -> Result<&Char8Str, StringError> {
+        let end = bytes.iter().position(|&byte| byte == 0).ok_or(StringError::MissingNulTerminator)?;
+        Self::from_bytes_with_nul(&bytes[..=end])
+    }
+
+    /// Creates a `&Char8Str` by scanning a raw pointer for a NUL terminator.
+    ///
+    /// # Safety
+    ///
+    /// The caller must ensure that:
+    ///
+    /// - `ptr` is non-null and aligned, even for a zero-length string.
+    /// - The memory pointed to by `ptr` contains a sequence of `u8` values that is valid for
+    ///   reads up to and including a NUL terminator.
+    ///   - The entire memory range of this `Char8Str`, from `ptr` through the terminator, must be
+    ///     contained within a single allocation.
+    ///   - The entire memory range must remain valid and unmodified for the lifetime `'a`.
+    ///   - The NUL terminator must be within `isize::MAX` bytes of `ptr`.
+    pub unsafe fn from_ptr<'a>(ptr: *const u8) -> &'a Char8Str {
+        let mut len = 0usize;
+        // SAFETY: The caller guarantees `ptr` points to a NUL-terminated sequence valid for reads.
+        while unsafe { *ptr.add(len) } != 0 {
+            len += 1;
+        }
+        // SAFETY: `len + 1` bytes up to and including the terminator are valid for reads.
+        let bytes = unsafe { core::slice::from_raw_parts(ptr, len + 1) };
+        // SAFETY: The scan guarantees a single trailing NUL with no interior NUL.
+        unsafe { Self::from_bytes_with_nul_unchecked(bytes) }
+    }
+
+    /// Creates a `&Char8Str` by scanning at most `max_bytes` bytes for a NUL terminator.
+    ///
+    /// # Safety
+    ///
+    /// The caller must ensure that:
+    ///
+    /// - `ptr` is non-null and aligned, even for a zero-length string.
+    /// - `max_units * size_of::<u8>()` must not exceed `isize::MAX` bytes.
+    /// - The memory pointed to by `ptr` contains a sequence of `u8` values that is valid for
+    ///   reads up to and including a NUL terminator.
+    ///   - The entire memory range of this `Char8Str`, from `ptr` through the terminator, must be
+    ///     contained within a single allocation.
+    ///   - The entire memory range must remain valid and unmodified for the lifetime `'a`.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`StringError::MissingNulTerminator`] if no NUL is found within `max_bytes` bytes.
+    pub unsafe fn from_ptr_bounded<'a>(ptr: *const u8, max_bytes: usize) -> Result<&'a Char8Str, StringError> {
+        let mut len = 0usize;
+        // SAFETY: The caller guarantees `max_bytes` bytes are valid for reads.
+        while len < max_bytes && unsafe { *ptr.add(len) } != 0 {
+            len += 1;
+        }
+        if len == max_bytes {
+            return Err(StringError::MissingNulTerminator);
+        }
+        // SAFETY: `len + 1 <= max_bytes` bytes up to and including the terminator are valid.
+        let bytes = unsafe { core::slice::from_raw_parts(ptr, len + 1) };
+        // SAFETY: The scan guarantees a single trailing NUL with no interior NUL.
+        Ok(unsafe { Self::from_bytes_with_nul_unchecked(bytes) })
+    }
+
+    /// Returns a pointer to the first byte, suitable for passing to `extern "efiapi"` interfaces.
+    ///
+    /// The pointed-to sequence is always NUL-terminated.
+    pub const fn as_ptr(&self) -> *const u8 {
+        self.0.as_ptr()
+    }
+
+    /// Returns the bytes including the trailing NUL terminator.
+    pub const fn as_bytes_with_nul(&self) -> &[u8] {
+        &self.0
+    }
+
+    /// Returns the bytes excluding the trailing NUL terminator.
+    pub fn as_bytes(&self) -> &[u8] {
+        match self.0.split_last() {
+            Some((_, body)) => body,
+            None => &[],
+        }
+    }
+
+    /// Returns the number of characters, excluding the trailing NUL terminator.
+    pub fn len(&self) -> usize {
+        self.as_bytes().len()
+    }
+
+    /// Returns `true` if the string contains no characters (only the NUL terminator).
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    /// Returns an iterator over the bytes, excluding the terminator.
+    ///
+    /// This borrows each byte rather than copying it. Call [`Iterator::copied`] on the result if
+    /// owned `u8` values are needed.
+    pub fn iter(&self) -> core::slice::Iter<'_, u8> {
+        self.as_bytes().iter()
+    }
+
+    /// Returns an iterator over the characters as [`char`] values.
+    ///
+    /// Each byte maps directly onto its ISO-Latin-1 Unicode scalar value, so this conversion is always
+    /// lossless.
+    pub fn chars(&self) -> impl Iterator<Item = char> + '_ {
+        self.iter().map(|&byte| byte as char)
+    }
+}
+
+impl PartialEq for Char8Str {
+    fn eq(&self, other: &Self) -> bool {
+        self.0 == other.0
+    }
+}
+
+impl Eq for Char8Str {}
+
+impl PartialOrd for Char8Str {
+    fn partial_cmp(&self, other: &Self) -> Option<core::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for Char8Str {
+    fn cmp(&self, other: &Self) -> core::cmp::Ordering {
+        self.0.cmp(&other.0)
+    }
+}
+
+impl core::hash::Hash for Char8Str {
+    fn hash<H: core::hash::Hasher>(&self, state: &mut H) {
+        self.0.hash(state);
+    }
+}
+
+impl PartialEq<str> for Char8Str {
+    fn eq(&self, other: &str) -> bool {
+        self.chars().eq(other.chars())
+    }
+}
+
+impl PartialEq<&str> for Char8Str {
+    fn eq(&self, other: &&str) -> bool {
+        self == *other
+    }
+}
+
+impl PartialEq<Char8Str> for str {
+    fn eq(&self, other: &Char8Str) -> bool {
+        other == self
+    }
+}
+
+impl core::fmt::Display for Char8Str {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        for c in self.chars() {
+            write!(f, "{c}")?;
+        }
+        Ok(())
+    }
+}
+
+impl core::fmt::Debug for Char8Str {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.write_str("\"")?;
+        for c in self.chars() {
+            write!(f, "{}", c.escape_debug())?;
+        }
+        f.write_str("\"")
+    }
+}
+
+/// An owned, heap-backed, NUL-terminated CHAR8 (ASCII / ISO-Latin-1) string.
+///
+/// This is the CHAR8 analogue of [`alloc::string::String`]. It dereferences to [`Char8Str`], so all
+/// borrowed operations are available on an owned value.
+///
+/// # Examples
+///
+/// ```rust
+/// use patina::base::string::Char8String;
+///
+/// let s = Char8String::try_from_str("Firmware").unwrap();
+/// assert_eq!(s.len(), 8);
+/// assert!(s == "Firmware");
+/// ```
+#[cfg(any(test, feature = "alloc"))]
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct Char8String(Vec<u8>);
+
+#[cfg(any(test, feature = "alloc"))]
+impl Char8String {
+    /// Creates an empty string containing only the NUL terminator.
+    pub fn new() -> Self {
+        Self(alloc::vec![0])
+    }
+
+    /// Creates a `Char8String` by encoding a Rust [`str`] as Latin-1.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`StringError::InteriorNul`] if the input contains a NUL character, or
+    /// [`StringError::NotLatin1`] if it contains a code point above `U+00FF`.
+    pub fn try_from_str(s: &str) -> Result<Self, StringError> {
+        let mut bytes = Vec::with_capacity(s.len() + 1);
+        for (position, c) in s.chars().enumerate() {
+            let value = c as u32;
+            if value == 0 {
+                return Err(StringError::InteriorNul { position });
+            }
+            if value > 0xFF {
+                return Err(StringError::NotLatin1 { position, value });
+            }
+            bytes.push(value as u8);
+        }
+        bytes.push(0);
+        Ok(Self(bytes))
+    }
+
+    /// Creates a `Char8String` from a `Vec<u8>` that ends with a NUL terminator.
+    ///
+    /// This validates `bytes` the same way [`Char8Str::from_bytes_with_nul`] does, then takes
+    /// ownership of the buffer directly instead of cloning it.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`StringError::MissingNulTerminator`] if `bytes` does not end with a NUL, or
+    /// [`StringError::InteriorNul`] if a NUL appears before the end.
+    pub fn from_bytes_with_nul(bytes: Vec<u8>) -> Result<Self, StringError> {
+        Char8Str::from_bytes_with_nul(&bytes)?;
+        Ok(Self(bytes))
+    }
+
+    /// Creates a `Char8String` from a NUL-terminated `Vec<u8>` without validating its contents.
+    ///
+    /// # Safety
+    ///
+    /// The caller must ensure that `bytes` ends with a single NUL terminator and contains no interior
+    /// NUL.
+    pub unsafe fn from_bytes_with_nul_unchecked(bytes: Vec<u8>) -> Self {
+        Self(bytes)
+    }
+
+    /// Borrows this owned string as a [`Char8Str`].
+    pub fn as_char8_str(&self) -> &Char8Str {
+        // SAFETY: The type invariant guarantees `self.0` is a valid NUL-terminated Latin-1 sequence.
+        unsafe { Char8Str::from_bytes_with_nul_unchecked(&self.0) }
+    }
+
+    /// Consumes the string and returns the backing bytes, including the trailing NUL.
+    pub fn into_bytes_with_nul(self) -> Vec<u8> {
+        self.0
+    }
+}
+
+#[cfg(any(test, feature = "alloc"))]
+impl Default for Char8String {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(any(test, feature = "alloc"))]
+impl core::ops::Deref for Char8String {
+    type Target = Char8Str;
+
+    fn deref(&self) -> &Char8Str {
+        self.as_char8_str()
+    }
+}
+
+#[cfg(any(test, feature = "alloc"))]
+impl core::borrow::Borrow<Char8Str> for Char8String {
+    fn borrow(&self) -> &Char8Str {
+        self.as_char8_str()
+    }
+}
+
+#[cfg(any(test, feature = "alloc"))]
+impl alloc::borrow::ToOwned for Char8Str {
+    type Owned = Char8String;
+
+    fn to_owned(&self) -> Char8String {
+        Char8String(self.0.to_vec())
+    }
+}
+
+#[cfg(any(test, feature = "alloc"))]
+impl From<&Char8Str> for Char8String {
+    fn from(s: &Char8Str) -> Self {
+        use alloc::borrow::ToOwned;
+        s.to_owned()
+    }
+}
+
+#[cfg(any(test, feature = "alloc"))]
+impl<'a> TryFrom<&'a str> for Char8String {
+    type Error = StringError;
+
+    fn try_from(s: &'a str) -> Result<Self, Self::Error> {
+        Self::try_from_str(s)
+    }
+}
+
+#[cfg(any(test, feature = "alloc"))]
+impl core::fmt::Display for Char8String {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        core::fmt::Display::fmt(self.as_char8_str(), f)
+    }
+}
+
+#[cfg(any(test, feature = "alloc"))]
+impl core::fmt::Debug for Char8String {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        core::fmt::Debug::fmt(self.as_char8_str(), f)
+    }
+}
+
+#[cfg(any(test, feature = "alloc"))]
+impl PartialEq<str> for Char8String {
+    fn eq(&self, other: &str) -> bool {
+        self.as_char8_str() == other
+    }
+}
+
+#[cfg(any(test, feature = "alloc"))]
+impl PartialEq<&str> for Char8String {
+    fn eq(&self, other: &&str) -> bool {
+        self.as_char8_str() == *other
+    }
+}
+
+#[cfg(any(test, feature = "alloc"))]
+impl PartialEq<Char8String> for str {
+    fn eq(&self, other: &Char8String) -> bool {
+        other.as_char8_str() == self
+    }
+}
+
+#[cfg(any(test, feature = "alloc"))]
+impl PartialEq<Char8Str> for Char8String {
+    fn eq(&self, other: &Char8Str) -> bool {
+        self.as_char8_str() == other
+    }
+}
+
+#[cfg(any(test, feature = "alloc"))]
+impl PartialEq<&Char8Str> for Char8String {
+    fn eq(&self, other: &&Char8Str) -> bool {
+        self.as_char8_str() == *other
+    }
+}
+
+#[cfg(any(test, feature = "alloc"))]
+impl PartialEq<Char8String> for Char8Str {
+    fn eq(&self, other: &Char8String) -> bool {
+        self == other.as_char8_str()
+    }
+}
+
+/// Returns the [`Char8Array`] capacity needed to hold `s` plus a NUL terminator.
+///
+/// This is an implementation detail of the [`char8!`](crate::char8) macro.
+#[doc(hidden)]
+pub const fn latin1_capacity(s: &str) -> usize {
+    // Every accepted Latin-1 character occupies a single byte, plus one for the terminator.
+    char_count(s) + 1
+}
+
+/// A fixed capacity, NUL-terminated CHAR8 (ASCII / ISO-Latin-1) string of `N` bytes.
+///
+/// The capacity `N` includes the trailing NUL terminator, so the array can hold up to `N - 1`
+/// characters. Unused trailing slots are filled with NUL. This type is `#[repr(transparent)]` over
+/// `[u8; N]`, making it suitable for `#[repr(C)]` structure fields.
+///
+/// Values can be built in `const` contexts via [`Char8Array::from_str`] and
+/// [`Char8Array::try_from_str`], which is how the [`char8!`](crate::char8) macro validates literals at
+/// compile time.
+///
+/// This type also implements [`zerocopy::FromBytes`] and [`zerocopy::IntoBytes`], so it can be used
+/// directly as a field of a `#[repr(C)]`/`#[repr(C, packed)]` structure that derives those traits for
+/// zero-copy parsing and serialization. Because `FromBytes` allows constructing a value from arbitrary
+/// bytes, a value built that way is not guaranteed to contain a NUL terminator. In that case,
+/// [`Char8Array::as_char8_str`] (and [`Deref`](core::ops::Deref)) return an empty string rather than
+/// panicking.
+///
+/// # Examples
+///
+/// ```rust
+/// use patina::base::string::Char8Array;
+///
+/// const NAME: Char8Array<4> = Char8Array::from_str("EFI");
+/// assert_eq!(NAME.as_char8_str().len(), 3);
+/// assert!(NAME.as_char8_str() == "EFI");
+/// ```
+#[repr(transparent)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, FromBytes, IntoBytes, Immutable, KnownLayout)]
+pub struct Char8Array<const N: usize>([u8; N]);
+
+impl<const N: usize> Char8Array<N> {
+    /// Creates a `Char8Array` by encoding a Rust [`str`] as Latin-1.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`StringError::InteriorNul`] if the input contains a NUL character,
+    /// [`StringError::NotLatin1`] if it contains a code point above `U+00FF`, or
+    /// [`StringError::TooLong`] if the encoded string plus its NUL terminator does not fit in `N`
+    /// bytes.
+    // `out[out_index]` is guarded by the `out_index + 1 >= N` check, so `out_index < N`.
+    #[allow(clippy::indexing_slicing)]
+    pub const fn try_from_str(s: &str) -> Result<Self, StringError> {
+        let bytes = s.as_bytes();
+        let mut out = [0u8; N];
+        let mut index = 0;
+        let mut out_index = 0;
+        let mut position = 0;
+
+        while index < bytes.len() {
+            let (value, len) = decode_utf8(bytes, index);
+            if value == 0 {
+                return Err(StringError::InteriorNul { position });
+            }
+            if value > 0xFF {
+                return Err(StringError::NotLatin1 { position, value });
+            }
+            // Require room for this byte and a trailing NUL terminator.
+            if out_index + 1 >= N {
+                return Err(StringError::TooLong { capacity: N.saturating_sub(1), required: out_index + 2 });
+            }
+            out[out_index] = value as u8;
+            out_index += 1;
+            index += len;
+            position += 1;
+        }
+
+        // Guard against `N == 0`, where there is no room for even a terminator.
+        if out_index >= N {
+            return Err(StringError::TooLong { capacity: 0, required: 1 });
+        }
+
+        Ok(Self(out))
+    }
+
+    /// Creates a `Char8Array`, panicking on invalid input.
+    ///
+    /// This is intended for compile-time string literals: because it is a `const fn`, an invalid
+    /// literal in a `const`/`static` context (including through the [`char8!`](crate::char8) macro) is
+    /// reported as a compile-time error, never a runtime panic. Runtime callers that cannot guarantee
+    /// valid input should use [`Char8Array::try_from_str`] instead, which returns a [`Result`] rather
+    /// than panicking.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the input is not valid Latin-1 or does not fit in `N` bytes. In a `const` context
+    /// this manifests as a compile-time error.
+    pub const fn from_str(s: &str) -> Self {
+        match Self::try_from_str(s) {
+            Ok(array) => array,
+            Err(_) => panic!("invalid Latin-1 string literal"),
+        }
+    }
+
+    /// Borrows the populated portion of the array as a [`Char8Str`].
+    ///
+    /// Every value produced by a safe constructor (`try_from_str`, `from_str`, `Default`) contains a
+    /// NUL terminator by construction. A value materialized from arbitrary bytes using `FromBytes` is
+    /// not guaranteed to, so this returns [`Char8Str::EMPTY`] in that case rather than panicking.
+    #[allow(clippy::indexing_slicing)]
+    pub fn as_char8_str(&self) -> &Char8Str {
+        let mut len = 0;
+        while len < N && self.0[len] != 0 {
+            len += 1;
+        }
+        if len == N {
+            return Char8Str::EMPTY;
+        }
+        // SAFETY: `self.0[..=len]` ends at the first NUL (found above) and contains only valid Latin-1
+        // bytes.
+        unsafe { Char8Str::from_bytes_with_nul_unchecked(&self.0[..=len]) }
+    }
+
+    /// Returns the full backing array, including trailing NUL padding.
+    pub const fn as_array(&self) -> &[u8; N] {
+        &self.0
+    }
+}
+
+impl<const N: usize> core::ops::Deref for Char8Array<N> {
+    type Target = Char8Str;
+
+    fn deref(&self) -> &Char8Str {
+        self.as_char8_str()
+    }
+}
+
+impl<const N: usize> core::fmt::Display for Char8Array<N> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        core::fmt::Display::fmt(self.as_char8_str(), f)
+    }
+}
+
+impl<const N: usize> Default for Char8Array<N> {
+    /// Returns an empty string backed by an all-zero array.
+    ///
+    /// `N` must be at least `1` to hold the mandatory NUL terminator; as with
+    /// [`Char8Array::try_from_str`], a capacity of `0` cannot represent a valid string.
+    fn default() -> Self {
+        Self([0; N])
+    }
+}
+
+#[cfg(test)]
+#[cfg_attr(coverage, coverage(off))]
+mod tests {
+    use super::*;
+    use crate::char8;
+    use alloc::string::ToString;
+
+    #[test]
+    fn test_char8_from_bytes_with_nul_valid() {
+        let bytes = *b"EFI\0";
+        let s = Char8Str::from_bytes_with_nul(&bytes).unwrap();
+        assert_eq!(s.len(), 3);
+        assert!(!s.is_empty());
+        assert_eq!(s.as_bytes(), b"EFI");
+        assert_eq!(s.as_bytes_with_nul(), b"EFI\0");
+    }
+
+    #[test]
+    fn test_char8_empty_string() {
+        let bytes = [0u8];
+        let s = Char8Str::from_bytes_with_nul(&bytes).unwrap();
+        assert_eq!(s.len(), 0);
+        assert!(s.is_empty());
+    }
+
+    #[test]
+    fn test_char8_missing_nul_terminator() {
+        assert_eq!(Char8Str::from_bytes_with_nul(b"EFI"), Err(StringError::MissingNulTerminator));
+        assert_eq!(Char8Str::from_bytes_with_nul(b""), Err(StringError::MissingNulTerminator));
+    }
+
+    #[test]
+    fn test_char8_interior_nul() {
+        let bytes = *b"E\0I\0";
+        assert_eq!(Char8Str::from_bytes_with_nul(&bytes), Err(StringError::InteriorNul { position: 1 }));
+    }
+
+    #[test]
+    fn test_char8_high_latin1_bytes_valid() {
+        let bytes = [0xE9u8, 0xFF, 0x00]; // "éÿ"
+        let s = Char8Str::from_bytes_with_nul(&bytes).unwrap();
+        let chars: alloc::vec::Vec<char> = s.chars().collect();
+        assert_eq!(chars, ['\u{00E9}', '\u{00FF}']);
+    }
+
+    #[test]
+    fn test_char8_iter() {
+        let bytes = *b"EFI\0";
+        let s = Char8Str::from_bytes_with_nul(&bytes).unwrap();
+        let collected: alloc::vec::Vec<u8> = s.iter().copied().collect();
+        assert_eq!(collected, b"EFI");
+    }
+
+    #[test]
+    fn test_char8_from_ptr() {
+        let bytes = *b"EFI\0";
+        // SAFETY: `bytes` is a valid NUL-terminated buffer that outlives the borrow.
+        let s = unsafe { Char8Str::from_ptr(bytes.as_ptr()) };
+        assert!(s == "EFI");
+    }
+
+    #[test]
+    fn test_char8_from_ptr_bounded_finds_nul() {
+        let bytes = *b"EF\0I";
+        // SAFETY: `bytes` has at least 4 readable bytes.
+        let s = unsafe { Char8Str::from_ptr_bounded(bytes.as_ptr(), 4) }.unwrap();
+        assert_eq!(s.len(), 2);
+    }
+
+    #[test]
+    fn test_char8_from_ptr_bounded_no_nul() {
+        let bytes = *b"EFI";
+        // SAFETY: `bytes` has at least 3 readable bytes.
+        let result = unsafe { Char8Str::from_ptr_bounded(bytes.as_ptr(), 3) };
+        assert_eq!(result, Err(StringError::MissingNulTerminator));
+    }
+
+    #[test]
+    fn test_char8_display_and_debug() {
+        let bytes = *b"EFI\0";
+        let s = Char8Str::from_bytes_with_nul(&bytes).unwrap();
+        assert_eq!(s.to_string(), "EFI");
+        assert_eq!(alloc::format!("{s:?}"), "\"EFI\"");
+    }
+
+    #[test]
+    fn test_char8_equality_and_ordering() {
+        let a = Char8Str::from_bytes_with_nul(b"A\0").unwrap();
+        let b = Char8Str::from_bytes_with_nul(b"B\0").unwrap();
+        assert!(a < b);
+        assert_ne!(a, b);
+        assert!(a == "A");
+        assert!(*"A" == *a);
+    }
+
+    #[test]
+    fn test_char8string_try_from_str() {
+        let s = Char8String::try_from_str("Firmware").unwrap();
+        assert_eq!(s.len(), 8);
+        assert!(*s == *"Firmware");
+        assert_eq!(s.to_string(), "Firmware");
+    }
+
+    #[test]
+    fn test_char8string_partial_eq_str() {
+        let s = Char8String::try_from_str("EFI").unwrap();
+        assert!(s == "EFI");
+        assert!(s == *"EFI");
+        assert!(*"EFI" == s);
+        assert!(s != "NOPE");
+        assert!(*"NOPE" != s);
+    }
+
+    #[test]
+    fn test_char8string_partial_eq_char8str() {
+        let s = Char8String::try_from_str("EFI").unwrap();
+        let same = Char8String::try_from_str("EFI").unwrap();
+        let different = Char8String::try_from_str("NOPE").unwrap();
+        let same_str: &Char8Str = same.as_char8_str();
+        let different_str: &Char8Str = different.as_char8_str();
+        assert!(s == *same_str);
+        assert!(s == same_str);
+        assert!(*same_str == s);
+        assert!(s != *different_str);
+        assert!(*different_str != s);
+    }
+
+    #[test]
+    fn test_char8string_latin1_boundary() {
+        // U+00FF is the last valid Latin-1 code point; U+0100 is the first invalid one.
+        assert!(Char8String::try_from_str("\u{00FF}").is_ok());
+        assert_eq!(Char8String::try_from_str("A\u{0100}"), Err(StringError::NotLatin1 { position: 1, value: 0x0100 }));
+    }
+
+    #[test]
+    fn test_char8string_rejects_interior_nul() {
+        assert_eq!(Char8String::try_from_str("A\0B"), Err(StringError::InteriorNul { position: 1 }));
+    }
+
+    #[test]
+    fn test_char8string_new_and_default() {
+        let a = Char8String::new();
+        let b = Char8String::default();
+        assert!(a.is_empty());
+        assert_eq!(a, b);
+        assert_eq!(a.clone().into_bytes_with_nul(), alloc::vec![0]);
+    }
+
+    #[test]
+    fn test_char8string_to_owned_roundtrip() {
+        use alloc::borrow::ToOwned;
+        let owned = Char8String::try_from_str("Test").unwrap();
+        let borrowed: &Char8Str = &owned;
+        let reowned = borrowed.to_owned();
+        assert_eq!(owned, reowned);
+    }
+
+    #[test]
+    fn test_char8string_from_ref_char8str() {
+        let owned = Char8String::try_from_str("Test").unwrap();
+        let borrowed: &Char8Str = &owned;
+        let converted = Char8String::from(borrowed);
+        assert_eq!(owned, converted);
+        let via_into: Char8String = borrowed.into();
+        assert_eq!(owned, via_into);
+    }
+
+    #[test]
+    fn test_char8str_partial_eq_ref_str() {
+        let s = Char8Str::from_bytes_with_nul(b"EFI\0").unwrap();
+        let other: &str = "EFI";
+        assert!(s == other);
+        assert!(s != "NOPE");
+    }
+
+    #[test]
+    fn test_char8str_hash() {
+        use core::hash::{Hash, Hasher};
+        use std::collections::hash_map::DefaultHasher;
+        let s = Char8Str::from_bytes_with_nul(b"E\0").unwrap();
+        let mut hasher = DefaultHasher::new();
+        s.hash(&mut hasher);
+        let _ = hasher.finish();
+    }
+
+    #[test]
+    fn test_char8string_debug_borrow_and_display() {
+        use core::borrow::Borrow;
+        let s = Char8String::try_from_str("EFI").unwrap();
+        assert_eq!(alloc::format!("{s:?}"), "\"EFI\"");
+        assert_eq!(s.to_string(), "EFI");
+        let borrowed: &Char8Str = s.borrow();
+        assert_eq!(borrowed.len(), 3);
+    }
+
+    #[test]
+    fn test_char8_from_bytes_until_nul_exact() {
+        let bytes = *b"EFI\0";
+        let s = Char8Str::from_bytes_until_nul(&bytes).unwrap();
+        assert!(s == "EFI");
+    }
+
+    #[test]
+    fn test_char8_from_bytes_until_nul_trailing_padding() {
+        // Extra trailing NUL padding after the terminator is ignored rather than rejected.
+        let bytes = *b"EFI\0\0\0";
+        let s = Char8Str::from_bytes_until_nul(&bytes).unwrap();
+        assert_eq!(s.len(), 3);
+        assert!(s == "EFI");
+    }
+
+    #[test]
+    fn test_char8_from_bytes_until_nul_trailing_garbage() {
+        // Anything after the first NUL is ignored, matching core::ffi::CStr::from_bytes_until_nul.
+        let bytes = [b'E', 0, 0xFF];
+        let s = Char8Str::from_bytes_until_nul(&bytes).unwrap();
+        assert_eq!(s.len(), 1);
+        assert!(s == "E");
+    }
+
+    #[test]
+    fn test_char8_from_bytes_until_nul_missing_nul() {
+        assert_eq!(Char8Str::from_bytes_until_nul(b"EFI"), Err(StringError::MissingNulTerminator));
+        assert_eq!(Char8Str::from_bytes_until_nul(b""), Err(StringError::MissingNulTerminator));
+    }
+
+    #[test]
+    fn test_char8string_from_bytes_with_nul() {
+        let bytes = alloc::vec![b'E', b'F', b'I', 0];
+        let s = Char8String::from_bytes_with_nul(bytes).unwrap();
+        assert_eq!(s.len(), 3);
+        assert!(*s == *"EFI");
+    }
+
+    #[test]
+    fn test_char8string_from_bytes_with_nul_missing_terminator() {
+        let bytes = alloc::vec![b'E', b'F', b'I'];
+        assert_eq!(Char8String::from_bytes_with_nul(bytes), Err(StringError::MissingNulTerminator));
+    }
+
+    #[test]
+    fn test_char8string_from_bytes_with_nul_interior_nul() {
+        let bytes = alloc::vec![b'E', 0, b'I', 0];
+        assert_eq!(Char8String::from_bytes_with_nul(bytes), Err(StringError::InteriorNul { position: 1 }));
+    }
+
+    #[test]
+    fn test_char8string_from_bytes_with_nul_unchecked() {
+        let bytes = alloc::vec![b'E', b'F', b'I', 0];
+        // SAFETY: `bytes` is a valid NUL-terminated Latin-1 sequence.
+        let s = unsafe { Char8String::from_bytes_with_nul_unchecked(bytes) };
+        assert!(*s == *"EFI");
+    }
+
+    #[test]
+    fn test_char8_array_from_str_exact_fit() {
+        const NAME: Char8Array<4> = Char8Array::from_str("EFI");
+        assert_eq!(NAME.as_char8_str().len(), 3);
+        assert!(NAME.as_char8_str() == "EFI");
+        assert_eq!(NAME.to_string(), "EFI");
+    }
+
+    #[test]
+    fn test_char8_array_with_padding() {
+        let array = Char8Array::<8>::from_str("EFI");
+        assert_eq!(array.as_char8_str().len(), 3);
+        assert_eq!(array.as_array(), b"EFI\0\0\0\0\0");
+    }
+
+    #[test]
+    fn test_char8_array_too_long() {
+        assert_eq!(Char8Array::<3>::try_from_str("EFI"), Err(StringError::TooLong { capacity: 2, required: 4 }));
+    }
+
+    #[test]
+    fn test_char8_array_rejects_non_latin1() {
+        assert_eq!(
+            Char8Array::<8>::try_from_str("A\u{0100}"),
+            Err(StringError::NotLatin1 { position: 1, value: 0x0100 })
+        );
+    }
+
+    #[test]
+    fn test_char8_macro() {
+        let name = char8!("Firmware");
+        assert_eq!(name.len(), 8);
+        assert!(name == "Firmware");
+    }
+
+    #[test]
+    fn test_char8_array_binary_layout() {
+        assert_eq!(core::mem::size_of::<Char8Array<8>>(), 8);
+    }
+
+    #[test]
+    fn test_char8_array_runtime_multibyte_decode() {
+        let latin1 = Char8Array::<8>::try_from_str("café").unwrap();
+        assert!(latin1.as_char8_str() == "café");
+        // '€' (U+20AC) exceeds Latin-1 and is rejected.
+        assert!(matches!(Char8Array::<8>::try_from_str("€"), Err(StringError::NotLatin1 { .. })));
+    }
+
+    #[test]
+    fn test_char8_capacity_helper_runtime() {
+        assert_eq!(latin1_capacity("café"), 5);
+    }
+}

--- a/sdk/patina/src/base/string/char8.rs
+++ b/sdk/patina/src/base/string/char8.rs
@@ -11,8 +11,13 @@
 use super::{StringError, char_count, decode_utf8};
 use zerocopy_derive::{FromBytes, Immutable, IntoBytes, KnownLayout};
 
+use super::char16::Char16Array;
+
 #[cfg(any(test, feature = "alloc"))]
-use alloc::vec::Vec;
+use alloc::{string::String, vec::Vec};
+
+#[cfg(any(test, feature = "alloc"))]
+use super::char16::{Char16Str, Char16String};
 
 /// A borrowed, NUL-terminated CHAR8 (ASCII / ISO-Latin-1) string.
 ///
@@ -398,6 +403,46 @@ impl<'a> TryFrom<&'a str> for Char8String {
 }
 
 #[cfg(any(test, feature = "alloc"))]
+impl TryFrom<&Char16Str> for Char8String {
+    type Error = StringError;
+
+    /// Converts UCS-2 to Latin-1.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`StringError::NotLatin1`] if any code unit is above `0xFF`.
+    fn try_from(value: &Char16Str) -> Result<Self, StringError> {
+        let mut bytes = Vec::with_capacity(value.len() + 1);
+        for (position, &unit) in value.iter().enumerate() {
+            if unit > 0xFF {
+                return Err(StringError::NotLatin1 { position, value: unit as u32 });
+            }
+            bytes.push(unit as u8);
+        }
+        bytes.push(0);
+        Ok(Self(bytes))
+    }
+}
+
+#[cfg(any(test, feature = "alloc"))]
+impl TryFrom<&Char16String> for Char8String {
+    type Error = StringError;
+
+    fn try_from(value: &Char16String) -> Result<Self, StringError> {
+        Self::try_from(value.as_char16_str())
+    }
+}
+
+#[cfg(any(test, feature = "alloc"))]
+impl TryFrom<Char16String> for Char8String {
+    type Error = StringError;
+
+    fn try_from(value: Char16String) -> Result<Self, StringError> {
+        Self::try_from(&value)
+    }
+}
+
+#[cfg(any(test, feature = "alloc"))]
 impl core::fmt::Display for Char8String {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         core::fmt::Display::fmt(self.as_char8_str(), f)
@@ -601,6 +646,62 @@ impl<const N: usize> Default for Char8Array<N> {
     /// [`Char8Array::try_from_str`], a capacity of `0` cannot represent a valid string.
     fn default() -> Self {
         Self([0; N])
+    }
+}
+
+impl<'a, const N: usize> TryFrom<&'a str> for Char8Array<N> {
+    type Error = StringError;
+
+    /// Equivalent to [`Char8Array::try_from_str`], provided for generic code written against the
+    /// standard [`TryFrom`] trait.
+    fn try_from(s: &'a str) -> Result<Self, StringError> {
+        Self::try_from_str(s)
+    }
+}
+
+impl<const N: usize> TryFrom<Char16Array<N>> for Char8Array<N> {
+    type Error = StringError;
+
+    /// Converts UCS-2 to Latin-1.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`StringError::NotLatin1`] if any code unit is above `0xFF`. This can never fail with
+    /// [`StringError::TooLong`] since both arrays share the same capacity `N`, and a `Char16Array<N>`'s
+    /// logical content is always at most `N - 1` code units.
+    // Note: `out[position]` is safe because `position < src.len() < N`, except when `N == 0`, where `src`
+    // is empty and the loop never runs.
+    #[allow(clippy::indexing_slicing)]
+    fn try_from(value: Char16Array<N>) -> Result<Self, StringError> {
+        let src = value.as_char16_str();
+        // Note: The terminator and any trailing padding are already present due to zero-initialization.
+        let mut out = [0u8; N];
+        for (position, &unit) in src.iter().enumerate() {
+            if unit > 0xFF {
+                return Err(StringError::NotLatin1 { position, value: unit as u32 });
+            }
+            out[position] = unit as u8;
+        }
+        Ok(Self(out))
+    }
+}
+
+#[cfg(any(test, feature = "alloc"))]
+impl<const N: usize> From<Char8Array<N>> for Char8String {
+    /// Converts a fixed-capacity array to a heap-owned string, dropping the const capacity `N`.
+    fn from(value: Char8Array<N>) -> Self {
+        use alloc::borrow::ToOwned;
+        value.as_char8_str().to_owned()
+    }
+}
+
+#[cfg(any(test, feature = "alloc"))]
+impl<const N: usize> From<Char8Array<N>> for String {
+    /// Converts to a native Rust string.
+    ///
+    /// This will always succeed since every Latin-1 character is a valid Unicode scalar value.
+    fn from(value: Char8Array<N>) -> Self {
+        value.as_char8_str().chars().collect()
     }
 }
 
@@ -909,5 +1010,74 @@ mod tests {
     #[test]
     fn test_char8_capacity_helper_runtime() {
         assert_eq!(latin1_capacity("café"), 5);
+    }
+
+    #[test]
+    fn test_char8_array_try_from_str_trait() {
+        let array = Char8Array::<9>::try_from("Firmware").unwrap();
+        assert!(array.as_char8_str() == "Firmware");
+    }
+
+    #[test]
+    fn test_char8_array_from_char16_array() {
+        let wide = Char16Array::<9>::from_str("Firmware");
+        let narrow = Char8Array::<9>::try_from(wide).unwrap();
+        assert!(narrow.as_char8_str() == "Firmware");
+    }
+
+    #[test]
+    fn test_char8_array_from_char16_array_high_latin1() {
+        let wide = Char16Array::<2>::from_str("\u{00E9}"); // 'é'
+        let narrow = Char8Array::<2>::try_from(wide).unwrap();
+        assert!(narrow.as_char8_str() == "\u{00E9}");
+    }
+
+    #[test]
+    fn test_char8_array_from_char16_array_not_latin1() {
+        let wide = Char16Array::<4>::from_str("A\u{20AC}"); // '€' (U+20AC) exceeds Latin-1
+        assert_eq!(Char8Array::<4>::try_from(wide), Err(StringError::NotLatin1 { position: 1, value: 0x20AC }));
+    }
+
+    #[test]
+    fn test_char8_array_from_char16_array_empty_capacity() {
+        let wide = Char16Array::<0>::default();
+        let narrow = Char8Array::<0>::try_from(wide).unwrap();
+        assert!(narrow.as_char8_str().is_empty());
+    }
+
+    #[test]
+    fn test_char8_array_to_char8string() {
+        let array = Char8Array::<9>::from_str("Firmware");
+        let owned: Char8String = array.into();
+        assert!(owned == "Firmware");
+    }
+
+    #[test]
+    fn test_char8_array_to_string() {
+        let array = Char8Array::<9>::from_str("Firmware");
+        let owned: alloc::string::String = array.into();
+        assert_eq!(owned, "Firmware");
+    }
+
+    #[test]
+    fn test_char8string_try_from_char16str() {
+        let wide = Char16Array::<4>::from_str("EFI");
+        let narrow = Char8String::try_from(wide.as_char16_str()).unwrap();
+        assert!(narrow == "EFI");
+    }
+
+    #[test]
+    fn test_char8string_try_from_char16string() {
+        let wide = Char16String::try_from_str("EFI").unwrap();
+        let narrow = Char8String::try_from(&wide).unwrap();
+        assert!(narrow == "EFI");
+        let narrow_owned = Char8String::try_from(wide).unwrap();
+        assert!(narrow_owned == "EFI");
+    }
+
+    #[test]
+    fn test_char8string_try_from_char16string_not_latin1() {
+        let wide = Char16String::try_from_str("A\u{20AC}").unwrap();
+        assert_eq!(Char8String::try_from(&wide), Err(StringError::NotLatin1 { position: 1, value: 0x20AC }));
     }
 }

--- a/sdk/patina/src/device_path/node_defs.rs
+++ b/sdk/patina/src/device_path/node_defs.rs
@@ -15,6 +15,7 @@ use core::{
 use alloc::{
     boxed::Box,
     string::{String, ToString},
+    vec::Vec,
 };
 
 use scroll::{
@@ -23,6 +24,7 @@ use scroll::{
 };
 
 use crate::{
+    Char16Str, Char16String,
     device_path::parse_node::{self, DevicePathNode, UnknownDevicePathNode},
     device_path_node,
 };
@@ -835,13 +837,12 @@ impl parse_node::DevicePathNode for FilePath {
         let header = self.header();
         let mut offset = 0;
         buffer.gwrite_with(header, &mut offset, scroll::Endian::Little)?;
-        // Write the path as UTF-16LE (UCS-2)
-        for c in self.path.chars() {
-            let code_point = c as u16;
-            buffer.gwrite_with(code_point, &mut offset, scroll::LE)?;
+        // Write the path as UCS-2 (UEFI CHAR16), including the trailing NUL terminator.
+        let encoded = Char16String::try_from_str(&self.path)
+            .map_err(|_| scroll::Error::BadInput { size: offset, msg: "file path is not valid UCS-2" })?;
+        for unit in encoded.as_units_with_nul() {
+            buffer.gwrite_with(*unit, &mut offset, scroll::LE)?;
         }
-        // Write null terminator (UTF-16)
-        buffer.gwrite_with(0u16, &mut offset, scroll::LE)?;
         Ok(offset)
     }
 }
@@ -863,13 +864,12 @@ impl TryIntoCtx<scroll::Endian> for FilePath {
 
     fn try_into_ctx(self, dest: &mut [u8], _ctx: scroll::Endian) -> Result<usize, Self::Error> {
         let mut offset = 0;
-        // Write the path as UTF-16LE (UCS-2)
-        for c in self.path.chars() {
-            let code_point = c as u16;
-            dest.gwrite_with(code_point, &mut offset, scroll::LE)?;
+        // Write the path as UCS-2 (UEFI CHAR16), including the trailing NUL terminator.
+        let encoded = Char16String::try_from_str(&self.path)
+            .map_err(|_| scroll::Error::BadInput { size: offset, msg: "file path is not valid UCS-2" })?;
+        for unit in encoded.as_units_with_nul() {
+            dest.gwrite_with(*unit, &mut offset, scroll::LE)?;
         }
-        // Write null terminator (UTF-16)
-        dest.gwrite_with(0u16, &mut offset, scroll::LE)?;
         Ok(offset)
     }
 }
@@ -879,22 +879,26 @@ impl TryFromCtx<'_, scroll::Endian> for FilePath {
 
     fn try_from_ctx(buffer: &[u8], _ctx: scroll::Endian) -> Result<(Self, usize), Self::Error> {
         let mut offset = 0;
-        let mut path = String::new();
+        let mut units = Vec::new();
 
-        // Read UTF-16LE characters until null terminator
+        // Read UCS-2 code units until the null terminator.
         loop {
             if offset + 2 > buffer.len() {
                 break;
             }
-            let code_point: u16 = buffer.gread_with(&mut offset, scroll::LE)?;
-            if code_point == 0 {
+            let code_unit: u16 = buffer.gread_with(&mut offset, scroll::LE)?;
+            if code_unit == 0 {
                 break;
             }
-            // Convert UTF-16 code point to char
-            if let Some(c) = char::from_u32(code_point as u32) {
-                path.push(c);
-            }
+            units.push(code_unit);
         }
+        units.push(0);
+
+        // Validate the collected code units as UCS-2 before decoding.
+        let path = Char16Str::from_units_with_nul(&units)
+            .map_err(|_| scroll::Error::BadInput { size: offset, msg: "file path is not valid UCS-2" })?
+            .chars()
+            .collect();
 
         Ok((Self { path }, offset))
     }

--- a/sdk/patina/src/lib.rs
+++ b/sdk/patina/src/lib.rs
@@ -23,6 +23,7 @@
 extern crate alloc;
 
 pub use base::guid::{BinaryGuid, Guid, GuidError, OwnedGuid};
+pub use base::string::{Char8Array, Char8Str, Char8String, Char16Array, Char16Str, Char16String, StringError};
 
 /// Common GUID constants
 pub mod guid_constants {

--- a/sdk/patina/src/pi/fw_fs.rs
+++ b/sdk/patina/src/pi/fw_fs.rs
@@ -40,6 +40,8 @@ pub use fv::{
 pub use fvb::attributes::{EfiFvbAttributes2, Fvb2 as Fvb2Attributes, raw::fvb2 as Fvb2RawAttributes};
 use zerocopy::FromBytes;
 
+#[cfg(test)]
+use crate::Char16String;
 use crate::{BinaryGuid, base::align_up};
 use alloc::{boxed::Box, collections::VecDeque, vec::Vec};
 use num_traits::WrappingSub;
@@ -1007,7 +1009,7 @@ mod unit_tests {
 
     use crate::pi::fw_fs::{SectionMetaData, guid};
 
-    use super::{FfsSectionType, FirmwareVolume, NullSectionExtractor, Section, SectionExtractor, fv};
+    use super::{Char16String, FfsSectionType, FirmwareVolume, NullSectionExtractor, Section, SectionExtractor, fv};
 
     #[derive(Debug, Deserialize)]
     struct TargetValues {
@@ -1102,9 +1104,7 @@ mod unit_tests {
 
     fn extract_text_from_section(section: &Section) -> Option<String> {
         if section.section_type() == Some(FfsSectionType::UserInterface) {
-            let display_name_chars: Vec<u16> =
-                section.section_data().chunks(2).map(|x| u16::from_le_bytes(x.try_into().unwrap())).collect();
-            Some(String::from_utf16_lossy(&display_name_chars).trim_end_matches(char::from(0)).to_string())
+            Char16String::from_le_bytes_until_nul(section.section_data()).ok().map(|s| s.to_string())
         } else {
             None
         }

--- a/sdk/patina_ffs/src/volume.rs
+++ b/sdk/patina_ffs/src/volume.rs
@@ -792,6 +792,7 @@ mod test {
         section::{Section, SectionComposer, SectionExtractor, SectionHeader},
         volume::{Volume, VolumeRef},
     };
+    use patina::Char16String;
 
     #[derive(Debug, Deserialize, Clone)]
     struct TargetValues {
@@ -849,13 +850,7 @@ mod test {
 
     fn extract_text_from_section(section: &Section) -> Option<String> {
         if section.section_type() == Some(ffs::section::Type::UserInterface) {
-            let display_name_chars: Vec<u16> = section
-                .try_content_as_slice()
-                .ok()?
-                .chunks(2)
-                .map(|x| u16::from_le_bytes(x.try_into().unwrap()))
-                .collect();
-            Some(String::from_utf16_lossy(&display_name_chars).trim_end_matches(char::from(0)).to_string())
+            Char16String::from_le_bytes_until_nul(section.try_content_as_slice().ok()?).ok().map(|s| s.to_string())
         } else {
             None
         }


### PR DESCRIPTION
## Description

Resolves #1656

The UEFI Specification defines two string types: [`CHAR8` and `CHAR16`](https://uefi.org/specs/UEFI/2.11/02_Overview.html#common-uefi-data-types).

- `CHAR8`: 1-byte character. Unless otherwise specified, all 1-byte or ASCII characters and strings are stored in 8-bit ASCII encoding format, using the ISO-Latin-1 character set.
- `CHAR16`: 2-byte Character. Unless otherwise specified all characters and strings are stored in the UCS-2 encoding format as defined by Unicode 2.1 and ISO/IEC 10646 standards.

`strings.md` (added to the mdbook) and doc comments explain the types in more detail, but at a high-level:

| Role                                       | CHAR8           | CHAR16           |
|--------------------------------------------|-----------------|------------------|
| Borrowed, unsized                          | `Char8Str`      | `Char16Str`      |
| Owned, heap-backed (requires `alloc`)      | `Char8String`   | `Char16String`   |
| Owned, fixed capacity (usable in `const`)  | `Char8Array<N>` | `Char16Array<N>` |

Some code usage is updated to use the new types that might not be exhaustive (future changes can adopt the types as needed). **However, more substantial changes to use the new types throughout the codebase would require changing public APIs** and that was avoided in this change so the types can be introduced to the `main` branch without the PR being a breaking change. This makes existing code updates not as clean as they'd be otherwise. For example, if a public API takes a string today as `Vec<u16>`, this will update the caller to convert the string to a `&Char16Str` to check correctness, but it will ultimately need to be converted to `Vec<u16>` when passed as an argument (instead of directly as `&Char16Str`).

After this PR is complete, it will be added to the `major` branch and the "breaking changes" to more completely use these types will be made there.

---

### Commits

**docs: set mdbook doctest edition to 2021**

mdbook doctests default to Rust edition 2015, since patina is on the
2021 edition, this updates the mdbook to it as well.

In particular, this is done now to allow path-based macro imports such
as (`use patina::{char16, char8};`) and invocations like
`patina::char16!(...)` to resolve.

---

**sdk: Add UEFI string types**

Adds two string families to the `sdk` modeled, to an extent, on
`CStr` and `CString`.

`Char8Str`/`Char8String` covers 8-bit Latin-1/ASCII strings which
follows the exact format defined as `CHAR8` in the UEFI
Specification. `Char16Str`/`Char16String` covers the fixed 2-byte
UCS-2 encoding format (following Unicode 2.1) defined as `CHAR16`
in the UEFI Specification.

These provide idiomatic and safe types to use for these strings
in Patina.

---

**docs: Add UEFI string docs**

Adds a "UEFI Strings" page to explain how to use the string types
recently added to the SDK.

---

**components: Use Patina SDK UEFI string types**

Updates a couple of components that have interfaces with raw string
pointers to use the `Char8Str` types for processing.

---

**sdk: Use Patina SDK UEFI string types**

Updates string handling to use the new Patina SDK string types. This
commit intentionally avoids larger refactors that impact public APIs.

Note: Device path buffers with surrogate code units now return a parse
error rather than being mapped to `U+FFFD`.

---

**patina_dxe_core: Use Patina SDK UEFI string types**

Updates string handling to use the new Patina SDK string types. This
commit intentionally avoids larger refactors that impact public APIs.

---

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [x] Includes tests?
- [x] Includes documentation?

## How This Was Tested

- `cargo make all`
- Boot to EFI shell on ArmVirt and Q35

## Integration Instructions

- Use these new string types when appropriate per the instructions in `strings.md`.