### PR TITLE
[feature/supv] SMM: Configure SMRR and SMM Code Access

### DIFF
--- a/patina_mm_supervisor/src/cpu.rs
+++ b/patina_mm_supervisor/src/cpu.rs
@@ -20,7 +20,8 @@ use core::{
     sync::atomic::{AtomicU8, AtomicU32, Ordering},
 };
 
-const CPUID_VERSION_INFO: u32 = 0x01;
+/// CPUID leaf 0x1: Version Information (Type, Family, Model, and Stepping ID).
+pub(crate) const CPUID_VERSION_INFO: u32 = 0x01;
 
 /// MSR index for IA32_APIC_BASE.
 const IA32_APIC_BASE_MSR_INDEX: u32 = 0x1B;

--- a/patina_mm_supervisor/src/init.rs
+++ b/patina_mm_supervisor/src/init.rs
@@ -33,6 +33,7 @@ use crate::{
     mm_policy::{self, MemDescriptorV1_0, dump_policy, gate::PolicyGate, walk_page_table},
     query_address_ownership, read_cr3,
     save_state::SaveStateInfo,
+    smrr::{configure_smm_code_access, smrr_initialize},
     state::{init_state, security_state},
 };
 
@@ -262,9 +263,9 @@ impl<P: PlatformInfo, const MAX_CPUS: usize> MmSupervisorCore<P, MAX_CPUS> {
         // Derive the SMRR range from the scanned regions, coalescing physically adjacent
         // regions, and store it for later SMRR programming.
         match smram_scanned_regions.coalesced_smrr_range() {
-            Some((smrr_base, smrr_size)) => {
-                log::info!("Discovered SMRR range: base=0x{:08x}, size=0x{:08x}", smrr_base, smrr_size);
-                init_state().set_smrr_base_size(smrr_base, smrr_size);
+            Some(range) => {
+                log::info!("Discovered SMRR range: base=0x{:08x}, size=0x{:08x}", range.base, range.size);
+                init_state().set_smrr_range(range);
             }
             None => panic!("Failed to determine SMRR range from scanned SMRAM regions"),
         }
@@ -497,7 +498,10 @@ impl<P: PlatformInfo, const MAX_CPUS: usize> MmSupervisorCore<P, MAX_CPUS> {
         let core_type = if is_bsp { "BSP" } else { "AP" };
         log::trace!("{} (CPU {}) performing per-core initialization...", core_type, cpu_id);
 
-        // TODO: Initialize per-CPU data structures
+        let range =
+            init_state().smrr_range().expect("SMRR range must be determined during BSP init before per-core init");
+        smrr_initialize(range);
+        configure_smm_code_access();
 
         log::trace!("{} (CPU {}) per-core initialization complete.", core_type, cpu_id);
     }

--- a/patina_mm_supervisor/src/init.rs
+++ b/patina_mm_supervisor/src/init.rs
@@ -29,7 +29,8 @@ use patina_paging::{
 
 use crate::{
     AllocationType, CommBufferConfig, MmSupervisorCore, PageOwnership, PlatformInfo, SharedPagingAllocator,
-    is_buffer_inside_mmram, mem,
+    is_buffer_inside_mmram,
+    mem::{self, page_allocator::coalesced_smrr_range},
     mm_policy::{self, MemDescriptorV1_0, dump_policy, gate::PolicyGate, walk_page_table},
     query_address_ownership, read_cr3,
     save_state::SaveStateInfo,
@@ -255,14 +256,15 @@ impl<P: PlatformInfo, const MAX_CPUS: usize> MmSupervisorCore<P, MAX_CPUS> {
         // Initialize the page allocator from the HOB list. This finds all SMRAM
         // regions and sets up memory tracking.
         // SAFETY: `hob_list` is a valid HOB list per this function's contract.
-        let smram_scanned_regions = match unsafe { security_state().page_allocator().init_from_hob_list(hob_list) } {
-            Ok(scanned_regions) => scanned_regions,
-            Err(e) => panic!("Failed to initialize page allocator: {:?}", e),
-        };
+        let (smram_regions, region_count) =
+            match unsafe { security_state().page_allocator().init_from_hob_list(hob_list) } {
+                Ok(scanned_regions) => scanned_regions,
+                Err(e) => panic!("Failed to initialize page allocator: {:?}", e),
+            };
 
-        // Derive the SMRR range from the scanned regions, coalescing physically adjacent
-        // regions, and store it for later SMRR programming.
-        match smram_scanned_regions.coalesced_smrr_range() {
+        // Derive the SMRR range from the scanned SMRAM regions, coalescing
+        // physically adjacent regions, and store it for later SMRR programming.
+        match coalesced_smrr_range(smram_regions.get(..region_count).unwrap_or(&smram_regions)) {
             Some(range) => {
                 log::info!("Discovered SMRR range: base=0x{:08x}, size=0x{:08x}", range.base, range.size);
                 init_state().set_smrr_range(range);

--- a/patina_mm_supervisor/src/init.rs
+++ b/patina_mm_supervisor/src/init.rs
@@ -38,6 +38,7 @@ use crate::{
 
 use patina_internal_cpu::interrupts::Interrupts;
 use zerocopy::FromBytes;
+use zerocopy_derive::Immutable;
 
 /// Errors that can occur during policy initialization.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -79,7 +80,7 @@ const FIXUP64_SMI_HANDLER_IDTR: usize = 5;
 /// `MM_SUPERVISOR_BUFFER_T` (0) in practice — the user channel uses the
 /// separate `gMmCommBufferHobGuid` HOB.
 #[repr(C)]
-#[derive(Debug, Clone, Copy, zerocopy_derive::FromBytes, zerocopy_derive::Immutable)]
+#[derive(Debug, Clone, Copy, FromBytes, Immutable)]
 pub struct MmCommonRegionHobData {
     /// Region type discriminator. Always `MM_SUPERVISOR_BUFFER_T` (0) for
     /// the HOB the supervisor consumes.
@@ -101,7 +102,7 @@ pub struct MmCommonRegionHobData {
 /// has the same byte layout the C producer emits while still allowing safe,
 /// reference-based field access once parsed via `zerocopy`.
 #[repr(C)]
-#[derive(Debug, Clone, Copy, zerocopy_derive::FromBytes, zerocopy_derive::Immutable)]
+#[derive(Debug, Clone, Copy, FromBytes, Immutable)]
 pub struct MmSupvPassDownHobData {
     /// Revision of this HOB structure
     pub revision: u32,
@@ -253,8 +254,19 @@ impl<P: PlatformInfo, const MAX_CPUS: usize> MmSupervisorCore<P, MAX_CPUS> {
         // Initialize the page allocator from the HOB list. This finds all SMRAM
         // regions and sets up memory tracking.
         // SAFETY: `hob_list` is a valid HOB list per this function's contract.
-        if let Err(e) = unsafe { security_state().page_allocator().init_from_hob_list(hob_list) } {
-            panic!("Failed to initialize page allocator: {:?}", e);
+        let smram_scanned_regions = match unsafe { security_state().page_allocator().init_from_hob_list(hob_list) } {
+            Ok(scanned_regions) => scanned_regions,
+            Err(e) => panic!("Failed to initialize page allocator: {:?}", e),
+        };
+
+        // Derive the SMRR range from the scanned regions, coalescing physically adjacent
+        // regions, and store it for later SMRR programming.
+        match smram_scanned_regions.coalesced_smrr_range() {
+            Some((smrr_base, smrr_size)) => {
+                log::info!("Discovered SMRR range: base=0x{:08x}, size=0x{:08x}", smrr_base, smrr_size);
+                init_state().set_smrr_base_size(smrr_base, smrr_size);
+            }
+            None => panic!("Failed to determine SMRR range from scanned SMRAM regions"),
         }
 
         // Reserve pages from the page allocator for paging structures. This is

--- a/patina_mm_supervisor/src/lib.rs
+++ b/patina_mm_supervisor/src/lib.rs
@@ -94,7 +94,7 @@ pub use cpu::CpuInfo;
 pub use init::PolicyInitError;
 pub use supervisor_handlers::SupervisorMmiHandler;
 
-use crate::smrr::{configure_smm_code_access, smrr_enable, smrr_initialize};
+use crate::smrr::smrr_enable;
 
 // The entry-point shim references `rust_main`, which is provided by the platform binary, and is
 // only meaningful on the firmware (UEFI) target. Exclude it from host builds (tests, doctests)
@@ -541,14 +541,6 @@ impl<P: PlatformInfo, const MAX_CPUS: usize> MmSupervisorCore<P, MAX_CPUS> {
         // Track that this core has completed per-core init
         let init_count = init_state().inc_per_core_init_count();
         log::trace!("CPU {} (index {}) completed per-core init ({} cores initialized)", cpu_id, cpu_index, init_count);
-
-        // If smrr region in the initstate is set, use that otherwise don't
-        // program smrr
-        if let Some((base, size)) = init_state().smrr_base_size() {
-            smrr_initialize(base, size);
-        }
-
-        configure_smm_code_access();
 
         // BSP waits for all registered CPUs to complete per-core init before returning
         if is_bsp {

--- a/patina_mm_supervisor/src/lib.rs
+++ b/patina_mm_supervisor/src/lib.rs
@@ -57,6 +57,7 @@ mod perf_timer;
 mod privilege_mgmt;
 mod runtime;
 mod save_state;
+mod smrr;
 mod state;
 mod supervisor_handlers;
 
@@ -92,6 +93,8 @@ pub use cpu::CpuInfo;
 // their function signatures and return types.
 pub use init::PolicyInitError;
 pub use supervisor_handlers::SupervisorMmiHandler;
+
+use crate::smrr::{configure_smm_code_access, smrr_enable, smrr_initialize};
 
 // The entry-point shim references `rust_main`, which is provided by the platform binary, and is
 // only meaningful on the firmware (UEFI) target. Exclude it from host builds (tests, doctests)
@@ -455,6 +458,7 @@ impl<P: PlatformInfo, const MAX_CPUS: usize> MmSupervisorCore<P, MAX_CPUS> {
                 cpu_id,
                 cpu_index
             );
+            smrr_enable();
             self.enter_runtime(cpu_id);
 
             return;
@@ -537,6 +541,14 @@ impl<P: PlatformInfo, const MAX_CPUS: usize> MmSupervisorCore<P, MAX_CPUS> {
         // Track that this core has completed per-core init
         let init_count = init_state().inc_per_core_init_count();
         log::trace!("CPU {} (index {}) completed per-core init ({} cores initialized)", cpu_id, cpu_index, init_count);
+
+        // If smrr region in the initstate is set, use that otherwise don't
+        // program smrr
+        if let Some((base, size)) = init_state().smrr_base_size() {
+            smrr_initialize(base, size);
+        }
+
+        configure_smm_code_access();
 
         // BSP waits for all registered CPUs to complete per-core init before returning
         if is_bsp {

--- a/patina_mm_supervisor/src/mem/page_allocator.rs
+++ b/patina_mm_supervisor/src/mem/page_allocator.rs
@@ -532,9 +532,7 @@ pub(crate) fn coalesced_smrr_range(regions: &[SmramRegion]) -> Option<SmramRegio
         }
     }
 
-    let (base, size) = current?;
-    let mut smrr_base = base as u32;
-    let mut smrr_size = size as u32;
+    let (mut smrr_base, mut smrr_size) = current?;
 
     // Coalesce any physically adjacent ranges into the selected range. This
     // scans the (unsorted) region array repeatedly until no further
@@ -546,14 +544,14 @@ pub(crate) fn coalesced_smrr_range(regions: &[SmramRegion]) -> Option<SmramRegio
         for region in regions {
             let region_base = region.base;
             let region_size = region.size;
-            if region_base < smrr_base as u64 && smrr_base as u64 == region_base + region_size {
+            if region_base < smrr_base && smrr_base == region_base + region_size {
                 // Region sits immediately before the current range: extend downward.
-                smrr_base = region_base as u32;
-                smrr_size = smrr_size.wrapping_add(region_size as u32);
+                smrr_base = region_base;
+                smrr_size = smrr_size.checked_add(region_size)?;
                 found = true;
-            } else if smrr_base as u64 + smrr_size as u64 == region_base && region_size > 0 {
+            } else if smrr_base + smrr_size == region_base && region_size > 0 {
                 // Region sits immediately after the current range: extend upward.
-                smrr_size = smrr_size.wrapping_add(region_size as u32);
+                smrr_size = smrr_size.checked_add(region_size)?;
                 found = true;
             }
         }
@@ -561,6 +559,9 @@ pub(crate) fn coalesced_smrr_range(regions: &[SmramRegion]) -> Option<SmramRegio
             break;
         }
     }
+
+    let smrr_base = u32::try_from(smrr_base).ok()?;
+    let smrr_size = u32::try_from(smrr_size).ok()?;
 
     if !verify_smrr_base_size(smrr_base, smrr_size) {
         log::warn!(

--- a/patina_mm_supervisor/src/mem/page_allocator.rs
+++ b/patina_mm_supervisor/src/mem/page_allocator.rs
@@ -49,6 +49,8 @@ use patina_paging::{MemoryAttributes, PageTable};
 use r_efi::efi;
 use spin::{Mutex, MutexGuard, relax::Spin};
 
+use crate::smrr::{SmrrRange, verify_smrr_base_size};
+
 /// Bits per byte.
 const BITS_PER_BYTE: usize = 8;
 
@@ -555,9 +557,9 @@ impl ScannedRegions {
     /// allocation state), scanning repeatedly until no further adjacent region
     /// is found.
     ///
-    /// Returns `(smrr_base, smrr_size)` on success, or `None` if no scanned
+    /// Returns the coalesced [`SmrrRange`] on success, or `None` if no scanned
     /// region meets the SMRR base/size requirements.
-    pub(crate) fn coalesced_smrr_range(&self) -> Option<(u32, u32)> {
+    pub(crate) fn coalesced_smrr_range(&self) -> Option<SmrrRange> {
         /// Lowest CPU start address a candidate SMRR range may have.
         const BASE_1MB: u64 = 0x0010_0000;
         /// Highest address the primary SMRR can cover (4 GiB).
@@ -607,8 +609,17 @@ impl ScannedRegions {
             }
         }
 
+        if !verify_smrr_base_size(smrr_base, smrr_size) {
+            log::warn!(
+                "Coalesced SMRR range base=0x{:x} size=0x{:x} does not meet SMRR alignment/size requirements",
+                smrr_base,
+                smrr_size
+            );
+            return None;
+        }
+
         log::info!("SMRR Base: 0x{:x}, SMRR Size: 0x{:x}", smrr_base, smrr_size);
-        Some((smrr_base, smrr_size))
+        Some(SmrrRange { base: smrr_base, size: smrr_size })
     }
 }
 
@@ -1068,15 +1079,16 @@ mod tests {
         let base = 0x8000_0000u64;
         let size = SIZE_256KB as u64;
         let scanned = regions_from(&[(base, size, false)]);
-        assert_eq!(scanned.coalesced_smrr_range(), Some((base as u32, size as u32)));
+        assert_eq!(scanned.coalesced_smrr_range(), Some(SmrrRange { base: base as u32, size: size as u32 }));
     }
 
     #[test]
-    fn test_page_allocator_coalesced_smrr_range_minimum_size_boundary() {
-        // Exactly the minimum accepted size is valid.
+    fn test_page_allocator_coalesced_smrr_range_rejects_non_power_of_two_size() {
+        // A region large enough to be selected but whose size is not a power of
+        // two fails SMRR verification and is rejected.
         let base = 0x8000_0000u64;
         let scanned = regions_from(&[(base, MIN_SMRR_SIZE, false)]);
-        assert_eq!(scanned.coalesced_smrr_range(), Some((base as u32, MIN_SMRR_SIZE as u32)));
+        assert_eq!(scanned.coalesced_smrr_range(), None);
     }
 
     #[test]
@@ -1084,7 +1096,7 @@ mod tests {
         let small = (0x8000_0000u64, SIZE_256KB as u64, false);
         let large = (0x9000_0000u64, SIZE_256KB as u64 * 4, false);
         let scanned = regions_from(&[small, large]);
-        assert_eq!(scanned.coalesced_smrr_range(), Some((large.0 as u32, large.1 as u32)));
+        assert_eq!(scanned.coalesced_smrr_range(), Some(SmrrRange { base: large.0 as u32, size: large.1 as u32 }));
     }
 
     #[test]
@@ -1097,22 +1109,44 @@ mod tests {
 
     #[test]
     fn test_page_allocator_coalesced_smrr_range_coalesces_adjacent_upward() {
+        // Selected (larger) region extends upward into the adjacent region; the
+        // coalesced size is a power of two with a naturally aligned base.
         let base = 0x8000_0000u64;
-        let size = SIZE_256KB as u64 * 2; // selected as the largest region
-        let above_size = SIZE_256KB as u64;
+        let size = SIZE_256KB as u64 * 6; // selected as the largest region
+        let above_size = SIZE_256KB as u64 * 2;
         let above = (base + size, above_size, false);
         let scanned = regions_from(&[(base, size, false), above]);
-        assert_eq!(scanned.coalesced_smrr_range(), Some((base as u32, (size + above_size) as u32)));
+        assert_eq!(
+            scanned.coalesced_smrr_range(),
+            Some(SmrrRange { base: base as u32, size: (size + above_size) as u32 })
+        );
     }
 
     #[test]
     fn test_page_allocator_coalesced_smrr_range_coalesces_adjacent_downward() {
-        let base = 0x8000_0000u64;
-        let size = SIZE_256KB as u64 * 2; // selected as the largest region
-        let below_size = SIZE_256KB as u64;
-        let below = (base - below_size, below_size, false);
+        // Selected (larger) region extends downward into the adjacent region;
+        // the coalesced size is a power of two with a naturally aligned base.
+        let low_base = 0x8000_0000u64;
+        let below_size = SIZE_256KB as u64 * 2;
+        let base = low_base + below_size;
+        let size = SIZE_256KB as u64 * 6; // selected as the largest region
+        let below = (low_base, below_size, false);
         let scanned = regions_from(&[below, (base, size, false)]);
-        assert_eq!(scanned.coalesced_smrr_range(), Some(((base - below_size) as u32, (size + below_size) as u32)));
+        assert_eq!(
+            scanned.coalesced_smrr_range(),
+            Some(SmrrRange { base: low_base as u32, size: (size + below_size) as u32 })
+        );
+    }
+
+    #[test]
+    fn test_page_allocator_coalesced_smrr_range_rejects_non_power_of_two_coalesced_size() {
+        // Coalescing yields 0xC0000 bytes, which is not a power of two, so the
+        // range is rejected rather than causing a later panic in smrr_initialize.
+        let base = 0x8000_0000u64;
+        let size = SIZE_256KB as u64 * 2; // 0x80000, selected
+        let above = (base + size, SIZE_256KB as u64, false); // + 0x40000 => 0xC0000
+        let scanned = regions_from(&[(base, size, false), above]);
+        assert_eq!(scanned.coalesced_smrr_range(), None);
     }
 
     #[test]
@@ -1123,6 +1157,6 @@ mod tests {
         // SMRR must cover a single contiguous physical range.
         let above = (base + size, size, true);
         let scanned = regions_from(&[(base, size, false), above]);
-        assert_eq!(scanned.coalesced_smrr_range(), Some((base as u32, (size * 2) as u32)));
+        assert_eq!(scanned.coalesced_smrr_range(), Some(SmrrRange { base: base as u32, size: (size * 2) as u32 }));
     }
 }

--- a/patina_mm_supervisor/src/mem/page_allocator.rs
+++ b/patina_mm_supervisor/src/mem/page_allocator.rs
@@ -49,7 +49,7 @@ use patina_paging::{MemoryAttributes, PageTable};
 use r_efi::efi;
 use spin::{Mutex, MutexGuard, relax::Spin};
 
-use crate::smrr::{SmrrRange, verify_smrr_base_size};
+use crate::smrr::{SmramRegion, verify_smrr_base_size};
 
 /// Bits per byte.
 const BITS_PER_BYTE: usize = 8;
@@ -463,33 +463,30 @@ impl LockedState<'_> {
     ///
     /// The `AllocatorState` header (including `region_count`) must already be
     /// written so that [`regions_mut`](Self::regions_mut) exposes the full array.
-    fn initialize(&mut self, scanned: &ScannedRegions, bookkeeping_base: u64, bookkeeping_pages: usize) {
+    fn initialize(&mut self, scanned: &[SmramRegion], bookkeeping_base: u64, bookkeeping_pages: usize) {
         // Fill in per-region metadata and assign each region its bitmap range.
         let mut bitmap_start_bit = 0usize;
-        for (region, &(base, size, _)) in self.regions_mut().iter_mut().zip(scanned.regions.iter()) {
-            let pages = uefi_size_to_pages!(size as usize);
-            region.base = base;
+        for (region, scanned_region) in self.regions_mut().iter_mut().zip(scanned.iter()) {
+            let pages = uefi_size_to_pages!(scanned_region.size as usize);
+            region.base = scanned_region.base;
             region.total_pages = pages;
             region.bitmap_start_bit = bitmap_start_bit;
             bitmap_start_bit += pages;
         }
 
         // Mark pre-allocated regions and the bookkeeping pages as allocated (supervisor).
-        for i in 0..scanned.count {
-            let Some(&(base, size, pre_allocated)) = scanned.regions.get(i) else {
-                continue;
-            };
-            let pages = uefi_size_to_pages!(size as usize);
+        for (i, scanned_region) in scanned.iter().enumerate() {
+            let pages = uefi_size_to_pages!(scanned_region.size as usize);
             let Some(start_bit) = self.regions().get(i).map(|region| region.bitmap_start_bit) else {
                 continue;
             };
 
-            if pre_allocated {
+            if scanned_region.pre_allocated {
                 // Mark the entire region as allocated.
                 for p in 0..pages {
                     self.set_bit_allocated(start_bit + p, AllocationType::Supervisor);
                 }
-            } else if base == bookkeeping_base {
+            } else if scanned_region.base == bookkeeping_base {
                 // Mark just the bookkeeping pages at the start of this region.
                 for p in 0..bookkeeping_pages {
                     self.set_bit_allocated(start_bit + p, AllocationType::Supervisor);
@@ -503,124 +500,79 @@ impl LockedState<'_> {
 /// HOB list. The authoritative region metadata is stored in SMRAM afterwards.
 const MAX_TEMP_REGIONS: usize = 256;
 
-/// SMRAM regions discovered while scanning the HOB list, before they are copied
-/// into the SMRAM bookkeeping structures.
-pub(crate) struct ScannedRegions {
-    /// Discovered regions as `(base, size, pre_allocated)`.
-    regions: [(u64, u64, bool); MAX_TEMP_REGIONS],
-    /// Number of valid entries in `regions`.
-    count: usize,
-    /// Total pages across all discovered regions.
-    total_pages: usize,
-    /// Base of the first non-pre-allocated region (used to host bookkeeping).
-    first_free_base: Option<u64>,
-    /// Size in bytes of the first non-pre-allocated region.
-    first_free_size: u64,
-}
+/// Selects the primary SMRR range from the scanned SMRAM regions and coalesces
+/// any physically adjacent regions into it.
+///
+/// It picks the largest non pre-allocated region in `[1 MiB, 4 GiB]` that is at
+/// least `256 KiB - 4 KiB`, then extends it downward and upward across every
+/// region that is physically contiguous with it (regardless of allocation
+/// state), scanning repeatedly until no further adjacent region is found.
+///
+/// Returns the coalesced [`SmramRegion`] on success (with `pre_allocated` set to
+/// `false`, as it describes the SMRR programming range rather than a discovered
+/// region), or `None` if no scanned region meets the SMRR base/size
+/// requirements.
+pub(crate) fn coalesced_smrr_range(regions: &[SmramRegion]) -> Option<SmramRegion> {
+    /// Lowest CPU start address a candidate SMRR range may have.
+    const BASE_1MB: u64 = 0x0010_0000;
+    /// Highest address the primary SMRR can cover (4 GiB).
+    const SMRR_MAX_ADDRESS: u64 = 0x1_0000_0000;
 
-impl ScannedRegions {
-    /// Creates an empty scan result.
-    fn new() -> Self {
-        Self {
-            regions: [(0, 0, false); MAX_TEMP_REGIONS],
-            count: 0,
-            total_pages: 0,
-            first_free_base: None,
-            first_free_size: 0,
+    // Find the largest usable (non-pre-allocated) range in [1 MiB, 4 GiB] that is at least
+    // 256 KiB - 4 KiB.
+    let mut max_size = SIZE_256KB as u64 - UEFI_PAGE_SIZE as u64;
+    let mut current: Option<(u64, u64)> = None;
+    for region in regions {
+        if region.pre_allocated {
+            continue;
+        }
+        if region.base >= BASE_1MB && region.base + region.size <= SMRR_MAX_ADDRESS && region.size >= max_size {
+            max_size = region.size;
+            current = Some((region.base, region.size));
         }
     }
 
-    /// Whether the temporary storage is full.
-    fn is_full(&self) -> bool {
-        self.count >= MAX_TEMP_REGIONS
+    let (base, size) = current?;
+    let mut smrr_base = base as u32;
+    let mut smrr_size = size as u32;
+
+    // Coalesce any physically adjacent ranges into the selected range. This
+    // scans the (unsorted) region array repeatedly until no further
+    // adjacent range is found, so ordering does not matter. Adjacency is
+    // considered regardless of allocation state, because the SMRR must
+    // cover a single contiguous physical range.
+    loop {
+        let mut found = false;
+        for region in regions {
+            let region_base = region.base;
+            let region_size = region.size;
+            if region_base < smrr_base as u64 && smrr_base as u64 == region_base + region_size {
+                // Region sits immediately before the current range: extend downward.
+                smrr_base = region_base as u32;
+                smrr_size = smrr_size.wrapping_add(region_size as u32);
+                found = true;
+            } else if smrr_base as u64 + smrr_size as u64 == region_base && region_size > 0 {
+                // Region sits immediately after the current range: extend upward.
+                smrr_size = smrr_size.wrapping_add(region_size as u32);
+                found = true;
+            }
+        }
+        if !found {
+            break;
+        }
     }
 
-    /// Records one region. Precondition: `!self.is_full()`.
-    fn push(&mut self, base: u64, size: u64, pre_allocated: bool) {
-        if let Some(slot) = self.regions.get_mut(self.count) {
-            *slot = (base, size, pre_allocated);
-        }
-        if self.first_free_base.is_none() && !pre_allocated {
-            self.first_free_base = Some(base);
-            self.first_free_size = size;
-        }
-        self.total_pages += uefi_size_to_pages!(size as usize);
-        self.count += 1;
+    if !verify_smrr_base_size(smrr_base, smrr_size) {
+        log::warn!(
+            "Coalesced SMRR range base=0x{:x} size=0x{:x} does not meet SMRR alignment/size requirements",
+            smrr_base,
+            smrr_size
+        );
+        return None;
     }
 
-    /// Selects the primary SMRR range from the scanned regions and coalesces
-    /// any physically adjacent regions into it.
-    ///
-    /// It picks the largest non pre-allocated region in `[1 MiB, 4 GiB]` that
-    /// is at least `256 KiB - 4 KiB`, then extends it downward and upward
-    /// across every region that is physically contiguous with it (regardless of
-    /// allocation state), scanning repeatedly until no further adjacent region
-    /// is found.
-    ///
-    /// Returns the coalesced [`SmrrRange`] on success, or `None` if no scanned
-    /// region meets the SMRR base/size requirements.
-    pub(crate) fn coalesced_smrr_range(&self) -> Option<SmrrRange> {
-        /// Lowest CPU start address a candidate SMRR range may have.
-        const BASE_1MB: u64 = 0x0010_0000;
-        /// Highest address the primary SMRR can cover (4 GiB).
-        const SMRR_MAX_ADDRESS: u64 = 0x1_0000_0000;
-
-        let regions = self.regions.get(..self.count).unwrap_or(&self.regions);
-
-        // Find the largest usable (non-pre-allocated) range in [1 MiB, 4 GiB] that is at least
-        // 256 KiB - 4 KiB.
-        let mut max_size = SIZE_256KB as u64 - UEFI_PAGE_SIZE as u64;
-        let mut current: Option<(u64, u64)> = None;
-        for &(base, size, pre_allocated) in regions {
-            if pre_allocated {
-                continue;
-            }
-            if base >= BASE_1MB && base + size <= SMRR_MAX_ADDRESS && size >= max_size {
-                max_size = size;
-                current = Some((base, size));
-            }
-        }
-
-        let (base, size) = current?;
-        let mut smrr_base = base as u32;
-        let mut smrr_size = size as u32;
-
-        // Coalesce any physically adjacent ranges into the selected range. This
-        // scans the (unsorted) region array repeatedly until no further
-        // adjacent range is found, so ordering does not matter. Adjacency is
-        // considered regardless of allocation state, because the SMRR must
-        // cover a single contiguous physical range.
-        loop {
-            let mut found = false;
-            for &(region_base, region_size, _) in regions {
-                if region_base < smrr_base as u64 && smrr_base as u64 == region_base + region_size {
-                    // Region sits immediately before the current range: extend downward.
-                    smrr_base = region_base as u32;
-                    smrr_size = smrr_size.wrapping_add(region_size as u32);
-                    found = true;
-                } else if smrr_base as u64 + smrr_size as u64 == region_base && region_size > 0 {
-                    // Region sits immediately after the current range: extend upward.
-                    smrr_size = smrr_size.wrapping_add(region_size as u32);
-                    found = true;
-                }
-            }
-            if !found {
-                break;
-            }
-        }
-
-        if !verify_smrr_base_size(smrr_base, smrr_size) {
-            log::warn!(
-                "Coalesced SMRR range base=0x{:x} size=0x{:x} does not meet SMRR alignment/size requirements",
-                smrr_base,
-                smrr_size
-            );
-            return None;
-        }
-
-        log::info!("SMRR Base: 0x{:x}, SMRR Size: 0x{:x}", smrr_base, smrr_size);
-        Some(SmrrRange { base: smrr_base, size: smrr_size })
-    }
+    log::info!("SMRR Base: 0x{:x}, SMRR Size: 0x{:x}", smrr_base, smrr_size);
+    Some(SmramRegion { base: smrr_base as u64, size: smrr_size as u64, pre_allocated: false })
 }
 
 /// Page-granularity allocator for SMRAM memory.
@@ -640,36 +592,73 @@ impl PageAllocator {
         Self { state: Mutex::new(StatePtr(ptr::null_mut())), initialized: AtomicBool::new(false) }
     }
 
-    /// Calculates the number of pages needed for bookkeeping.
-    fn calculate_bookkeeping_pages(region_count: usize, total_pages: usize) -> usize {
+    /// Determines where the bookkeeping structures live and how large they are.
+    ///
+    /// Sums the pages across `regions`, selects the first non-pre-allocated
+    /// region to host the bookkeeping, and verifies that region is large enough
+    /// to hold it. Returns `(bookkeeping_base, bookkeeping_pages)`.
+    fn calculate_bookkeeping(regions: &[SmramRegion]) -> Result<(u64, usize), PageAllocError> {
+        let total_pages: usize = regions.iter().map(|region| uefi_size_to_pages!(region.size as usize)).sum();
+
         let header_size = size_of::<AllocatorState>();
-        let regions_size = region_count * size_of::<RegionInfo>();
+        let regions_size = regions.len() * size_of::<RegionInfo>();
         let bitmap_bytes = total_pages.div_ceil(BITS_PER_BYTE);
         let total_bytes = header_size + regions_size + bitmap_bytes * 2; // alloc + type bitmaps
-        uefi_size_to_pages!(total_bytes)
+        let bookkeeping_pages = uefi_size_to_pages!(total_bytes);
+
+        log::info!(
+            "Allocator needs {} pages for bookkeeping ({} regions, {} total pages)",
+            bookkeeping_pages,
+            regions.len(),
+            total_pages
+        );
+
+        // Reserve bookkeeping space in the first free (non-pre-allocated) region.
+        let first_free = regions.iter().find(|region| !region.pre_allocated);
+        let bookkeeping_base = first_free.map(|region| region.base).ok_or_else(|| {
+            log::error!("No free SMRAM region available for bookkeeping");
+            PageAllocError::OutOfMemory
+        })?;
+        let first_free_size = first_free.map(|region| region.size).unwrap_or(0);
+
+        if uefi_pages_to_size!(bookkeeping_pages) as u64 > first_free_size {
+            log::error!("First free region too small for bookkeeping");
+            return Err(PageAllocError::OutOfMemory);
+        }
+
+        Ok((bookkeeping_base, bookkeeping_pages))
     }
 
     /// Scans the entire HOB list and collects every SMRAM/MMRAM region reported
-    /// under the supported GUIDs into `scanned`.
-    fn scan_smram_regions(handoff: &PhaseHandoffInformationTable, scanned: &mut ScannedRegions) {
+    /// under the supported GUIDs into `regions`, updating `count`.
+    fn scan_smram_regions(
+        handoff: &PhaseHandoffInformationTable,
+        regions: &mut [SmramRegion; MAX_TEMP_REGIONS],
+        region_count: &mut usize,
+    ) -> Result<(), PageAllocError> {
         let hob = Hob::Handoff(handoff);
         for current_hob in &hob {
             if let Hob::GuidHob(guid_hob, data) = current_hob
                 && (guid_hob.name == SMM_SMRAM_MEMORY_GUID || guid_hob.name == MM_PEI_MMRAM_MEMORY_RESERVE_GUID)
             {
                 log::info!("Found SMRAM memory HOB with GUID {}", guid_hob.name.as_guid());
-                Self::collect_smram_regions(data, scanned);
+                Self::collect_smram_regions(data, regions, region_count)?;
             }
         }
+        Ok(())
     }
 
     /// Parses the `SmramReserveHobData` header and trailing `SmramDescriptor`
     /// array from a single matching GUID HOB payload, appending each region to
-    /// `scanned`.
-    fn collect_smram_regions(data: &[u8], scanned: &mut ScannedRegions) {
+    /// `regions` and updating `region_count`.
+    fn collect_smram_regions(
+        data: &[u8],
+        regions: &mut [SmramRegion; MAX_TEMP_REGIONS],
+        region_count: &mut usize,
+    ) -> Result<(), PageAllocError> {
         let header_size = size_of::<SmramReserveHobData>();
         if data.len() < header_size {
-            return;
+            return Ok(());
         }
 
         // SAFETY: `data` is at least `header_size` bytes (checked above) and, per the
@@ -690,7 +679,7 @@ impl PageAllocator {
         // out-of-range offset would be caught).
         let end = header_size + count * size_of::<SmramDescriptor>();
         let Some(descriptor_bytes) = data.get(header_size..end) else {
-            return;
+            return Ok(());
         };
 
         // SAFETY: `descriptor_bytes` is exactly `count` `SmramDescriptor`s' worth of in-bounds
@@ -699,9 +688,12 @@ impl PageAllocator {
         let descriptors = unsafe { slice::from_raw_parts(descriptor_bytes.as_ptr() as *const SmramDescriptor, count) };
 
         for descriptor in descriptors {
-            if scanned.is_full() {
-                log::warn!("Too many SMRAM regions for temp storage, increase MAX_TEMP_REGIONS");
-                break;
+            if *region_count >= MAX_TEMP_REGIONS {
+                log::error!(
+                    "Too many SMRAM regions for temp storage (MAX_TEMP_REGIONS = {}), increase MAX_TEMP_REGIONS",
+                    MAX_TEMP_REGIONS
+                );
+                return Err(PageAllocError::OutOfMemory);
             }
 
             let pre_allocated = (descriptor.region_state & EFI_ALLOCATED) != 0;
@@ -709,7 +701,7 @@ impl PageAllocator {
 
             log::info!(
                 "SMRAM Region {}: base=0x{:016x}, size=0x{:x}, pages={}, state=0x{:x}, allocated={}",
-                scanned.count,
+                *region_count,
                 descriptor.physical_start,
                 descriptor.physical_size,
                 pages,
@@ -717,8 +709,18 @@ impl PageAllocator {
                 pre_allocated
             );
 
-            scanned.push(descriptor.physical_start, descriptor.physical_size, pre_allocated);
+            let Some(slot) = regions.get_mut(*region_count) else {
+                log::error!(
+                    "Too many SMRAM regions for temp storage (MAX_TEMP_REGIONS = {}), increase MAX_TEMP_REGIONS",
+                    MAX_TEMP_REGIONS
+                );
+                return Err(PageAllocError::OutOfMemory);
+            };
+            *slot = SmramRegion { base: descriptor.physical_start, size: descriptor.physical_size, pre_allocated };
+            *region_count += 1;
         }
+
+        Ok(())
     }
 
     /// Acquires the state lock and returns a [`LockedState`] view over the SMRAM
@@ -749,7 +751,10 @@ impl PageAllocator {
     /// ## Safety
     ///
     /// The caller must ensure that `hob_list` points to a valid HOB list. Only null pointer will be rejected.
-    pub unsafe fn init_from_hob_list(&self, hob_list: *const c_void) -> Result<ScannedRegions, PageAllocError> {
+    pub unsafe fn init_from_hob_list(
+        &self,
+        hob_list: *const c_void,
+    ) -> Result<([SmramRegion; MAX_TEMP_REGIONS], usize), PageAllocError> {
         if hob_list.is_null() {
             return Err(PageAllocError::NotInitialized);
         }
@@ -763,33 +768,20 @@ impl PageAllocator {
         };
 
         // First pass: scan the HOB list for every SMRAM region.
-        let mut scanned = ScannedRegions::new();
-        Self::scan_smram_regions(hob_list_info, &mut scanned);
+        let mut regions = [SmramRegion::default(); MAX_TEMP_REGIONS];
+        let mut count = 0usize;
+        Self::scan_smram_regions(hob_list_info, &mut regions, &mut count)?;
 
-        if scanned.count == 0 {
+        if count == 0 {
             log::error!("No SMRAM regions found in HOB list");
             return Err(PageAllocError::NotInitialized);
         }
 
-        // Reserve bookkeeping space in the first free region.
-        let bookkeeping_pages = Self::calculate_bookkeeping_pages(scanned.count, scanned.total_pages);
+        let scanned = regions.get(..count).ok_or(PageAllocError::NotInitialized)?;
+        let total_pages: usize = scanned.iter().map(|region| uefi_size_to_pages!(region.size as usize)).sum();
 
-        log::info!(
-            "Allocator needs {} pages for bookkeeping ({} regions, {} total pages)",
-            bookkeeping_pages,
-            scanned.count,
-            scanned.total_pages
-        );
-
-        let bookkeeping_base = scanned.first_free_base.ok_or_else(|| {
-            log::error!("No free SMRAM region available for bookkeeping");
-            PageAllocError::OutOfMemory
-        })?;
-
-        if uefi_pages_to_size!(bookkeeping_pages) as u64 > scanned.first_free_size {
-            log::error!("First free region too small for bookkeeping");
-            return Err(PageAllocError::OutOfMemory);
-        }
+        // Determine where the bookkeeping structures live and how large they are.
+        let (bookkeeping_base, bookkeeping_pages) = Self::calculate_bookkeeping(scanned)?;
 
         log::info!("Using 0x{:016x} for bookkeeping ({} pages)", bookkeeping_base, bookkeeping_pages);
 
@@ -804,24 +796,14 @@ impl PageAllocator {
             ptr::write_bytes(bookkeeping_base as *mut u8, 0, uefi_pages_to_size!(bookkeeping_pages));
             &mut *state_ptr
         };
-        *state = AllocatorState {
-            region_count: scanned.count,
-            total_pages: scanned.total_pages,
-            bookkeeping_pages,
-            bookkeeping_base,
-        };
+        *state = AllocatorState { region_count: count, total_pages, bookkeeping_pages, bookkeeping_base };
 
         *guard = StatePtr(state_ptr);
 
         // Populate region metadata and the allocation bitmaps under the held lock, then
         // release the lock before the stats logging below re-acquires it.
-        let mut locked = LockedState {
-            state: state_ptr,
-            region_count: scanned.count,
-            total_pages: scanned.total_pages,
-            _guard: guard,
-        };
-        locked.initialize(&scanned, bookkeeping_base, bookkeeping_pages);
+        let mut locked = LockedState { state: state_ptr, region_count: count, total_pages, _guard: guard };
+        locked.initialize(scanned, bookkeeping_base, bookkeeping_pages);
         drop(locked);
 
         self.initialized.store(true, Ordering::Release);
@@ -836,7 +818,7 @@ impl PageAllocator {
             self.allocated_page_count(AllocationType::User)
         );
 
-        Ok(scanned)
+        Ok((regions, count))
     }
 
     /// Allocates contiguous pages from SMRAM for supervisor use.
@@ -1039,47 +1021,42 @@ mod tests {
     /// Smallest region size `coalesced_smrr_range` will accept (256 KiB - 4 KiB).
     const MIN_SMRR_SIZE: u64 = SIZE_256KB as u64 - UEFI_PAGE_SIZE as u64;
 
-    /// Builds a `ScannedRegions` from `(base, size, pre_allocated)` tuples.
-    fn regions_from(entries: &[(u64, u64, bool)]) -> ScannedRegions {
-        let mut scanned = ScannedRegions::new();
-        for &(base, size, pre_allocated) in entries {
-            scanned.push(base, size, pre_allocated);
-        }
-        scanned
+    /// Builds a `SmramRegion` list from `(base, size, pre_allocated)` tuples.
+    fn regions_from(entries: &[(u64, u64, bool)]) -> Vec<SmramRegion> {
+        entries.iter().map(|&(base, size, pre_allocated)| SmramRegion { base, size, pre_allocated }).collect()
     }
 
     #[test]
     fn test_page_allocator_coalesced_smrr_range_empty_returns_none() {
-        let scanned = ScannedRegions::new();
-        assert_eq!(scanned.coalesced_smrr_range(), None);
+        assert_eq!(coalesced_smrr_range(&[]), None);
     }
 
     #[test]
     fn test_page_allocator_coalesced_smrr_range_region_too_small_returns_none() {
-        let scanned = regions_from(&[(0x0010_0000, MIN_SMRR_SIZE - UEFI_PAGE_SIZE as u64, false)]);
-        assert_eq!(scanned.coalesced_smrr_range(), None);
+        let regions = regions_from(&[(0x0010_0000, MIN_SMRR_SIZE - UEFI_PAGE_SIZE as u64, false)]);
+        assert_eq!(coalesced_smrr_range(&regions), None);
     }
 
     #[test]
     fn test_page_allocator_coalesced_smrr_range_below_1mb_returns_none() {
         // Base below 1 MiB is rejected even when the region is large enough.
-        let scanned = regions_from(&[(0x0008_0000, SIZE_256KB as u64, false)]);
-        assert_eq!(scanned.coalesced_smrr_range(), None);
+        let regions = regions_from(&[(0x0008_0000, SIZE_256KB as u64, false)]);
+        assert_eq!(coalesced_smrr_range(&regions), None);
     }
 
     #[test]
     fn test_page_allocator_coalesced_smrr_range_above_4gb_returns_none() {
         // A range whose end exceeds 4 GiB is rejected.
-        let scanned = regions_from(&[(0xFFFF_F000, SIZE_256KB as u64, false)]);
-        assert_eq!(scanned.coalesced_smrr_range(), None);
+        let regions = regions_from(&[(0xFFFF_F000, SIZE_256KB as u64, false)]);
+        assert_eq!(coalesced_smrr_range(&regions), None);
     }
 
     #[test]
     fn test_page_allocator_coalesced_smrr_range_single_valid_region() {
         let base = 0x8000_0000u64;
         let size = SIZE_256KB as u64;
-        let scanned = regions_from(&[(base, size, false)]);
-        assert_eq!(scanned.coalesced_smrr_range(), Some(SmrrRange { base: base as u32, size: size as u32 }));
+        let regions = regions_from(&[(base, size, false)]);
+        assert_eq!(coalesced_smrr_range(&regions), Some(SmramRegion { base, size, pre_allocated: false }));
     }
 
     #[test]
@@ -1087,24 +1064,27 @@ mod tests {
         // A region large enough to be selected but whose size is not a power of
         // two fails SMRR verification and is rejected.
         let base = 0x8000_0000u64;
-        let scanned = regions_from(&[(base, MIN_SMRR_SIZE, false)]);
-        assert_eq!(scanned.coalesced_smrr_range(), None);
+        let regions = regions_from(&[(base, MIN_SMRR_SIZE, false)]);
+        assert_eq!(coalesced_smrr_range(&regions), None);
     }
 
     #[test]
     fn test_page_allocator_coalesced_smrr_range_selects_largest_region() {
         let small = (0x8000_0000u64, SIZE_256KB as u64, false);
         let large = (0x9000_0000u64, SIZE_256KB as u64 * 4, false);
-        let scanned = regions_from(&[small, large]);
-        assert_eq!(scanned.coalesced_smrr_range(), Some(SmrrRange { base: large.0 as u32, size: large.1 as u32 }));
+        let regions = regions_from(&[small, large]);
+        assert_eq!(
+            coalesced_smrr_range(&regions),
+            Some(SmramRegion { base: large.0, size: large.1, pre_allocated: false })
+        );
     }
 
     #[test]
     fn test_page_allocator_coalesced_smrr_range_ignores_pre_allocated_for_selection() {
         // A pre-allocated region cannot be selected as the primary range, so with
         // no other usable region the result is None.
-        let scanned = regions_from(&[(0x8000_0000, SIZE_256KB as u64, true)]);
-        assert_eq!(scanned.coalesced_smrr_range(), None);
+        let regions = regions_from(&[(0x8000_0000, SIZE_256KB as u64, true)]);
+        assert_eq!(coalesced_smrr_range(&regions), None);
     }
 
     #[test]
@@ -1115,10 +1095,10 @@ mod tests {
         let size = SIZE_256KB as u64 * 6; // selected as the largest region
         let above_size = SIZE_256KB as u64 * 2;
         let above = (base + size, above_size, false);
-        let scanned = regions_from(&[(base, size, false), above]);
+        let regions = regions_from(&[(base, size, false), above]);
         assert_eq!(
-            scanned.coalesced_smrr_range(),
-            Some(SmrrRange { base: base as u32, size: (size + above_size) as u32 })
+            coalesced_smrr_range(&regions),
+            Some(SmramRegion { base, size: size + above_size, pre_allocated: false })
         );
     }
 
@@ -1131,10 +1111,10 @@ mod tests {
         let base = low_base + below_size;
         let size = SIZE_256KB as u64 * 6; // selected as the largest region
         let below = (low_base, below_size, false);
-        let scanned = regions_from(&[below, (base, size, false)]);
+        let regions = regions_from(&[below, (base, size, false)]);
         assert_eq!(
-            scanned.coalesced_smrr_range(),
-            Some(SmrrRange { base: low_base as u32, size: (size + below_size) as u32 })
+            coalesced_smrr_range(&regions),
+            Some(SmramRegion { base: low_base, size: size + below_size, pre_allocated: false })
         );
     }
 
@@ -1145,8 +1125,8 @@ mod tests {
         let base = 0x8000_0000u64;
         let size = SIZE_256KB as u64 * 2; // 0x80000, selected
         let above = (base + size, SIZE_256KB as u64, false); // + 0x40000 => 0xC0000
-        let scanned = regions_from(&[(base, size, false), above]);
-        assert_eq!(scanned.coalesced_smrr_range(), None);
+        let regions = regions_from(&[(base, size, false), above]);
+        assert_eq!(coalesced_smrr_range(&regions), None);
     }
 
     #[test]
@@ -1156,7 +1136,7 @@ mod tests {
         // A physically adjacent pre-allocated region is still coalesced, since the
         // SMRR must cover a single contiguous physical range.
         let above = (base + size, size, true);
-        let scanned = regions_from(&[(base, size, false), above]);
-        assert_eq!(scanned.coalesced_smrr_range(), Some(SmrrRange { base: base as u32, size: (size * 2) as u32 }));
+        let regions = regions_from(&[(base, size, false), above]);
+        assert_eq!(coalesced_smrr_range(&regions), Some(SmramRegion { base, size: size * 2, pre_allocated: false }));
     }
 }

--- a/patina_mm_supervisor/src/mem/page_allocator.rs
+++ b/patina_mm_supervisor/src/mem/page_allocator.rs
@@ -41,7 +41,7 @@ use core::{
 };
 
 use patina::{
-    base::UEFI_PAGE_SIZE,
+    base::{SIZE_256KB, UEFI_PAGE_SIZE},
     pi::hob::{Hob, PhaseHandoffInformationTable},
     uefi_pages_to_size, uefi_size_to_pages,
 };
@@ -94,7 +94,7 @@ pub enum AllocationType {
 
 /// SMRAM descriptor structure matching EFI_SMRAM_DESCRIPTOR.
 #[repr(C)]
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct SmramDescriptor {
     /// Physical start address of the SMRAM region.
     pub physical_start: efi::PhysicalAddress,
@@ -503,7 +503,7 @@ const MAX_TEMP_REGIONS: usize = 256;
 
 /// SMRAM regions discovered while scanning the HOB list, before they are copied
 /// into the SMRAM bookkeeping structures.
-struct ScannedRegions {
+pub(crate) struct ScannedRegions {
     /// Discovered regions as `(base, size, pre_allocated)`.
     regions: [(u64, u64, bool); MAX_TEMP_REGIONS],
     /// Number of valid entries in `regions`.
@@ -544,6 +544,71 @@ impl ScannedRegions {
         }
         self.total_pages += uefi_size_to_pages!(size as usize);
         self.count += 1;
+    }
+
+    /// Selects the primary SMRR range from the scanned regions and coalesces
+    /// any physically adjacent regions into it.
+    ///
+    /// It picks the largest non pre-allocated region in `[1 MiB, 4 GiB]` that
+    /// is at least `256 KiB - 4 KiB`, then extends it downward and upward
+    /// across every region that is physically contiguous with it (regardless of
+    /// allocation state), scanning repeatedly until no further adjacent region
+    /// is found.
+    ///
+    /// Returns `(smrr_base, smrr_size)` on success, or `None` if no scanned
+    /// region meets the SMRR base/size requirements.
+    pub(crate) fn coalesced_smrr_range(&self) -> Option<(u32, u32)> {
+        /// Lowest CPU start address a candidate SMRR range may have.
+        const BASE_1MB: u64 = 0x0010_0000;
+        /// Highest address the primary SMRR can cover (4 GiB).
+        const SMRR_MAX_ADDRESS: u64 = 0x1_0000_0000;
+
+        let regions = self.regions.get(..self.count).unwrap_or(&self.regions);
+
+        // Find the largest usable (non-pre-allocated) range in [1 MiB, 4 GiB] that is at least
+        // 256 KiB - 4 KiB.
+        let mut max_size = SIZE_256KB as u64 - UEFI_PAGE_SIZE as u64;
+        let mut current: Option<(u64, u64)> = None;
+        for &(base, size, pre_allocated) in regions {
+            if pre_allocated {
+                continue;
+            }
+            if base >= BASE_1MB && base + size <= SMRR_MAX_ADDRESS && size >= max_size {
+                max_size = size;
+                current = Some((base, size));
+            }
+        }
+
+        let (base, size) = current?;
+        let mut smrr_base = base as u32;
+        let mut smrr_size = size as u32;
+
+        // Coalesce any physically adjacent ranges into the selected range. This
+        // scans the (unsorted) region array repeatedly until no further
+        // adjacent range is found, so ordering does not matter. Adjacency is
+        // considered regardless of allocation state, because the SMRR must
+        // cover a single contiguous physical range.
+        loop {
+            let mut found = false;
+            for &(region_base, region_size, _) in regions {
+                if region_base < smrr_base as u64 && smrr_base as u64 == region_base + region_size {
+                    // Region sits immediately before the current range: extend downward.
+                    smrr_base = region_base as u32;
+                    smrr_size = smrr_size.wrapping_add(region_size as u32);
+                    found = true;
+                } else if smrr_base as u64 + smrr_size as u64 == region_base && region_size > 0 {
+                    // Region sits immediately after the current range: extend upward.
+                    smrr_size = smrr_size.wrapping_add(region_size as u32);
+                    found = true;
+                }
+            }
+            if !found {
+                break;
+            }
+        }
+
+        log::info!("SMRR Base: 0x{:x}, SMRR Size: 0x{:x}", smrr_base, smrr_size);
+        Some((smrr_base, smrr_size))
     }
 }
 
@@ -673,7 +738,7 @@ impl PageAllocator {
     /// ## Safety
     ///
     /// The caller must ensure that `hob_list` points to a valid HOB list. Only null pointer will be rejected.
-    pub unsafe fn init_from_hob_list(&self, hob_list: *const c_void) -> Result<(), PageAllocError> {
+    pub unsafe fn init_from_hob_list(&self, hob_list: *const c_void) -> Result<ScannedRegions, PageAllocError> {
         if hob_list.is_null() {
             return Err(PageAllocError::NotInitialized);
         }
@@ -760,7 +825,7 @@ impl PageAllocator {
             self.allocated_page_count(AllocationType::User)
         );
 
-        Ok(())
+        Ok(scanned)
     }
 
     /// Allocates contiguous pages from SMRAM for supervisor use.
@@ -952,5 +1017,112 @@ impl PageAllocator {
             return false;
         }
         self.lock_state().is_region_inside_mmram(addr, size)
+    }
+}
+
+#[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
+mod tests {
+    use super::*;
+
+    /// Smallest region size `coalesced_smrr_range` will accept (256 KiB - 4 KiB).
+    const MIN_SMRR_SIZE: u64 = SIZE_256KB as u64 - UEFI_PAGE_SIZE as u64;
+
+    /// Builds a `ScannedRegions` from `(base, size, pre_allocated)` tuples.
+    fn regions_from(entries: &[(u64, u64, bool)]) -> ScannedRegions {
+        let mut scanned = ScannedRegions::new();
+        for &(base, size, pre_allocated) in entries {
+            scanned.push(base, size, pre_allocated);
+        }
+        scanned
+    }
+
+    #[test]
+    fn test_page_allocator_coalesced_smrr_range_empty_returns_none() {
+        let scanned = ScannedRegions::new();
+        assert_eq!(scanned.coalesced_smrr_range(), None);
+    }
+
+    #[test]
+    fn test_page_allocator_coalesced_smrr_range_region_too_small_returns_none() {
+        let scanned = regions_from(&[(0x0010_0000, MIN_SMRR_SIZE - UEFI_PAGE_SIZE as u64, false)]);
+        assert_eq!(scanned.coalesced_smrr_range(), None);
+    }
+
+    #[test]
+    fn test_page_allocator_coalesced_smrr_range_below_1mb_returns_none() {
+        // Base below 1 MiB is rejected even when the region is large enough.
+        let scanned = regions_from(&[(0x0008_0000, SIZE_256KB as u64, false)]);
+        assert_eq!(scanned.coalesced_smrr_range(), None);
+    }
+
+    #[test]
+    fn test_page_allocator_coalesced_smrr_range_above_4gb_returns_none() {
+        // A range whose end exceeds 4 GiB is rejected.
+        let scanned = regions_from(&[(0xFFFF_F000, SIZE_256KB as u64, false)]);
+        assert_eq!(scanned.coalesced_smrr_range(), None);
+    }
+
+    #[test]
+    fn test_page_allocator_coalesced_smrr_range_single_valid_region() {
+        let base = 0x8000_0000u64;
+        let size = SIZE_256KB as u64;
+        let scanned = regions_from(&[(base, size, false)]);
+        assert_eq!(scanned.coalesced_smrr_range(), Some((base as u32, size as u32)));
+    }
+
+    #[test]
+    fn test_page_allocator_coalesced_smrr_range_minimum_size_boundary() {
+        // Exactly the minimum accepted size is valid.
+        let base = 0x8000_0000u64;
+        let scanned = regions_from(&[(base, MIN_SMRR_SIZE, false)]);
+        assert_eq!(scanned.coalesced_smrr_range(), Some((base as u32, MIN_SMRR_SIZE as u32)));
+    }
+
+    #[test]
+    fn test_page_allocator_coalesced_smrr_range_selects_largest_region() {
+        let small = (0x8000_0000u64, SIZE_256KB as u64, false);
+        let large = (0x9000_0000u64, SIZE_256KB as u64 * 4, false);
+        let scanned = regions_from(&[small, large]);
+        assert_eq!(scanned.coalesced_smrr_range(), Some((large.0 as u32, large.1 as u32)));
+    }
+
+    #[test]
+    fn test_page_allocator_coalesced_smrr_range_ignores_pre_allocated_for_selection() {
+        // A pre-allocated region cannot be selected as the primary range, so with
+        // no other usable region the result is None.
+        let scanned = regions_from(&[(0x8000_0000, SIZE_256KB as u64, true)]);
+        assert_eq!(scanned.coalesced_smrr_range(), None);
+    }
+
+    #[test]
+    fn test_page_allocator_coalesced_smrr_range_coalesces_adjacent_upward() {
+        let base = 0x8000_0000u64;
+        let size = SIZE_256KB as u64 * 2; // selected as the largest region
+        let above_size = SIZE_256KB as u64;
+        let above = (base + size, above_size, false);
+        let scanned = regions_from(&[(base, size, false), above]);
+        assert_eq!(scanned.coalesced_smrr_range(), Some((base as u32, (size + above_size) as u32)));
+    }
+
+    #[test]
+    fn test_page_allocator_coalesced_smrr_range_coalesces_adjacent_downward() {
+        let base = 0x8000_0000u64;
+        let size = SIZE_256KB as u64 * 2; // selected as the largest region
+        let below_size = SIZE_256KB as u64;
+        let below = (base - below_size, below_size, false);
+        let scanned = regions_from(&[below, (base, size, false)]);
+        assert_eq!(scanned.coalesced_smrr_range(), Some(((base - below_size) as u32, (size + below_size) as u32)));
+    }
+
+    #[test]
+    fn test_page_allocator_coalesced_smrr_range_coalesces_pre_allocated_adjacent() {
+        let base = 0x8000_0000u64;
+        let size = SIZE_256KB as u64;
+        // A physically adjacent pre-allocated region is still coalesced, since the
+        // SMRR must cover a single contiguous physical range.
+        let above = (base + size, size, true);
+        let scanned = regions_from(&[(base, size, false), above]);
+        assert_eq!(scanned.coalesced_smrr_range(), Some((base as u32, (size * 2) as u32)));
     }
 }

--- a/patina_mm_supervisor/src/smrr.rs
+++ b/patina_mm_supervisor/src/smrr.rs
@@ -13,6 +13,7 @@
 //! SPDX-License-Identifier: Apache-2.0
 //!
 
+use crate::cpu::CPUID_VERSION_INFO;
 use crate::cpu::read_msr;
 use crate::cpu::write_msr;
 use core::arch::x86_64::__cpuid;
@@ -38,12 +39,21 @@ const MSR_SMRR_MASK: u32 = 0x1F3;
 const _MTRR_CACHE_WRITE_PROTECTED: u8 = 5;
 const MTRR_CACHE_WRITE_BACK: u8 = 6;
 
-const CPUID_VERSION_INFO: u32 = 0x1;
-
 const PHYS_ADDR_MASK: u64 = 0xFFFF_F000; // bits [31:12]
 const MEMTYPE_MASK: u64 = 0x0000_00FF; // bits [7:0]
 const MASK_BIT_10: u64 = 1 << 10;
 const MASK_VALID_BIT: u64 = 1 << 11;
+
+/// A System Management Range Register (SMRR) region: a physical base address
+/// and a size in bytes. Validity (power-of-two size, naturally aligned base) is
+/// checked with [`verify_smrr_base_size`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct SmrrRange {
+    /// Physical base address of the SMRR region.
+    pub base: u32,
+    /// Size of the SMRR region, in bytes.
+    pub size: u32,
+}
 
 /// Enables the SMM Code Access Check feature.
 ///
@@ -56,7 +66,7 @@ const MASK_VALID_BIT: u64 = 1 << 11;
 ///
 /// Panics if the CPU does not report support for SMM Code Access Check.
 #[cfg_attr(coverage_nightly, coverage(off))]
-pub fn configure_smm_code_access() {
+pub(crate) fn configure_smm_code_access() {
     // SAFETY: MSR_SMM_MCA_CAP is a read-only architectural capability MSR that is
     // valid on all CPUs targeted by this code; reading it has no side effects.
     let smm_code_access_supported = (unsafe { read_msr(MSR_SMM_MCA_CAP) } & SMM_CODE_ACCESS_CHK_BIT) != 0;
@@ -83,27 +93,30 @@ const fn get_power_of_two32(value: u32) -> u32 {
 }
 
 /// Sets the memory type field ([7:0]) of a raw SMRR base register value.
-fn base_reg_set_memtype(raw: u64, memtype: u8) -> u64 {
+const fn base_reg_set_memtype(raw: u64, memtype: u8) -> u64 {
     (raw & !MEMTYPE_MASK) | (memtype as u64 & MEMTYPE_MASK)
 }
 
 /// Sets the physical base address field ([31:12]) of a raw SMRR base register
 /// value.
-fn base_reg_set_base(raw: u64, base: u32) -> u64 {
-    // Stores `base >> 12` into [31:12], i.e. the address bits [31:12].
+const fn base_reg_set_base(raw: u64, base: u32) -> u64 {
+    // `base` is a naturally aligned physical address whose low 12 bits are
+    // zero, so its address bits [31:12] already sit at the register field's
+    // positions; mask them in place without shifting.
     (raw & !PHYS_ADDR_MASK) | (base as u64 & PHYS_ADDR_MASK)
 }
 
 /// Sets the mask field ([31:12]) of a raw SMRR mask register value for the
 /// given region `size`.
-fn mask_reg_set_mask(raw: u64, size: u32) -> u64 {
-    // Mask field = ~(size - 1) >> 12, placed back into [31:12].
+const fn mask_reg_set_mask(raw: u64, size: u32) -> u64 {
+    // Mask field = ~(size - 1), which for a power-of-two `size` has zeros in the
+    // low bits and ones above; mask its bits [31:12] in place without shifting.
     let mask_bits = (!(size.wrapping_sub(1))) as u64 & PHYS_ADDR_MASK;
     (raw & !PHYS_ADDR_MASK) | mask_bits
 }
 
 /// Returns `true` if bit 10 is set in a raw SMRR mask register value.
-fn mask_reg_bit10_set(raw: u64) -> bool {
+const fn mask_reg_bit10_set(raw: u64) -> bool {
     (raw & MASK_BIT_10) != 0
 }
 
@@ -112,7 +125,7 @@ fn mask_reg_bit10_set(raw: u64) -> bool {
 ///
 /// A valid region must be at least 4 KiB, have a size that is a power of two,
 /// and have a base address that is naturally aligned to its size.
-pub const fn verify_smrr_base_size(smrr_base: u32, smrr_size: u32) -> bool {
+pub(crate) const fn verify_smrr_base_size(smrr_base: u32, smrr_size: u32) -> bool {
     if smrr_size < SIZE_4KB
         || smrr_size != get_power_of_two32(smrr_size)
         || (smrr_base & !(smrr_size.wrapping_sub(1))) != smrr_base
@@ -156,10 +169,11 @@ fn is_smrr_ext_supported() -> bool {
 /// # Panics
 ///
 /// Panics if the CPU does not support MTRRs, SMRRs, or the extended SMRR
-/// capability, or if the provided `smrr_base`/`smrr_size` fail
-/// [`verify_smrr_base_size`].
+/// capability, or if the provided `range` fails [`verify_smrr_base_size`].
 #[cfg_attr(coverage_nightly, coverage(off))]
-pub fn smrr_initialize(smrr_base: u32, smrr_size: u32) {
+pub(crate) fn smrr_initialize(range: SmrrRange) {
+    let SmrrRange { base: smrr_base, size: smrr_size } = range;
+
     if !is_mtrr_supported() {
         panic!("Unsupported CPU: MTRR not supported");
     }
@@ -202,28 +216,15 @@ pub fn smrr_initialize(smrr_base: u32, smrr_size: u32) {
 /// already set, the function does nothing, since a finalized SMRR cannot be
 /// modified until the next processor reset.
 ///
-/// # Panics
-///
-/// Panics if the CPU does not support MTRRs, SMRRs, or the extended SMRR
-/// capability.
+/// CPU MTRR/SMRR support is verified once in [`smrr_initialize`] on the first
+/// SMI, so it is not re-checked here on every SMI.
 #[cfg_attr(coverage_nightly, coverage(off))]
-pub fn smrr_enable() {
-    if !is_mtrr_supported() {
-        panic!("Unsupported CPU: MTRR not supported");
-    }
-
-    if !is_smrr_supported() {
-        panic!("Unsupported CPU: SMRR not supported");
-    }
-
-    if !is_smrr_ext_supported() {
-        panic!("Unsupported CPU: SMRR extended capability not supported");
-    }
-
-    // SAFETY: SMRR support was verified above, so MSR_SMRR_MASK is a valid
-    // architectural MSR. We only set the valid and bit-10 fields to enable and
-    // finalize the previously programmed range, preserving all other bits. The
-    // write is skipped if the range is already finalized.
+pub(crate) fn smrr_enable() {
+    // SAFETY: SMRR support was verified in `smrr_initialize` on the first SMI,
+    // so MSR_SMRR_MASK is a valid architectural MSR. We only set the valid and
+    // bit-10 fields to enable and finalize the previously programmed range,
+    // preserving all other bits. The write is skipped if the range is already
+    // finalized.
     unsafe {
         let mut mask = read_msr(MSR_SMRR_MASK);
         if !mask_reg_bit10_set(mask) {

--- a/patina_mm_supervisor/src/smrr.rs
+++ b/patina_mm_supervisor/src/smrr.rs
@@ -44,15 +44,16 @@ const MEMTYPE_MASK: u64 = 0x0000_00FF; // bits [7:0]
 const MASK_BIT_10: u64 = 1 << 10;
 const MASK_VALID_BIT: u64 = 1 << 11;
 
-/// A System Management Range Register (SMRR) region: a physical base address
-/// and a size in bytes. Validity (power-of-two size, naturally aligned base) is
-/// checked with [`verify_smrr_base_size`].
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(crate) struct SmrrRange {
-    /// Physical base address of the SMRR region.
-    pub base: u32,
-    /// Size of the SMRR region, in bytes.
-    pub size: u32,
+/// A region of SMRAM: a physical base address, a size in bytes, and whether it
+/// was reported as pre-allocated in the HOB list.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub(crate) struct SmramRegion {
+    /// Physical base address of the region.
+    pub base: u64,
+    /// Size of the region, in bytes.
+    pub size: u64,
+    /// Whether the region was reported as pre-allocated (`EFI_ALLOCATED`).
+    pub pre_allocated: bool,
 }
 
 /// Enables the SMM Code Access Check feature.
@@ -171,8 +172,9 @@ fn is_smrr_ext_supported() -> bool {
 /// Panics if the CPU does not support MTRRs, SMRRs, or the extended SMRR
 /// capability, or if the provided `range` fails [`verify_smrr_base_size`].
 #[cfg_attr(coverage_nightly, coverage(off))]
-pub(crate) fn smrr_initialize(range: SmrrRange) {
-    let SmrrRange { base: smrr_base, size: smrr_size } = range;
+pub(crate) fn smrr_initialize(range: SmramRegion) {
+    let smrr_base = range.base as u32;
+    let smrr_size = range.size as u32;
 
     if !is_mtrr_supported() {
         panic!("Unsupported CPU: MTRR not supported");

--- a/patina_mm_supervisor/src/smrr.rs
+++ b/patina_mm_supervisor/src/smrr.rs
@@ -1,0 +1,339 @@
+//! System Management Range Register (SMRR) configuration.
+//!
+//! This module programs the SMRR base and mask MSRs to protect the SMRAM region
+//! from non SMM accesses, and enables the SMM Code Access Check feature. The
+//! SMRRs are initialized on the first SMI entry and, on every subsequent SMI
+//! rendezvous, enabled and finalized by setting the valid in the SMRR mask
+//! register.
+//!
+//! ## License
+//!
+//! Copyright (c) Microsoft Corporation.
+//!
+//! SPDX-License-Identifier: Apache-2.0
+//!
+
+use crate::cpu::read_msr;
+use crate::cpu::write_msr;
+use core::arch::x86_64::__cpuid;
+
+const SIZE_4KB: u32 = 0x0000_1000;
+
+// SMM Code Access Check related MSR and bit definitions
+const MSR_SMM_MCA_CAP: u32 = 0x17D;
+const SMM_CODE_ACCESS_CHK_BIT: u64 = 1 << 58;
+
+const MSR_SMM_FEATURE_CONTROL: u32 = 0x4E0;
+const SMM_FEATURE_CONTROL_LOCK_BIT: u64 = 1 << 0;
+const SMM_CODE_CHK_EN_BIT: u64 = 1 << 2;
+
+// SMM Range Register (SMRR) related MSR and bit definitions
+const MSR_MTRR_CAP: u32 = 0x0FE;
+const MTRR_CAP_SMRR_BIT: u64 = 1 << 11;
+const MTRR_CAP_SMRR_EXT_BIT: u64 = 1 << 14;
+
+const MSR_SMRR_BASE: u32 = 0x1F2;
+const MSR_SMRR_MASK: u32 = 0x1F3;
+
+const _MTRR_CACHE_WRITE_PROTECTED: u8 = 5;
+const MTRR_CACHE_WRITE_BACK: u8 = 6;
+
+const CPUID_VERSION_INFO: u32 = 0x1;
+
+const PHYS_ADDR_MASK: u64 = 0xFFFF_F000; // bits [31:12]
+const MEMTYPE_MASK: u64 = 0x0000_00FF; // bits [7:0]
+const MASK_BIT_10: u64 = 1 << 10;
+const MASK_VALID_BIT: u64 = 1 << 11;
+
+/// Enables the SMM Code Access Check feature.
+///
+/// When enabled, the CPU raises a machine check if code is fetched from outside
+/// the SMRR protected region while in SMM. This also sets the lock bit in the
+/// SMM feature control MSR, after which the feature configuration cannot be
+/// modified until the next processor reset.
+///
+/// # Panics
+///
+/// Panics if the CPU does not report support for SMM Code Access Check.
+#[cfg_attr(coverage_nightly, coverage(off))]
+pub fn configure_smm_code_access() {
+    // SAFETY: MSR_SMM_MCA_CAP is a read-only architectural capability MSR that is
+    // valid on all CPUs targeted by this code; reading it has no side effects.
+    let smm_code_access_supported = (unsafe { read_msr(MSR_SMM_MCA_CAP) } & SMM_CODE_ACCESS_CHK_BIT) != 0;
+    if !smm_code_access_supported {
+        panic!("Unsupported CPU: SMM Code Access Check not supported");
+    }
+
+    // SAFETY: MSR_SMM_FEATURE_CONTROL is an architectural MSR; reading it has no
+    // side effects.
+    let smm_feature_control_msr = unsafe { read_msr(MSR_SMM_FEATURE_CONTROL) };
+    let new_smm_feature_control_msr = smm_feature_control_msr | SMM_CODE_CHK_EN_BIT | SMM_FEATURE_CONTROL_LOCK_BIT;
+    if new_smm_feature_control_msr != smm_feature_control_msr {
+        // SAFETY: We only set the code check enable and lock bits, which is the
+        // architecturally defined way to enable SMM Code Access Check. The write
+        // is idempotent and performed only when the value actually changes.
+        unsafe { write_msr(MSR_SMM_FEATURE_CONTROL, new_smm_feature_control_msr) };
+    }
+}
+
+/// Returns the largest power of two less than or equal to `value`, or `0` if
+/// `value` is `0`.
+const fn get_power_of_two32(value: u32) -> u32 {
+    if value == 0 { 0 } else { 1u32 << (31 - value.leading_zeros()) }
+}
+
+/// Sets the memory type field ([7:0]) of a raw SMRR base register value.
+fn base_reg_set_memtype(raw: u64, memtype: u8) -> u64 {
+    (raw & !MEMTYPE_MASK) | (memtype as u64 & MEMTYPE_MASK)
+}
+
+/// Sets the physical base address field ([31:12]) of a raw SMRR base register
+/// value.
+fn base_reg_set_base(raw: u64, base: u32) -> u64 {
+    // Stores `base >> 12` into [31:12], i.e. the address bits [31:12].
+    (raw & !PHYS_ADDR_MASK) | (base as u64 & PHYS_ADDR_MASK)
+}
+
+/// Sets the mask field ([31:12]) of a raw SMRR mask register value for the
+/// given region `size`.
+fn mask_reg_set_mask(raw: u64, size: u32) -> u64 {
+    // Mask field = ~(size - 1) >> 12, placed back into [31:12].
+    let mask_bits = (!(size.wrapping_sub(1))) as u64 & PHYS_ADDR_MASK;
+    (raw & !PHYS_ADDR_MASK) | mask_bits
+}
+
+/// Returns `true` if bit 10 is set in a raw SMRR mask register value.
+fn mask_reg_bit10_set(raw: u64) -> bool {
+    (raw & MASK_BIT_10) != 0
+}
+
+/// Validates that the SMRR base and size satisfy the hardware alignment and
+/// size constraints.
+///
+/// A valid region must be at least 4 KiB, have a size that is a power of two,
+/// and have a base address that is naturally aligned to its size.
+pub const fn verify_smrr_base_size(smrr_base: u32, smrr_size: u32) -> bool {
+    if smrr_size < SIZE_4KB
+        || smrr_size != get_power_of_two32(smrr_size)
+        || (smrr_base & !(smrr_size.wrapping_sub(1))) != smrr_base
+    {
+        return false;
+    }
+
+    true
+}
+
+/// Returns `true` if the CPU reports MTRR support via CPUID.
+#[cfg_attr(coverage_nightly, coverage(off))]
+fn is_mtrr_supported() -> bool {
+    let version = __cpuid(CPUID_VERSION_INFO);
+    let reg_edx = version.edx;
+    (reg_edx & (1 << 12)) != 0
+}
+
+/// Returns `true` if the CPU reports SMRR support via `MTRR CAP`.
+#[cfg_attr(coverage_nightly, coverage(off))]
+fn is_smrr_supported() -> bool {
+    // SAFETY: MSR_MTRR_CAP is a read-only architectural capability MSR; reading
+    // it has no side effects.
+    (unsafe { read_msr(MSR_MTRR_CAP) } & MTRR_CAP_SMRR_BIT) != 0
+}
+
+/// Returns `true` if the CPU reports the extended SMRR capability via `MTRR CAP`.
+#[cfg_attr(coverage_nightly, coverage(off))]
+fn is_smrr_ext_supported() -> bool {
+    // SAFETY: MSR_MTRR_CAP is a read-only architectural capability MSR; reading
+    // it has no side effects.
+    (unsafe { read_msr(MSR_MTRR_CAP) } & MTRR_CAP_SMRR_EXT_BIT) != 0
+}
+
+/// Programs the SMRR base and mask registers to protect the given SMRAM region.
+///
+/// This is called on the first SMI entry. The region is configured as
+/// write-back cacheable but is not yet enabled or finalized; call [`smrr_enable`]
+/// to set the valid and bit-10 fields and activate the range.
+///
+/// # Panics
+///
+/// Panics if the CPU does not support MTRRs, SMRRs, or the extended SMRR
+/// capability, or if the provided `smrr_base`/`smrr_size` fail
+/// [`verify_smrr_base_size`].
+#[cfg_attr(coverage_nightly, coverage(off))]
+pub fn smrr_initialize(smrr_base: u32, smrr_size: u32) {
+    if !is_mtrr_supported() {
+        panic!("Unsupported CPU: MTRR not supported");
+    }
+
+    if !is_smrr_supported() {
+        panic!("Unsupported CPU: SMRR not supported");
+    }
+
+    if !is_smrr_ext_supported() {
+        panic!("Unsupported CPU: SMRR extended capability not supported");
+    }
+
+    if !verify_smrr_base_size(smrr_base, smrr_size) {
+        panic!(
+            "SMM Base/Size does not meet alignment/size requirement! Base: {:#X}, Size: {:#X}",
+            smrr_base, smrr_size
+        );
+    }
+
+    // SAFETY: SMRR support was verified above, so MSR_SMRR_BASE/MSR_SMRR_MASK
+    // are valid architectural MSRs. `smrr_base`/`smrr_size` were validated by
+    // `verify_smrr_base_size`, so the values written form a well-formed SMRR
+    // range. The valid bit is left clear, so the range is not yet enforced.
+    unsafe {
+        let mut base = read_msr(MSR_SMRR_BASE);
+        base = base_reg_set_memtype(base, MTRR_CACHE_WRITE_BACK);
+        base = base_reg_set_base(base, smrr_base);
+        write_msr(MSR_SMRR_BASE, base);
+
+        let mut mask = read_msr(MSR_SMRR_MASK);
+        mask = mask_reg_set_mask(mask, smrr_size);
+        write_msr(MSR_SMRR_MASK, mask);
+    }
+}
+
+/// Enables and finalizes the SMRR by setting the valid and bit-10 fields on the
+/// mask register.
+///
+/// This is called on every subsequent SMI entry (rendezvous). If bit 10 is
+/// already set, the function does nothing, since a finalized SMRR cannot be
+/// modified until the next processor reset.
+///
+/// # Panics
+///
+/// Panics if the CPU does not support MTRRs, SMRRs, or the extended SMRR
+/// capability.
+#[cfg_attr(coverage_nightly, coverage(off))]
+pub fn smrr_enable() {
+    if !is_mtrr_supported() {
+        panic!("Unsupported CPU: MTRR not supported");
+    }
+
+    if !is_smrr_supported() {
+        panic!("Unsupported CPU: SMRR not supported");
+    }
+
+    if !is_smrr_ext_supported() {
+        panic!("Unsupported CPU: SMRR extended capability not supported");
+    }
+
+    // SAFETY: SMRR support was verified above, so MSR_SMRR_MASK is a valid
+    // architectural MSR. We only set the valid and bit-10 fields to enable and
+    // finalize the previously programmed range, preserving all other bits. The
+    // write is skipped if the range is already finalized.
+    unsafe {
+        let mut mask = read_msr(MSR_SMRR_MASK);
+        if !mask_reg_bit10_set(mask) {
+            mask |= MASK_VALID_BIT | MASK_BIT_10;
+            write_msr(MSR_SMRR_MASK, mask);
+        }
+    }
+}
+
+#[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_smrr_verify_accepts_minimum_size() {
+        // A 4 KiB region at base 0 is the smallest valid configuration.
+        assert!(verify_smrr_base_size(0, SIZE_4KB));
+    }
+
+    #[test]
+    fn test_smrr_verify_accepts_naturally_aligned_regions() {
+        // Base is naturally aligned to the (power-of-two) size.
+        assert!(verify_smrr_base_size(0x0080_0000, 0x0080_0000));
+        assert!(verify_smrr_base_size(0x1000_0000, 0x1000_0000));
+        assert!(verify_smrr_base_size(0x0000_8000, SIZE_4KB));
+    }
+
+    #[test]
+    fn test_smrr_verify_rejects_size_below_4kb() {
+        assert!(!verify_smrr_base_size(0, 0));
+        assert!(!verify_smrr_base_size(0, SIZE_4KB - 1));
+        assert!(!verify_smrr_base_size(0, 0x800));
+    }
+
+    #[test]
+    fn test_smrr_verify_rejects_non_power_of_two_size() {
+        assert!(!verify_smrr_base_size(0, 0x3000));
+        assert!(!verify_smrr_base_size(0, 0x5000));
+        assert!(!verify_smrr_base_size(0, SIZE_4KB + 1));
+    }
+
+    #[test]
+    fn test_smrr_verify_rejects_misaligned_base() {
+        // Base must be aligned to the size; these are off by 4 KiB or unaligned.
+        assert!(!verify_smrr_base_size(SIZE_4KB, 0x0080_0000));
+        assert!(!verify_smrr_base_size(0x0080_1000, 0x0080_0000));
+        assert!(!verify_smrr_base_size(0x0000_1000, 0x0000_2000));
+    }
+
+    #[test]
+    fn test_smrr_get_power_of_two32_returns_zero_for_zero() {
+        assert_eq!(get_power_of_two32(0), 0);
+    }
+
+    #[test]
+    fn test_smrr_get_power_of_two32_exact_powers_are_unchanged() {
+        assert_eq!(get_power_of_two32(1), 1);
+        assert_eq!(get_power_of_two32(2), 2);
+        assert_eq!(get_power_of_two32(SIZE_4KB), SIZE_4KB);
+        assert_eq!(get_power_of_two32(0x0080_0000), 0x0080_0000);
+        assert_eq!(get_power_of_two32(0x8000_0000), 0x8000_0000);
+    }
+
+    #[test]
+    fn test_smrr_get_power_of_two32_rounds_down_to_previous_power() {
+        assert_eq!(get_power_of_two32(3), 2);
+        assert_eq!(get_power_of_two32(0x0080_0001), 0x0080_0000);
+        assert_eq!(get_power_of_two32(0x00FF_FFFF), 0x0080_0000);
+        assert_eq!(get_power_of_two32(u32::MAX), 0x8000_0000);
+    }
+
+    #[test]
+    fn test_smrr_base_reg_set_memtype_sets_low_byte_only() {
+        // Memory type occupies bits [7:0]; all other bits must be preserved.
+        assert_eq!(base_reg_set_memtype(0, MTRR_CACHE_WRITE_BACK), MTRR_CACHE_WRITE_BACK as u64);
+        // Existing memory-type bits are replaced, not OR-ed.
+        assert_eq!(base_reg_set_memtype(0xFF, MTRR_CACHE_WRITE_BACK), MTRR_CACHE_WRITE_BACK as u64);
+        // Upper bits outside [7:0] are left untouched.
+        assert_eq!(
+            base_reg_set_memtype(0x1234_5600, MTRR_CACHE_WRITE_BACK),
+            0x1234_5600 | MTRR_CACHE_WRITE_BACK as u64
+        );
+    }
+
+    #[test]
+    fn test_smrr_base_reg_set_base_sets_phys_addr_bits() {
+        // Base address occupies bits [31:12].
+        assert_eq!(base_reg_set_base(0, 0x0080_0000), 0x0080_0000);
+        // Bits below [12] of the supplied base are ignored (masked out).
+        assert_eq!(base_reg_set_base(0, 0x0080_0FFF), 0x0080_0000);
+        // Existing [31:12] bits are replaced while [11:0] and [63:32] are preserved.
+        assert_eq!(base_reg_set_base(0xFFFF_FFFF_FFFF_FFFF, 0x0080_0000), 0xFFFF_FFFF_0080_0FFF);
+    }
+
+    #[test]
+    fn test_smrr_mask_reg_set_mask_computes_size_mask() {
+        // Mask field = ~(size - 1) restricted to [31:12].
+        assert_eq!(mask_reg_set_mask(0, SIZE_4KB), 0xFFFF_F000);
+        assert_eq!(mask_reg_set_mask(0, 0x0080_0000), 0xFF80_0000);
+        assert_eq!(mask_reg_set_mask(0, 0x1000_0000), 0xF000_0000);
+        // Bits outside [31:12] of `raw` are preserved.
+        assert_eq!(mask_reg_set_mask(0xFFFF_FFFF_0000_0FFF, 0x0080_0000), 0xFFFF_FFFF_FF80_0FFF);
+    }
+
+    #[test]
+    fn test_smrr_mask_reg_bit10_detection() {
+        assert!(!mask_reg_bit10_set(0));
+        assert!(!mask_reg_bit10_set(MASK_VALID_BIT));
+        assert!(mask_reg_bit10_set(MASK_BIT_10));
+        assert!(mask_reg_bit10_set(MASK_BIT_10 | MASK_VALID_BIT));
+    }
+}

--- a/patina_mm_supervisor/src/state.rs
+++ b/patina_mm_supervisor/src/state.rs
@@ -59,6 +59,8 @@ pub(crate) struct InitState {
     ap_startup_fn: Once<fn(u64, u64, u64) -> u64>,
     /// Set once ExitBootServices has been signaled.
     at_runtime: Once<()>,
+    /// SMRR base and size
+    smrr_base_size: Once<(u32, u32)>,
 }
 
 impl InitState {
@@ -72,6 +74,7 @@ impl InitState {
             user_entry_point: Once::new(),
             ap_startup_fn: Once::new(),
             at_runtime: Once::new(),
+            smrr_base_size: Once::new(),
         }
     }
 
@@ -148,6 +151,16 @@ impl InitState {
     /// Returns whether ExitBootServices has been signaled.
     pub(crate) fn is_at_runtime(&self) -> bool {
         self.at_runtime.is_completed()
+    }
+
+    /// Stores the SMRR base and size (one-time).
+    pub(crate) fn set_smrr_base_size(&self, base: u32, size: u32) {
+        self.smrr_base_size.call_once(|| (base, size));
+    }
+
+    /// Returns the SMRR base and size, if set.
+    pub(crate) fn smrr_base_size(&self) -> Option<(u32, u32)> {
+        self.smrr_base_size.get().copied()
     }
 }
 

--- a/patina_mm_supervisor/src/state.rs
+++ b/patina_mm_supervisor/src/state.rs
@@ -34,6 +34,7 @@ use crate::{
     mem::{PageAllocator, PagingPoolAllocator, SharedPagingAllocator},
     mm_policy::gate::PolicyGate,
     save_state::{SaveStateAccessHolder, SaveStateInfo},
+    smrr::SmrrRange,
     supervisor_handlers::{
         EFI_DXE_MM_READY_TO_LOCK_PROTOCOL_GUID, SupervisorMmiHandler, UnblockedMemoryTracker,
         mm_exit_boot_services_handler, mm_ready_to_lock_handler, mm_supv_request_handler,
@@ -59,8 +60,8 @@ pub(crate) struct InitState {
     ap_startup_fn: Once<fn(u64, u64, u64) -> u64>,
     /// Set once ExitBootServices has been signaled.
     at_runtime: Once<()>,
-    /// SMRR base and size
-    smrr_base_size: Once<(u32, u32)>,
+    /// SMRR region (base and size) derived during BSP initialization.
+    smrr_range: Once<SmrrRange>,
 }
 
 impl InitState {
@@ -74,7 +75,7 @@ impl InitState {
             user_entry_point: Once::new(),
             ap_startup_fn: Once::new(),
             at_runtime: Once::new(),
-            smrr_base_size: Once::new(),
+            smrr_range: Once::new(),
         }
     }
 
@@ -153,14 +154,14 @@ impl InitState {
         self.at_runtime.is_completed()
     }
 
-    /// Stores the SMRR base and size (one-time).
-    pub(crate) fn set_smrr_base_size(&self, base: u32, size: u32) {
-        self.smrr_base_size.call_once(|| (base, size));
+    /// Stores the SMRR region (one-time).
+    pub(crate) fn set_smrr_range(&self, range: SmrrRange) {
+        self.smrr_range.call_once(|| range);
     }
 
-    /// Returns the SMRR base and size, if set.
-    pub(crate) fn smrr_base_size(&self) -> Option<(u32, u32)> {
-        self.smrr_base_size.get().copied()
+    /// Returns the SMRR region, if set.
+    pub(crate) fn smrr_range(&self) -> Option<SmrrRange> {
+        self.smrr_range.get().copied()
     }
 }
 

--- a/patina_mm_supervisor/src/state.rs
+++ b/patina_mm_supervisor/src/state.rs
@@ -34,7 +34,7 @@ use crate::{
     mem::{PageAllocator, PagingPoolAllocator, SharedPagingAllocator},
     mm_policy::gate::PolicyGate,
     save_state::{SaveStateAccessHolder, SaveStateInfo},
-    smrr::SmrrRange,
+    smrr::SmramRegion,
     supervisor_handlers::{
         EFI_DXE_MM_READY_TO_LOCK_PROTOCOL_GUID, SupervisorMmiHandler, UnblockedMemoryTracker,
         mm_exit_boot_services_handler, mm_ready_to_lock_handler, mm_supv_request_handler,
@@ -61,7 +61,7 @@ pub(crate) struct InitState {
     /// Set once ExitBootServices has been signaled.
     at_runtime: Once<()>,
     /// SMRR region (base and size) derived during BSP initialization.
-    smrr_range: Once<SmrrRange>,
+    smrr_range: Once<SmramRegion>,
 }
 
 impl InitState {
@@ -155,12 +155,12 @@ impl InitState {
     }
 
     /// Stores the SMRR region (one-time).
-    pub(crate) fn set_smrr_range(&self, range: SmrrRange) {
+    pub(crate) fn set_smrr_range(&self, range: SmramRegion) {
         self.smrr_range.call_once(|| range);
     }
 
     /// Returns the SMRR region, if set.
-    pub(crate) fn smrr_range(&self) -> Option<SmrrRange> {
+    pub(crate) fn smrr_range(&self) -> Option<SmramRegion> {
         self.smrr_range.get().copied()
     }
 }


### PR DESCRIPTION
## Description

- This commit programs the SMRRs in two phases
    1. Initialize the SMRR base and mask registers on the first SMI entry
    2. Enable the Valid bit (if not already) on every subsequent SMI entry
- Also programs the SMM Code Access for every CPU on the first SMI entry
   
    Address https://github.com/OpenDevicePartnership/patina/issues/1610

---
- [x] Impacts functionality?
- [x] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Validated boot to desktop on physical platform.

## Integration Instructions

NA