### PR TITLE
Remove `doc` feature in favor of `doc` cfg

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -336,13 +336,13 @@ dependencies = ["individual-package-targets"]
 [tasks.doc]
 description = "Builds all rust documentation in the workspace. Example `cargo make doc`"
 command = "cargo"
-args = ["doc", "@@split(INDIVIDUAL_PACKAGE_TARGETS, )", "--features", "doc", "--no-deps"]
+args = ["doc", "@@split(INDIVIDUAL_PACKAGE_TARGETS, )", "--no-deps"]
 
 [tasks.doc-open]
 description = "Builds all rust documentation in the workspace and opens the documentation. Example `cargo make doc-open`"
 clear = true
 command = "cargo"
-args = ["doc", "@@split(INDIVIDUAL_PACKAGE_TARGETS, )", "--features", "doc", "--open"]
+args = ["doc", "@@split(INDIVIDUAL_PACKAGE_TARGETS, )", "--open"]
 
 [tasks.clippy]
 description = "Run cargo clippy for the host target and both UEFI cross-compilation targets."

--- a/components/patina_mm/Cargo.toml
+++ b/components/patina_mm/Cargo.toml
@@ -26,7 +26,6 @@ patina = { workspace = true, features = ["mockall"] }
 patina_dxe_core = { path = "../../patina_dxe_core"}
 
 [features]
-doc = []
 mockall = ["dep:mockall", "std"]
 std = []
 # All non-std features to test in CI

