### PR TITLE
[major] SDK Refactor:  Republish base, update consumers, and cleanup [REBASE & FF]

### DIFF
--- a/components/patina_acpi/Cargo.toml
+++ b/components/patina_acpi/Cargo.toml
@@ -13,7 +13,6 @@ workspace = true
 log = { workspace = true }
 memoffset = { workspace = true }
 mockall = { workspace = true, optional = true }
-r-efi = { workspace = true }
 zerocopy = { workspace = true }
 zerocopy-derive = { workspace = true }
 

--- a/components/patina_acpi/src/acpi.rs
+++ b/components/patina_acpi/src/acpi.rs
@@ -20,7 +20,7 @@ use core::{
 };
 
 use patina::{
-    base::SIZE_4GB,
+    SIZE_4GB,
     component::{
         hob::Hob,
         service::{IntoService, Service, memory::MemoryManager},

--- a/components/patina_acpi/src/acpi.rs
+++ b/components/patina_acpi/src/acpi.rs
@@ -818,11 +818,11 @@ mod tests {
 
     use super::*;
     use mockall::predicate::always;
+    use patina::standard::efi;
     use patina::{
         component::service::memory::{MockMemoryManager, StdMemoryManager},
         uefi::boot_services::MockBootServices,
     };
-    use r_efi::efi;
     use std::{
         boxed::Box,
         sync::atomic::{AtomicBool, Ordering as AtomicOrdering},

--- a/components/patina_acpi/src/acpi_protocol.rs
+++ b/components/patina_acpi/src/acpi_protocol.rs
@@ -14,7 +14,7 @@ use crate::{
 };
 
 use core::{ffi::c_void, mem};
-use patina::base::protocol::ProtocolInterface;
+use patina::protocol::ProtocolInterface;
 use patina::standard::efi;
 
 use crate::{

--- a/components/patina_acpi/src/acpi_protocol.rs
+++ b/components/patina_acpi/src/acpi_protocol.rs
@@ -15,7 +15,7 @@ use crate::{
 
 use core::{ffi::c_void, mem};
 use patina::base::protocol::ProtocolInterface;
-use r_efi::efi;
+use patina::standard::efi;
 
 use crate::{
     acpi::STANDARD_ACPI_PROVIDER,
@@ -54,12 +54,12 @@ impl AcpiTableProtocol {
     ///
     /// # Errors
     ///
-    /// Returns [`INVALID_PARAMETER`](r_efi::efi::Status::INVALID_PARAMETER) the table buffer is null or too small to contain the ACPI table header.
-    /// Returns [`UNSUPPORTED`](r_efi::efi::Status::UNSUPPORTED) if the system page size is not 64B-aligned (required for FACS in ACPI 2.0+).
-    /// Returns [`UNSUPPORTED`](r_efi::efi::Status::UNSUPPORTED) if boot services cannot install the given table format.
-    /// Returns [`OUT_OF_RESOURCES`](r_efi::efi::Status::OUT_OF_RESOURCES) if allocating memory for the table fails.
-    /// Returns [`ALREADY_STARTED`](r_efi::efi::Status::ALREADY_STARTED) if the FADT already exists and `install` is called on a FADT again.
-    /// Returns [`NOT_STARTED`](r_efi::efi::Status::NOT_STARTED) if memory or boot services are not properly initialized.
+    /// Returns [`INVALID_PARAMETER`](efi::Status::INVALID_PARAMETER) the table buffer is null or too small to contain the ACPI table header.
+    /// Returns [`UNSUPPORTED`](efi::Status::UNSUPPORTED) if the system page size is not 64B-aligned (required for FACS in ACPI 2.0+).
+    /// Returns [`UNSUPPORTED`](efi::Status::UNSUPPORTED) if boot services cannot install the given table format.
+    /// Returns [`OUT_OF_RESOURCES`](efi::Status::OUT_OF_RESOURCES) if allocating memory for the table fails.
+    /// Returns [`ALREADY_STARTED`](efi::Status::ALREADY_STARTED) if the FADT already exists and `install` is called on a FADT again.
+    /// Returns [`NOT_STARTED`](efi::Status::NOT_STARTED) if memory or boot services are not properly initialized.
     extern "efiapi" fn install_acpi_table_ext(
         _protocol: *const AcpiTableProtocol,
         acpi_table_buffer: *const c_void,
@@ -139,8 +139,8 @@ impl AcpiTableProtocol {
     ///
     /// # Errors
     ///
-    /// Returns [`INVALID_PARAMETER`](r_efi::efi::Status::INVALID_PARAMETER) if the table key does not correspond to an installed table.
-    /// Returns [`OUT_OF_RESOURCES`](r_efi::efi::Status::OUT_OF_RESOURCES) if memory operations fail.
+    /// Returns [`INVALID_PARAMETER`](efi::Status::INVALID_PARAMETER) if the table key does not correspond to an installed table.
+    /// Returns [`OUT_OF_RESOURCES`](efi::Status::OUT_OF_RESOURCES) if memory operations fail.
     extern "efiapi" fn uninstall_acpi_table_ext(_protocol: *const AcpiTableProtocol, table_key: usize) -> efi::Status {
         match STANDARD_ACPI_PROVIDER.uninstall_acpi_table(TableKey(table_key)) {
             Ok(_) => {
@@ -188,9 +188,9 @@ impl AcpiGetProtocol {
     ///
     /// # Errors
     ///
-    /// Returns [`INVALID_PARAMETER`](r_efi::efi::Status::INVALID_PARAMETER) the index is out of bounds of the list of installed tables.
-    /// Returns [`INVALID_PARAMETER`](r_efi::efi::Status::INVALID_PARAMETER) any input or output parameters are null.
-    /// Returns [`OUT_OF_RESOURCES`](r_efi::efi::Status::OUT_OF_RESOURCES) if memory operations fail.
+    /// Returns [`INVALID_PARAMETER`](efi::Status::INVALID_PARAMETER) the index is out of bounds of the list of installed tables.
+    /// Returns [`INVALID_PARAMETER`](efi::Status::INVALID_PARAMETER) any input or output parameters are null.
+    /// Returns [`OUT_OF_RESOURCES`](efi::Status::OUT_OF_RESOURCES) if memory operations fail.
     extern "efiapi" fn get_acpi_table_ext(
         index: usize,
         table: *mut *mut AcpiTableHeader,
@@ -236,8 +236,8 @@ impl AcpiGetProtocol {
     ///
     /// # Errors
     ///
-    /// Returns [`INVALID_PARAMETER`](r_efi::efi::Status::INVALID_PARAMETER) if there is an attempt to unregister a notify function that was never registered.
-    /// Returns [`INVALID_PARAMETER`](r_efi::efi::Status::INVALID_PARAMETER) if the notify function pointer is null or does not match the standard notify function signature.
+    /// Returns [`INVALID_PARAMETER`](efi::Status::INVALID_PARAMETER) if there is an attempt to unregister a notify function that was never registered.
+    /// Returns [`INVALID_PARAMETER`](efi::Status::INVALID_PARAMETER) if the notify function pointer is null or does not match the standard notify function signature.
     extern "efiapi" fn register_notify_ext(register: bool, notify_fn: *const AcpiNotifyFnExt) -> efi::Status {
         // SAFETY: the caller must pass in a valid pointer to a notify function
         let rust_fn: AcpiNotifyFn = match unsafe { notify_fn.as_ref() } {

--- a/components/patina_acpi/src/acpi_table.rs
+++ b/components/patina_acpi/src/acpi_table.rs
@@ -16,7 +16,7 @@ use crate::{
 };
 use alloc::{boxed::Box, vec::Vec};
 use patina::{
-    base::SIZE_4GB,
+    SIZE_4GB,
     component::service::{
         Service,
         memory::{AllocationOptions, MemoryManager, PageAllocationStrategy},

--- a/components/patina_acpi/src/component.rs
+++ b/components/patina_acpi/src/component.rs
@@ -23,11 +23,11 @@ use patina::{
 };
 
 use patina::{
-    base::error::EfiError,
     component::{
         hob::Hob,
         service::{Service, memory::MemoryManager},
     },
+    error::EfiError,
     uefi::memory::EfiMemoryType,
 };
 
@@ -77,7 +77,7 @@ impl AcpiComponent {
         boot_services: StandardBootServices,
         acpi_hob: Option<Hob<AcpiMemoryHob>>,
         memory_manager: Service<dyn MemoryManager>,
-    ) -> patina::base::error::Result<()> {
+    ) -> patina::error::Result<()> {
         // Produce the EDKII ACPI protocol interfaces.
         boot_services.install_protocol_interface(None, Box::new(AcpiTableProtocol::new()))?;
         boot_services.install_protocol_interface(None, Box::new(AcpiGetProtocol::new()))?;

--- a/components/patina_acpi/src/error.rs
+++ b/components/patina_acpi/src/error.rs
@@ -9,7 +9,7 @@
 //! SPDX-License-Identifier: Apache-2.0
 //!
 
-use r_efi::efi;
+use patina::standard::efi;
 
 /// Custom errors for ACPI operations
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/components/patina_acpi/src/integration_test.rs
+++ b/components/patina_acpi/src/integration_test.rs
@@ -10,12 +10,12 @@
 
 use core::{ffi::c_void, mem};
 
+use patina::standard::efi;
 use patina::{
     component::service::Service,
     uefi::boot_services::{BootServices, StandardBootServices},
 };
 use patina_test::{patina_test, u_assert, u_assert_eq};
-use r_efi::efi;
 
 use crate::{
     acpi_protocol::{AcpiGetProtocol, AcpiTableProtocol},

--- a/components/patina_acpi/src/service.rs
+++ b/components/patina_acpi/src/service.rs
@@ -12,7 +12,7 @@ use core::any::TypeId;
 
 use alloc::vec::Vec;
 use patina::component::service::{IntoService, Service, memory::MemoryManager};
-use r_efi::efi;
+use patina::standard::efi;
 
 use crate::{
     acpi_table::{AcpiTable, AcpiTableHeader},

--- a/components/patina_adv_logger/Cargo.toml
+++ b/components/patina_adv_logger/Cargo.toml
@@ -19,7 +19,6 @@ required-features = ['std']
 log = { workspace = true }
 patina = { workspace = true }
 patina_test = { workspace = true }
-r-efi = { workspace = true }
 spin = { workspace = true }
 zerocopy = { workspace = true }
 zerocopy-derive = { workspace = true }

--- a/components/patina_adv_logger/src/component.rs
+++ b/components/patina_adv_logger/src/component.rs
@@ -12,11 +12,11 @@
 use alloc::boxed::Box;
 use patina::standard::efi;
 use patina::{
-    base::error::{EfiError, Result},
     component::{
         component,
         service::{Service, perf_timer::ArchTimerFunctionality},
     },
+    error::{EfiError, Result},
     peripheral::serial::SerialIO,
     uefi::boot_services::{BootServices, StandardBootServices},
 };

--- a/components/patina_adv_logger/src/component.rs
+++ b/components/patina_adv_logger/src/component.rs
@@ -10,6 +10,7 @@
 //! SPDX-License-Identifier: Apache-2.0
 //!
 use alloc::boxed::Box;
+use patina::standard::efi;
 use patina::{
     base::error::{EfiError, Result},
     component::{
@@ -19,7 +20,6 @@ use patina::{
     peripheral::serial::SerialIO,
     uefi::boot_services::{BootServices, StandardBootServices},
 };
-use r_efi::efi;
 
 use crate::{logger::AdvancedLogger, protocol::AdvancedLoggerProtocol};
 

--- a/components/patina_adv_logger/src/integration_test.rs
+++ b/components/patina_adv_logger/src/integration_test.rs
@@ -13,7 +13,7 @@
 use patina::uefi::boot_services::{BootServices, StandardBootServices};
 use patina_test::{patina_test, u_assert, u_assert_eq};
 
-use r_efi::efi;
+use patina::standard::efi;
 
 use crate::{memory_log, protocol::AdvancedLoggerProtocol, reader::AdvancedLogReader};
 

--- a/components/patina_adv_logger/src/logger.rs
+++ b/components/patina_adv_logger/src/logger.rs
@@ -17,9 +17,9 @@ use core::{ffi::c_void, marker::Send, ptr};
 use log::Level;
 use patina::standard::efi;
 use patina::{
-    base::error::EfiError,
     component::service::{Service, perf_timer::ArchTimerFunctionality},
     debug::log::Format,
+    error::EfiError,
     peripheral::serial::{SerialIO, shared::SharedSerial},
     pi::hob::{Hob, PhaseHandoffInformationTable},
 };

--- a/components/patina_adv_logger/src/logger.rs
+++ b/components/patina_adv_logger/src/logger.rs
@@ -15,6 +15,7 @@ use crate::{
 };
 use core::{ffi::c_void, marker::Send, ptr};
 use log::Level;
+use patina::standard::efi;
 use patina::{
     base::error::EfiError,
     component::service::{Service, perf_timer::ArchTimerFunctionality},
@@ -22,7 +23,6 @@ use patina::{
     peripheral::serial::{SerialIO, shared::SharedSerial},
     pi::hob::{Hob, PhaseHandoffInformationTable},
 };
-use r_efi::efi;
 use spin::RwLock;
 
 // Exists for the debugger to find the log buffer.
@@ -354,13 +354,13 @@ mod tests {
 
     use alloc::boxed::Box;
     use log::Log;
+    use patina::standard::efi;
     use patina::{
         component::service::{IntoService, perf_timer::ArchTimerFunctionality},
         debug::log::Format,
         peripheral::serial::uart::UartNull,
         pi::hob::{GUID_EXTENSION, GuidHob, HobHeader},
     };
-    use r_efi::efi;
 
     use crate::{
         logger::{AdvancedLogger, TargetFilter},

--- a/components/patina_adv_logger/src/memory_log.rs
+++ b/components/patina_adv_logger/src/memory_log.rs
@@ -19,8 +19,8 @@ use core::{
 };
 use patina::standard::efi;
 use patina::{
-    base::align_up,
-    base::error::{EfiError, Result},
+    align_up,
+    error::{EfiError, Result},
 };
 use zerocopy_derive::*;
 

--- a/components/patina_adv_logger/src/memory_log.rs
+++ b/components/patina_adv_logger/src/memory_log.rs
@@ -17,11 +17,11 @@ use core::{
     mem::size_of,
     sync::atomic::{AtomicU32, AtomicU64, Ordering},
 };
+use patina::standard::efi;
 use patina::{
     base::align_up,
     base::error::{EfiError, Result},
 };
-use r_efi::efi;
 use zerocopy_derive::*;
 
 // { 0x4d60cfb5, 0xf481, 0x4a98, {0x9c, 0x81, 0xbf, 0xf8, 0x64, 0x60, 0xc4, 0x3e }}

--- a/components/patina_adv_logger/src/parser.rs
+++ b/components/patina_adv_logger/src/parser.rs
@@ -10,7 +10,7 @@
 use crate::{memory_log::LogEntry, reader::AdvancedLogReader};
 use alloc::format;
 use core::str;
-use patina::base::error::EfiError;
+use patina::error::EfiError;
 
 /// Parser for the Advanced Logger buffer.
 pub struct Parser<'a> {

--- a/components/patina_adv_logger/src/protocol.rs
+++ b/components/patina_adv_logger/src/protocol.rs
@@ -8,7 +8,7 @@
 //!
 
 use patina::base::protocol::ProtocolInterface;
-use r_efi::efi;
+use patina::standard::efi;
 
 /// C struct for the Advanced Logger protocol version 2.
 #[repr(C)]

--- a/components/patina_adv_logger/src/protocol.rs
+++ b/components/patina_adv_logger/src/protocol.rs
@@ -7,7 +7,7 @@
 //! SPDX-License-Identifier: Apache-2.0
 //!
 
-use patina::base::protocol::ProtocolInterface;
+use patina::protocol::ProtocolInterface;
 use patina::standard::efi;
 
 /// C struct for the Advanced Logger protocol version 2.

--- a/components/patina_adv_logger/src/reader.rs
+++ b/components/patina_adv_logger/src/reader.rs
@@ -10,7 +10,7 @@
 //! SPDX-License-Identifier: Apache-2.0
 //!
 use core::{mem::size_of, slice, sync::atomic::Ordering};
-use patina::base::error::{EfiError, Result};
+use patina::error::{EfiError, Result};
 use patina::standard::efi;
 use zerocopy::FromBytes;
 

--- a/components/patina_adv_logger/src/reader.rs
+++ b/components/patina_adv_logger/src/reader.rs
@@ -11,7 +11,7 @@
 //!
 use core::{mem::size_of, slice, sync::atomic::Ordering};
 use patina::base::error::{EfiError, Result};
-use r_efi::efi;
+use patina::standard::efi;
 use zerocopy::FromBytes;
 
 use crate::memory_log::{AdvLoggerInfoRef, AdvLoggerMessageEntry, LogEntry};

--- a/components/patina_adv_logger/src/writer.rs
+++ b/components/patina_adv_logger/src/writer.rs
@@ -11,8 +11,8 @@
 use core::{cell::UnsafeCell, mem::size_of, ptr, slice, sync::atomic::Ordering};
 use patina::standard::efi;
 use patina::{
-    base::align_up,
-    base::error::{EfiError, Result},
+    align_up,
+    error::{EfiError, Result},
 };
 use zerocopy::IntoBytes;
 

--- a/components/patina_adv_logger/src/writer.rs
+++ b/components/patina_adv_logger/src/writer.rs
@@ -9,11 +9,11 @@
 //! SPDX-License-Identifier: Apache-2.0
 //!
 use core::{cell::UnsafeCell, mem::size_of, ptr, slice, sync::atomic::Ordering};
+use patina::standard::efi;
 use patina::{
     base::align_up,
     base::error::{EfiError, Result},
 };
-use r_efi::efi;
 use zerocopy::IntoBytes;
 
 use crate::memory_log::{AdvLoggerInfo, AdvLoggerInfoRef, AdvLoggerMessageEntry, LogEntry};

--- a/components/patina_mm/Cargo.toml
+++ b/components/patina_mm/Cargo.toml
@@ -14,7 +14,6 @@ workspace = true
 cfg-if = { workspace = true }
 log = { workspace = true }
 mockall = { workspace = true, optional = true }
-r-efi = { workspace = true }
 patina = { workspace = true }
 zerocopy = { workspace = true }
 zerocopy-derive = { workspace = true }

--- a/components/patina_mm/README.md
+++ b/components/patina_mm/README.md
@@ -50,7 +50,7 @@ and `SwMmiTrigger` services for consumption by components throughout the dispatc
 
 ```rust
 use patina_dxe_core::*;
-use patina::{component::service::IntoService, base::error::Result};
+use patina::{component::service::IntoService, error::Result};
 use patina_mm::service::PlatformMmControl;
 
 /// An optional service to ensure Platform MM is initialized.
@@ -60,7 +60,7 @@ struct ExamplePlatformMmControl;
 
 impl PlatformMmControl for ExamplePlatformMmControl {
   /// Platform hardware enabling required to support MMIs
-  fn init(&self) -> patina::base::error::Result<()> {
+  fn init(&self) -> patina::error::Result<()> {
     /* platform MMI init code */
     Ok(())
   }
@@ -123,7 +123,7 @@ pub struct ExampleComponent;
 #[component]
 impl ExampleComponent {
   /// Example Entry point that just sends a single message
-  pub fn entry_point(self, mm_comm: Service<dyn MmCommunication>) -> patina::base::error::Result<()> {
+  pub fn entry_point(self, mm_comm: Service<dyn MmCommunication>) -> patina::error::Result<()> {
     let data = DataToSend {
       signature: u32::from_le_bytes([b'M', b'S', b'U', b'P']),
       buffer: [b'H', b'E', b'L', b'L', b'O', b'\0', 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0],
@@ -143,7 +143,7 @@ impl ExampleComponent {
         )
         .map_err(|_| {
           log::error!("MM Communication failed");
-          patina::base::error::EfiError::DeviceError // Todo: Map actual codes
+          patina::error::EfiError::DeviceError // Todo: Map actual codes
         })?
     };
     Ok(())

--- a/components/patina_mm/src/component/communicator.rs
+++ b/components/patina_mm/src/component/communicator.rs
@@ -199,7 +199,7 @@ impl MmCommunicator {
         storage: &mut Storage,
         sw_mmi_trigger: Service<dyn SwMmiTrigger>,
         boot_services: StandardBootServices,
-    ) -> patina::base::error::Result<()> {
+    ) -> patina::error::Result<()> {
         log::info!(target: "mm_comm", "MM Communicator entry...");
 
         // Create the real MM executor

--- a/components/patina_mm/src/component/communicator/comm_buffer_update.rs
+++ b/components/patina_mm/src/component/communicator/comm_buffer_update.rs
@@ -12,7 +12,7 @@
 
 use crate::config::CommunicateBuffer;
 use patina::{
-    base::UEFI_PAGE_SIZE,
+    UEFI_PAGE_SIZE,
     management_mode::protocol::mm_comm_buffer_update::{self, MmCommBufferUpdateProtocol},
     standard::efi,
     uefi::{
@@ -52,14 +52,14 @@ pub(super) struct ProtocolNotifyContext {
 ///
 /// # Returns
 /// - `Ok(&'static ProtocolNotifyContext)`: Context that should be stored for later use
-/// - `Err(patina::base::error::Error)`: If event creation or protocol notify registration fails
+/// - `Err(patina::error::Error)`: If event creation or protocol notify registration fails
 ///
 /// # Safety
 /// - The returned context is leaked and will live for a static lifetime
 pub(super) fn register_buffer_update_notify(
     boot_services: StandardBootServices,
     updatable_buffer_id: u8,
-) -> patina::base::error::Result<&'static ProtocolNotifyContext> {
+) -> patina::error::Result<&'static ProtocolNotifyContext> {
     log::trace!(target: "mm_comm", "Setting up protocol notify callback for buffer ID {}", updatable_buffer_id);
 
     let context = Box::leak(Box::new(ProtocolNotifyContext {

--- a/components/patina_mm/src/component/communicator/comm_buffer_update.rs
+++ b/components/patina_mm/src/component/communicator/comm_buffer_update.rs
@@ -14,8 +14,11 @@ use crate::config::CommunicateBuffer;
 use patina::{
     base::UEFI_PAGE_SIZE,
     management_mode::protocol::mm_comm_buffer_update::{self, MmCommBufferUpdateProtocol},
-    uefi::boot_services::{BootServices, StandardBootServices, tpl::Tpl},
-    uefi::event::EventType,
+    standard::efi,
+    uefi::{
+        boot_services::{BootServices, StandardBootServices, tpl::Tpl},
+        event::EventType,
+    },
 };
 use zerocopy::FromBytes;
 
@@ -165,7 +168,7 @@ pub(super) fn apply_pending_buffer_update(
 ///
 /// ELements of the protocol update process are unit tested but the notification function as a whole is not.
 #[cfg_attr(coverage, coverage(off))]
-extern "efiapi" fn protocol_notify_callback(_event: r_efi::efi::Event, context: &'static ProtocolNotifyContext) {
+extern "efiapi" fn protocol_notify_callback(_event: efi::Event, context: &'static ProtocolNotifyContext) {
     log::trace!(target: "mm_comm", "=== Protocol callback ENTRY ===");
     log::info!(target: "mm_comm", "Protocol notify callback triggered for {}", mm_comm_buffer_update::PROTOCOL_GUID);
 
@@ -285,8 +288,8 @@ mod tests {
 
     /// Helper to create a test protocol notify context without boot services
     fn create_test_context(updatable_buffer_id: u8) -> Box<ProtocolNotifyContext> {
-        let mock_bs = Box::leak(Box::new([0u8; core::mem::size_of::<r_efi::system::BootServices>()]));
-        let bs_ptr = mock_bs.as_mut_ptr() as *mut r_efi::system::BootServices;
+        let mock_bs = Box::leak(Box::new([0u8; core::mem::size_of::<patina::standard::efi::BootServices>()]));
+        let bs_ptr = mock_bs.as_mut_ptr() as *mut patina::standard::efi::BootServices;
         let bs = StandardBootServices::new(bs_ptr);
 
         Box::new(ProtocolNotifyContext {

--- a/components/patina_mm/src/component/sw_mmi_manager.rs
+++ b/components/patina_mm/src/component/sw_mmi_manager.rs
@@ -42,7 +42,7 @@ use mockall::automock;
 #[cfg_attr(any(test, feature = "mockall"), automock)]
 pub unsafe trait SwMmiTrigger {
     /// Triggers a software Management Mode Interrupt (MMI).
-    fn trigger_sw_mmi(&self, cmd_port_value: u8, data_port_value: u8) -> patina::base::error::Result<()>;
+    fn trigger_sw_mmi(&self, cmd_port_value: u8, data_port_value: u8) -> patina::error::Result<()>;
 }
 
 /// A component that provides the `SwMmiTrigger` service.
@@ -70,7 +70,7 @@ impl SwMmiManager {
         config: Config<MmCommunicationConfiguration>,
         platform_mm_control: Option<Service<dyn PlatformMmControl>>,
         mut commands: Commands,
-    ) -> patina::base::error::Result<()> {
+    ) -> patina::error::Result<()> {
         log::info!(target: "sw_mmi", "Initializing SwMmiManager...");
         log::debug!(target: "sw_mmi", "MM config - cmd_port: {:?}, data_port: {:?}, acpi_base: {:?}",
             config.cmd_port, config.data_port, config.acpi_base);
@@ -102,7 +102,7 @@ unsafe impl SwMmiTrigger for SwMmiManager {
     // This is tested in integration tests, but it is difficult to unit test with little value returned due to
     // the nature of hardware I/O port operations.
     #[cfg_attr(coverage, coverage(off))]
-    fn trigger_sw_mmi(&self, _cmd_port_value: u8, _data_port_value: u8) -> patina::base::error::Result<()> {
+    fn trigger_sw_mmi(&self, _cmd_port_value: u8, _data_port_value: u8) -> patina::error::Result<()> {
         log::debug!(target: "sw_mmi", "Triggering SW MMI with cmd_port_value=0x{:02X}, data_port_value=0x{:02X}", _cmd_port_value, _data_port_value);
 
         log::trace!(target: "sw_mmi", "Writing to MMI command port...");

--- a/components/patina_mm/src/config.rs
+++ b/components/patina_mm/src/config.rs
@@ -22,7 +22,7 @@ use alloc::vec::Vec;
 use core::{fmt, pin::Pin, ptr::NonNull};
 
 use patina::{
-    BinaryGuid, Guid, base::UEFI_PAGE_MASK, management_mode::MmCommBufferStatus,
+    BinaryGuid, Guid, UEFI_PAGE_MASK, management_mode::MmCommBufferStatus,
     pi::protocol::communication::EfiMmCommunicateHeader, writelncrlf,
 };
 
@@ -935,7 +935,7 @@ mod tests {
 
     #[test]
     fn test_from_firmware_region_success() {
-        use patina::base::UEFI_PAGE_SIZE;
+        use patina::UEFI_PAGE_SIZE;
 
         let aligned_buf = Box::new(AlignedBuffer([0u8; 64]));
         let buffer_ptr = aligned_buf.0.as_ptr();
@@ -966,7 +966,7 @@ mod tests {
 
     #[test]
     fn test_from_raw_parts_success() {
-        use patina::base::UEFI_PAGE_SIZE;
+        use patina::UEFI_PAGE_SIZE;
 
         let mut aligned_buf = Box::new(AlignedBuffer([0u8; 64]));
         let buffer = &mut aligned_buf.0;

--- a/components/patina_mm/src/service/platform_mm_control.rs
+++ b/components/patina_mm/src/service/platform_mm_control.rs
@@ -19,5 +19,5 @@ use mockall::automock;
 #[cfg_attr(any(test, feature = "mockall"), automock)]
 pub trait PlatformMmControl {
     /// Platform-specific initialization of the MM environment.
-    fn init(&self) -> patina::base::error::Result<()>;
+    fn init(&self) -> patina::error::Result<()>;
 }

--- a/components/patina_mm/tests/patina_mm_integration/common/constants.rs
+++ b/components/patina_mm/tests/patina_mm_integration/common/constants.rs
@@ -6,7 +6,7 @@
 //!
 //! SPDX-License-Identifier: Apache-2.0
 
-use patina::base::SIZE_4KB;
+use patina::SIZE_4KB;
 
 /// Standard test buffer size
 pub const TEST_BUFFER_SIZE: usize = SIZE_4KB;

--- a/components/patina_mm/tests/patina_mm_integration/common/framework.rs
+++ b/components/patina_mm/tests/patina_mm_integration/common/framework.rs
@@ -56,9 +56,9 @@ impl core::fmt::Display for TestFrameworkError {
 
 impl std::error::Error for TestFrameworkError {}
 
-impl From<TestFrameworkError> for patina::base::error::EfiError {
+impl From<TestFrameworkError> for patina::error::EfiError {
     fn from(_err: TestFrameworkError) -> Self {
-        patina::base::error::EfiError::Aborted // Convert to appropriate EFI error
+        patina::error::EfiError::Aborted // Convert to appropriate EFI error
     }
 }
 

--- a/components/patina_mm/tests/patina_mm_integration/common/handlers.rs
+++ b/components/patina_mm/tests/patina_mm_integration/common/handlers.rs
@@ -17,7 +17,7 @@
 //! SPDX-License-Identifier: Apache-2.0
 
 use crate::patina_mm_integration::common::constants::*;
-use r_efi::efi;
+use patina::standard::efi;
 
 extern crate alloc;
 use alloc::{string::String, vec::Vec};

--- a/components/patina_mm/tests/patina_mm_integration/mm_communicator/component_integration_tests.rs
+++ b/components/patina_mm/tests/patina_mm_integration/mm_communicator/component_integration_tests.rs
@@ -25,7 +25,7 @@ use patina_mm::{
 
 use core::pin::Pin;
 
-use r_efi::efi;
+use patina::standard::efi;
 
 use crate::patina_mm_integration::common::*;
 

--- a/components/patina_mm/tests/patina_mm_integration/mm_communicator/stress_tests.rs
+++ b/components/patina_mm/tests/patina_mm_integration/mm_communicator/stress_tests.rs
@@ -12,8 +12,7 @@ use crate::patina_mm_integration::common::{constants::*, framework::*};
 
 use core::pin::Pin;
 use patina::{
-    Guid,
-    base::SIZE_4KB,
+    Guid, SIZE_4KB,
     component::{Storage, service::Service},
 };
 use patina_mm::{

--- a/components/patina_mm/tests/patina_mm_integration/mm_supervisor/communication_tests.rs
+++ b/components/patina_mm/tests/patina_mm_integration/mm_supervisor/communication_tests.rs
@@ -16,7 +16,7 @@
 
 use crate::patina_mm_integration::common::*;
 use patina::management_mode::protocol::{mm_supervisor_request, mm_supervisor_request::RequestType};
-use r_efi::efi;
+use patina::standard::efi;
 
 #[test]
 fn test_mm_supervisor_version_request_integration() {

--- a/components/patina_performance/Cargo.toml
+++ b/components/patina_performance/Cargo.toml
@@ -11,7 +11,6 @@ description = "Performance measurement infrastructure."
 workspace = true
 
 [dependencies]
-r-efi = { workspace = true }
 log = { workspace = true }
 
 patina = { workspace = true }

--- a/components/patina_performance/README.md
+++ b/components/patina_performance/README.md
@@ -79,7 +79,7 @@ Core and consumed both internally by the core and by components via dependency i
 ```rust,no_run
 # extern crate patina;
 use patina::component::service::{Service, performance::PerformanceManager};
-use patina::base::guid::CALLER_ID;
+use patina::guid::CALLER_ID;
 
 fn record(perf: Service<dyn PerformanceManager>) {
     perf.perf_cross_module_begin("DXE", CALLER_ID.as_efi_guid());

--- a/components/patina_performance/src/component/performance.rs
+++ b/components/patina_performance/src/component/performance.rs
@@ -22,11 +22,12 @@ use alloc::{boxed::Box, string::String, vec::Vec};
 use core::ffi::c_void;
 use patina::standard::efi::EVENT_GROUP_READY_TO_BOOT;
 use patina::{
-    base::{UEFI_PAGE_SIZE, error::EfiError},
+    UEFI_PAGE_SIZE,
     component::{
         component,
         service::{Service, perf_timer::ArchTimerFunctionality, performance::PerformanceManager},
     },
+    error::EfiError,
     performance::{
         guid::{EDKII_FPDT_EXTENDED_FIRMWARE_PERFORMANCE_GUID, PERFORMANCE_PROTOCOL_GUID},
         measurement::PerformanceProperty,
@@ -457,7 +458,7 @@ where
         EFI_PROGRESS_CODE,
         EFI_SOFTWARE_DXE_BS_DRIVER,
         0,
-        patina::base::guid::CALLER_ID.as_efi_guid(),
+        patina::guid::CALLER_ID.as_efi_guid(),
         *EDKII_FPDT_EXTENDED_FIRMWARE_PERFORMANCE_GUID.as_efi_guid(),
         fbpt_address,
     );
@@ -531,16 +532,13 @@ mod tests {
 
     use alloc::sync::Arc;
     use patina::{
-        base::{
-            c_ptr::{CMutPtr, CPtr},
-            protocol::ProtocolInterface,
-        },
+        c_ptr::{CMutPtr, CPtr},
         component::service::{IntoService, Service},
-        performance::{
-            error::Error,
-            measurement::{CallerIdentifier, PerfAttribute},
-        },
-        uefi::{boot_services::MockBootServices, runtime_services::MockRuntimeServices},
+        performance::measurement::PerfAttribute,
+        performance::{error::Error, measurement::CallerIdentifier},
+        protocol::ProtocolInterface,
+        uefi::boot_services::MockBootServices,
+        uefi::runtime_services::MockRuntimeServices,
     };
     use patina_mm::component::communicator::{MmCommunication, Status};
 

--- a/components/patina_performance/src/component/performance.rs
+++ b/components/patina_performance/src/component/performance.rs
@@ -20,6 +20,7 @@ use crate::{
 };
 use alloc::{boxed::Box, string::String, vec::Vec};
 use core::ffi::c_void;
+use patina::standard::efi::EVENT_GROUP_READY_TO_BOOT;
 use patina::{
     base::{UEFI_PAGE_SIZE, error::EfiError},
     component::{
@@ -43,7 +44,6 @@ use patina::{
     },
 };
 use patina_mm::component::communicator::MmCommunication;
-use r_efi::system::EVENT_GROUP_READY_TO_BOOT;
 
 use patina::function;
 
@@ -174,7 +174,7 @@ enum MmPerformanceError {
     /// Failed to parse response data from MM
     ParseError,
     /// An MM operation returned a non-success EFI status code
-    StatusError(r_efi::efi::Status),
+    StatusError(patina::standard::efi::Status),
     /// An error occurred while processing performance record data
     RecordError(String),
 }
@@ -205,7 +205,7 @@ fn fetch_mm_record_size(comm_service: &Service<dyn MmCommunication>) -> Result<u
 
     let (size_resp, _) = mm::GetRecordSize::read_from(&size_resp_bytes).map_err(|_| MmPerformanceError::ParseError)?;
 
-    if size_resp.return_status != r_efi::efi::Status::SUCCESS {
+    if size_resp.return_status != patina::standard::efi::Status::SUCCESS {
         return Err(MmPerformanceError::StatusError(size_resp.return_status));
     }
 
@@ -235,7 +235,7 @@ fn fetch_mm_record_chunk(
     let (data_resp, _) =
         mm::GetRecordDataByOffset::read_from_default(&data_resp_bytes).map_err(|_| MmPerformanceError::ParseError)?;
 
-    if data_resp.return_status != r_efi::efi::Status::SUCCESS {
+    if data_resp.return_status != patina::standard::efi::Status::SUCCESS {
         return Err(MmPerformanceError::StatusError(data_resp.return_status));
     }
 
@@ -400,7 +400,7 @@ fn process_mm_performance_records(
 
 /// Adds MM performance records to the FBPT.
 pub extern "efiapi" fn fetch_and_add_mm_performance_records<B>(
-    event: r_efi::efi::Event,
+    event: patina::standard::efi::Event,
     ctx: MmPerformanceEventContext<B>,
 ) where
     B: BootServices + Clone + 'static,
@@ -416,7 +416,7 @@ pub extern "efiapi" fn fetch_and_add_mm_performance_records<B>(
 /// Reports the FBPT at End of DXE: queries the required size from the [`PerformanceMeasurement`] service, allocates the
 /// publishing buffer, has the service serialize the table into it, reports it through a status code, and installs it as
 /// a configuration table.
-pub extern "efiapi" fn report_fbpt_event<B, R>(event: r_efi::efi::Event, ctx: ReportFbptEventContext<B, R>)
+pub extern "efiapi" fn report_fbpt_event<B, R>(event: patina::standard::efi::Event, ctx: ReportFbptEventContext<B, R>)
 where
     B: BootServices + Clone + 'static,
     R: RuntimeServices + Clone + 'static,
@@ -527,7 +527,7 @@ mod tests {
         assert_eq,
         sync::atomic::{AtomicBool, AtomicUsize, Ordering},
     };
-    use r_efi::efi;
+    use patina::standard::efi;
 
     use alloc::sync::Arc;
     use patina::{

--- a/components/patina_performance/src/component/protocol.rs
+++ b/components/patina_performance/src/component/protocol.rs
@@ -18,6 +18,7 @@ use core::{
 };
 
 use alloc::string::ToString;
+use patina::standard::efi;
 use patina::{
     BinaryGuid, Char8Str,
     base::protocol::ProtocolInterface,
@@ -28,7 +29,6 @@ use patina::{
         record::known::KnownPerfId,
     },
 };
-use r_efi::efi;
 
 /// GUID for the EDKII Performance Measurement Protocol.
 pub const EDKII_PERFORMANCE_MEASUREMENT_PROTOCOL_GUID: BinaryGuid =

--- a/components/patina_performance/src/component/protocol.rs
+++ b/components/patina_performance/src/component/protocol.rs
@@ -21,13 +21,13 @@ use alloc::string::ToString;
 use patina::standard::efi;
 use patina::{
     BinaryGuid, Char8Str,
-    base::protocol::ProtocolInterface,
     component::service::{Service, performance::PerformanceManager},
     performance::{
         error::Error,
         measurement::{CallerIdentifier, PerfAttribute},
         record::known::KnownPerfId,
     },
+    protocol::ProtocolInterface,
 };
 
 /// GUID for the EDKII Performance Measurement Protocol.

--- a/components/patina_performance/src/mm.rs
+++ b/components/patina_performance/src/mm.rs
@@ -6,7 +6,7 @@
 //!
 //! SPDX-License-Identifier: Apache-2.0
 //!
-use r_efi::efi;
+use patina::standard::efi;
 use zerocopy::{IntoBytes, LittleEndian, U64};
 use zerocopy_derive::*;
 

--- a/components/patina_samples/src/component/hello_world.rs
+++ b/components/patina_samples/src/component/hello_world.rs
@@ -9,8 +9,8 @@
 //! SPDX-License-Identifier: Apache-2.0
 //!
 use patina::{
-    base::error::Result,
     component::{component, params::Config},
+    error::Result,
 };
 
 /// A simple struct component example.

--- a/components/patina_samples/src/smbios_platform.rs
+++ b/components/patina_samples/src/smbios_platform.rs
@@ -32,8 +32,8 @@ extern crate alloc;
 
 use alloc::{string::String, vec};
 use patina::{
-    base::error::Result,
     component::{component, service::Service},
+    error::Result,
 };
 use patina_macro::SmbiosRecord;
 use patina_smbios::{
@@ -184,7 +184,7 @@ impl SmbiosExampleComponent {
 
         let handle = smbios.add_record(None, &bios_info).map_err(|e| {
             log::error!("Failed to add BIOS info: {:?}", e);
-            patina::base::error::EfiError::DeviceError
+            patina::error::EfiError::DeviceError
         })?;
 
         log::info!("  Type 0 (BIOS Info) - Handle 0x{:04X}", handle);
@@ -217,7 +217,7 @@ impl SmbiosExampleComponent {
 
         let handle = smbios.add_record(None, &system_info).map_err(|e| {
             log::error!("Failed to add system info: {:?}", e);
-            patina::base::error::EfiError::DeviceError
+            patina::error::EfiError::DeviceError
         })?;
 
         log::info!("  Type 1 (System Info) - Handle 0x{:04X}", handle);
@@ -252,7 +252,7 @@ impl SmbiosExampleComponent {
 
         let handle = smbios.add_record(None, &baseboard_info).map_err(|e| {
             log::error!("Failed to add baseboard info: {:?}", e);
-            patina::base::error::EfiError::DeviceError
+            patina::error::EfiError::DeviceError
         })?;
 
         log::info!("  Type 2 (Baseboard Info) - Handle 0x{:04X}", handle);
@@ -289,7 +289,7 @@ impl SmbiosExampleComponent {
 
         let handle = smbios.add_record(None, &enclosure_info).map_err(|e| {
             log::error!("Failed to add system enclosure: {:?}", e);
-            patina::base::error::EfiError::DeviceError
+            patina::error::EfiError::DeviceError
         })?;
 
         log::info!("  Type 3 (System Enclosure) - Handle 0x{:04X}", handle);
@@ -309,7 +309,7 @@ impl SmbiosExampleComponent {
 
         let handle = smbios.add_record(None, &vendor_record).map_err(|e| {
             log::error!("Failed to add vendor OEM record: {:?}", e);
-            patina::base::error::EfiError::DeviceError
+            patina::error::EfiError::DeviceError
         })?;
 
         log::info!("  Type 0x80 (Vendor OEM) - Handle 0x{:04X}", handle);

--- a/components/patina_smbios/Cargo.toml
+++ b/components/patina_smbios/Cargo.toml
@@ -12,7 +12,6 @@ log = { workspace = true }
 mockall = { workspace = true, optional = true }
 patina = { workspace = true }
 patina_macro = { workspace = true }
-r-efi = { workspace = true }
 zerocopy = { workspace = true }
 zerocopy-derive = { workspace = true }
 bitfield-struct = { workspace = true }

--- a/components/patina_smbios/src/component.rs
+++ b/components/patina_smbios/src/component.rs
@@ -16,8 +16,8 @@ use crate::{
 };
 use alloc::boxed::Box;
 use patina::{
-    base::error::Result,
     component::{Storage, component, service::memory::MemoryManager},
+    error::Result,
     uefi::boot_services::tpl::Tpl,
     uefi::tpl_mutex::TplMutex,
 };
@@ -101,8 +101,7 @@ impl SmbiosProvider {
         let manager = SmbiosManager::new(cfg.major_version, cfg.minor_version)?;
 
         // Get the MemoryManager service for memory allocations
-        let memory_manager =
-            storage.get_service::<dyn MemoryManager>().ok_or(patina::base::error::EfiError::Unsupported)?;
+        let memory_manager = storage.get_service::<dyn MemoryManager>().ok_or(patina::error::EfiError::Unsupported)?;
 
         // Allocate buffers and add Type 127 End-of-Table marker
         // This must be done before protocol installation to avoid allocate_pages during Add()

--- a/components/patina_smbios/src/error.rs
+++ b/components/patina_smbios/src/error.rs
@@ -73,23 +73,19 @@ pub enum SmbiosError {
 
 impl From<SmbiosError> for patina::standard::efi::Status {
     fn from(error: SmbiosError) -> Self {
-        let efi_error: patina::base::error::EfiError = error.into();
+        let efi_error: patina::error::EfiError = error.into();
         efi_error.into()
     }
 }
 
-impl From<SmbiosError> for patina::base::error::EfiError {
+impl From<SmbiosError> for patina::error::EfiError {
     fn from(error: SmbiosError) -> Self {
         match error {
             // Resource allocation errors map to OUT_OF_RESOURCES
-            SmbiosError::AllocationFailed | SmbiosError::HandleExhausted => {
-                patina::base::error::EfiError::OutOfResources
-            }
+            SmbiosError::AllocationFailed | SmbiosError::HandleExhausted => patina::error::EfiError::OutOfResources,
 
             // Size errors map to BUFFER_TOO_SMALL
-            SmbiosError::RecordTooSmall | SmbiosError::StringPoolTooSmall => {
-                patina::base::error::EfiError::BufferTooSmall
-            }
+            SmbiosError::RecordTooSmall | SmbiosError::StringPoolTooSmall => patina::error::EfiError::BufferTooSmall,
 
             // Invalid parameters map to INVALID_PARAMETER
             SmbiosError::StringTooLong
@@ -100,18 +96,18 @@ impl From<SmbiosError> for patina::base::error::EfiError {
             | SmbiosError::StringIndexOutOfRange
             | SmbiosError::Type127Managed
             | SmbiosError::HandleInUse
-            | SmbiosError::HandleOutOfRange => patina::base::error::EfiError::InvalidParameter,
+            | SmbiosError::HandleOutOfRange => patina::error::EfiError::InvalidParameter,
 
             // Not found errors map to NOT_FOUND
-            SmbiosError::NoRecordsAvailable | SmbiosError::RecordNotFound => patina::base::error::EfiError::NotFound,
+            SmbiosError::NoRecordsAvailable | SmbiosError::RecordNotFound => patina::error::EfiError::NotFound,
 
             // Version and initialization errors map to UNSUPPORTED
             SmbiosError::UnsupportedVersion | SmbiosError::AlreadyInitialized | SmbiosError::NotInitialized => {
-                patina::base::error::EfiError::Unsupported
+                patina::error::EfiError::Unsupported
             }
 
             // Table integrity errors map to DEVICE_ERROR (indicates corrupted/invalid state)
-            SmbiosError::TableDirectlyModified => patina::base::error::EfiError::DeviceError,
+            SmbiosError::TableDirectlyModified => patina::error::EfiError::DeviceError,
         }
     }
 }
@@ -182,49 +178,49 @@ mod tests {
     #[test]
     fn test_smbios_error_to_efi_error_conversion() {
         // Test resource allocation errors map to OUT_OF_RESOURCES
-        let efi_err: patina::base::error::EfiError = SmbiosError::AllocationFailed.into();
-        assert_eq!(efi_err, patina::base::error::EfiError::OutOfResources);
+        let efi_err: patina::error::EfiError = SmbiosError::AllocationFailed.into();
+        assert_eq!(efi_err, patina::error::EfiError::OutOfResources);
 
-        let efi_err: patina::base::error::EfiError = SmbiosError::HandleExhausted.into();
-        assert_eq!(efi_err, patina::base::error::EfiError::OutOfResources);
+        let efi_err: patina::error::EfiError = SmbiosError::HandleExhausted.into();
+        assert_eq!(efi_err, patina::error::EfiError::OutOfResources);
 
         // Test invalid parameters map to INVALID_PARAMETER
-        let efi_err: patina::base::error::EfiError = SmbiosError::StringTooLong.into();
-        assert_eq!(efi_err, patina::base::error::EfiError::InvalidParameter);
+        let efi_err: patina::error::EfiError = SmbiosError::StringTooLong.into();
+        assert_eq!(efi_err, patina::error::EfiError::InvalidParameter);
 
-        let efi_err: patina::base::error::EfiError = SmbiosError::Type127Managed.into();
-        assert_eq!(efi_err, patina::base::error::EfiError::InvalidParameter);
+        let efi_err: patina::error::EfiError = SmbiosError::Type127Managed.into();
+        assert_eq!(efi_err, patina::error::EfiError::InvalidParameter);
 
-        let efi_err: patina::base::error::EfiError = SmbiosError::HandleInUse.into();
-        assert_eq!(efi_err, patina::base::error::EfiError::InvalidParameter);
+        let efi_err: patina::error::EfiError = SmbiosError::HandleInUse.into();
+        assert_eq!(efi_err, patina::error::EfiError::InvalidParameter);
 
-        let efi_err: patina::base::error::EfiError = SmbiosError::HandleOutOfRange.into();
-        assert_eq!(efi_err, patina::base::error::EfiError::InvalidParameter);
+        let efi_err: patina::error::EfiError = SmbiosError::HandleOutOfRange.into();
+        assert_eq!(efi_err, patina::error::EfiError::InvalidParameter);
 
         // Test size errors map to BUFFER_TOO_SMALL
-        let efi_err: patina::base::error::EfiError = SmbiosError::RecordTooSmall.into();
-        assert_eq!(efi_err, patina::base::error::EfiError::BufferTooSmall);
+        let efi_err: patina::error::EfiError = SmbiosError::RecordTooSmall.into();
+        assert_eq!(efi_err, patina::error::EfiError::BufferTooSmall);
 
-        let efi_err: patina::base::error::EfiError = SmbiosError::StringPoolTooSmall.into();
-        assert_eq!(efi_err, patina::base::error::EfiError::BufferTooSmall);
+        let efi_err: patina::error::EfiError = SmbiosError::StringPoolTooSmall.into();
+        assert_eq!(efi_err, patina::error::EfiError::BufferTooSmall);
 
         // Test not found errors map to NOT_FOUND
-        let efi_err: patina::base::error::EfiError = SmbiosError::RecordNotFound.into();
-        assert_eq!(efi_err, patina::base::error::EfiError::NotFound);
+        let efi_err: patina::error::EfiError = SmbiosError::RecordNotFound.into();
+        assert_eq!(efi_err, patina::error::EfiError::NotFound);
 
-        let efi_err: patina::base::error::EfiError = SmbiosError::NoRecordsAvailable.into();
-        assert_eq!(efi_err, patina::base::error::EfiError::NotFound);
+        let efi_err: patina::error::EfiError = SmbiosError::NoRecordsAvailable.into();
+        assert_eq!(efi_err, patina::error::EfiError::NotFound);
 
         // Test version and initialization errors map to UNSUPPORTED
-        let efi_err: patina::base::error::EfiError = SmbiosError::UnsupportedVersion.into();
-        assert_eq!(efi_err, patina::base::error::EfiError::Unsupported);
+        let efi_err: patina::error::EfiError = SmbiosError::UnsupportedVersion.into();
+        assert_eq!(efi_err, patina::error::EfiError::Unsupported);
 
-        let efi_err: patina::base::error::EfiError = SmbiosError::NotInitialized.into();
-        assert_eq!(efi_err, patina::base::error::EfiError::Unsupported);
+        let efi_err: patina::error::EfiError = SmbiosError::NotInitialized.into();
+        assert_eq!(efi_err, patina::error::EfiError::Unsupported);
 
         // Test table integrity errors map to DEVICE_ERROR
-        let efi_err: patina::base::error::EfiError = SmbiosError::TableDirectlyModified.into();
-        assert_eq!(efi_err, patina::base::error::EfiError::DeviceError);
+        let efi_err: patina::error::EfiError = SmbiosError::TableDirectlyModified.into();
+        assert_eq!(efi_err, patina::error::EfiError::DeviceError);
     }
 
     #[test]

--- a/components/patina_smbios/src/error.rs
+++ b/components/patina_smbios/src/error.rs
@@ -71,7 +71,7 @@ pub enum SmbiosError {
     TableDirectlyModified,
 }
 
-impl From<SmbiosError> for r_efi::efi::Status {
+impl From<SmbiosError> for patina::standard::efi::Status {
     fn from(error: SmbiosError) -> Self {
         let efi_error: patina::base::error::EfiError = error.into();
         efi_error.into()
@@ -229,7 +229,7 @@ mod tests {
 
     #[test]
     fn test_smbios_error_to_efi_status_conversion() {
-        use r_efi::efi;
+        use patina::standard::efi;
 
         // Verify the SmbiosError -> efi::Status conversion produces the same result
         // as going through SmbiosError -> EfiError -> efi::Status manually.

--- a/components/patina_smbios/src/manager.rs
+++ b/components/patina_smbios/src/manager.rs
@@ -14,7 +14,7 @@
 
 extern crate alloc;
 
-use patina::base::protocol::ProtocolInterface;
+use patina::protocol::ProtocolInterface;
 
 mod core;
 mod protocol;

--- a/components/patina_smbios/src/manager.rs
+++ b/components/patina_smbios/src/manager.rs
@@ -26,11 +26,11 @@ pub(crate) use record::SmbiosRecord;
 
 use alloc::boxed::Box;
 
+use patina::standard::efi;
 use patina::{
     uefi::boot_services::{BootServices, StandardBootServices},
     uefi::tpl_mutex::TplMutex,
 };
-use r_efi::efi;
 
 use crate::error::SmbiosError;
 

--- a/components/patina_smbios/src/manager/core.rs
+++ b/components/patina_smbios/src/manager/core.rs
@@ -15,7 +15,7 @@ extern crate alloc;
 use alloc::{boxed::Box, collections::BTreeSet, string::String, vec::Vec};
 use core::cell::RefCell;
 use patina::standard::efi::{Handle, PhysicalAddress};
-use patina::{base::SIZE_64KB, uefi_size_to_pages};
+use patina::{SIZE_64KB, uefi_size_to_pages};
 use zerocopy::{IntoBytes, Ref};
 use zerocopy_derive::*;
 
@@ -465,7 +465,7 @@ impl SmbiosManager {
     /// that a simple checksum would miss. Not for cryptographic integrity.
     fn calculate_table_checksum(data: &[u8]) -> u64 {
         use core::hash::Hasher;
-        let mut hasher = patina::base::hash::Xorshift64starHasher::default();
+        let mut hasher = patina::hash::Xorshift64starHasher::default();
         hasher.write(data);
         hasher.finish()
     }

--- a/components/patina_smbios/src/manager/core.rs
+++ b/components/patina_smbios/src/manager/core.rs
@@ -14,8 +14,8 @@ extern crate alloc;
 
 use alloc::{boxed::Box, collections::BTreeSet, string::String, vec::Vec};
 use core::cell::RefCell;
+use patina::standard::efi::{Handle, PhysicalAddress};
 use patina::{base::SIZE_64KB, uefi_size_to_pages};
-use r_efi::efi::{Handle, PhysicalAddress};
 use zerocopy::{IntoBytes, Ref};
 use zerocopy_derive::*;
 
@@ -775,7 +775,7 @@ mod tests {
         error::SmbiosError,
         service::{SMBIOS_HANDLE_PI_RESERVED, SMBIOS_STRING_MAX_LENGTH, SmbiosHandle, SmbiosTableHeader},
     };
-    use r_efi::efi;
+    use patina::standard::efi;
     use zerocopy::IntoBytes;
 
     /// Test helper: Build a simple SMBIOS record with the given header and strings

--- a/components/patina_smbios/src/manager/protocol.rs
+++ b/components/patina_smbios/src/manager/protocol.rs
@@ -18,8 +18,8 @@ extern crate alloc;
 use core::ffi::c_char;
 
 use alloc::string::ToString;
+use patina::standard::efi;
 use patina::{Char8Str, base::protocol::ProtocolInterface, uefi::tpl_mutex::TplMutex};
-use r_efi::efi;
 
 use crate::service::{SMBIOS_HANDLE_PI_RESERVED, SmbiosHandle, SmbiosTableHeader, SmbiosType};
 

--- a/components/patina_smbios/src/manager/protocol.rs
+++ b/components/patina_smbios/src/manager/protocol.rs
@@ -19,7 +19,7 @@ use core::ffi::c_char;
 
 use alloc::string::ToString;
 use patina::standard::efi;
-use patina::{Char8Str, base::protocol::ProtocolInterface, uefi::tpl_mutex::TplMutex};
+use patina::{Char8Str, protocol::ProtocolInterface, uefi::tpl_mutex::TplMutex};
 
 use crate::service::{SMBIOS_HANDLE_PI_RESERVED, SmbiosHandle, SmbiosTableHeader, SmbiosType};
 
@@ -469,7 +469,7 @@ mod tests {
 
     #[test]
     fn test_protocol_guid() {
-        use patina::base::protocol::ProtocolInterface;
+        use patina::protocol::ProtocolInterface;
 
         // Verify the GUID matches the EDK2 SMBIOS protocol GUID
         let expected_guid = patina::BinaryGuid::from_string("03583FF6-CB36-4940-947E-B9B39F4AFAF7");

--- a/components/patina_smbios/src/manager/record.rs
+++ b/components/patina_smbios/src/manager/record.rs
@@ -15,7 +15,7 @@ extern crate alloc;
 use alloc::vec::Vec;
 
 use crate::service::SmbiosTableHeader;
-use r_efi::efi::Handle;
+use patina::standard::efi::Handle;
 
 /// Internal SMBIOS record representation
 ///
@@ -43,7 +43,7 @@ mod tests {
     extern crate std;
     use std::vec;
 
-    use r_efi::efi;
+    use patina::standard::efi;
 
     #[test]
     fn test_smbios_record_new() {

--- a/components/patina_smbios/src/service.rs
+++ b/components/patina_smbios/src/service.rs
@@ -13,8 +13,8 @@
 extern crate alloc;
 use alloc::vec::Vec;
 use core::cell::Ref;
+use patina::standard::efi::{self, Handle, SMBIOS3_TABLE_GUID};
 use patina::uefi::boot_services::{BootServices, StandardBootServices};
-use r_efi::{efi::Handle, system::SMBIOS3_TABLE_GUID};
 use zerocopy_derive::*;
 
 #[cfg(any(test, feature = "mockall"))]
@@ -132,7 +132,7 @@ pub trait Smbios {
     /// Returns `SmbiosError` if no records, allocation fails, or installation fails.
     fn publish_table(
         &self,
-    ) -> core::result::Result<(r_efi::efi::PhysicalAddress, r_efi::efi::PhysicalAddress), crate::error::SmbiosError>;
+    ) -> core::result::Result<(efi::PhysicalAddress, efi::PhysicalAddress), crate::error::SmbiosError>;
 
     /// Updates a string in an existing SMBIOS record.
     ///
@@ -165,7 +165,7 @@ pub trait Smbios {
     /// * `bytes` - Serialized SMBIOS record bytes
     fn add_from_bytes(
         &self,
-        producer_handle: Option<r_efi::efi::Handle>,
+        producer_handle: Option<efi::Handle>,
         bytes: &[u8],
     ) -> core::result::Result<SmbiosHandle, crate::error::SmbiosError>;
 }
@@ -222,8 +222,7 @@ impl<B: BootServices> Smbios for SmbiosImpl<B> {
 
     fn publish_table(
         &self,
-    ) -> core::result::Result<(r_efi::efi::PhysicalAddress, r_efi::efi::PhysicalAddress), crate::error::SmbiosError>
-    {
+    ) -> core::result::Result<(efi::PhysicalAddress, efi::PhysicalAddress), crate::error::SmbiosError> {
         // Table addresses are stored before calling install_configuration_table.
         // install_configuration_table triggers EVENT_DB.signal_group, which may invoke
         // event handlers that call SMBIOS Add/Update/Remove, triggering republish_table.
@@ -276,7 +275,7 @@ impl<B: BootServices> Smbios for SmbiosImpl<B> {
 
     fn add_from_bytes(
         &self,
-        producer_handle: Option<r_efi::efi::Handle>,
+        producer_handle: Option<efi::Handle>,
         bytes: &[u8],
     ) -> core::result::Result<SmbiosHandle, crate::error::SmbiosError> {
         let handle = {
@@ -322,7 +321,7 @@ pub trait SmbiosExt {
     /// Returns the assigned SMBIOS handle for the newly added record.
     fn add_record<T>(
         &self,
-        producer_handle: Option<r_efi::efi::Handle>,
+        producer_handle: Option<efi::Handle>,
         record: &T,
     ) -> core::result::Result<SmbiosHandle, crate::error::SmbiosError>
     where
@@ -333,7 +332,7 @@ pub trait SmbiosExt {
 impl SmbiosExt for patina::component::service::Service<dyn Smbios> {
     fn add_record<T>(
         &self,
-        producer_handle: Option<r_efi::efi::Handle>,
+        producer_handle: Option<efi::Handle>,
         record: &T,
     ) -> core::result::Result<SmbiosHandle, crate::error::SmbiosError>
     where
@@ -519,8 +518,7 @@ mod tests {
 
         fn publish_table(
             &self,
-        ) -> core::result::Result<(r_efi::efi::PhysicalAddress, r_efi::efi::PhysicalAddress), crate::error::SmbiosError>
-        {
+        ) -> core::result::Result<(efi::PhysicalAddress, efi::PhysicalAddress), crate::error::SmbiosError> {
             Ok((0x1000, 0x2000))
         }
 
@@ -539,7 +537,7 @@ mod tests {
 
         fn add_from_bytes(
             &self,
-            _producer_handle: Option<r_efi::efi::Handle>,
+            _producer_handle: Option<efi::Handle>,
             bytes: &[u8],
         ) -> core::result::Result<SmbiosHandle, crate::error::SmbiosError> {
             // Verify expected bytes if provided

--- a/components/patina_test/Cargo.toml
+++ b/components/patina_test/Cargo.toml
@@ -15,7 +15,6 @@ linkme = { workspace = true }
 log = { workspace = true }
 patina = { workspace = true }
 patina_macro = { workspace = true }
-r-efi = { workspace = true }
 spin = { workspace = true }
 
 [features]

--- a/components/patina_test/src/component.rs
+++ b/components/patina_test/src/component.rs
@@ -306,30 +306,30 @@ pub(crate) mod tests {
 
         let mut storage = Storage::new();
         storage.add_service(Recorder::default());
-        let bs: MaybeUninit<r_efi::efi::BootServices> = MaybeUninit::uninit();
+        let bs: MaybeUninit<patina::standard::efi::BootServices> = MaybeUninit::uninit();
 
         // SAFETY: This is very unsafe, because it is not initialized, however this code path only calls create_event
         // and create_event_ex, which we will fill in with no-op functions.
         let mut bs = unsafe { bs.assume_init() };
         extern "efiapi" fn noop_create_event(
             _type: u32,
-            _tpl: r_efi::efi::Tpl,
-            _notify_function: Option<unsafe extern "efiapi" fn(r_efi::efi::Event, *mut core::ffi::c_void)>,
+            _tpl: patina::standard::efi::Tpl,
+            _notify_function: Option<unsafe extern "efiapi" fn(patina::standard::efi::Event, *mut core::ffi::c_void)>,
             _notify_context: *mut core::ffi::c_void,
-            _event: *mut r_efi::efi::Event,
-        ) -> r_efi::efi::Status {
-            r_efi::efi::Status::SUCCESS
+            _event: *mut patina::standard::efi::Event,
+        ) -> patina::standard::efi::Status {
+            patina::standard::efi::Status::SUCCESS
         }
 
         extern "efiapi" fn noop_create_event_ex(
             _type: u32,
-            _tpl: r_efi::efi::Tpl,
-            _notify_function: Option<unsafe extern "efiapi" fn(r_efi::efi::Event, *mut core::ffi::c_void)>,
+            _tpl: patina::standard::efi::Tpl,
+            _notify_function: Option<unsafe extern "efiapi" fn(patina::standard::efi::Event, *mut core::ffi::c_void)>,
             _notify_context: *const core::ffi::c_void,
-            _guid: *const r_efi::efi::Guid,
-            _event: *mut r_efi::efi::Event,
-        ) -> r_efi::efi::Status {
-            r_efi::efi::Status::SUCCESS
+            _guid: *const patina::standard::efi::Guid,
+            _event: *mut patina::standard::efi::Event,
+        ) -> patina::standard::efi::Status {
+            patina::standard::efi::Status::SUCCESS
         }
 
         bs.create_event = noop_create_event;
@@ -347,38 +347,38 @@ pub(crate) mod tests {
         let test_runner = TestRunner::default().with_filter(Filter::include("triggered_test"));
 
         let mut storage = Storage::new();
-        let bs: MaybeUninit<r_efi::efi::BootServices> = MaybeUninit::uninit();
+        let bs: MaybeUninit<patina::standard::efi::BootServices> = MaybeUninit::uninit();
 
         // SAFETY: This is very unsafe, because it is not initialized, however this code path only calls create_event
         // create_event_ex, and set_timer which we will fill in with no-op functions.
         let mut bs = unsafe { bs.assume_init() };
         extern "efiapi" fn noop_create_event(
             _type: u32,
-            _tpl: r_efi::efi::Tpl,
-            _notify_function: Option<unsafe extern "efiapi" fn(r_efi::efi::Event, *mut core::ffi::c_void)>,
+            _tpl: patina::standard::efi::Tpl,
+            _notify_function: Option<unsafe extern "efiapi" fn(patina::standard::efi::Event, *mut core::ffi::c_void)>,
             _notify_context: *mut core::ffi::c_void,
-            _event: *mut r_efi::efi::Event,
-        ) -> r_efi::efi::Status {
-            r_efi::efi::Status::SUCCESS
+            _event: *mut patina::standard::efi::Event,
+        ) -> patina::standard::efi::Status {
+            patina::standard::efi::Status::SUCCESS
         }
 
         extern "efiapi" fn noop_create_event_ex(
             _type: u32,
-            _tpl: r_efi::efi::Tpl,
-            _notify_function: Option<unsafe extern "efiapi" fn(r_efi::efi::Event, *mut core::ffi::c_void)>,
+            _tpl: patina::standard::efi::Tpl,
+            _notify_function: Option<unsafe extern "efiapi" fn(patina::standard::efi::Event, *mut core::ffi::c_void)>,
             _notify_context: *const core::ffi::c_void,
-            _guid: *const r_efi::efi::Guid,
-            _event: *mut r_efi::efi::Event,
-        ) -> r_efi::efi::Status {
-            r_efi::efi::Status::SUCCESS
+            _guid: *const patina::standard::efi::Guid,
+            _event: *mut patina::standard::efi::Event,
+        ) -> patina::standard::efi::Status {
+            patina::standard::efi::Status::SUCCESS
         }
 
         extern "efiapi" fn noop_set_timer(
-            _event: r_efi::efi::Event,
-            _type: r_efi::efi::TimerDelay,
+            _event: patina::standard::efi::Event,
+            _type: patina::standard::efi::TimerDelay,
             _trigger_time: u64,
-        ) -> r_efi::efi::Status {
-            r_efi::efi::Status::SUCCESS
+        ) -> patina::standard::efi::Status {
+            patina::standard::efi::Status::SUCCESS
         }
 
         bs.create_event = noop_create_event;

--- a/components/patina_test/src/component.rs
+++ b/components/patina_test/src/component.rs
@@ -99,7 +99,7 @@ impl TestRunner {
 
     /// The entry point for the test runner component.
     #[cfg_attr(coverage, coverage(off))]
-    fn entry_point(self, storage: &mut Storage) -> patina::base::error::Result<()> {
+    fn entry_point(self, storage: &mut Storage) -> patina::error::Result<()> {
         let test_list: &'static [__private_api::TestCase] = __private_api::test_cases();
         self.register_tests(test_list, storage)
     }
@@ -109,7 +109,7 @@ impl TestRunner {
         &self,
         test_list: &'static [__private_api::TestCase],
         storage: &mut Storage,
-    ) -> patina::base::error::Result<()> {
+    ) -> patina::error::Result<()> {
         let recorder = match storage.get_service::<Recorder>() {
             Some(recorder) => recorder,
             None => {

--- a/components/patina_test/src/service.rs
+++ b/components/patina_test/src/service.rs
@@ -27,7 +27,7 @@ use patina::{
     writelncrlf,
 };
 
-use r_efi::efi::EVENT_GROUP_READY_TO_BOOT;
+use patina::standard::efi::EVENT_GROUP_READY_TO_BOOT;
 
 /// A structure containing all necessary data to execute a test at any time.
 #[derive(Clone)]
@@ -149,7 +149,10 @@ impl TestRecord {
     }
 
     /// EFIAPI event callback to locate a specific test and run it.
-    extern "efiapi" fn run_test(_: r_efi::efi::Event, &(test, mut storage): &'static (&'static str, NonNull<Storage>)) {
+    extern "efiapi" fn run_test(
+        _: patina::standard::efi::Event,
+        &(test, mut storage): &'static (&'static str, NonNull<Storage>),
+    ) {
         // SAFETY: Storage is a valid pointer as the pointer is generated from a static reference.
         let storage = unsafe { storage.as_mut() };
 
@@ -160,9 +163,10 @@ impl TestRecord {
 
     #[cfg_attr(coverage, coverage(off))]
     /// An EFIAPI compatible event callback to disable a timer event at ReadyToBoot
-    extern "efiapi" fn disable_timer(rtb_event: r_efi::efi::Event, context: *mut core::ffi::c_void) {
+    extern "efiapi" fn disable_timer(rtb_event: patina::standard::efi::Event, context: *mut core::ffi::c_void) {
         // SAFETY: We set up the context pointer in `run_tests` to point to a valid tuple of (Event, StandardBootServices).
-        let (timer_event, boot_services) = unsafe { &mut *(context as *mut (r_efi::efi::Event, StandardBootServices)) };
+        let (timer_event, boot_services) =
+            unsafe { &mut *(context as *mut (patina::standard::efi::Event, StandardBootServices)) };
         let _ = boot_services.set_timer(*timer_event, EventTimerType::Cancel, 0);
         let _ = boot_services.close_event(rtb_event);
     }
@@ -254,7 +258,7 @@ impl Recorder {
     }
 
     /// An EFIAPI compatible event callback to run the manually triggered tests and log the current results of patina-test
-    extern "efiapi" fn run_tests_and_report(event: r_efi::efi::Event, mut storage: NonNull<Storage>) {
+    extern "efiapi" fn run_tests_and_report(event: patina::standard::efi::Event, mut storage: NonNull<Storage>) {
         // SAFETY: event callbacks are executed in series, so there exists no other mutable access to storage.
         let storage = unsafe { storage.as_mut() };
 
@@ -396,13 +400,13 @@ mod tests {
 
     #[test]
     fn test_efiapi_run_tests_and_report() {
-        let bs: MaybeUninit<r_efi::efi::BootServices> = MaybeUninit::uninit();
+        let bs: MaybeUninit<patina::standard::efi::BootServices> = MaybeUninit::uninit();
         // SAFETY: This is very unsafe, because it is not initialized, however this code path only calls create_event
         // create_event_ex, and set_timer which we will fill in with no-op functions.
         let mut bs = unsafe { bs.assume_init() };
 
-        extern "efiapi" fn noop_close_event(_: r_efi::efi::Event) -> r_efi::efi::Status {
-            r_efi::efi::Status::SUCCESS
+        extern "efiapi" fn noop_close_event(_: patina::standard::efi::Event) -> patina::standard::efi::Status {
+            patina::standard::efi::Status::SUCCESS
         }
 
         bs.close_event = noop_close_event;

--- a/components/patina_test/src/service.rs
+++ b/components/patina_test/src/service.rs
@@ -91,7 +91,7 @@ impl TestRecord {
     }
 
     /// Schedules the test to be run according to its triggers.
-    pub fn schedule_run(&self, storage: &mut Storage) -> patina::base::error::Result<()> {
+    pub fn schedule_run(&self, storage: &mut Storage) -> patina::error::Result<()> {
         let name = self.test_case.name;
 
         for trigger in self.test_case.triggers {
@@ -191,7 +191,7 @@ impl Recorder {
     }
 
     /// Registers UEFI event callbacks to log the test results at specific points in the boot process.
-    pub fn initialize(&self, storage: &mut Storage) -> patina::base::error::Result<()> {
+    pub fn initialize(&self, storage: &mut Storage) -> patina::error::Result<()> {
         // Log results at ready to boot
         storage.boot_services().create_event_ex(
             EventType::NOTIFY_SIGNAL,

--- a/core/patina_debugger/src/lib.rs
+++ b/core/patina_debugger/src/lib.rs
@@ -197,7 +197,7 @@ enum DebugError {
     /// Failure from the GDB stub initialization.
     GdbStubInit,
     /// Failure from the GDB stub.
-    GdbStubError(gdbstub::stub::GdbStubError<(), patina::base::error::EfiError>),
+    GdbStubError(gdbstub::stub::GdbStubError<(), patina::error::EfiError>),
     /// Failure to reboot the system.
     RebootFailure,
     /// Failure in the transport layer.

--- a/core/patina_debugger/src/transport.rs
+++ b/core/patina_debugger/src/transport.rs
@@ -33,7 +33,7 @@ impl<'a, T: SerialIO> SerialConnection<'a, T> {
 }
 
 impl<T: SerialIO> Connection for SerialConnection<'_, T> {
-    type Error = patina::base::error::EfiError;
+    type Error = patina::error::EfiError;
 
     /// Write a byte to the serial transport.
     fn write(&mut self, byte: u8) -> Result<(), Self::Error> {

--- a/core/patina_internal_core/Cargo.toml
+++ b/core/patina_internal_core/Cargo.toml
@@ -20,7 +20,7 @@ ci_features = ["alloc"]
 
 [dependencies]
 log = { workspace=true }
-r-efi = { workspace = true }
+patina = { workspace = true }
 uuid = { workspace = true }
 
 [dev-dependencies]

--- a/core/patina_internal_core/src/depex.rs
+++ b/core/patina_internal_core/src/depex.rs
@@ -14,11 +14,11 @@ use alloc::{
     vec::Vec,
 };
 use core::mem;
-use r_efi::efi;
+use patina::standard::efi;
 use uuid::Uuid;
 
 /// The size of a GUID in bytes
-const GUID_SIZE: usize = mem::size_of::<r_efi::efi::Guid>();
+const GUID_SIZE: usize = mem::size_of::<efi::Guid>();
 
 /// The initial size of the dependency expression stack in bytes
 const DEPEX_STACK_SIZE_INCREMENT: usize = 0x100;
@@ -387,7 +387,7 @@ mod tests {
     extern crate std;
     use alloc::vec;
     use core::str::FromStr;
-    use r_efi::efi;
+    use patina::standard::efi;
     use std::println;
     use uuid::Uuid;
 

--- a/core/patina_internal_cpu/Cargo.toml
+++ b/core/patina_internal_cpu/Cargo.toml
@@ -15,7 +15,6 @@ features = ["doc", "std"]
 
 [dependencies]
 log = { workspace = true }
-r-efi = { workspace = true }
 patina = { workspace = true, features = ["core"] }
 spin = { workspace = true, features = ["rwlock"] }
 patina_paging = { workspace = true }

--- a/core/patina_internal_cpu/src/cpu/x64/cpu.rs
+++ b/core/patina_internal_cpu/src/cpu/x64/cpu.rs
@@ -16,7 +16,6 @@ use patina::{
     base::error::EfiError,
     pi::protocol::cpu_arch::{CpuFlushType, CpuInitType},
 };
-use r_efi::efi;
 
 pub const CACHE_WRITEBACK_GRANULE: u32 = 4; // Using 4 bytes following precedence set by Tianocore
 

--- a/core/patina_internal_cpu/src/cpu/x64/cpu.rs
+++ b/core/patina_internal_cpu/src/cpu/x64/cpu.rs
@@ -13,7 +13,7 @@ use crate::interrupts;
 use core::arch::asm;
 use patina::{
     arch as interrupts,
-    base::error::EfiError,
+    error::EfiError,
     pi::protocol::cpu_arch::{CpuFlushType, CpuInitType},
 };
 

--- a/core/patina_internal_cpu/src/gdt.rs
+++ b/core/patina_internal_cpu/src/gdt.rs
@@ -9,7 +9,7 @@
 #![cfg_attr(test, allow(dead_code))]
 #![cfg_attr(test, allow(unused_imports))]
 use core::ptr::{addr_of, addr_of_mut};
-use patina::base::SIZE_4GB;
+use patina::SIZE_4GB;
 
 struct GdtEntry {
     limit15_0: u16,

--- a/core/patina_internal_cpu/src/interrupts.rs
+++ b/core/patina_internal_cpu/src/interrupts.rs
@@ -16,7 +16,7 @@
 //!
 
 use core::ops::{Deref, DerefMut};
-use patina::{base::error::EfiError, pi::protocol::cpu_arch::EfiSystemContext, standard};
+use patina::{error::EfiError, pi::protocol::cpu_arch::EfiSystemContext, standard};
 
 mod exception_handling;
 

--- a/core/patina_internal_cpu/src/interrupts.rs
+++ b/core/patina_internal_cpu/src/interrupts.rs
@@ -16,7 +16,7 @@
 //!
 
 use core::ops::{Deref, DerefMut};
-use patina::{base::error::EfiError, pi::protocol::cpu_arch::EfiSystemContext};
+use patina::{base::error::EfiError, pi::protocol::cpu_arch::EfiSystemContext, standard};
 
 mod exception_handling;
 
@@ -47,9 +47,9 @@ cfg_if::cfg_if! {
 }
 
 /// Republished structure for x64 exception context as defined by the UEFI specification.
-pub type ExceptionContextX64 = r_efi::protocols::debug_support::SystemContextX64;
+pub type ExceptionContextX64 = standard::efi::protocols::debug_support::SystemContextX64;
 /// Republished structure for AArch64 exception context as defined by the UEFI specification.
-pub type ExceptionContextAArch64 = r_efi::protocols::debug_support::SystemContextAArch64;
+pub type ExceptionContextAArch64 = standard::efi::protocols::debug_support::SystemContextAArch64;
 
 cfg_if::cfg_if! {
     if #[cfg(any(test, doc))] {

--- a/core/patina_internal_cpu/src/interrupts/aarch64.rs
+++ b/core/patina_internal_cpu/src/interrupts/aarch64.rs
@@ -18,7 +18,7 @@ mod interrupt_manager;
 #[allow(unused)]
 pub use interrupt_manager::InterruptsAarch64;
 
-pub type ExceptionContextAArch64 = r_efi::protocols::debug_support::SystemContextAArch64;
+pub type ExceptionContextAArch64 = patina::standard::efi::protocols::debug_support::SystemContextAArch64;
 
 impl super::EfiSystemContextFactory for ExceptionContextAArch64 {
     fn create_efi_system_context(&mut self) -> EfiSystemContext {

--- a/core/patina_internal_cpu/src/interrupts/aarch64/gic_manager.rs
+++ b/core/patina_internal_cpu/src/interrupts/aarch64/gic_manager.rs
@@ -3,7 +3,7 @@ use arm_gic::{
     gicv3::{GicCpuInterface, GicDistributorContext, GicRedistributorContext, GicRedistributorIterator, GicV3},
 };
 use core::ptr::NonNull;
-use patina::base::error::EfiError;
+use patina::error::EfiError;
 
 use patina::{
     arch::aarch64::{AArch64El, get_current_el},

--- a/core/patina_internal_cpu/src/interrupts/aarch64/interrupt_manager.rs
+++ b/core/patina_internal_cpu/src/interrupts/aarch64/interrupt_manager.rs
@@ -9,8 +9,8 @@
 
 use patina::{
     arch::{disable_interrupts, enable_interrupts},
-    base::{UEFI_PAGE_MASK, UEFI_PAGE_SIZE, error::EfiError},
     bit,
+    {UEFI_PAGE_MASK, UEFI_PAGE_SIZE, error::EfiError},
 };
 use patina_paging::PageTable;
 

--- a/core/patina_internal_cpu/src/interrupts/exception_handling.rs
+++ b/core/patina_internal_cpu/src/interrupts/exception_handling.rs
@@ -8,7 +8,7 @@
 //! SPDX-License-Identifier: Apache-2.0
 //!
 
-use patina::{base::error::EfiError, pi::protocol::cpu_arch::EfiExceptionType};
+use patina::{error::EfiError, pi::protocol::cpu_arch::EfiExceptionType};
 use spin::rwlock::RwLock;
 
 use crate::interrupts::EfiExceptionInfoDump;

--- a/core/patina_internal_cpu/src/interrupts/stub.rs
+++ b/core/patina_internal_cpu/src/interrupts/stub.rs
@@ -7,7 +7,7 @@
 //! SPDX-License-Identifier: Apache-2.0
 //!
 
-use patina::{base::error::EfiError, pi::protocol::cpu_arch::EfiSystemContext};
+use patina::{error::EfiError, pi::protocol::cpu_arch::EfiSystemContext};
 
 use crate::interrupts::InterruptManager;
 

--- a/core/patina_internal_cpu/src/interrupts/x64/idt.rs
+++ b/core/patina_internal_cpu/src/interrupts/x64/idt.rs
@@ -8,7 +8,7 @@
 //!
 
 use core::{arch::global_asm, cell::UnsafeCell};
-use patina::base::SIZE_4GB;
+use patina::SIZE_4GB;
 
 global_asm!(include_str!("interrupt_handler.asm"));
 // Use efiapi for the consistent calling convention.

--- a/core/patina_internal_cpu/src/interrupts/x64/interrupt_manager.rs
+++ b/core/patina_internal_cpu/src/interrupts/x64/interrupt_manager.rs
@@ -8,10 +8,10 @@
 //!
 
 use patina::{
-    base::error::EfiError,
-    base::{UEFI_PAGE_MASK, UEFI_PAGE_SIZE},
     bit,
+    error::EfiError,
     pi::protocol::cpu_arch::EfiSystemContext,
+    {UEFI_PAGE_MASK, UEFI_PAGE_SIZE},
 };
 #[cfg(target_arch = "x86_64")]
 use patina_mtrr::Mtrr;

--- a/core/patina_internal_cpu/src/paging/aarch64.rs
+++ b/core/patina_internal_cpu/src/paging/aarch64.rs
@@ -12,8 +12,9 @@ use patina_paging::{MemoryAttributes, PageTable, PagingType, PtError, aarch64::A
 
 use crate::paging::{CacheAttributeValue, PatinaPageTable};
 use patina::pi::protocol::cpu_arch::CpuFlushType;
+use patina::standard::efi;
+
 use patina_paging::page_allocator::PageAllocator;
-use r_efi::efi;
 
 /// Memory attributes that indicate cached mappings (writeback or write-through).
 const CACHED_ATTRS: MemoryAttributes = MemoryAttributes::Writeback.union(MemoryAttributes::WriteThrough);

--- a/core/patina_internal_cpu/src/paging/null.rs
+++ b/core/patina_internal_cpu/src/paging/null.rs
@@ -13,7 +13,6 @@ use patina_paging::{CacheAttributeValue, MemoryAttributes, PtError};
 
 use crate::paging::PatinaPageTable;
 use patina_paging::page_allocator::PageAllocator;
-use r_efi::efi;
 
 #[derive(Default)]
 #[allow(dead_code)]

--- a/core/patina_internal_cpu/src/paging/x64.rs
+++ b/core/patina_internal_cpu/src/paging/x64.rs
@@ -9,7 +9,7 @@
 //! SPDX-License-Identifier: Apache-2.0
 //!
 use crate::paging::{CacheAttributeValue, PatinaPageTable};
-use patina::{base::error::EfiError, standard::efi};
+use patina::{error::EfiError, standard::efi};
 use patina_mtrr::{Mtrr, create_mtrr_lib, error::MtrrError, structs::MtrrMemoryCacheType};
 use patina_paging::{
     MemoryAttributes, PageTable, PagingType, PtError, page_allocator::PageAllocator, x64::X64PageTable,

--- a/core/patina_internal_cpu/src/paging/x64.rs
+++ b/core/patina_internal_cpu/src/paging/x64.rs
@@ -9,12 +9,11 @@
 //! SPDX-License-Identifier: Apache-2.0
 //!
 use crate::paging::{CacheAttributeValue, PatinaPageTable};
-use patina::base::error::EfiError;
+use patina::{base::error::EfiError, standard::efi};
 use patina_mtrr::{Mtrr, create_mtrr_lib, error::MtrrError, structs::MtrrMemoryCacheType};
 use patina_paging::{
     MemoryAttributes, PageTable, PagingType, PtError, page_allocator::PageAllocator, x64::X64PageTable,
 };
-use r_efi::efi;
 
 /// The x86_64 paging implementation. It acts as a bridge between the EFI CPU
 /// Architecture Protocol and the x86_64 paging implementation.

--- a/docs/src/background/memory_safety_strategy.md
+++ b/docs/src/background/memory_safety_strategy.md
@@ -161,19 +161,19 @@ Patina compiles all components into a single binary:
 # #[component]
 # impl MemoryManagerExampleComponent {
 #     fn new() -> Self { MemoryManagerExampleComponent }
-#    fn entry_point(self) -> patina::base::error::Result<()> { Ok(()) }
+#    fn entry_point(self) -> patina::error::Result<()> { Ok(()) }
 # }
 # pub struct SecurityPolicyExampleComponent;
 # #[component]
 # impl SecurityPolicyExampleComponent {
 #    fn new() -> Self { SecurityPolicyExampleComponent }
-#    fn entry_point(self) -> patina::base::error::Result<()> { Ok(()) }
+#    fn entry_point(self) -> patina::error::Result<()> { Ok(()) }
 # }
 # pub struct DeviceDriverExampleComponent;
 # #[component]
 # impl DeviceDriverExampleComponent {
 #    fn new() -> Self { DeviceDriverExampleComponent }
-#    fn entry_point(self) -> patina::base::error::Result<()> { Ok(()) }
+#    fn entry_point(self) -> patina::error::Result<()> { Ok(()) }
 # }
 # // Note: End mock types for compilation
 

--- a/docs/src/component/interface.md
+++ b/docs/src/component/interface.md
@@ -239,7 +239,7 @@ This handle is the DXE Core's image handle, shared across all components. It sho
 conflict with protocol open/close tracking in the UEFI driver model.
 ```
 
-`Handle` implements `Deref` to the underlying `r_efi::efi::Handle`, so it can be dereferenced directly.
+`Handle` implements `Deref` to the underlying `patina::standard::efi::Handle`, so it can be dereferenced directly.
 
 This type comes with a `mock(...)` method to make unit testing simple.
 

--- a/docs/src/component/interface.md
+++ b/docs/src/component/interface.md
@@ -168,7 +168,7 @@ mocking of the underlying functionality, but provides an easy to use interface a
 ```rust
 # extern crate patina;
 use patina::{
-    base::error::Result,
+    error::Result,
     component::service::Service,
 };
 
@@ -205,7 +205,7 @@ component execution, the changes are queued and applied after the component fini
 ```rust
 # extern crate patina;
 use patina::{
-    base::error::Result,
+    error::Result,
     component::{component, params::Commands},
 };
 
@@ -251,7 +251,7 @@ have been initialized. Each component receives its own cloned instance.
 ```rust
 # extern crate patina;
 use patina::{
-    base::error::Result,
+    error::Result,
     component::component,
     uefi::boot_services::StandardBootServices,
 };
@@ -316,7 +316,7 @@ usage models for components and their parameters.
 ```rust
 # extern crate patina;
 use patina::{
-    base::error::{EfiError, Result},
+    error::{EfiError, Result},
     component::{
         component,
         params::{Config, ConfigMut},

--- a/docs/src/component/requirements.md
+++ b/docs/src/component/requirements.md
@@ -101,7 +101,7 @@ be used as seen below:
 # extern crate patina;
 # extern crate patina_test;
 use patina::{
-   base::error::Result,
+   error::Result,
    component::component,
 };
 use patina_test::patina_test;

--- a/docs/src/dev/principles/error-handling.md
+++ b/docs/src/dev/principles/error-handling.md
@@ -119,8 +119,8 @@ For example, the following excerpt is part of an `extern "efiapi"` function that
 returns an EFI status code, where the status is specific to the error state encountered.
 
 ``` rust
-# extern crate r_efi;
-use r_efi::efi;
+# extern crate patina;
+use patina::standard::efi;
 
 extern "efiapi" fn get_memory_map(
     memory_map_size: *mut usize,

--- a/docs/src/dev/principles/error-handling.md
+++ b/docs/src/dev/principles/error-handling.md
@@ -165,7 +165,7 @@ caller.
 # extern crate patina_internal_core;
 # extern crate patina;
 use patina_internal_core::collections::Error as PicError;
-use patina::base::error::EfiError;
+use patina::error::EfiError;
 
 // An error type for working with the GCD
 pub enum Error {
@@ -191,7 +191,7 @@ impl From<PicError> for Error {
 }
 
 // The GCD eventually bubbles up to external EFIAPI functions, so lets also make it easy to convert the `Error` type
-// to `patina::base::error::EfiError`
+// to `patina::error::EfiError`
 impl From<Error> for EfiError {
     fn from(value: Error) -> EfiError {
         match value {

--- a/docs/src/dxe_core/component_model.md
+++ b/docs/src/dxe_core/component_model.md
@@ -100,7 +100,7 @@ Once the component and its params are fully registered, the component is stored 
 # pub struct ExampleComponent;
 # #[component]
 # impl ExampleComponent {
-#   fn entry_point(self) -> patina::base::error::Result<()> { Ok(()) }
+#   fn entry_point(self) -> patina::error::Result<()> { Ok(()) }
 # }
 use patina_dxe_core::*;
 

--- a/docs/src/dxe_core/memory_management.md
+++ b/docs/src/dxe_core/memory_management.md
@@ -248,7 +248,6 @@ An example of how the `Allocator` trait can be used in the core to allocate memo
 ```rust
 #![feature(allocator_api)]
 # extern crate patina;
-# extern crate r_efi;
 use patina::{
     uefi::memory::EfiMemoryType,
     component::service::{

--- a/docs/src/dxe_core/synchronization.md
+++ b/docs/src/dxe_core/synchronization.md
@@ -89,7 +89,7 @@ and `DerefMut`, which allows access to the underlying data:
 
 ```rust,ignore
 use crate::tpl_mutex::TplMutex;
-use r_efi::efi;
+use patina::standard::efi;
 let tpl_mutex = TplMutex::new(efi::TPL_HIGH_LEVEL, 1_usize, "test_lock");
 
 *tpl_mutex.lock() = 2_usize; //deref to set
@@ -101,7 +101,7 @@ scope or is dropped, the lock is automatically released:
 
 ```rust,ignore
 use crate::tpl_mutex::TplMutex;
-use r_efi::efi;
+use patina::standard::efi;
 let tpl_mutex1 = TplMutex::new(efi::TPL_HIGH_LEVEL, 1_usize, "test_lock");
 
 let mut guard1 = tpl_mutex1.lock(); //mutex1 locked.

--- a/patina_dxe_core/Cargo.toml
+++ b/patina_dxe_core/Cargo.toml
@@ -22,7 +22,6 @@ goblin = { workspace = true, features = ["pe32", "pe64", "te"] }
 linked_list_allocator = { workspace = true }
 log = { workspace = true }
 patina_paging = { workspace = true }
-r-efi = { workspace = true }
 scroll = { workspace = true, features = ["derive"] }
 spin = { workspace = true }
 corosensei = { workspace = true  }

--- a/patina_dxe_core/src/allocator.rs
+++ b/patina_dxe_core/src/allocator.rs
@@ -41,7 +41,7 @@ use patina::pi::{
     dxe_services::GcdMemoryType,
     hob::{self, EFiMemoryTypeInformation, Hob, HobList, MEMORY_TYPE_INFO_HOB_GUID},
 };
-use r_efi::{efi, system::TPL_HIGH_LEVEL};
+use patina::standard::efi::{self, TPL_HIGH_LEVEL};
 pub use uefi_allocator::UefiAllocator;
 
 #[cfg(test)]
@@ -1644,7 +1644,7 @@ mod tests {
         dxe_services, guid as pi_guids,
         hob::{GUID_EXTENSION, GuidHob, Hob, HobHeader},
     };
-    use r_efi::efi;
+    use patina::standard::efi;
 
     enum GcdInit {
         /// Initializes a simple test GCD (via init_test_gcd()) with the given size.

--- a/patina_dxe_core/src/allocator.rs
+++ b/patina_dxe_core/src/allocator.rs
@@ -45,12 +45,11 @@ use patina::standard::efi::{self, TPL_HIGH_LEVEL};
 pub use uefi_allocator::UefiAllocator;
 
 #[cfg(test)]
-use patina::base::guid as base_guids;
+use patina::guid as base_guids;
 use patina::{
-    base::error::EfiError,
-    base::{SIZE_4KB, UEFI_PAGE_MASK, UEFI_PAGE_SIZE},
+    error::EfiError,
     uefi::memory::EFI_MAX_MEMORY_TYPE,
-    uefi_size_to_pages, writelncrlf,
+    uefi_size_to_pages, writelncrlf, {SIZE_4KB, UEFI_PAGE_MASK, UEFI_PAGE_SIZE},
 };
 
 // Type alias for a UefiAllocator with a SpinLockedFixedSizeBlockAllocator
@@ -100,7 +99,7 @@ pub(crate) const DEFAULT_PAGE_ALLOCATION_GRANULARITY: usize = SIZE_4KB;
 // granularity requirements for them.
 cfg_if::cfg_if! {
     if #[cfg(target_arch = "aarch64")] {
-        pub(crate) const RUNTIME_PAGE_ALLOCATION_GRANULARITY: usize = patina::base::SIZE_64KB;
+        pub(crate) const RUNTIME_PAGE_ALLOCATION_GRANULARITY: usize = patina::SIZE_64KB;
     } else {
         pub(crate) const RUNTIME_PAGE_ALLOCATION_GRANULARITY: usize = DEFAULT_PAGE_ALLOCATION_GRANULARITY;
     }
@@ -2066,7 +2065,7 @@ mod tests {
                 .allocate_memory_space(
                     DEFAULT_ALLOCATION_STRATEGY,
                     GcdMemoryType::SystemMemory,
-                    patina::base::UEFI_PAGE_SHIFT,
+                    patina::UEFI_PAGE_SHIFT,
                     fv_len,
                     protocol_db::DXE_CORE_HANDLE,
                     None,
@@ -2170,7 +2169,7 @@ mod tests {
 
                 let expected_pages = match *memory_type {
                     efi::BOOT_SERVICES_DATA => 3, // Stack + build_test_hob_list allocation
-                    _ => granularity / patina::base::SIZE_4KB,
+                    _ => granularity / patina::SIZE_4KB,
                 };
 
                 let claimed = allocator.stats().claimed_pages;

--- a/patina_dxe_core/src/allocator/fixed_size_block_allocator.rs
+++ b/patina_dxe_core/src/allocator/fixed_size_block_allocator.rs
@@ -29,10 +29,9 @@ use core::{
 use linked_list_allocator::{align_down_size, align_up_size};
 use patina::standard::efi;
 use patina::{
-    base::error::EfiError,
-    base::{UEFI_PAGE_SIZE, align_up, page_shift_from_alignment},
+    error::EfiError,
     pi::dxe_services::GcdMemoryType,
-    uefi_pages_to_size, uefi_size_to_pages, writelncrlf,
+    uefi_pages_to_size, uefi_size_to_pages, writelncrlf, {UEFI_PAGE_SIZE, align_up, page_shift_from_alignment},
 };
 
 /// Type for describing errors that this implementation can produce.
@@ -859,8 +858,7 @@ mod tests {
     use std::alloc::System;
 
     use patina::{
-        base::{SIZE_64KB, UEFI_PAGE_SHIFT, UEFI_PAGE_SIZE},
-        uefi_pages_to_size,
+        uefi_pages_to_size, {SIZE_64KB, UEFI_PAGE_SHIFT, UEFI_PAGE_SIZE},
     };
 
     use super::*;

--- a/patina_dxe_core/src/allocator/fixed_size_block_allocator.rs
+++ b/patina_dxe_core/src/allocator/fixed_size_block_allocator.rs
@@ -27,13 +27,13 @@ use core::{
     result::Result,
 };
 use linked_list_allocator::{align_down_size, align_up_size};
+use patina::standard::efi;
 use patina::{
     base::error::EfiError,
     base::{UEFI_PAGE_SIZE, align_up, page_shift_from_alignment},
     pi::dxe_services::GcdMemoryType,
     uefi_pages_to_size, uefi_size_to_pages, writelncrlf,
 };
-use r_efi::efi;
 
 /// Type for describing errors that this implementation can produce.
 #[derive(Debug, PartialEq)]

--- a/patina_dxe_core/src/allocator/uefi_allocator.rs
+++ b/patina_dxe_core/src/allocator/uefi_allocator.rs
@@ -9,7 +9,7 @@
 //! SPDX-License-Identifier: Apache-2.0
 //!
 use patina::standard::efi;
-use patina::{base::error::EfiError, writelncrlf};
+use patina::{error::EfiError, writelncrlf};
 
 use super::{AllocationStatistics, AllocationStrategy, PageAllocator};
 use core::{
@@ -277,9 +277,9 @@ mod tests {
     use std::alloc::{GlobalAlloc, System};
 
     use patina::{
-        base::{SIZE_4KB, SIZE_64KB, UEFI_PAGE_SIZE, align_up, page_shift_from_alignment},
         pi::dxe_services,
         uefi_pages_to_size, uefi_size_to_pages,
+        {SIZE_4KB, SIZE_64KB, UEFI_PAGE_SIZE, align_up, page_shift_from_alignment},
     };
 
     use crate::{

--- a/patina_dxe_core/src/allocator/uefi_allocator.rs
+++ b/patina_dxe_core/src/allocator/uefi_allocator.rs
@@ -8,8 +8,8 @@
 //!
 //! SPDX-License-Identifier: Apache-2.0
 //!
+use patina::standard::efi;
 use patina::{base::error::EfiError, writelncrlf};
-use r_efi::efi;
 
 use super::{AllocationStatistics, AllocationStrategy, PageAllocator};
 use core::{
@@ -33,7 +33,7 @@ struct AllocationInfo {
 /// UEFI Allocator
 ///
 /// Wraps a `PageAllocator` to provide additional UEFI-specific functionality:
-/// - Association of a particular [`r_efi::efi::MemoryType`] with the allocator
+/// - Association of a particular [`efi::MemoryType`] with the allocator
 /// - A pool implementation that allows tracking the layout and memory_type of UEFI pool allocations.
 pub struct UefiAllocator<A>
 where

--- a/patina_dxe_core/src/allocator/usage_tests/uefi_memory_map.rs
+++ b/patina_dxe_core/src/allocator/usage_tests/uefi_memory_map.rs
@@ -149,12 +149,12 @@ mod tests {
     use patina::standard::efi;
     use patina::{
         BinaryGuid,
-        base::*,
         pi::{
             BootMode,
             hob::{self, HobHeader, HobList, PhaseHandoffInformationTable, ResourceDescriptor},
         },
         uefi::memory_map,
+        *,
     };
     use serial_test::serial;
     use std::panic::RefUnwindSafe;

--- a/patina_dxe_core/src/allocator/usage_tests/uefi_memory_map.rs
+++ b/patina_dxe_core/src/allocator/usage_tests/uefi_memory_map.rs
@@ -54,7 +54,7 @@
 //! ```rust
 //! use patina::BinaryGuid;
 //! use patina::pi::hob;
-//! use r_efi::efi;
+//! use patina::standard::efi;
 //!
 //! let scenario = MemoryMapTestScenario::new("Test Name", 64 * 1024 * 1024) // 64MB
 //!     .with_resource_descriptor(ResourceDescriptorConfig {
@@ -86,7 +86,7 @@
 //!
 //! ```rust
 //! use crate::allocator::memory_map_integration_tests::{MemoryMapTestScenario, MemoryMapValidation};
-//! use r_efi::efi;
+//! use patina::standard::efi;
 //!
 //! // Set up test scenario
 //! let scenario = MemoryMapTestScenario::new("Runtime Services Test", 256 * 1024 * 1024)
@@ -146,6 +146,7 @@ mod tests {
         test_support,
     };
     use alloc::vec::Vec;
+    use patina::standard::efi;
     use patina::{
         BinaryGuid,
         base::*,
@@ -155,7 +156,6 @@ mod tests {
         },
         uefi::memory_map,
     };
-    use r_efi::efi;
     use serial_test::serial;
     use std::panic::RefUnwindSafe;
 
@@ -431,7 +431,7 @@ mod tests {
                         name: patina::pi::guid::MEMORY_ALLOC_STACK_HOB_GUID,
                         memory_base_address: stack_base,
                         memory_length: stack_size,
-                        memory_type: r_efi::efi::BOOT_SERVICES_DATA,
+                        memory_type: efi::BOOT_SERVICES_DATA,
                         reserved: Default::default(),
                     },
                 };

--- a/patina_dxe_core/src/component_dispatcher.rs
+++ b/patina_dxe_core/src/component_dispatcher.rs
@@ -11,6 +11,7 @@
 extern crate alloc;
 
 use crate::tpl_mutex::TplMutex;
+use patina::standard::efi;
 use patina::{
     component::{IntoComponent, Storage, service::IntoService},
     log_debug_assert,
@@ -18,7 +19,6 @@ use patina::{
     uefi::boot_services::StandardBootServices,
     uefi::runtime_services::StandardRuntimeServices,
 };
-use r_efi::efi;
 
 use alloc::{borrow::Cow, boxed::Box, vec::Vec};
 

--- a/patina_dxe_core/src/component_dispatcher.rs
+++ b/patina_dxe_core/src/component_dispatcher.rs
@@ -312,7 +312,7 @@ mod tests {
 
         #[component]
         impl TestComponent {
-            fn entry_point(self) -> patina::base::error::Result<()> {
+            fn entry_point(self) -> patina::error::Result<()> {
                 Ok(())
             }
         }
@@ -424,7 +424,7 @@ mod tests {
                 self,
                 hob1: patina::component::hob::Hob<TestHob1>,
                 hob2: patina::component::hob::Hob<TestHob2>,
-            ) -> patina::base::error::Result<()> {
+            ) -> patina::error::Result<()> {
                 assert_eq!(hob1.value, HOB1_VALUE);
                 assert_eq!(hob2.value, HOB2_VALUE);
                 Ok(())
@@ -460,10 +460,7 @@ mod tests {
 
         #[component]
         impl TestComponent {
-            fn entry_point(
-                self,
-                _: patina::component::service::Service<dyn TestService>,
-            ) -> patina::base::error::Result<()> {
+            fn entry_point(self, _: patina::component::service::Service<dyn TestService>) -> patina::error::Result<()> {
                 Ok(())
             }
         }
@@ -480,8 +477,8 @@ mod tests {
 
         #[component]
         impl TestComponent {
-            fn entry_point(self) -> patina::base::error::Result<()> {
-                Err(patina::base::error::EfiError::Unsupported)
+            fn entry_point(self) -> patina::error::Result<()> {
+                Err(patina::error::EfiError::Unsupported)
             }
         }
 

--- a/patina_dxe_core/src/config_tables.rs
+++ b/patina_dxe_core/src/config_tables.rs
@@ -14,7 +14,7 @@ use core::{
     ptr::{NonNull, slice_from_raw_parts_mut},
     slice::{from_raw_parts, from_raw_parts_mut},
 };
-use patina::base::error::EfiError;
+use patina::error::EfiError;
 use patina::standard::efi;
 
 use crate::{
@@ -165,7 +165,7 @@ pub fn init_config_tables_support(st: &mut EfiSystemTable) {
 
 #[cfg(test)]
 mod tests {
-    use patina::base::guid;
+    use patina::guid;
 
     use crate::{systemtables::init_system_table, test_support};
 

--- a/patina_dxe_core/src/config_tables.rs
+++ b/patina_dxe_core/src/config_tables.rs
@@ -15,7 +15,7 @@ use core::{
     slice::{from_raw_parts, from_raw_parts_mut},
 };
 use patina::base::error::EfiError;
-use r_efi::efi;
+use patina::standard::efi;
 
 use crate::{
     allocator::EFI_RUNTIME_SERVICES_DATA_ALLOCATOR,

--- a/patina_dxe_core/src/config_tables/memory_attributes_table.rs
+++ b/patina_dxe_core/src/config_tables/memory_attributes_table.rs
@@ -260,7 +260,7 @@ mod tests {
         systemtables::init_system_table,
         test_support,
     };
-    use patina::{base::UEFI_PAGE_SIZE, uefi_size_to_pages};
+    use patina::{UEFI_PAGE_SIZE, uefi_size_to_pages};
 
     fn with_locked_state<F: Fn() + std::panic::RefUnwindSafe>(f: F) {
         test_support::with_clean_global_lock(|| {

--- a/patina_dxe_core/src/config_tables/memory_attributes_table.rs
+++ b/patina_dxe_core/src/config_tables/memory_attributes_table.rs
@@ -22,8 +22,8 @@ use crate::{
     gcd::MemoryProtectionPolicy,
     systemtables,
 };
+use patina::standard::efi;
 use patina::writelncrlf;
-use r_efi::efi;
 
 // create a wrapper struct so that we can create an install method on it. That way, we can have the install function
 // be a no-op until after ReadyToBoot

--- a/patina_dxe_core/src/core_patina_tests/audit_tests.rs
+++ b/patina_dxe_core/src/core_patina_tests/audit_tests.rs
@@ -16,7 +16,7 @@ use patina_test::{patina_test, u_assert};
 #[allow(unused)]
 use patina::BinaryGuid;
 #[allow(unused)]
-use r_efi::efi;
+use patina::standard::efi;
 
 // Verify that all adjacent free memory descriptors in the GCD are merged together
 #[patina_test]

--- a/patina_dxe_core/src/core_patina_tests/stability_tests.rs
+++ b/patina_dxe_core/src/core_patina_tests/stability_tests.rs
@@ -14,8 +14,8 @@ use crate::{GCD, gcd::AllocateType};
 use alloc::vec::Vec;
 use patina::standard::efi;
 use patina::{
-    base::{SIZE_1GB, SIZE_2MB, SIZE_4KB},
     pi::dxe_services::GcdMemoryType,
+    {SIZE_1GB, SIZE_2MB, SIZE_4KB},
 };
 use patina_paging::MemoryAttributes;
 use patina_test::{patina_test, u_assert, u_assert_eq};

--- a/patina_dxe_core/src/core_patina_tests/stability_tests.rs
+++ b/patina_dxe_core/src/core_patina_tests/stability_tests.rs
@@ -12,13 +12,13 @@
 use super::test_support::*;
 use crate::{GCD, gcd::AllocateType};
 use alloc::vec::Vec;
+use patina::standard::efi;
 use patina::{
     base::{SIZE_1GB, SIZE_2MB, SIZE_4KB},
     pi::dxe_services::GcdMemoryType,
 };
 use patina_paging::MemoryAttributes;
 use patina_test::{patina_test, u_assert, u_assert_eq};
-use r_efi::efi;
 
 /// Stability Test: Split a 2MB page into 4KB pages and verify correctness
 #[patina_test]

--- a/patina_dxe_core/src/core_patina_tests/test_support.rs
+++ b/patina_dxe_core/src/core_patina_tests/test_support.rs
@@ -12,7 +12,7 @@
 use alloc::slice;
 use bitfield_struct::bitfield;
 use core::arch::asm;
-use patina::base::{SIZE_1GB, SIZE_2MB, SIZE_4KB, UEFI_PAGE_SHIFT};
+use patina::{SIZE_1GB, SIZE_2MB, SIZE_4KB, UEFI_PAGE_SHIFT};
 use patina_paging::MemoryAttributes;
 
 pub(super) struct PteInfo {

--- a/patina_dxe_core/src/cpu/cpu_arch_protocol.rs
+++ b/patina_dxe_core/src/cpu/cpu_arch_protocol.rs
@@ -14,12 +14,12 @@ use core::ffi::c_void;
 use patina::standard::efi;
 use patina::{
     arch,
-    base::error::{EfiError, Result},
-    base::protocol::ProtocolInterface,
     component::{
         Storage, component,
         service::{IntoService, Service},
     },
+    error::{EfiError, Result},
+    protocol::ProtocolInterface,
     uefi::boot_services::{BootServices, StandardBootServices},
 };
 use patina_internal_cpu::interrupts::{self, ExceptionType, HandlerType, InterruptManager, Interrupts};

--- a/patina_dxe_core/src/cpu/cpu_arch_protocol.rs
+++ b/patina_dxe_core/src/cpu/cpu_arch_protocol.rs
@@ -11,6 +11,7 @@
 use crate::{dxe_services, protocols::PROTOCOL_DB};
 use alloc::boxed::Box;
 use core::ffi::c_void;
+use patina::standard::efi;
 use patina::{
     arch,
     base::error::{EfiError, Result},
@@ -22,7 +23,6 @@ use patina::{
     uefi::boot_services::{BootServices, StandardBootServices},
 };
 use patina_internal_cpu::interrupts::{self, ExceptionType, HandlerType, InterruptManager, Interrupts};
-use r_efi::efi;
 
 use core::sync::atomic::{AtomicU64, Ordering};
 

--- a/patina_dxe_core/src/cpu/efi_cpu/aarch64/cpu.rs
+++ b/patina_dxe_core/src/cpu/efi_cpu/aarch64/cpu.rs
@@ -6,7 +6,7 @@
 //!
 //! SPDX-License-Identifier: Apache-2.0
 //!
-use patina::base::error::EfiError;
+use patina::error::EfiError;
 
 /// Struct to implement AArch64 Cpu Init.
 ///

--- a/patina_dxe_core/src/cpu/efi_cpu/stub.rs
+++ b/patina_dxe_core/src/cpu/efi_cpu/stub.rs
@@ -6,7 +6,7 @@
 //!
 //! SPDX-License-Identifier: Apache-2.0
 //!
-use patina::base::error::EfiError;
+use patina::error::EfiError;
 
 /// Struct to implement Null Cpu Init.
 ///

--- a/patina_dxe_core/src/cpu/efi_cpu/x64/cpu.rs
+++ b/patina_dxe_core/src/cpu/efi_cpu/x64/cpu.rs
@@ -9,7 +9,7 @@
 #[cfg(not(test))]
 use core::arch::asm;
 use patina::arch as interrupts;
-use patina::base::error::EfiError;
+use patina::error::EfiError;
 
 /// Struct to implement X64 Cpu Init.
 ///

--- a/patina_dxe_core/src/cpu/hw_interrupt_protocol.rs
+++ b/patina_dxe_core/src/cpu/hw_interrupt_protocol.rs
@@ -1,9 +1,9 @@
 use crate::tpl_mutex::TplMutex;
 use alloc::{boxed::Box, vec, vec::Vec};
+use patina::standard::efi;
 use patina_internal_cpu::interrupts::{
     ExceptionContext, InterruptHandler, InterruptManager, gic_manager::AArch64InterruptInitializer,
 };
-use r_efi::efi;
 use spin::rwlock::RwLock;
 
 use arm_gic::{InterruptGroup, Trigger, gicv3::GicCpuInterface};

--- a/patina_dxe_core/src/cpu/hw_interrupt_protocol.rs
+++ b/patina_dxe_core/src/cpu/hw_interrupt_protocol.rs
@@ -9,8 +9,8 @@ use spin::rwlock::RwLock;
 use arm_gic::{InterruptGroup, Trigger, gicv3::GicCpuInterface};
 use patina::{
     BinaryGuid,
-    base::protocol::ProtocolInterface,
     component::{component, service::Service},
+    protocol::ProtocolInterface,
     uefi::boot_services::{BootServices, StandardBootServices},
 };
 
@@ -517,7 +517,7 @@ impl HwInterruptProtocolInstaller {
         self,
         interrupt_manager: Service<dyn InterruptManager>,
         boot_services: StandardBootServices,
-    ) -> patina::base::error::Result<()> {
+    ) -> patina::error::Result<()> {
         log::info!("GIC initializing {:x?}", (self.gic_bases.gicd, self.gic_bases.gicr));
         // SAFETY: The invariants of the `GicBases` struct upholds the safety requirements for this function.
         let aarch64_int = unsafe {

--- a/patina_dxe_core/src/debugger_reload.rs
+++ b/patina_dxe_core/src/debugger_reload.rs
@@ -15,8 +15,8 @@ use core::ffi::c_void;
 
 use alloc::vec::Vec;
 use patina::{
-    base::guid as base_guids,
     component::service::memory::{AllocationOptions, MemoryManager, PageAllocationStrategy},
+    guid as base_guids,
     pi::{
         guid as pi_guids,
         hob::{self},

--- a/patina_dxe_core/src/decompress.rs
+++ b/patina_dxe_core/src/decompress.rs
@@ -12,14 +12,12 @@ use core::ffi::c_void;
 
 use alloc::boxed::Box;
 use patina::{
-    base::error::EfiError,
     component::{Storage, component},
+    error::EfiError,
     log_debug_assert,
     standard::efi::{self, protocols::decompress},
-    uefi::{
-        boot_services::BootServices,
-        decompress::{DecompressionAlgorithm, decompress_into_with_algo},
-    },
+    uefi::boot_services::BootServices,
+    uefi::decompress::{DecompressionAlgorithm, decompress_into_with_algo},
 };
 
 /// Component to install the UEFI Decompress Protocol.
@@ -28,7 +26,7 @@ pub(crate) struct DecompressProtocolInstaller;
 
 #[component]
 impl DecompressProtocolInstaller {
-    fn entry_point(self, storage: &mut Storage) -> patina::base::error::Result<()> {
+    fn entry_point(self, storage: &mut Storage) -> patina::error::Result<()> {
         let protocol = Box::new(decompress::Protocol { get_info, decompress });
 
         match storage.boot_services().install_protocol_interface(None, protocol) {

--- a/patina_dxe_core/src/driver_services.rs
+++ b/patina_dxe_core/src/driver_services.rs
@@ -16,7 +16,7 @@ use patina::{
     uefi::device_path::walker::{concat_device_path_to_boxed_slice, copy_device_path_to_boxed_slice},
 };
 
-use r_efi::{efi, protocols::device_path::Protocol};
+use patina::standard::efi::{self, protocols::device_path::Protocol};
 
 use crate::{performance::CORE_PERFORMANCE, protocols::PROTOCOL_DB, systemtables::EfiSystemTable};
 

--- a/patina_dxe_core/src/driver_services.rs
+++ b/patina_dxe_core/src/driver_services.rs
@@ -12,7 +12,7 @@ use alloc::{
 };
 use core::ptr::NonNull;
 use patina::{
-    base::error::EfiError,
+    error::EfiError,
     uefi::device_path::walker::{concat_device_path_to_boxed_slice, copy_device_path_to_boxed_slice},
 };
 

--- a/patina_dxe_core/src/dxe_dispatch_service.rs
+++ b/patina_dxe_core/src/dxe_dispatch_service.rs
@@ -12,8 +12,8 @@
 //! SPDX-License-Identifier: Apache-2.0
 //!
 use patina::{
-    base::error::Result,
     component::service::{IntoService, dxe_dispatch::DxeDispatch},
+    error::Result,
 };
 
 use crate::{Core, PlatformInfo};

--- a/patina_dxe_core/src/dxe_services.rs
+++ b/patina_dxe_core/src/dxe_services.rs
@@ -12,7 +12,7 @@ use core::{
     mem,
     slice::{self, from_raw_parts},
 };
-use patina::base::error::EfiError;
+use patina::error::EfiError;
 use patina_ffs::volume::VolumeRef;
 
 use patina::pi::dxe_services;

--- a/patina_dxe_core/src/dxe_services.rs
+++ b/patina_dxe_core/src/dxe_services.rs
@@ -16,7 +16,7 @@ use patina::base::error::EfiError;
 use patina_ffs::volume::VolumeRef;
 
 use patina::pi::dxe_services;
-use r_efi::efi;
+use patina::standard::efi;
 
 use crate::{Core, GCD, PlatformInfo, allocator::core_allocate_pool, config_tables, gcd, systemtables::EfiSystemTable};
 

--- a/patina_dxe_core/src/event_db.rs
+++ b/patina_dxe_core/src/event_db.rs
@@ -23,7 +23,7 @@ use core::{
     ops::{Deref, DerefMut},
 };
 use patina::standard::efi;
-use patina::{base::error::EfiError, log_debug_assert};
+use patina::{error::EfiError, log_debug_assert};
 
 use crate::{runtime, tpl_mutex};
 

--- a/patina_dxe_core/src/event_db.rs
+++ b/patina_dxe_core/src/event_db.rs
@@ -22,8 +22,8 @@ use core::{
     fmt,
     ops::{Deref, DerefMut},
 };
+use patina::standard::efi;
 use patina::{base::error::EfiError, log_debug_assert};
-use r_efi::efi;
 
 use crate::{runtime, tpl_mutex};
 
@@ -316,7 +316,7 @@ impl EventDb {
     fn create_event(
         &mut self,
         event_type: u32,
-        notify_tpl: r_efi::base::Tpl,
+        notify_tpl: efi::Tpl,
         notify_function: Option<efi::EventNotify>,
         notify_context: Option<*mut c_void>,
         event_group: Option<efi::Guid>,
@@ -662,11 +662,11 @@ impl SpinLockedEventDb {
     ///
     /// ## Errors
     ///
-    /// Returns r_efi:efi::Status::INVALID_PARAMETER if incorrect parameters are given.
+    /// Returns efi::Status::INVALID_PARAMETER if incorrect parameters are given.
     pub fn create_event(
         &self,
         event_type: u32,
-        notify_tpl: r_efi::base::Tpl,
+        notify_tpl: efi::Tpl,
         notify_function: Option<efi::EventNotify>,
         notify_context: Option<*mut c_void>,
         event_group: Option<efi::Guid>,
@@ -681,7 +681,7 @@ impl SpinLockedEventDb {
     ///
     /// ## Errors
     ///
-    /// Returns r_efi:efi::Status::INVALID_PARAMETER if incorrect parameters are given.
+    /// Returns efi::Status::INVALID_PARAMETER if incorrect parameters are given.
     pub fn close_event(&self, event: efi::Event) -> Result<(), EfiError> {
         self.lock().close_event(event)
     }
@@ -693,7 +693,7 @@ impl SpinLockedEventDb {
     ///
     /// ## Errors
     ///
-    /// Returns r_efi:efi::Status::INVALID_PARAMETER if incorrect parameters are given.
+    /// Returns efi::Status::INVALID_PARAMETER if incorrect parameters are given.
     pub fn signal_event(&self, event: efi::Event) -> Result<(), EfiError> {
         if let Some(mut guard) = self.try_lock() {
             guard.signal_event(event)
@@ -731,7 +731,7 @@ impl SpinLockedEventDb {
     ///
     /// ## Errors
     ///
-    /// Returns r_efi:efi::Status::INVALID_PARAMETER if incorrect event is given.
+    /// Returns efi::Status::INVALID_PARAMETER if incorrect event is given.
     pub fn get_event_type(&self, event: efi::Event) -> Result<EventType, EfiError> {
         self.lock().get_event_type(event)
     }
@@ -746,7 +746,7 @@ impl SpinLockedEventDb {
     ///
     /// ## Errors
     ///
-    /// Returns r_efi:efi::Status::INVALID_PARAMETER if incorrect parameters are given.
+    /// Returns efi::Status::INVALID_PARAMETER if incorrect parameters are given.
     #[allow(dead_code)]
     pub fn clear_signal(&self, event: efi::Event) -> Result<(), EfiError> {
         self.lock().clear_signal(event)
@@ -756,7 +756,7 @@ impl SpinLockedEventDb {
     ///
     /// ## Errors
     ///
-    /// Returns r_efi:efi::Status::INVALID_PARAMETER if incorrect parameters are given.
+    /// Returns efi::Status::INVALID_PARAMETER if incorrect parameters are given.
     pub fn read_and_clear_signaled(&self, event: efi::Event) -> Result<bool, EfiError> {
         let mut event_db = self.lock();
         let signaled = event_db.is_signaled(event);
@@ -772,7 +772,7 @@ impl SpinLockedEventDb {
     ///
     /// ## Errors
     ///
-    /// Returns r_efi:efi::Status::INVALID_PARAMETER if incorrect parameters are given.
+    /// Returns efi::Status::INVALID_PARAMETER if incorrect parameters are given.
     pub fn queue_event_notify(&self, event: efi::Event) -> Result<(), EfiError> {
         self.lock().queue_event_notify(event)
     }
@@ -781,7 +781,7 @@ impl SpinLockedEventDb {
     ///
     /// ## Errors
     ///
-    /// Returns r_efi:efi::Status::INVALID_PARAMETER if incorrect parameters are given.
+    /// Returns efi::Status::INVALID_PARAMETER if incorrect parameters are given.
     #[allow(dead_code)]
     pub fn get_notification_data(&self, event: efi::Event) -> Result<EventNotification, EfiError> {
         self.lock().get_notification_data(event)
@@ -794,7 +794,7 @@ impl SpinLockedEventDb {
     ///
     /// ## Errors
     ///
-    /// Returns r_efi:efi::Status::INVALID_PARAMETER if incorrect parameters are given.
+    /// Returns efi::Status::INVALID_PARAMETER if incorrect parameters are given.
     pub fn set_timer(
         &self,
         event: efi::Event,
@@ -850,7 +850,7 @@ mod tests {
 
     use alloc::{vec, vec::Vec};
     use patina::Guid;
-    use r_efi::efi;
+    use patina::standard::efi;
     use uuid::Uuid;
 
     use crate::test_support;

--- a/patina_dxe_core/src/events.rs
+++ b/patina_dxe_core/src/events.rs
@@ -11,7 +11,7 @@ use core::{
     sync::atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering},
 };
 
-use r_efi::efi;
+use patina::standard::efi;
 
 use patina::{arch, pi::protocol::timer};
 

--- a/patina_dxe_core/src/filesystems.rs
+++ b/patina_dxe_core/src/filesystems.rs
@@ -8,7 +8,7 @@
 //!
 use alloc::{vec, vec::Vec};
 use core::{ffi::c_void, mem::size_of};
-use patina::base::error::EfiError;
+use patina::error::EfiError;
 use patina::standard::efi;
 
 use crate::protocols::PROTOCOL_DB;

--- a/patina_dxe_core/src/filesystems.rs
+++ b/patina_dxe_core/src/filesystems.rs
@@ -9,7 +9,7 @@
 use alloc::{vec, vec::Vec};
 use core::{ffi::c_void, mem::size_of};
 use patina::base::error::EfiError;
-use r_efi::efi;
+use patina::standard::efi;
 
 use crate::protocols::PROTOCOL_DB;
 

--- a/patina_dxe_core/src/gcd.rs
+++ b/patina_dxe_core/src/gcd.rs
@@ -16,17 +16,17 @@ use alloc::boxed::Box;
 use core::{cell::Cell, ffi::c_void, ops::Range};
 use patina::standard::efi;
 use patina::{
-    base::error::EfiError,
-    base::{DEFAULT_CACHE_ATTR, align_down, align_up},
+    error::EfiError,
     pi::{
         dxe_services::{GcdIoType, GcdMemoryType, MemorySpaceDescriptor},
         hob::{self, Hob, HobList, MEMORY_TYPE_INFO_HOB_GUID, PhaseHandoffInformationTable},
     },
+    {DEFAULT_CACHE_ATTR, align_down, align_up},
 };
 use patina_internal_cpu::paging::{PatinaPageTable, create_cpu_paging};
 
 #[cfg(feature = "compatibility_mode_allowed")]
-use patina::base::{UEFI_PAGE_SIZE, align_range};
+use patina::{UEFI_PAGE_SIZE, align_range};
 
 use crate::{GCD, gcd::spin_locked_gcd::PagingAllocator, pecoff};
 
@@ -435,7 +435,7 @@ impl MemoryProtectionPolicy {
                 d.memory_type != GcdMemoryType::NonExistent
             })
             .map(|desc| desc.attributes & efi::CACHE_ATTRIBUTE_MASK)
-            .unwrap_or(patina::base::DEFAULT_CACHE_ATTR);
+            .unwrap_or(patina::DEFAULT_CACHE_ATTR);
         if gcd
             .set_memory_space_attributes(image_base_page, patina::uefi_pages_to_size!(image_num_pages), stripped_attrs)
             .is_err()

--- a/patina_dxe_core/src/gcd.rs
+++ b/patina_dxe_core/src/gcd.rs
@@ -14,6 +14,7 @@ use goblin::pe::section_table;
 
 use alloc::boxed::Box;
 use core::{cell::Cell, ffi::c_void, ops::Range};
+use patina::standard::efi;
 use patina::{
     base::error::EfiError,
     base::{DEFAULT_CACHE_ATTR, align_down, align_up},
@@ -23,7 +24,6 @@ use patina::{
     },
 };
 use patina_internal_cpu::paging::{PatinaPageTable, create_cpu_paging};
-use r_efi::efi;
 
 #[cfg(feature = "compatibility_mode_allowed")]
 use patina::base::{UEFI_PAGE_SIZE, align_range};

--- a/patina_dxe_core/src/gcd/io_block.rs
+++ b/patina_dxe_core/src/gcd/io_block.rs
@@ -9,7 +9,7 @@
 use core::fmt::Debug;
 
 use patina::pi::dxe_services;
-use r_efi::efi;
+use patina::standard::efi;
 
 use crate::error;
 

--- a/patina_dxe_core/src/gcd/memory_block.rs
+++ b/patina_dxe_core/src/gcd/memory_block.rs
@@ -9,7 +9,7 @@
 use core::fmt::Debug;
 
 use patina::pi::dxe_services;
-use r_efi::efi;
+use patina::standard::efi;
 
 use crate::error;
 

--- a/patina_dxe_core/src/gcd/spin_locked_gcd.rs
+++ b/patina_dxe_core/src/gcd/spin_locked_gcd.rs
@@ -9,19 +9,18 @@
 use crate::pecoff::UefiPeInfo;
 use alloc::{boxed::Box, slice, vec, vec::Vec};
 use core::{fmt::Display, ptr};
-use patina::{base::DEFAULT_CACHE_ATTR, base::error::EfiError, log_debug_assert};
+use patina::{DEFAULT_CACHE_ATTR, error::EfiError, log_debug_assert};
 
 use patina::standard::efi;
 use patina::{
-    base::guid as base_guids,
-    base::{SIZE_4GB, UEFI_PAGE_MASK, UEFI_PAGE_SHIFT, UEFI_PAGE_SIZE, align_up},
-    function,
+    function, guid as base_guids,
     pi::{
         dxe_services::{self, GcdMemoryType, MemorySpaceDescriptor},
         guid as pi_guids, hob,
     },
     uefi::event::CACHE_ATTRIBUTE_CHANGE_EVENT_GROUP_GUID,
     uefi_pages_to_size, uefi_size_to_pages, writelncrlf,
+    {SIZE_4GB, UEFI_PAGE_MASK, UEFI_PAGE_SHIFT, UEFI_PAGE_SIZE, align_up},
 };
 use patina_internal_core::collections::{Error as SliceError, Rbt, SliceKey, node_size};
 
@@ -2331,9 +2330,7 @@ impl SpinLockedGcd {
                 Hob::MemoryAllocationModule(module) if module.module_name == base_guids::DXE_CORE_ID => Some(module),
                 _ => None,
             })
-            .expect(
-                "Did not find MemoryAllocationModule Hob for DxeCore. Use patina::base::guid::DXE_CORE_ID as FFS GUID.",
-            );
+            .expect("Did not find MemoryAllocationModule Hob for DxeCore. Use patina::guid::DXE_CORE_ID as FFS GUID.");
 
         // SAFETY: the DXE core HOB points to the loaded image buffer and size.
         let pe_info = unsafe {
@@ -3081,7 +3078,7 @@ mod tests {
     //! - The test lock prevents concurrent access during reset operations
     extern crate std;
     use core::{alloc::Layout, sync::atomic::AtomicBool};
-    use patina::base::align_up;
+    use patina::align_up;
 
     use crate::test_support::{self, MockPageTable, MockPageTableWrapper};
 

--- a/patina_dxe_core/src/gcd/spin_locked_gcd.rs
+++ b/patina_dxe_core/src/gcd/spin_locked_gcd.rs
@@ -11,6 +11,7 @@ use alloc::{boxed::Box, slice, vec, vec::Vec};
 use core::{fmt::Display, ptr};
 use patina::{base::DEFAULT_CACHE_ATTR, base::error::EfiError, log_debug_assert};
 
+use patina::standard::efi;
 use patina::{
     base::guid as base_guids,
     base::{SIZE_4GB, UEFI_PAGE_MASK, UEFI_PAGE_SHIFT, UEFI_PAGE_SIZE, align_up},
@@ -23,7 +24,6 @@ use patina::{
     uefi_pages_to_size, uefi_size_to_pages, writelncrlf,
 };
 use patina_internal_core::collections::{Error as SliceError, Rbt, SliceKey, node_size};
-use r_efi::efi;
 
 use crate::{
     GCD,
@@ -3087,7 +3087,8 @@ mod tests {
 
     use super::*;
     use alloc::vec::Vec;
-    use r_efi::efi;
+    use patina::pi::dxe_services::GcdMemoryType;
+    use patina::standard::efi;
     use std::{alloc::GlobalAlloc, cell::RefCell, rc::Rc};
 
     const DXE_CORE_PE_HEADER_DATA: [u8; 1057] = [

--- a/patina_dxe_core/src/lib.rs
+++ b/patina_dxe_core/src/lib.rs
@@ -13,7 +13,7 @@
 //! # struct ExampleComponent;
 //! # #[patina::component::component]
 //! # impl ExampleComponent {
-//! #     fn entry_point(self) -> patina::base::error::Result<()> { Ok(()) }
+//! #     fn entry_point(self) -> patina::error::Result<()> { Ok(()) }
 //! # }
 //! struct ExamplePlatform;
 //!
@@ -122,8 +122,8 @@ use gcd::SpinLockedGcd;
 use memory_manager::CoreMemoryManager;
 use patina::standard::efi;
 use patina::{
-    base::error::{self, Result},
     component::{IntoComponent, service::performance::PerformanceManager},
+    error::{self, Result},
     performance::config::PerformanceConfig,
     pi::{
         hob::{HobList, get_pi_hob_list_size},
@@ -277,7 +277,7 @@ type MockCore = Core<MockPlatformInfo>;
 /// # struct ExampleComponent;
 /// # #[patina::component::component]
 /// # impl ExampleComponent {
-/// #     fn entry_point(self) -> patina::base::error::Result<()> { Ok(()) }
+/// #     fn entry_point(self) -> patina::error::Result<()> { Ok(()) }
 /// # }
 /// struct ExamplePlatform;
 ///
@@ -500,7 +500,7 @@ impl<P: PlatformInfo> Core<P> {
         if performance.enabled() {
             // Record the PEI-end / DXE-begin cross-module markers. This runs during core memory initialization, as early
             // as the performance engine can record into its table, so the DXE span is captured close to the phase boundary.
-            let dxe_core_guid = patina::base::guid::DXE_CORE_ID.into_inner();
+            let dxe_core_guid = patina::guid::DXE_CORE_ID.into_inner();
             performance.perf_cross_module_end("PEI", &dxe_core_guid);
             performance.perf_cross_module_begin("DXE", &dxe_core_guid);
 
@@ -681,7 +681,7 @@ fn call_bds() -> ! {
                 // SAFETY: Some(status_code_protocol_ptr) guarantees that the pointer is non-NULL
                 let status_code_protocol =
                     unsafe { status_code_protocol_ptr.cast::<status_code::StatusCodeProtocol>().as_ref() };
-                let dxe_core_guid = patina::base::guid::DXE_CORE_ID.into_inner();
+                let dxe_core_guid = patina::guid::DXE_CORE_ID.into_inner();
                 (status_code_protocol.report_status_code)(
                     EFI_PROGRESS_CODE,
                     EFI_SOFTWARE_DXE_CORE | EFI_SW_DXE_CORE_PC_HANDOFF_TO_NEXT,

--- a/patina_dxe_core/src/lib.rs
+++ b/patina_dxe_core/src/lib.rs
@@ -120,6 +120,7 @@ use core::{
 use cpu::DxeInterruptManager;
 use gcd::SpinLockedGcd;
 use memory_manager::CoreMemoryManager;
+use patina::standard::efi;
 use patina::{
     base::error::{self, Result},
     component::{IntoComponent, service::performance::PerformanceManager},
@@ -134,7 +135,6 @@ use patina::{
 };
 use patina_ffs::section::SectionExtractor;
 use protocols::PROTOCOL_DB;
-use r_efi::efi;
 
 use crate::{
     component_dispatcher::ComponentDispatcher, config_tables::memory_attributes_table, performance::CorePerformance,

--- a/patina_dxe_core/src/memory_attributes_protocol.rs
+++ b/patina_dxe_core/src/memory_attributes_protocol.rs
@@ -15,7 +15,7 @@ use core::{
     sync::atomic::{AtomicPtr, AtomicUsize, Ordering},
 };
 use patina::standard::efi;
-use patina::{base::UEFI_PAGE_MASK, base::error::EfiError, function};
+use patina::{UEFI_PAGE_MASK, error::EfiError, function};
 
 #[repr(C)]
 pub struct EfiMemoryAttributesProtocolImpl {
@@ -317,8 +317,8 @@ mod tests {
     };
 
     use patina::{
-        base::{UEFI_PAGE_SHIFT, align_up},
         pi::dxe_services::GcdMemoryType,
+        {UEFI_PAGE_SHIFT, align_up},
     };
     use std::{cell::RefCell, ptr, rc::Rc};
 

--- a/patina_dxe_core/src/memory_attributes_protocol.rs
+++ b/patina_dxe_core/src/memory_attributes_protocol.rs
@@ -14,8 +14,8 @@ use core::{
     ffi::c_void,
     sync::atomic::{AtomicPtr, AtomicUsize, Ordering},
 };
+use patina::standard::efi;
 use patina::{base::UEFI_PAGE_MASK, base::error::EfiError, function};
-use r_efi::efi;
 
 #[repr(C)]
 pub struct EfiMemoryAttributesProtocolImpl {

--- a/patina_dxe_core/src/memory_bin.rs
+++ b/patina_dxe_core/src/memory_bin.rs
@@ -27,10 +27,9 @@
 use crate::allocator::{DEFAULT_PAGE_ALLOCATION_GRANULARITY, RUNTIME_PAGE_ALLOCATION_GRANULARITY};
 use patina::standard::efi;
 use patina::{
-    base::{UEFI_PAGE_SHIFT, align_up},
     pi::hob::{self, EFiMemoryTypeInformation, Hob, HobList, MEMORY_TYPE_INFO_HOB_GUID},
     uefi::memory::{EFI_MAX_MEMORY_TYPE, INVALID_INFORMATION_INDEX},
-    uefi_pages_to_size, uefi_size_to_pages,
+    uefi_pages_to_size, uefi_size_to_pages, {UEFI_PAGE_SHIFT, align_up},
 };
 
 use alloc::vec::Vec;
@@ -939,7 +938,7 @@ pub(crate) fn extract_memory_type_info_from_hob(hob_list: &HobList) -> Option<Ve
 #[cfg_attr(coverage, coverage(off))]
 mod tests {
     use super::*;
-    use patina::base::{SIZE_64KB, UEFI_PAGE_SIZE};
+    use patina::{SIZE_64KB, UEFI_PAGE_SIZE};
 
     const RT_GRAN_PAGES: u64 =
         (MemoryBinManager::granularity_for_type(efi::RUNTIME_SERVICES_DATA) / UEFI_PAGE_SIZE) as u64;

--- a/patina_dxe_core/src/memory_bin.rs
+++ b/patina_dxe_core/src/memory_bin.rs
@@ -25,13 +25,13 @@
 //!
 
 use crate::allocator::{DEFAULT_PAGE_ALLOCATION_GRANULARITY, RUNTIME_PAGE_ALLOCATION_GRANULARITY};
+use patina::standard::efi;
 use patina::{
     base::{UEFI_PAGE_SHIFT, align_up},
     pi::hob::{self, EFiMemoryTypeInformation, Hob, HobList, MEMORY_TYPE_INFO_HOB_GUID},
     uefi::memory::{EFI_MAX_MEMORY_TYPE, INVALID_INFORMATION_INDEX},
     uefi_pages_to_size, uefi_size_to_pages,
 };
-use r_efi::efi;
 
 use alloc::vec::Vec;
 

--- a/patina_dxe_core/src/memory_manager.rs
+++ b/patina_dxe_core/src/memory_manager.rs
@@ -9,8 +9,6 @@
 use alloc::boxed::Box;
 use patina::standard::efi;
 use patina::{
-    base::error::EfiError,
-    base::{UEFI_PAGE_MASK, UEFI_PAGE_SIZE},
     component::service::{
         IntoService, Service,
         memory::{
@@ -18,8 +16,9 @@ use patina::{
             PageAllocationStrategy,
         },
     },
+    error::EfiError,
     uefi::memory::EfiMemoryType,
-    uefi_pages_to_size,
+    uefi_pages_to_size, {UEFI_PAGE_MASK, UEFI_PAGE_SIZE},
 };
 use patina_test::{patina_test, u_assert, u_assert_eq};
 

--- a/patina_dxe_core/src/memory_manager.rs
+++ b/patina_dxe_core/src/memory_manager.rs
@@ -7,6 +7,7 @@
 //! SPDX-License-Identifier: Apache-2.0
 //!
 use alloc::boxed::Box;
+use patina::standard::efi;
 use patina::{
     base::error::EfiError,
     base::{UEFI_PAGE_MASK, UEFI_PAGE_SIZE},
@@ -21,7 +22,6 @@ use patina::{
     uefi_pages_to_size,
 };
 use patina_test::{patina_test, u_assert, u_assert_eq};
-use r_efi::efi;
 
 use crate::{
     GCD,

--- a/patina_dxe_core/src/misc_boot_services.rs
+++ b/patina_dxe_core/src/misc_boot_services.rs
@@ -8,13 +8,13 @@
 //!
 use core::{ffi::c_void, slice::from_raw_parts, sync::atomic::Ordering};
 use patina::arch as interrupts;
+use patina::standard::efi;
 use patina::{
     base::guid as base_guids,
     log_debug_assert,
     pi::{protocol, status_code},
     uefi::event::EXIT_BOOT_SERVICES_FAILED_EVENT_GROUP_GUID,
 };
-use r_efi::efi;
 use spin::Once;
 
 use crate::{
@@ -321,7 +321,7 @@ mod tests {
     };
     use core::{ffi::c_void, ptr};
     use patina::pi::protocol::watchdog;
-    use r_efi::efi;
+    use patina::standard::efi;
 
     fn with_locked_state<F>(f: F)
     where

--- a/patina_dxe_core/src/misc_boot_services.rs
+++ b/patina_dxe_core/src/misc_boot_services.rs
@@ -10,8 +10,7 @@ use core::{ffi::c_void, slice::from_raw_parts, sync::atomic::Ordering};
 use patina::arch as interrupts;
 use patina::standard::efi;
 use patina::{
-    base::guid as base_guids,
-    log_debug_assert,
+    guid as base_guids, log_debug_assert,
     pi::{protocol, status_code},
     uefi::event::EXIT_BOOT_SERVICES_FAILED_EVENT_GROUP_GUID,
 };

--- a/patina_dxe_core/src/performance.rs
+++ b/patina_dxe_core/src/performance.rs
@@ -38,8 +38,8 @@ use patina::{
 
 use crate::{cpu::PerfTimer, protocols::PROTOCOL_DB, tpl_mutex::TplMutex};
 
-use r_efi::{
-    efi,
+use patina::standard::efi::{
+    self,
     protocols::device_path::{Media, TYPE_MEDIA},
 };
 
@@ -589,7 +589,7 @@ pub(crate) fn push_generic_record(buffer: &mut PerformanceRecordBuffer, record_t
 mod tests {
     use super::*;
     use crate::test_support::with_global_lock;
-    use r_efi::efi;
+    use patina::standard::efi;
 
     /// Builds a `CorePerformance` backed by a real FBPT and a fixed-frequency timer for host testing.
     fn test_core_performance() -> CorePerformance {

--- a/patina_dxe_core/src/performance.rs
+++ b/patina_dxe_core/src/performance.rs
@@ -14,11 +14,11 @@ use alloc::vec::Vec;
 
 use patina::{
     BinaryGuid,
-    base::error::EfiError,
     component::{
         hob::FromHob,
         service::{IntoService, Service, perf_timer::ArchTimerFunctionality, performance::PerformanceManager},
     },
+    error::EfiError,
     performance::{
         Measurement,
         config::PerformanceConfig,

--- a/patina_dxe_core/src/performance.rs
+++ b/patina_dxe_core/src/performance.rs
@@ -58,7 +58,7 @@ pub(crate) static CORE_PERFORMANCE: Service<CorePerformance> = Service::new_unin
 /// Owns all performance measurement state (the FBPT, measurement mask, load-image count, and arch timer). It is
 /// registered as a [`Service<dyn PerformanceManager>`] for components and used directly by core internals.
 #[derive(IntoService)]
-#[service(dyn PerformanceManager)]
+#[service(dyn PerformanceManager, CorePerformance)]
 pub(crate) struct CorePerformance {
     enabled: AtomicBool,
     loaded_image_count: AtomicU32,

--- a/patina_dxe_core/src/pi_dispatcher.rs
+++ b/patina_dxe_core/src/pi_dispatcher.rs
@@ -21,6 +21,7 @@ use alloc::{
     vec::Vec,
 };
 use core::{cmp::Ordering, ffi::c_void};
+use patina::standard::efi;
 use patina::{
     BinaryGuid, Char16Str, OwnedGuid,
     base::error::EfiError,
@@ -37,7 +38,6 @@ use patina_ffs::{
     volume::VolumeRef,
 };
 use patina_internal_core::depex::{AssociatedDependency, Depex, Opcode};
-use r_efi::efi;
 use spin::RwLock;
 
 use image::ImageStatus;
@@ -760,17 +760,17 @@ impl DispatcherContext {
                             // In this case, this is sizeof(guid) + sizeof(protocol) = 20, so it should always fit an u8
                             const FILENAME_NODE_SIZE: usize =
                                 core::mem::size_of::<efi::protocols::device_path::Protocol>()
-                                    + core::mem::size_of::<r_efi::efi::Guid>();
+                                    + core::mem::size_of::<efi::Guid>();
                             // In this case, this is sizeof(protocol) = 4, so it should always fit an u8
                             const END_NODE_SIZE: usize = core::mem::size_of::<efi::protocols::device_path::Protocol>();
 
                             let filename_node = efi::protocols::device_path::Protocol {
-                                r#type: r_efi::protocols::device_path::TYPE_MEDIA,
-                                sub_type: r_efi::protocols::device_path::Media::SUBTYPE_PIWG_FIRMWARE_FILE,
+                                r#type: efi::protocols::device_path::TYPE_MEDIA,
+                                sub_type: efi::protocols::device_path::Media::SUBTYPE_PIWG_FIRMWARE_FILE,
                                 length: [FILENAME_NODE_SIZE as u8, 0x00],
                             };
                             let filename_end_node = efi::protocols::device_path::Protocol {
-                                r#type: r_efi::protocols::device_path::TYPE_END,
+                                r#type: efi::protocols::device_path::TYPE_END,
                                 sub_type: efi::protocols::device_path::End::SUBTYPE_ENTIRE,
                                 length: [END_NODE_SIZE as u8, 0x00],
                             };
@@ -1479,14 +1479,8 @@ mod tests {
             );
 
             // Check that a non-existent FV GUID is not detected
-            let non_existent_guid = r_efi::efi::Guid::from_fields(
-                0x11111111,
-                0x2222,
-                0x3333,
-                0x44,
-                0x55,
-                &[0x66, 0x77, 0x88, 0x99, 0xAA, 0xBB],
-            );
+            let non_existent_guid =
+                efi::Guid::from_fields(0x11111111, 0x2222, 0x3333, 0x44, 0x55, &[0x66, 0x77, 0x88, 0x99, 0xAA, 0xBB]);
             assert!(
                 !CORE.pi_dispatcher.is_fv_already_installed(non_existent_guid),
                 "Should return false for non-existent FV GUID"
@@ -1506,7 +1500,7 @@ mod tests {
             CORE.override_instance();
             // Test that no FVB handles installed returns false
             assert!(
-                !CORE.pi_dispatcher.is_fv_already_installed(r_efi::efi::Guid::from_fields(
+                !CORE.pi_dispatcher.is_fv_already_installed(efi::Guid::from_fields(
                     0xAAAAAAAA,
                     0xBBBB,
                     0xCCCC,
@@ -1530,7 +1524,7 @@ mod tests {
 
             // Test that a non-matching GUID returns false
             assert!(
-                !CORE.pi_dispatcher.is_fv_already_installed(r_efi::efi::Guid::from_fields(
+                !CORE.pi_dispatcher.is_fv_already_installed(efi::Guid::from_fields(
                     0x11111111,
                     0x2222,
                     0x3333,
@@ -1666,14 +1660,8 @@ mod tests {
                 .expect("Failed to install null protocol");
 
             // Should return false since the FVB protocol is null
-            let test_guid = r_efi::efi::Guid::from_fields(
-                0xAAAAAAAA,
-                0xBBBB,
-                0xCCCC,
-                0xDD,
-                0xEE,
-                &[0xFF, 0x00, 0x11, 0x22, 0x33, 0x44],
-            );
+            let test_guid =
+                efi::Guid::from_fields(0xAAAAAAAA, 0xBBBB, 0xCCCC, 0xDD, 0xEE, &[0xFF, 0x00, 0x11, 0x22, 0x33, 0x44]);
             assert!(
                 !CORE.pi_dispatcher.is_fv_already_installed(test_guid),
                 "Should return false when the FVB protocol is null"
@@ -1710,14 +1698,8 @@ mod tests {
             // SAFETY: protocol was retrieved from PROTOCOL_DB and remains valid for this test scope.
             unsafe { &mut *protocol }.get_physical_address = get_physical_address1;
 
-            let test_guid = r_efi::efi::Guid::from_fields(
-                0xAAAAAAAA,
-                0xBBBB,
-                0xCCCC,
-                0xDD,
-                0xEE,
-                &[0xFF, 0x00, 0x11, 0x22, 0x33, 0x44],
-            );
+            let test_guid =
+                efi::Guid::from_fields(0xAAAAAAAA, 0xBBBB, 0xCCCC, 0xDD, 0xEE, &[0xFF, 0x00, 0x11, 0x22, 0x33, 0x44]);
             assert!(
                 !CORE.pi_dispatcher.is_fv_already_installed(test_guid),
                 "Should return false when get_physical_address fails"
@@ -1754,14 +1736,8 @@ mod tests {
             // SAFETY: protocol was retrieved from PROTOCOL_DB and remains valid for this test scope.
             unsafe { &mut *protocol }.get_physical_address = get_physical_address2;
 
-            let test_guid = r_efi::efi::Guid::from_fields(
-                0xAAAAAAAA,
-                0xBBBB,
-                0xCCCC,
-                0xDD,
-                0xEE,
-                &[0xFF, 0x00, 0x11, 0x22, 0x33, 0x44],
-            );
+            let test_guid =
+                efi::Guid::from_fields(0xAAAAAAAA, 0xBBBB, 0xCCCC, 0xDD, 0xEE, &[0xFF, 0x00, 0x11, 0x22, 0x33, 0x44]);
             assert!(
                 !CORE.pi_dispatcher.is_fv_already_installed(test_guid),
                 "Should return false when the address is zero"
@@ -1807,14 +1783,8 @@ mod tests {
             // SAFETY: Test-only mutable static is used under the global lock.
             unsafe { GET_PHYSICAL_ADDRESS3_VALUE = invalid_fv_raw.expose_provenance() as u64 };
 
-            let test_guid = r_efi::efi::Guid::from_fields(
-                0xAAAAAAAA,
-                0xBBBB,
-                0xCCCC,
-                0xDD,
-                0xEE,
-                &[0xFF, 0x00, 0x11, 0x22, 0x33, 0x44],
-            );
+            let test_guid =
+                efi::Guid::from_fields(0xAAAAAAAA, 0xBBBB, 0xCCCC, 0xDD, 0xEE, &[0xFF, 0x00, 0x11, 0x22, 0x33, 0x44]);
             assert!(
                 !CORE.pi_dispatcher.is_fv_already_installed(test_guid),
                 "Should return false when volume parsing fails"
@@ -1940,7 +1910,7 @@ mod tests {
             // Create a pending FV image with the corrupted section
             let pending_fv = PendingFirmwareVolumeImage {
                 parent_fv_handle: std::ptr::null_mut(),
-                file_name: r_efi::efi::Guid::from_fields(
+                file_name: efi::Guid::from_fields(
                     0x11111111,
                     0x2222,
                     0x3333,

--- a/patina_dxe_core/src/pi_dispatcher.rs
+++ b/patina_dxe_core/src/pi_dispatcher.rs
@@ -24,8 +24,8 @@ use core::{cmp::Ordering, ffi::c_void};
 use patina::standard::efi;
 use patina::{
     BinaryGuid, Char16Str, OwnedGuid,
-    base::error::EfiError,
     component::service::Service,
+    error::EfiError,
     pi::{
         fw_fs::ffs,
         hob::{Hob, HobList},
@@ -220,7 +220,7 @@ impl<P: PlatformInfo> PiDispatcher<P> {
             crate::gcd::AllocateType::TopDown(None),
             patina::pi::dxe_services::GcdMemoryType::SystemMemory,
             ALIGNMENT_SHIFT_4MB,
-            patina::base::UEFI_PAGE_SIZE,
+            patina::UEFI_PAGE_SIZE,
             crate::protocol_db::EFI_BOOT_SERVICES_DATA_ALLOCATOR_HANDLE,
             None,
         ) else {

--- a/patina_dxe_core/src/pi_dispatcher/debug_image_info_table.rs
+++ b/patina_dxe_core/src/pi_dispatcher/debug_image_info_table.rs
@@ -11,7 +11,7 @@ use core::{
     fmt,
     ptr::{self, NonNull},
 };
-use r_efi::efi;
+use patina::standard::efi;
 use spin::rwlock::RwLock;
 
 /// Default allocation size for the debug image info table.

--- a/patina_dxe_core/src/pi_dispatcher/fv.rs
+++ b/patina_dxe_core/src/pi_dispatcher/fv.rs
@@ -22,8 +22,8 @@ use patina::{
 };
 
 use patina::base::error::EfiError;
+use patina::standard::efi::{self, MEMORY_MAPPED_IO};
 use patina_ffs::{file::FileRef, section::SectionExtractor, volume::VolumeRef};
-use r_efi::efi::{self, MEMORY_MAPPED_IO};
 
 use crate::{
     Core, PlatformInfo,

--- a/patina_dxe_core/src/pi_dispatcher/fv.rs
+++ b/patina_dxe_core/src/pi_dispatcher/fv.rs
@@ -21,7 +21,7 @@ use patina::{
     },
 };
 
-use patina::base::error::EfiError;
+use patina::error::EfiError;
 use patina::standard::efi::{self, MEMORY_MAPPED_IO};
 use patina_ffs::{file::FileRef, section::SectionExtractor, volume::VolumeRef};
 

--- a/patina_dxe_core/src/pi_dispatcher/image.rs
+++ b/patina_dxe_core/src/pi_dispatcher/image.rs
@@ -15,6 +15,7 @@ use core::{
     slice,
     slice::from_raw_parts,
 };
+use patina::standard::efi::{self, protocols::device_path::Protocol};
 use patina::{
     Char16Str,
     base::error::EfiError,
@@ -31,7 +32,6 @@ use patina::{
     uefi::memory::EfiMemoryType,
     uefi_size_to_pages,
 };
-use r_efi::{efi, protocols::device_path::Protocol};
 
 use crate::{
     GCD,
@@ -309,7 +309,7 @@ impl PrivateImageData {
         // update the entry point. Transmute is required here to cast the raw function address to the ImageEntryPoint function pointer type.
         // SAFETY: Entry point is computed from a validated PE image base and entry offset.
         self.entry_point = unsafe {
-            transmute::<usize, extern "efiapi" fn(*mut c_void, *mut r_efi::system::SystemTable) -> efi::Status>(
+            transmute::<usize, extern "efiapi" fn(*mut c_void, *mut efi::SystemTable) -> efi::Status>(
                 physical_addr + self.pe_info.entry_point_offset,
             )
         };
@@ -585,7 +585,7 @@ impl ImageData {
         // The entry point in the HOB is a u64 address. transmute it to the correct function pointer type.
         // SAFETY: The module entry_point is spec defined as the below function signature.
         let entry_point = unsafe {
-            transmute::<u64, extern "efiapi" fn(*mut c_void, *mut r_efi::system::SystemTable) -> r_efi::base::Status>(
+            transmute::<u64, extern "efiapi" fn(*mut c_void, *mut efi::SystemTable) -> efi::Status>(
                 dxe_core_hob.entry_point,
             )
         };
@@ -1609,16 +1609,16 @@ mod tests {
         test_collateral, test_support,
     };
     use core::{ffi::c_void, sync::atomic::AtomicBool};
+    use patina::standard::efi::{
+        self,
+        protocols::device_path::{End, Hardware, Media, TYPE_END, TYPE_HARDWARE, TYPE_MEDIA},
+    };
     use patina::{
         base::error::EfiError,
         pi::{
             self,
             hob::{HobList, MemoryAllocationHeader, MemoryAllocationModule},
         },
-    };
-    use r_efi::{
-        efi,
-        protocols::device_path::{End, Hardware, Media, TYPE_END, TYPE_HARDWARE, TYPE_MEDIA},
     };
     use std::{fs::File, io::Read, ptr::NonNull, slice::from_raw_parts};
 
@@ -2159,7 +2159,7 @@ mod tests {
             static ENTRY_POINT_RAN: AtomicBool = AtomicBool::new(false);
             pub extern "efiapi" fn test_entry_point(
                 _image_handle: *mut core::ffi::c_void,
-                _system_table: *mut r_efi::system::SystemTable,
+                _system_table: *mut efi::SystemTable,
             ) -> efi::Status {
                 println!("test_entry_point executed.");
                 ENTRY_POINT_RAN.store(true, core::sync::atomic::Ordering::Relaxed);
@@ -2205,7 +2205,7 @@ mod tests {
             static ENTRY_POINT_RAN: AtomicBool = AtomicBool::new(false);
             extern "efiapi" fn test_entry_point(
                 _image_handle: *mut core::ffi::c_void,
-                _system_table: *mut r_efi::system::SystemTable,
+                _system_table: *mut efi::SystemTable,
             ) -> efi::Status {
                 log::info!("test_entry_point executed.");
                 ENTRY_POINT_RAN.store(true, core::sync::atomic::Ordering::Relaxed);

--- a/patina_dxe_core/src/pi_dispatcher/image.rs
+++ b/patina_dxe_core/src/pi_dispatcher/image.rs
@@ -18,11 +18,9 @@ use core::{
 use patina::standard::efi::{self, protocols::device_path::Protocol};
 use patina::{
     Char16Str,
-    base::error::EfiError,
-    base::guid as base_guids,
-    base::{DEFAULT_CACHE_ATTR, UEFI_PAGE_SIZE, align_up},
     component::service::memory::{AllocationOptions, MemoryManager, PageFree},
-    log_debug_assert,
+    error::EfiError,
+    guid as base_guids, log_debug_assert,
     pi::{
         self,
         fw_fs::FfsSectionRawType::PE32,
@@ -30,7 +28,7 @@ use patina::{
     },
     uefi::device_path::walker::{DevicePathWalker, copy_device_path_to_boxed_slice, device_path_node_count},
     uefi::memory::EfiMemoryType,
-    uefi_size_to_pages,
+    uefi_size_to_pages, {DEFAULT_CACHE_ATTR, UEFI_PAGE_SIZE, align_up},
 };
 
 use crate::{
@@ -573,9 +571,7 @@ impl ImageData {
                     None
                 }
             })
-            .expect(
-                "Did not find MemoryAllocationModule Hob for DxeCore. Use patina::base::guid::DXE_CORE_ID as FFS GUID.",
-            );
+            .expect("Did not find MemoryAllocationModule Hob for DxeCore. Use patina::guid::DXE_CORE_ID as FFS GUID.");
 
         let mut image_info = empty_image_info();
         image_info.system_table = system_table as *mut _ as *mut efi::SystemTable;
@@ -1614,7 +1610,7 @@ mod tests {
         protocols::device_path::{End, Hardware, Media, TYPE_END, TYPE_HARDWARE, TYPE_MEDIA},
     };
     use patina::{
-        base::error::EfiError,
+        error::EfiError,
         pi::{
             self,
             hob::{HobList, MemoryAllocationHeader, MemoryAllocationModule},

--- a/patina_dxe_core/src/protocol_db.rs
+++ b/patina_dxe_core/src/protocol_db.rs
@@ -17,7 +17,7 @@ use alloc::{
 };
 use core::{cmp::Ordering, ffi::c_void, hash::Hasher};
 use patina::standard::efi;
-use patina::{base::error::EfiError, base::hash::Xorshift64starHasher};
+use patina::{error::EfiError, hash::Xorshift64starHasher};
 
 use crate::tpl_mutex;
 

--- a/patina_dxe_core/src/protocol_db.rs
+++ b/patina_dxe_core/src/protocol_db.rs
@@ -16,8 +16,8 @@ use alloc::{
     vec::Vec,
 };
 use core::{cmp::Ordering, ffi::c_void, hash::Hasher};
+use patina::standard::efi;
 use patina::{base::error::EfiError, base::hash::Xorshift64starHasher};
-use r_efi::efi;
 
 use crate::tpl_mutex;
 
@@ -684,7 +684,7 @@ impl SpinLockedProtocolDb {
     ///
     /// ## Errors
     ///
-    /// Returns r_efi:efi::Status::INVALID_PARAMETER if incorrect parameters are given.
+    /// Returns efi::Status::INVALID_PARAMETER if incorrect parameters are given.
     pub fn install_protocol_interface(
         &self,
         handle: Option<efi::Handle>,
@@ -701,7 +701,7 @@ impl SpinLockedProtocolDb {
     ///
     /// ## Errors
     ///
-    /// Returns r_efi:efi::Status::INVALID_PARAMETER if incorrect parameters are given.
+    /// Returns efi::Status::INVALID_PARAMETER if incorrect parameters are given.
     pub fn uninstall_protocol_interface(
         &self,
         handle: efi::Handle,
@@ -719,8 +719,8 @@ impl SpinLockedProtocolDb {
     ///
     /// ## Errors
     ///
-    /// Returns [`INVALID_PARAMETER`](r_efi::efi::Status::INVALID_PARAMETER) if incorrect parameters are given.
-    /// Returns [`NOT_FOUND`](r_efi::efi::Status::NOT_FOUND) if no matching handles are found.
+    /// Returns [`INVALID_PARAMETER`](efi::Status::INVALID_PARAMETER) if incorrect parameters are given.
+    /// Returns [`NOT_FOUND`](efi::Status::NOT_FOUND) if no matching handles are found.
     pub fn locate_handles(&self, protocol: Option<efi::Guid>) -> Result<Vec<efi::Handle>, EfiError> {
         self.lock().locate_handles(protocol)
     }
@@ -733,8 +733,8 @@ impl SpinLockedProtocolDb {
     ///
     /// ## Errors
     ///
-    /// Returns [`INVALID_PARAMETER`](r_efi::efi::Status::INVALID_PARAMETER) if incorrect parameters are given.
-    /// Returns [`NOT_FOUND`](r_efi::efi::Status::NOT_FOUND) if no matching interfaces are found.
+    /// Returns [`INVALID_PARAMETER`](efi::Status::INVALID_PARAMETER) if incorrect parameters are given.
+    /// Returns [`NOT_FOUND`](efi::Status::NOT_FOUND) if no matching interfaces are found.
     pub fn locate_protocol(&self, protocol: efi::Guid) -> Result<*mut c_void, EfiError> {
         self.lock().locate_protocol(protocol)
     }
@@ -745,8 +745,8 @@ impl SpinLockedProtocolDb {
     ///
     /// ## Errors
     ///
-    /// Returns [`INVALID_PARAMETER`](r_efi::efi::Status::INVALID_PARAMETER) if incorrect parameters are given.
-    /// Returns [`NOT_FOUND`](r_efi::efi::Status::NOT_FOUND) if no matching interfaces are found on the given handle.
+    /// Returns [`INVALID_PARAMETER`](efi::Status::INVALID_PARAMETER) if incorrect parameters are given.
+    /// Returns [`NOT_FOUND`](efi::Status::NOT_FOUND) if no matching interfaces are found on the given handle.
     pub fn get_interface_for_handle(&self, handle: efi::Handle, protocol: efi::Guid) -> Result<*mut c_void, EfiError> {
         self.lock().get_interface_for_handle(handle, protocol)
     }
@@ -766,14 +766,14 @@ impl SpinLockedProtocolDb {
     ///
     /// # Errors
     ///
-    /// Returns [`INVALID_PARAMETER`](r_efi::efi::Status::INVALID_PARAMETER) if incorrect parameters are given.
-    /// Returns [`NOT_FOUND`](r_efi::efi::Status::NOT_FOUND) if no matching interfaces are found.
-    /// Returns [`ALREADY_STARTED`](r_efi::efi::Status::ALREADY_STARTED) if attributes is BY_DRIVER and there is an
+    /// Returns [`INVALID_PARAMETER`](efi::Status::INVALID_PARAMETER) if incorrect parameters are given.
+    /// Returns [`NOT_FOUND`](efi::Status::NOT_FOUND) if no matching interfaces are found.
+    /// Returns [`ALREADY_STARTED`](efi::Status::ALREADY_STARTED) if attributes is BY_DRIVER and there is an
     ///     existing usage by the agent handle.
-    /// Returns [`ACCESS_DENIED`](r_efi::efi::Status::ACCESS_DENIED) if attributes is efi::OPEN_PROTOCOL_BY_DRIVER |
+    /// Returns [`ACCESS_DENIED`](efi::Status::ACCESS_DENIED) if attributes is efi::OPEN_PROTOCOL_BY_DRIVER |
     ///     efi::OPEN_PROTOCOL_EXCLUSIVE | BY_DRIVER_EXCLUSIVE and there is an existing usage that conflicts with those
     ///     attributes.
-    /// Returns [`UNSUPPORTED`](r_efi::efi::Status::UNSUPPORTED) if the handle does not support the specified protocol.
+    /// Returns [`UNSUPPORTED`](efi::Status::UNSUPPORTED) if the handle does not support the specified protocol.
     pub fn add_protocol_usage(
         &self,
         handle: efi::Handle,
@@ -792,9 +792,9 @@ impl SpinLockedProtocolDb {
     ///
     /// # Errors
     ///
-    /// Returns [`INVALID_PARAMETER`](r_efi::efi::Status::INVALID_PARAMETER) if incorrect parameters are given.
-    /// Returns [`NOT_FOUND`](r_efi::efi::Status::NOT_FOUND) if the specified handle does not support the specified protocol.
-    /// Returns [`NOT_FOUND`](r_efi::efi::Status::NOT_FOUND) if the protocol interface specified by handle and protocol are not
+    /// Returns [`INVALID_PARAMETER`](efi::Status::INVALID_PARAMETER) if incorrect parameters are given.
+    /// Returns [`NOT_FOUND`](efi::Status::NOT_FOUND) if the specified handle does not support the specified protocol.
+    /// Returns [`NOT_FOUND`](efi::Status::NOT_FOUND) if the protocol interface specified by handle and protocol are not
     ///   opened by the specified agent and controller handle.
     pub fn remove_protocol_usage(
         &self,
@@ -814,8 +814,8 @@ impl SpinLockedProtocolDb {
     ///
     /// # Errors
     ///
-    /// Returns [`INVALID_PARAMETER`](r_efi::efi::Status::INVALID_PARAMETER) if incorrect parameters are given.
-    /// Returns [`NOT_FOUND`](r_efi::efi::Status::NOT_FOUND) if the specified handle does not support the specified protocol.
+    /// Returns [`INVALID_PARAMETER`](efi::Status::INVALID_PARAMETER) if incorrect parameters are given.
+    /// Returns [`NOT_FOUND`](efi::Status::NOT_FOUND) if the specified handle does not support the specified protocol.
     pub fn get_open_protocol_information_by_protocol(
         &self,
         handle: efi::Handle,
@@ -829,8 +829,8 @@ impl SpinLockedProtocolDb {
     ///
     /// # Errors
     ///
-    /// Returns [`INVALID_PARAMETER`](r_efi::efi::Status::INVALID_PARAMETER) if incorrect parameters are given.
-    /// Returns [`NOT_FOUND`](r_efi::efi::Status::NOT_FOUND) if the specified handle does not support the specified protocol.
+    /// Returns [`INVALID_PARAMETER`](efi::Status::INVALID_PARAMETER) if incorrect parameters are given.
+    /// Returns [`NOT_FOUND`](efi::Status::NOT_FOUND) if the specified handle does not support the specified protocol.
     pub fn get_open_protocol_information(
         &self,
         handle: efi::Handle,
@@ -889,7 +889,7 @@ mod tests {
     use core::str::FromStr;
     use std::println;
 
-    use r_efi::efi;
+    use patina::standard::efi;
     use uuid::Uuid;
 
     use crate::test_support;

--- a/patina_dxe_core/src/protocols.rs
+++ b/patina_dxe_core/src/protocols.rs
@@ -12,7 +12,7 @@ use alloc::{slice, vec, vec::Vec};
 use patina::standard::efi::{self, protocols::device_path::Protocol};
 use patina::{
     OwnedGuid,
-    base::error::EfiError,
+    error::EfiError,
     uefi::device_path::walker::{is_device_path_end, remaining_device_path},
 };
 use tpl_mutex::TplMutex;

--- a/patina_dxe_core/src/protocols.rs
+++ b/patina_dxe_core/src/protocols.rs
@@ -9,12 +9,12 @@
 use core::{ffi::c_void, mem::size_of, ptr::NonNull};
 
 use alloc::{slice, vec, vec::Vec};
+use patina::standard::efi::{self, protocols::device_path::Protocol};
 use patina::{
     OwnedGuid,
     base::error::EfiError,
     uefi::device_path::walker::{is_device_path_end, remaining_device_path},
 };
-use r_efi::{efi, protocols::device_path::Protocol};
 use tpl_mutex::TplMutex;
 
 use crate::{
@@ -888,7 +888,7 @@ pub fn core_locate_device_path(
     protocol: efi::Guid,
     device_path: NonNull<Protocol>,
 ) -> Result<(NonNull<Protocol>, efi::Handle), EfiError> {
-    let device_path_protocol_guid = &r_efi::protocols::device_path::PROTOCOL_GUID as *const _ as *mut efi::Guid;
+    let device_path_protocol_guid = &efi::protocols::device_path::PROTOCOL_GUID as *const _ as *mut efi::Guid;
 
     let mut best_device: efi::Handle = core::ptr::null_mut();
     let mut best_match: isize = -1;
@@ -897,7 +897,7 @@ pub fn core_locate_device_path(
     let handles = PROTOCOL_DB.locate_handles(Some(protocol))?;
 
     for handle in handles {
-        let mut temp_device_path: *mut r_efi::protocols::device_path::Protocol = core::ptr::null_mut();
+        let mut temp_device_path: *mut efi::protocols::device_path::Protocol = core::ptr::null_mut();
         let temp_device_path_ptr: *mut *mut c_void = &mut temp_device_path as *mut _ as *mut *mut c_void;
         // SAFETY: `handle` comes from `locate_handles` and is valid. `device_path_protocol_guid`
         // points to a valid static GUID. `temp_device_path_ptr` is derived from a local variable
@@ -947,7 +947,7 @@ pub fn core_locate_device_path(
 /// referenced memory is the caller's responsibility.
 unsafe extern "efiapi" fn locate_device_path(
     protocol: *mut efi::Guid,
-    device_path: *mut *mut r_efi::protocols::device_path::Protocol,
+    device_path: *mut *mut efi::protocols::device_path::Protocol,
     device: *mut efi::Handle,
 ) -> efi::Status {
     if protocol.is_null() || device_path.is_null() {

--- a/patina_dxe_core/src/runtime.rs
+++ b/patina_dxe_core/src/runtime.rs
@@ -10,7 +10,7 @@
 use core::{ffi::c_void, ptr};
 
 use alloc::collections::LinkedList;
-use patina::base::error::EfiError;
+use patina::error::EfiError;
 use patina::standard::efi;
 use spin::Mutex;
 

--- a/patina_dxe_core/src/runtime.rs
+++ b/patina_dxe_core/src/runtime.rs
@@ -11,7 +11,7 @@ use core::{ffi::c_void, ptr};
 
 use alloc::collections::LinkedList;
 use patina::base::error::EfiError;
-use r_efi::efi;
+use patina::standard::efi;
 use spin::Mutex;
 
 use crate::{events::EVENT_DB, pecoff::relocation::RelocationBlock, protocols::PROTOCOL_DB};

--- a/patina_dxe_core/src/systemtables.rs
+++ b/patina_dxe_core/src/systemtables.rs
@@ -884,7 +884,7 @@ pub(crate) struct SystemTableChecksumInstaller;
 
 #[component]
 impl SystemTableChecksumInstaller {
-    fn entry_point(self, bs: patina::uefi::boot_services::StandardBootServices) -> patina::base::error::Result<()> {
+    fn entry_point(self, bs: patina::uefi::boot_services::StandardBootServices) -> patina::error::Result<()> {
         extern "efiapi" fn callback(_event: efi::Event, _: *mut c_void) {
             SYSTEM_TABLE.lock().as_mut().expect("System Table is initialized").checksum_all();
         }

--- a/patina_dxe_core/src/systemtables.rs
+++ b/patina_dxe_core/src/systemtables.rs
@@ -11,8 +11,8 @@
 use core::{ffi::c_void, mem::size_of, slice::from_raw_parts};
 
 use alloc::boxed::Box;
+use patina::standard::efi;
 use patina::{component::component, pi::error_codes::EFI_NOT_AVAILABLE_YET, uefi::boot_services::BootServices};
-use r_efi::efi;
 
 use crate::{allocator::EFI_RUNTIME_SERVICES_DATA_ALLOCATOR, tpl_mutex};
 

--- a/patina_dxe_core/src/test_support.rs
+++ b/patina_dxe_core/src/test_support.rs
@@ -666,7 +666,7 @@ pub(crate) fn build_test_hob_list(mem_size: u64) -> *const c_void {
             } as u64;
 
             // Make sure the memory region is aligned as needed.
-            address = patina::base::align_up(address, granularity).unwrap();
+            address = patina::align_up(address, granularity).unwrap();
             allocation_hob_template.alloc_descriptor.memory_base_address = address;
             allocation_hob_template.alloc_descriptor.memory_type = *memory_type;
             allocation_hob_template.alloc_descriptor.memory_length = granularity;
@@ -752,7 +752,7 @@ mod tests {
         test_support::{BootMode, HobHeader, MemoryAllocationHeader, get_memory, hob},
     };
     use patina::{
-        base::guid as base_guids,
+        guid as base_guids,
         pi::hob::{Hob::MemoryAllocationModule, ResourceDescriptorV2},
     };
 

--- a/patina_dxe_core/src/test_support.rs
+++ b/patina_dxe_core/src/test_support.rs
@@ -10,6 +10,7 @@
 //!
 use crate::{GCD, allocator::DEFAULT_PAGE_ALLOCATION_GRANULARITY, protocols::PROTOCOL_DB};
 use core::ffi::c_void;
+use patina::standard::efi;
 use patina::{
     BinaryGuid,
     pi::{
@@ -20,7 +21,6 @@ use patina::{
 };
 use patina_internal_cpu::paging::{CacheAttributeValue, PatinaPageTable};
 use patina_paging::{MemoryAttributes, PtError};
-use r_efi::efi;
 use spin::{Once, RwLock};
 use std::{any::Any, cell::RefCell, fs::File, io::Read, slice};
 

--- a/patina_dxe_core/src/tpl_mutex.rs
+++ b/patina_dxe_core/src/tpl_mutex.rs
@@ -20,7 +20,7 @@ use core::{
     sync::atomic::{AtomicBool, Ordering},
 };
 
-use r_efi::efi;
+use patina::standard::efi;
 
 use crate::events::{raise_tpl, restore_tpl};
 
@@ -146,7 +146,7 @@ mod tests {
     };
 
     use super::TplMutex;
-    use r_efi::efi;
+    use patina::standard::efi;
 
     fn with_reset_state<F: Fn() + std::panic::RefUnwindSafe>(f: F) {
         let result = crate::test_support::with_global_lock(|| {

--- a/sdk/patina/README.md
+++ b/sdk/patina/README.md
@@ -27,7 +27,7 @@ The SDK is organized into the following root-level modules.
 | Module | Description |
 | ------ | ----------- |
 | **arch** | Abstractions for architecture-specific functionality (e.g. caching) and architecture-specific functions. |
-| **base** | Foundational primitives: errors, constants, GUID structures, C-pointer helpers, etc. |
+| **base** | Foundational primitives: errors, constants, basic structures. This module gets republished from the root. |
 | **component** | Component and service definitions for the dependency-injected component model. |
 | **debug** | Macros and definitions for logging and diagnostics. |
 | **management_mode** | Definitions for Management Mode (MM/SMM) interactions. |

--- a/sdk/patina/benches/bench_component.rs
+++ b/sdk/patina/benches/bench_component.rs
@@ -88,7 +88,7 @@ fn add_component_abstracted(b: &mut Bencher<'_>, count: &usize) {
 }
 
 fn run_component_abstracted(b: &mut Bencher<'_>, count: &usize) {
-    let mut mock_bs = core::mem::MaybeUninit::<r_efi::efi::BootServices>::zeroed();
+    let mut mock_bs = core::mem::MaybeUninit::<patina::standard::efi::BootServices>::zeroed();
 
     let mut init = |count: usize| -> Scheduler {
         let mut core = Scheduler::new();
@@ -110,7 +110,7 @@ fn run_component_abstracted(b: &mut Bencher<'_>, count: &usize) {
 }
 
 fn add_and_run_component_abstracted(b: &mut Bencher<'_>, count: &usize) {
-    let mut mock_bs = core::mem::MaybeUninit::<r_efi::efi::BootServices>::zeroed();
+    let mut mock_bs = core::mem::MaybeUninit::<patina::standard::efi::BootServices>::zeroed();
 
     let init = || -> Scheduler {
         let mut core = Scheduler::new();

--- a/sdk/patina/benches/bench_component.rs
+++ b/sdk/patina/benches/bench_component.rs
@@ -28,8 +28,8 @@
 //!
 use criterion::{Bencher, Criterion, criterion_group, criterion_main};
 use patina::{
-    base::error::Result,
     component::{Component, IntoComponent, Storage, component, params::*},
+    error::Result,
     uefi::boot_services::StandardBootServices,
 };
 

--- a/sdk/patina/benches/bench_guid.rs
+++ b/sdk/patina/benches/bench_guid.rs
@@ -1,7 +1,7 @@
 //! Benchmarks for GUID operations.
 //!
 //! This benchmark compares the performance of patina::Guid wrapper operations
-//! against r_efi::efi::Guid operations to measure performance delta.
+//! against patina::standard::efi::Guid operations to measure performance delta.
 //!
 //! ## Benchmark execution
 //!
@@ -38,7 +38,7 @@
 //!
 use criterion::{Bencher, Criterion, criterion_group, criterion_main};
 use patina::base::guid::{Guid, OwnedGuid};
-use r_efi::efi;
+use patina::standard::efi;
 
 const TEST_GUID_STRING: &str = "12345678-9abc-def0-1122-334455667788";
 

--- a/sdk/patina/benches/bench_guid.rs
+++ b/sdk/patina/benches/bench_guid.rs
@@ -37,7 +37,7 @@
 //! SPDX-License-Identifier: Apache-2.0
 //!
 use criterion::{Bencher, Criterion, criterion_group, criterion_main};
-use patina::base::guid::{Guid, OwnedGuid};
+use patina::guid::{Guid, OwnedGuid};
 use patina::standard::efi;
 
 const TEST_GUID_STRING: &str = "12345678-9abc-def0-1122-334455667788";

--- a/sdk/patina/examples/basic_guid_usage.rs
+++ b/sdk/patina/examples/basic_guid_usage.rs
@@ -24,10 +24,9 @@
 //! The implementation avoids heap allocations, using stack-allocated buffers for formatting.
 
 use patina::{
-    BinaryGuid, Guid, GuidError, OwnedGuid, base::guid::DXE_CORE_ID,
-    management_mode::guid::SMM_COMMUNICATION_PROTOCOL_GUID, performance::guid::PERFORMANCE_PROTOCOL_GUID,
-    pi::event::END_OF_DXE_EVENT_GROUP_GUID, pi::hob::MEMORY_TYPE_INFO_HOB_GUID,
-    uefi::event::EXIT_BOOT_SERVICES_FAILED_EVENT_GROUP_GUID,
+    BinaryGuid, Guid, GuidError, OwnedGuid, guid::DXE_CORE_ID, management_mode::guid::SMM_COMMUNICATION_PROTOCOL_GUID,
+    performance::guid::PERFORMANCE_PROTOCOL_GUID, pi::event::END_OF_DXE_EVENT_GROUP_GUID,
+    pi::hob::MEMORY_TYPE_INFO_HOB_GUID, uefi::event::EXIT_BOOT_SERVICES_FAILED_EVENT_GROUP_GUID,
 };
 
 /// The zero GUID (00000000-0000-0000-0000-000000000000).

--- a/sdk/patina/examples/brotli.rs
+++ b/sdk/patina/examples/brotli.rs
@@ -1,7 +1,7 @@
 use alloc_no_stdlib::{self, SliceWrapper, SliceWrapperMut, define_index_ops_mut};
 use brotli_decompressor::{BrotliDecompressStream, BrotliResult, BrotliState, HuffmanCode};
 use patina::pi::fw_fs::{FirmwareVolume, SectionExtractor, SectionMetaData, guid};
-use r_efi::efi;
+use patina::standard::efi;
 use std::{env, error::Error, fmt::Debug, fs, path::Path};
 
 //Rebox and HeapAllocator satisfy BrotliDecompress custom allocation requirement.

--- a/sdk/patina/src/arch/aarch64.rs
+++ b/sdk/patina/src/arch/aarch64.rs
@@ -9,9 +9,8 @@
 //! Portions Copyright 2023 The arm-gic Authors.
 //! arm-gic is dual-licensed under Apache 2.0 and MIT terms.
 
-use crate::{base::error::EfiError, pi::protocol::cpu_arch::CpuFlushType};
+use crate::{base::error::EfiError, pi::protocol::cpu_arch::CpuFlushType, standard::efi};
 use core::num::NonZeroU64;
-use r_efi::efi;
 
 pub(super) struct AArch64;
 

--- a/sdk/patina/src/arch/stub.rs
+++ b/sdk/patina/src/arch/stub.rs
@@ -11,10 +11,9 @@
 //! SPDX-License-Identifier: Apache-2.0
 //!
 
-use crate::{base::error::EfiError, pi::protocol::cpu_arch::CpuFlushType};
+use crate::{base::error::EfiError, pi::protocol::cpu_arch::CpuFlushType, standard::efi};
 use core::num::NonZeroU64;
 use core::sync::atomic::{AtomicBool, Ordering};
-use r_efi::efi;
 
 /// Stub architecture used for host/unit-test builds.
 pub(crate) struct StubArch;

--- a/sdk/patina/src/arch/x64.rs
+++ b/sdk/patina/src/arch/x64.rs
@@ -7,10 +7,9 @@
 //! SPDX-License-Identifier: Apache-2.0
 //!
 
-use crate::{base::error::EfiError, pi::protocol::cpu_arch::CpuFlushType};
+use crate::{base::error::EfiError, pi::protocol::cpu_arch::CpuFlushType, standard::efi};
 use core::arch::asm;
 use core::num::NonZeroU64;
-use r_efi::efi;
 
 pub(crate) struct X64;
 

--- a/sdk/patina/src/base.rs
+++ b/sdk/patina/src/base.rs
@@ -8,10 +8,8 @@
 //!
 //! SPDX-License-Identifier: Apache-2.0
 
-use crate::standard::efi;
-use num_traits;
-
 use crate::base::error::EfiError;
+use crate::standard::efi;
 
 pub mod c_ptr;
 pub mod error;
@@ -166,7 +164,7 @@ pub const DEFAULT_CACHE_ATTR: u64 = efi::MEMORY_WB;
 /// # Example
 ///
 /// ```rust
-/// use patina::base::UEFI_PAGE_SIZE;
+/// use patina::UEFI_PAGE_SIZE;
 /// use patina::uefi_size_to_pages;
 ///
 /// let size_in_bytes = UEFI_PAGE_SIZE * 3;
@@ -178,7 +176,7 @@ pub const DEFAULT_CACHE_ATTR: u64 = efi::MEMORY_WB;
 #[macro_export]
 macro_rules! uefi_size_to_pages {
     ($size:expr) => {
-        (($size) + patina::base::UEFI_PAGE_MASK) / patina::base::UEFI_PAGE_SIZE
+        (($size) + patina::UEFI_PAGE_MASK) / patina::UEFI_PAGE_SIZE
     };
 }
 
@@ -198,7 +196,7 @@ macro_rules! uefi_size_to_pages {
 /// # Example
 ///
 /// ```rust
-/// use patina::base::UEFI_PAGE_SIZE;
+/// use patina::UEFI_PAGE_SIZE;
 /// use patina::uefi_pages_to_size;
 ///
 /// let pages = 3;
@@ -210,7 +208,7 @@ macro_rules! uefi_size_to_pages {
 #[macro_export]
 macro_rules! uefi_pages_to_size {
     ($pages:expr) => {
-        ($pages) * $crate::base::UEFI_PAGE_SIZE
+        ($pages) * $crate::UEFI_PAGE_SIZE
     };
 }
 
@@ -256,7 +254,7 @@ where
 /// # Example
 ///
 /// ```rust
-/// use patina::base::align_down;
+/// use patina::align_down;
 ///
 /// let addr: u64 = 1023;
 /// let align: u64 = 512;
@@ -302,8 +300,8 @@ where
 /// # Example
 ///
 /// ```rust
-/// use patina::base::align_up;
-/// use patina::base::error::EfiError;
+/// use patina::align_up;
+/// use patina::error::EfiError;
 ///
 /// let addr: u64 = 1025;
 /// let align: u64 = 512;
@@ -355,7 +353,7 @@ where
 ///
 /// # Example
 /// ```rust
-/// use patina::base::align_range;
+/// use patina::align_range;
 /// let base: u64 = 1023;
 /// let length: u64 = 2048;
 /// let align: u64 = 512;

--- a/sdk/patina/src/base/guid/constants.rs
+++ b/sdk/patina/src/base/guid/constants.rs
@@ -33,7 +33,7 @@ pub const CALLER_ID: BinaryGuid = BinaryGuid::from_string(match option_env!("FIL
 ///
 /// (`23C9322F-2AF2-476A-BC4C-26BC88266C71`)
 /// ```
-/// # use patina::base::guid::DXE_CORE_ID;
+/// # use patina::guid::DXE_CORE_ID;
 /// # assert_eq!("23C9322F-2AF2-476A-BC4C-26BC88266C71", format!("{}", DXE_CORE_ID));
 /// ```
 pub const DXE_CORE_ID: BinaryGuid = BinaryGuid::from_string("23C9322F-2AF2-476A-BC4C-26BC88266C71");

--- a/sdk/patina/src/base/string.rs
+++ b/sdk/patina/src/base/string.rs
@@ -208,8 +208,8 @@ impl From<StringError> for EfiError {
 #[macro_export]
 macro_rules! char16 {
     ($s:literal) => {{
-        static CHAR16_LITERAL: $crate::base::string::Char16Array<{ $crate::base::string::ucs2_capacity($s) }> =
-            $crate::base::string::Char16Array::from_str($s);
+        static CHAR16_LITERAL: $crate::string::Char16Array<{ $crate::string::ucs2_capacity($s) }> =
+            $crate::string::Char16Array::from_str($s);
         CHAR16_LITERAL.as_char16_str()
     }};
 }
@@ -231,8 +231,8 @@ macro_rules! char16 {
 #[macro_export]
 macro_rules! char8 {
     ($s:literal) => {{
-        static CHAR8_LITERAL: $crate::base::string::Char8Array<{ $crate::base::string::latin1_capacity($s) }> =
-            $crate::base::string::Char8Array::from_str($s);
+        static CHAR8_LITERAL: $crate::string::Char8Array<{ $crate::string::latin1_capacity($s) }> =
+            $crate::string::Char8Array::from_str($s);
         CHAR8_LITERAL.as_char8_str()
     }};
 }

--- a/sdk/patina/src/base/string/char16.rs
+++ b/sdk/patina/src/base/string/char16.rs
@@ -37,7 +37,7 @@ const SURROGATE_RANGE: core::ops::RangeInclusive<u16> = 0xD800..=0xDFFF;
 /// # Examples
 ///
 /// ```rust
-/// use patina::base::string::Char16Str;
+/// use patina::string::Char16Str;
 ///
 /// let units = [0x0045u16, 0x0046, 0x0049, 0x0000]; // "EFI\0"
 /// let s = Char16Str::from_units_with_nul(&units).unwrap();
@@ -306,7 +306,7 @@ fn decode_le_units(bytes: &[u8]) -> Result<Vec<u16>, StringError> {
 /// # Examples
 ///
 /// ```rust
-/// use patina::base::string::Char16String;
+/// use patina::string::Char16String;
 ///
 /// let s = Char16String::try_from_str("Boot0001").unwrap();
 /// assert_eq!(s.len(), 8);
@@ -582,7 +582,7 @@ pub const fn ucs2_capacity(s: &str) -> usize {
 /// # Examples
 ///
 /// ```rust
-/// use patina::base::string::Char16Array;
+/// use patina::string::Char16Array;
 ///
 /// const NAME: Char16Array<4> = Char16Array::from_str("EFI");
 /// assert_eq!(NAME.as_char16_str().len(), 3);

--- a/sdk/patina/src/base/string/char8.rs
+++ b/sdk/patina/src/base/string/char8.rs
@@ -35,7 +35,7 @@ use super::char16::{Char16Str, Char16String};
 /// # Examples
 ///
 /// ```rust
-/// use patina::base::string::Char8Str;
+/// use patina::string::Char8Str;
 ///
 /// let bytes = *b"EFI\0";
 /// let s = Char8Str::from_bytes_with_nul(&bytes).unwrap();
@@ -278,7 +278,7 @@ impl core::fmt::Debug for Char8Str {
 /// # Examples
 ///
 /// ```rust
-/// use patina::base::string::Char8String;
+/// use patina::string::Char8String;
 ///
 /// let s = Char8String::try_from_str("Firmware").unwrap();
 /// assert_eq!(s.len(), 8);
@@ -527,7 +527,7 @@ pub const fn latin1_capacity(s: &str) -> usize {
 /// # Examples
 ///
 /// ```rust
-/// use patina::base::string::Char8Array;
+/// use patina::string::Char8Array;
 ///
 /// const NAME: Char8Array<4> = Char8Array::from_str("EFI");
 /// assert_eq!(NAME.as_char8_str().len(), 3);

--- a/sdk/patina/src/component.rs
+++ b/sdk/patina/src/component.rs
@@ -29,7 +29,7 @@
 //!
 //! ```rust,ignore
 //! use patina::component::component;
-//! use patina::base::error::Result;
+//! use patina::error::Result;
 //!
 //! pub struct MyComponent {
 //!     data: u32,
@@ -92,7 +92,7 @@
 //!
 //! ```rust
 //! use patina::{
-//!     base::error::Result,
+//!     error::Result,
 //!     component::{
 //!         component,
 //!         params::Config,

--- a/sdk/patina/src/component/hob.rs
+++ b/sdk/patina/src/component/hob.rs
@@ -10,7 +10,7 @@
 //!
 //! ```rust
 //! use patina::{
-//!    base::error::Result,
+//!    error::Result,
 //!    component::hob::{Hob, FromHob},
 //!    BinaryGuid
 //! };

--- a/sdk/patina/src/component/params.rs
+++ b/sdk/patina/src/component/params.rs
@@ -60,7 +60,7 @@
 //! ### Example Option Usage
 //!
 //! ``` rust
-//! # use patina::{base::error::Result, component::params::{ConfigMut, Config}};
+//! # use patina::{error::Result, component::params::{ConfigMut, Config}};
 //! // This component will execute even if the config is already locked. If the interface was just
 //! // `config: ConfigMut<u32>`, and the config was locked, this component would never execute.
 //! fn my_driver(mut config: Option<ConfigMut<u32>>) -> Result<()> {
@@ -191,7 +191,7 @@ impl ComponentInput for () {}
     note = "1. The first parameter must be Self, &Self, or &mut Self.",
     note = "2. The remaining parameters must implement patina::component::params::Param",
     note = "3. Only a function with up to 5 parameters, excluding self, is supported.",
-    note = "4. The return type must be patina::base::error::Result<()>"
+    note = "4. The return type must be patina::error::Result<()>"
 )]
 pub trait ParamFunction<Marker>: Send + Sync + 'static {
     /// All parameters of the function that are retrievable from [Storage].
@@ -731,7 +731,7 @@ unsafe impl Param for StandardRuntimeServices {
 /// ```rust,ignore
 /// use patina::component::{component, params::Handle};
 /// use patina::uefi::boot_services::BootServices;
-/// use patina::base::error::Result;
+/// use patina::error::Result;
 ///
 /// struct BootLoader;
 ///

--- a/sdk/patina/src/component/service.rs
+++ b/sdk/patina/src/component/service.rs
@@ -37,7 +37,7 @@
 //!
 //! ```rust
 //! use patina::{
-//!    base::error::Result,
+//!    error::Result,
 //!    component::{
 //!        service::{IntoService, Service},
 //!        Storage,
@@ -72,7 +72,7 @@
 //!
 //! ```rust
 //! use patina::{
-//!   base::error::Result,
+//!   error::Result,
 //!   component::{
 //!     service::{IntoService, Service},
 //!     Storage,
@@ -201,7 +201,7 @@ impl<T: ?Sized + 'static> Service<T> {
     /// ## Example
     ///
     /// ```rust
-    /// # use patina::{base::error::Result, component::service::Service};
+    /// # use patina::{error::Result, component::service::Service};
     /// # trait MyService {}
     /// static MY_SERVICE: Service<dyn MyService> = Service::new_uninit();
     ///

--- a/sdk/patina/src/component/service/performance.rs
+++ b/sdk/patina/src/component/service/performance.rs
@@ -6,7 +6,7 @@
 //!
 //! SPDX-License-Identifier: Apache-2.0
 //!
-use r_efi::efi;
+use crate::standard::efi;
 
 #[cfg(any(test, feature = "mockall"))]
 use mockall::automock;

--- a/sdk/patina/src/lib.rs
+++ b/sdk/patina/src/lib.rs
@@ -11,7 +11,6 @@
 //!
 #![cfg_attr(all(not(feature = "std"), not(test), not(feature = "mockall")), no_std)]
 #![cfg_attr(any(test, feature = "alloc"), feature(allocator_api))]
-#![allow(static_mut_refs)]
 #![cfg_attr(coverage, feature(coverage_attribute))]
 
 #[cfg(any(test, feature = "alloc"))]

--- a/sdk/patina/src/lib.rs
+++ b/sdk/patina/src/lib.rs
@@ -2,7 +2,6 @@
 //!
 //! This crate implements the core SDK for Patina and is only part of the Patina
 //! solution. For general knowledge on Patina, refer to the [Patina book](https://opendevicepartnership.github.io/patina/).
-
 //!
 //! ## License
 //!
@@ -18,11 +17,14 @@
 #[cfg(any(test, feature = "alloc"))]
 extern crate alloc;
 
-pub use base::guid::{BinaryGuid, Guid, GuidError, OwnedGuid};
-pub use base::string::{Char8Array, Char8Str, Char8String, Char16Array, Char16Str, Char16String, StringError};
+// The base module gets republished from the root to flatten dependencies for common structures.
+// Additionally, certain types will also be directly exposed from the root for convenience.
+mod base;
+pub use base::*;
+pub use guid::{BinaryGuid, Guid, GuidError, OwnedGuid};
+pub use string::{Char8Array, Char8Str, Char8String, Char16Array, Char16Str, Char16String, StringError};
 
 pub mod arch;
-pub mod base;
 #[cfg(any(test, feature = "alloc"))]
 pub mod component;
 pub mod debug;

--- a/sdk/patina/src/uefi/boot_services.rs
+++ b/sdk/patina/src/uefi/boot_services.rs
@@ -6,7 +6,6 @@
 //!
 //! SPDX-License-Identifier: Apache-2.0
 //!
-
 #[cfg(feature = "global_allocator")]
 pub mod global_allocator;
 
@@ -2061,6 +2060,8 @@ impl BootServices for StandardBootServices {
 #[cfg(test)]
 #[cfg_attr(coverage, coverage(off))]
 mod tests {
+    #![allow(static_mut_refs)]
+
     use crate::BinaryGuid;
     use c_ptr::CPtr;
     use efi::{Boolean, Char16, OpenProtocolInformationEntry, protocols::device_path};

--- a/sdk/patina/src/uefi/driver_binding.rs
+++ b/sdk/patina/src/uefi/driver_binding.rs
@@ -314,6 +314,8 @@ impl<T: DriverBinding + 'static, U: BootServices + 'static> UefiDriverBinding<T,
 #[cfg(test)]
 #[cfg_attr(coverage, coverage(off))]
 mod tests {
+    #![allow(static_mut_refs)]
+
     use core::{
         mem::MaybeUninit,
         ptr,

--- a/sdk/patina/tests/test_new_component_attr.rs
+++ b/sdk/patina/tests/test_new_component_attr.rs
@@ -1,8 +1,8 @@
 //! Test for new component attribute on impl blocks
 
 use patina::{
-    base::error::Result,
     component::{IntoComponent, component, params::Config},
+    error::Result,
 };
 
 pub struct TestComponent {

--- a/sdk/patina/tests/ui/config_and_config_mut_conflict.rs
+++ b/sdk/patina/tests/ui/config_and_config_mut_conflict.rs
@@ -1,11 +1,11 @@
 //! Test that Config<T> and ConfigMut<T> for the same type are rejected at compile time.
 
 use patina::{
-    base::error::Result,
     component::{
         component,
         params::{Config, ConfigMut},
     },
+    error::Result,
 };
 
 pub struct TestComponent;

--- a/sdk/patina/tests/ui/duplicate_boot_services.rs
+++ b/sdk/patina/tests/ui/duplicate_boot_services.rs
@@ -1,6 +1,6 @@
 //! Test that duplicate StandardBootServices parameters are rejected at compile time.
 
-use patina::{base::error::Result, component::component, uefi::boot_services::StandardBootServices};
+use patina::{component::component, error::Result, uefi::boot_services::StandardBootServices};
 
 pub struct TestComponent;
 

--- a/sdk/patina/tests/ui/duplicate_commands.rs
+++ b/sdk/patina/tests/ui/duplicate_commands.rs
@@ -1,8 +1,8 @@
 //! Test that duplicate Commands parameters are rejected at compile time.
 
 use patina::{
-    base::error::Result,
     component::{component, params::Commands},
+    error::Result,
 };
 
 pub struct TestComponent;

--- a/sdk/patina/tests/ui/duplicate_config_mut.rs
+++ b/sdk/patina/tests/ui/duplicate_config_mut.rs
@@ -1,8 +1,8 @@
 //! Test that duplicate ConfigMut<T> parameters are rejected at compile time.
 
 use patina::{
-    base::error::Result,
     component::{component, params::ConfigMut},
+    error::Result,
 };
 
 pub struct TestComponent;

--- a/sdk/patina/tests/ui/duplicate_runtime_services.rs
+++ b/sdk/patina/tests/ui/duplicate_runtime_services.rs
@@ -1,6 +1,6 @@
 //! Test that duplicate StandardRuntimeServices parameters are rejected at compile time.
 
-use patina::{base::error::Result, component::component, uefi::runtime_services::StandardRuntimeServices};
+use patina::{component::component, error::Result, uefi::runtime_services::StandardRuntimeServices};
 
 pub struct TestComponent;
 

--- a/sdk/patina/tests/ui/duplicate_storage_mut.rs
+++ b/sdk/patina/tests/ui/duplicate_storage_mut.rs
@@ -1,8 +1,8 @@
 //! Test that duplicate &mut Storage parameters are rejected at compile time.
 
 use patina::{
-    base::error::Result,
     component::{Storage, component},
+    error::Result,
 };
 
 pub struct TestComponent;

--- a/sdk/patina/tests/ui/multiple_storage_allowed.rs
+++ b/sdk/patina/tests/ui/multiple_storage_allowed.rs
@@ -2,8 +2,8 @@
 //! Note: This should compile successfully.
 
 use patina::{
-    base::error::Result,
     component::{Storage, component},
+    error::Result,
 };
 
 pub struct TestComponent;

--- a/sdk/patina/tests/ui/storage_and_storage_mut_conflict.rs
+++ b/sdk/patina/tests/ui/storage_and_storage_mut_conflict.rs
@@ -1,8 +1,8 @@
 //! Test that &Storage and &mut Storage parameters cannot be mixed.
 
 use patina::{
-    base::error::Result,
     component::{Storage, component},
+    error::Result,
 };
 
 pub struct TestComponent;

--- a/sdk/patina/tests/ui/storage_mut_and_storage_conflict.rs
+++ b/sdk/patina/tests/ui/storage_mut_and_storage_conflict.rs
@@ -1,8 +1,8 @@
 //! Test that &mut Storage and &Storage parameters cannot be mixed (reverse order).
 
 use patina::{
-    base::error::Result,
     component::{Storage, component},
+    error::Result,
 };
 
 pub struct TestComponent;

--- a/sdk/patina/tests/ui/storage_mut_with_config.rs
+++ b/sdk/patina/tests/ui/storage_mut_with_config.rs
@@ -1,8 +1,8 @@
 //! Test that &mut Storage with Config<T> is rejected at compile time.
 
 use patina::{
-    base::error::Result,
     component::{Storage, component, params::Config},
+    error::Result,
 };
 
 pub struct TestComponent;

--- a/sdk/patina/tests/ui/storage_mut_with_config_mut.rs
+++ b/sdk/patina/tests/ui/storage_mut_with_config_mut.rs
@@ -1,8 +1,8 @@
 //! Test that &mut Storage with ConfigMut<T> is rejected at compile time.
 
 use patina::{
-    base::error::Result,
     component::{Storage, component, params::ConfigMut},
+    error::Result,
 };
 
 pub struct TestComponent;

--- a/sdk/patina/tests/ui/storage_with_config_mut.rs
+++ b/sdk/patina/tests/ui/storage_with_config_mut.rs
@@ -1,8 +1,8 @@
 //! Test that &Storage with ConfigMut<T> is rejected at compile time.
 
 use patina::{
-    base::error::Result,
     component::{Storage, component, params::ConfigMut},
+    error::Result,
 };
 
 pub struct TestComponent;

--- a/sdk/patina_ffs/Cargo.toml
+++ b/sdk/patina_ffs/Cargo.toml
@@ -12,7 +12,6 @@ workspace = true
 
 [dependencies]
 patina = {workspace = true}
-r-efi = {workspace = true}
 log = {workspace = true}
 
 [dev-dependencies]

--- a/sdk/patina_ffs/README.md
+++ b/sdk/patina_ffs/README.md
@@ -67,7 +67,7 @@ use alloc::vec::Vec;
 use patina::pi::fw_fs::ffs;
 use patina_ffs::file::File;
 use patina_ffs::section::{Section, SectionHeader};
-use r_efi::efi;
+use patina::standard::efi;
 
 fn build_driver_section(pe_image: Vec<u8>) -> File {
     let mut file = File::new(efi::Guid::from_bytes(&[0u8; 16]), ffs::file::raw::r#type::DRIVER);

--- a/sdk/patina_ffs/src/err.rs
+++ b/sdk/patina_ffs/src/err.rs
@@ -6,7 +6,7 @@
 //!
 //! SPDX-License-Identifier: Apache-2.0
 
-use patina::base::error::EfiError;
+use patina::error::EfiError;
 use patina::standard::efi;
 
 /// Error definitions for Firmware File System

--- a/sdk/patina_ffs/src/err.rs
+++ b/sdk/patina_ffs/src/err.rs
@@ -7,7 +7,7 @@
 //! SPDX-License-Identifier: Apache-2.0
 
 use patina::base::error::EfiError;
-use r_efi::efi;
+use patina::standard::efi;
 
 /// Error definitions for Firmware File System
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/sdk/patina_ffs/src/file.rs
+++ b/sdk/patina_ffs/src/file.rs
@@ -54,7 +54,7 @@ impl<'a> FileRef<'a> {
     ///
     /// ```rust no_run
     /// use patina_ffs::file::{File, FileRef};
-    /// use r_efi::efi;
+    /// use patina::standard::efi;
     /// use patina::pi::fw_fs::ffs;
     /// use patina_ffs::section::{Section, SectionHeader};
     ///
@@ -235,7 +235,7 @@ impl<'a> FileRef<'a> {
     ///
     /// ```rust no_run
     /// use patina::pi::fw_fs::ffs;
-    /// use r_efi::efi;
+    /// use patina::standard::efi;
     /// use patina_ffs::file::{File, FileRef};
     /// use patina_ffs::FirmwareFileSystemError;
     /// use patina_ffs::section::{Section, SectionHeader, SectionExtractor};
@@ -321,7 +321,7 @@ impl File {
     ///
     /// ```rust no_run
     /// use patina::pi::fw_fs::ffs;
-    /// use r_efi::efi;
+    /// use patina::standard::efi;
     /// use patina_ffs::file::File;
     /// use patina_ffs::section::{Section, SectionHeader};
     ///
@@ -522,7 +522,7 @@ impl File {
     ///
     /// ```rust no_run
     /// use patina::pi::fw_fs::ffs;
-    /// use r_efi::efi;
+    /// use patina::standard::efi;
     /// use patina_ffs::file::File;
     /// use patina_ffs::section::{Section, SectionHeader, SectionComposer};
     /// use patina_ffs::section::{SectionHeader as SH};
@@ -559,7 +559,7 @@ impl File {
     ///
     /// ```rust no_run
     /// use patina::pi::fw_fs::ffs;
-    /// use r_efi::efi;
+    /// use patina::standard::efi;
     /// use patina_ffs::file::File;
     /// use patina_ffs::section::{Section, SectionHeader, SectionComposer};
     /// use patina_ffs::section::SectionHeader as SH;

--- a/sdk/patina_ffs/src/section.rs
+++ b/sdk/patina_ffs/src/section.rs
@@ -11,8 +11,8 @@
 //!
 use alloc::{boxed::Box, vec, vec::Vec};
 use patina::{
-    base::align_up,
-    base::c_ptr::CPtr,
+    align_up,
+    c_ptr::CPtr,
     pi::fw_fs::ffs::{self, section},
 };
 

--- a/sdk/patina_ffs/src/volume.rs
+++ b/sdk/patina_ffs/src/volume.rs
@@ -465,7 +465,7 @@ impl Volume {
     /// use patina_ffs::volume::Volume;
     /// use patina_ffs::file::File;
     /// use patina::pi::fw_fs::{ffs, fv::BlockMapEntry};
-    /// use r_efi::efi;
+    /// use patina::standard::efi;
     ///
     /// let mut fv = Volume::new(vec![BlockMapEntry { num_blocks: 1, length: 4096 }]);
     /// fv.files_mut().push(File::new(patina::BinaryGuid::from_bytes(&[0u8; 16]), ffs::file::raw::r#type::FFS_PAD));
@@ -490,7 +490,7 @@ impl Volume {
     /// use patina_ffs::file::File;
     /// use patina_ffs::section::{Section, SectionHeader};
     /// use patina::pi::fw_fs::{ffs, fv::BlockMapEntry};
-    /// use r_efi::efi;
+    /// use patina::standard::efi;
     ///
     /// // Create a volume and add several files, each with a RAW section.
     /// let mut fv = Volume::new(vec![BlockMapEntry { num_blocks: 4, length: 4096 }]);
@@ -696,7 +696,7 @@ impl Volume {
     /// use patina_ffs::volume::Volume;
     /// use patina_ffs::section::{Section, SectionComposer, SectionHeader};
     /// use patina::pi::fw_fs::{ffs, fv::BlockMapEntry};
-    /// use r_efi::efi;
+    /// use patina::standard::efi;
     ///
     /// struct Passthrough;
     /// impl SectionComposer for Passthrough {
@@ -776,7 +776,7 @@ mod test {
     use log::{self, Level, LevelFilter, Metadata, Record};
     use lzma_rust2::{LzmaOptions, LzmaReader, LzmaWriter, Read, Write};
     use patina::pi::fw_fs::{self, ffs, fv};
-    use r_efi::efi;
+    use patina::standard::efi;
     use serde::Deserialize;
     use std::{
         collections::HashMap,

--- a/sdk/patina_ffs/src/volume.rs
+++ b/sdk/patina_ffs/src/volume.rs
@@ -18,7 +18,7 @@ use core::{
     fmt, iter, mem, ptr,
     slice::{self, from_raw_parts},
 };
-use patina::{BinaryGuid, base::align_up, log_debug_assert};
+use patina::{BinaryGuid, align_up, log_debug_assert};
 
 use patina::pi::fw_fs::{
     ffs::{self, file},
@@ -1367,7 +1367,7 @@ mod test {
                     && guid_header.section_definition_guid == fw_fs::guid::LZMA_SECTION_GUID
                 {
                     let data = section.try_content_as_slice()?;
-                    let mut reader = LzmaReader::new_mem_limit(data, patina::base::SIZE_512MB as u32, None)
+                    let mut reader = LzmaReader::new_mem_limit(data, patina::SIZE_512MB as u32, None)
                         .map_err(|_| FirmwareFileSystemError::DataCorrupt)?;
                     let mut decompressed: Vec<u8> = Vec::new();
                     let mut chunk = [0u8; 4096];
@@ -1434,7 +1434,7 @@ mod test {
                     && guid_header.section_definition_guid == fw_fs::guid::LZMA_SECTION_GUID
                 {
                     let data = section.try_content_as_slice()?;
-                    let mut reader = LzmaReader::new_mem_limit(data, patina::base::SIZE_512MB as u32, None)
+                    let mut reader = LzmaReader::new_mem_limit(data, patina::SIZE_512MB as u32, None)
                         .map_err(|_| FirmwareFileSystemError::DataCorrupt)?;
                     let mut decompressed: Vec<u8> = Vec::new();
                     let mut chunk = [0u8; 4096];

--- a/sdk/patina_ffs_extractors/src/lib.rs
+++ b/sdk/patina_ffs_extractors/src/lib.rs
@@ -46,7 +46,7 @@ pub use null::NullSectionExtractor;
 
 #[cfg(any(feature = "brotli", feature = "lzma"))]
 /// Maximum memory limit for compressed section decompression. This is set to 512MB as a reasonable upper limit.
-const DECOMPRESSION_MAX_MEMORY_LIMIT: u32 = patina::base::SIZE_512MB as u32;
+const DECOMPRESSION_MAX_MEMORY_LIMIT: u32 = patina::SIZE_512MB as u32;
 
 #[cfg(test)]
 #[cfg_attr(coverage, coverage(off))]


### PR DESCRIPTION
## Description

Second phase of large Patina SDK refactor, including:

### Add `CorePerformance` to services

The performance refactor left out declaring the `CorePerformance` service
in the derive service macro for `CorePerformance`. This commit simply
adds the missing service declaration.

### SDK Refactor: Consume r_efi republish from patina crate

This commit changes all uses of r_efi in the patina repro to instead use
the r_efi republished from the patina crate, and removing r_efi from
individual cargo dependencies.
 
### SDK Refactor: Publish all of base from Patina root

This commit republishes all of the `Patina::base::*` from the Patina
root. This flattens callers' imports and makes accessing common base types
easier.

### patina: Scope allow(static_mut_refs) only to necessary tests

Moves the global `#![allow(static_mut_refs)]` attributes to the test
modules that require it, rather than having it at the crate level.
This change improves code safety and clarity by limiting the scope of
this allowance to only where it's needed.

###

- [ ] Impacts functionality?
- [ ] Impacts security?
- [x] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

- [x] Q35 Boot
- [x] ArmVirt Boot
- [x] Cargo make all

## Integration Instructions

Consumers that import anything under `patina::base::` should instead import directly from `patina::`