--- a/components/patina_mm/src/component/sw_mmi_manager.rs
+++ b/components/patina_mm/src/component/sw_mmi_manager.rs
@@ -110,7 +110,7 @@ unsafe impl SwMmiTrigger for SwMmiManager {
             MmiPort::Smi(_port) => {
                 log::trace!(target: "sw_mmi", "Using SMI command port: 0x{:04X}", _port);
                 cfg_if::cfg_if! {
-                    if #[cfg(all(target_arch = "x86_64", any(target_os = "uefi", feature = "doc")))] {
+                    if #[cfg(all(target_arch = "x86_64", any(target_os = "uefi", doc)))] {
                         log::trace!(target: "sw_mmi", "Writing SMI command port: {_port:#X}");
                         // SAFETY: This I/O port write is considered safe to use because:
                         // 1. The port address comes from platform configuration (self.inner_config.cmd_port)
@@ -136,7 +136,7 @@ unsafe impl SwMmiTrigger for SwMmiManager {
             MmiPort::Smi(_port) => {
                 log::trace!(target: "sw_mmi", "Using SMI data port: 0x{:04X}", _port);
                 cfg_if::cfg_if! {
-                    if #[cfg(all(target_arch = "x86_64", any(target_os = "uefi", feature = "doc")))] {
+                    if #[cfg(all(target_arch = "x86_64", any(target_os = "uefi", doc)))] {
                         log::trace!(target: "sw_mmi", "Writing SMI data port: {_port:#X}");
                         // SAFETY: This I/O port write is considered safe to use because:
                         // 1. The port address comes from platform configuration (self.inner_config.data_port)

--- a/components/patina_mm/src/component/sw_mmi_manager.rs
+++ b/components/patina_mm/src/component/sw_mmi_manager.rs
@@ -110,7 +110,7 @@ unsafe impl SwMmiTrigger for SwMmiManager {
             MmiPort::Smi(_port) => {
                 log::trace!(target: "sw_mmi", "Using SMI command port: 0x{:04X}", _port);
                 cfg_if::cfg_if! {
-                    if #[cfg(all(target_arch = "x86_64", any(target_os = "uefi", doc)))] {
+                    if #[cfg(all(target_arch = "x86_64", target_os = "uefi"))] {
                         log::trace!(target: "sw_mmi", "Writing SMI command port: {_port:#X}");
                         // SAFETY: This I/O port write is considered safe to use because:
                         // 1. The port address comes from platform configuration (self.inner_config.cmd_port)
@@ -136,7 +136,7 @@ unsafe impl SwMmiTrigger for SwMmiManager {
             MmiPort::Smi(_port) => {
                 log::trace!(target: "sw_mmi", "Using SMI data port: 0x{:04X}", _port);
                 cfg_if::cfg_if! {
-                    if #[cfg(all(target_arch = "x86_64", any(target_os = "uefi", doc)))] {
+                    if #[cfg(all(target_arch = "x86_64", target_os = "uefi"))] {
                         log::trace!(target: "sw_mmi", "Writing SMI data port: {_port:#X}");
                         // SAFETY: This I/O port write is considered safe to use because:
                         // 1. The port address comes from platform configuration (self.inner_config.data_port)

--- a/core/patina_internal_cpu/Cargo.toml
+++ b/core/patina_internal_cpu/Cargo.toml
@@ -11,7 +11,7 @@ description = "CPU support."
 workspace = true
 
 [package.metadata.docs.rs]
-features = ["doc", "std"]
+features = ["std"]
 
 [dependencies]
 log = { workspace = true }
@@ -35,6 +35,5 @@ serial_test = { workspace = true }
 [features]
 default = []
 std = []
-doc = []
 # All non-std features to test in CI
 ci_features = []

--- a/core/patina_stacktrace/Cargo.toml
+++ b/core/patina_stacktrace/Cargo.toml
@@ -16,6 +16,5 @@ log = { workspace = true }
 
 [features]
 std = []
-doc = []
 # All non-std features to test in CI
 ci_features = []

--- a/docs/src/background/rust_tools.md
+++ b/docs/src/background/rust_tools.md
@@ -355,11 +355,11 @@ pub fn process_buffer(buffer: &mut [u8]) {
 # Makefile.toml - Documentation generation
 [tasks.doc]
 command = "cargo"
-args = ["doc", "@@split(INDIVIDUAL_PACKAGE_TARGETS, )", "--features", "doc"]
+args = ["doc", "@@split(INDIVIDUAL_PACKAGE_TARGETS, )"]
 
 [tasks.doc-open]
 command = "cargo"
-args = ["doc", "--features", "doc", "--open"]
+args = ["doc", "--open"]
 
 # Environment variables for strict documentation
 [env]

--- a/patina_dxe_core/Cargo.toml
+++ b/patina_dxe_core/Cargo.toml
@@ -7,10 +7,6 @@ edition.workspace = true
 readme = "README.md"
 description = "A pure rust implementation of the UEFI DXE Core."
 
-# Metadata to tell docs.rs how to build the documentation when uploading
-[package.metadata.docs.rs]
-features = ["doc"]
-
 [lints]
 workspace = true
 
@@ -54,7 +50,6 @@ arm-gic = { workspace = true }
 [features]
 default = []
 std = ["patina/std"]
-doc = ["patina_internal_cpu/doc"]
 compatibility_mode_allowed = []
 v1_resource_descriptor_support = []
 debugger_reload = []

--- a/sdk/patina/Cargo.toml
+++ b/sdk/patina/Cargo.toml
@@ -67,7 +67,6 @@ trybuild = { version = "1.0", features = ["diff"] }
 [features]
 core = ['alloc']
 std = ['alloc']
-doc = ['alloc']
 alloc = ["dep:goblin", "dep:fixedbitset"]
 mockall = ["dep:mockall", "std"]
 global_allocator = []

--- a/sdk/patina/README.md
+++ b/sdk/patina/README.md
@@ -27,7 +27,6 @@ The crate is `no_std` unless `std` is selected. Tests or host utilities can enab
 | `core` | Expose dispatcher-facing types such as `Storage` (enables `alloc`). |
 | `alloc` | Allow allocation APIs when targeting `no_std` firmware environments with a custom allocator. |
 | `std` | Link the standard library. For example, when building host utilities. |
-| `doc` | Pull in items needed to build documentation. |
 | `mockall` | Provide mock implementations for Boot Services and other traits (implies `std`). |
 | `global_allocator` | Install the global allocator support used by Patina firmware images. |
 | `serde` | Enable serialization support for configuration and PI data structures. |

--- a/sdk/patina/src/serial/uart.rs
+++ b/sdk/patina/src/serial/uart.rs
@@ -27,7 +27,7 @@ impl super::SerialIO for UartNull {
 }
 
 cfg_if::cfg_if! {
-    if #[cfg(all(target_arch = "x86_64", any(target_os = "uefi", feature = "doc")))] {
+    if #[cfg(all(target_arch = "x86_64", any(target_os = "uefi", doc)))] {
 
         use uart_16550::MmioSerialPort;
         use uart_16550::SerialPort as IoSerialPort;
@@ -163,7 +163,7 @@ cfg_if::cfg_if! {
 }
 
 cfg_if::cfg_if! {
-    if #[cfg(any(feature = "doc", all(target_os = "uefi", target_arch = "aarch64")))] {
+    if #[cfg(any(doc, all(target_os = "uefi", target_arch = "aarch64")))] {
         use core::ptr::NonNull;
         use crate::mmio::{field, fields::{ReadPure, ReadWrite}, UniqueMmioPointer};
 


### PR DESCRIPTION
## Description

Sync'd files are also updated via this PR: https://github.com/OpenDevicePartnership/patina-devops/pull/183

ref: [doc cfg functionality](https://doc.rust-lang.org/rustdoc/advanced-features.html#cfgdoc-documenting-platform-specific-or-feature-specific-information)

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

N/A

## Integration Instructions

N/A
