### PR TITLE
[major] Breaking changes for Patina SDK UEFI Strings [Rebase & FF]

### DIFF
--- a/components/patina_performance/src/component/table.rs
+++ b/components/patina_performance/src/component/table.rs
@@ -10,13 +10,13 @@
 use alloc::vec::Vec;
 use core::{mem, ptr};
 
-use patina::{BinaryGuid, uefi::runtime_services::RuntimeServices};
+use patina::{BinaryGuid, Char16Str, uefi::runtime_services::RuntimeServices};
 
 /// Return the address where the FBPT has been allocated during the previous boot.
 pub(crate) fn find_previous_table_address(runtime_services: &impl RuntimeServices) -> Option<usize> {
     runtime_services
         .get_variable::<FirmwarePerformanceVariable>(
-            &[0],
+            Char16Str::EMPTY,
             &FirmwarePerformanceVariable::ADDRESS_VARIABLE_GUID,
             Some(mem::size_of::<FirmwarePerformanceVariable>()),
         )
@@ -61,7 +61,7 @@ mod tests {
             .expect_get_variable::<FirmwarePerformanceVariable>()
             .once()
             .withf(|name, namespace, size_hint| {
-                assert_eq!(&[0], name);
+                assert_eq!(Char16Str::EMPTY, name);
                 assert_eq!(&FirmwarePerformanceVariable::ADDRESS_VARIABLE_GUID, namespace);
                 assert_eq!(&Some(16), size_hint);
                 true

--- a/components/patina_smbios/src/error.rs
+++ b/components/patina_smbios/src/error.rs
@@ -20,6 +20,8 @@ pub enum SmbiosError {
     StringTooLong,
     /// String contains null terminator (not allowed - terminators are added during serialization)
     StringContainsNull,
+    /// String contains a character that cannot be represented in Latin-1 (CHAR8)
+    StringNotLatin1,
     /// Empty string in string pool (consecutive null bytes)
     EmptyStringInPool,
 
@@ -90,6 +92,7 @@ impl From<SmbiosError> for patina::error::EfiError {
             // Invalid parameters map to INVALID_PARAMETER
             SmbiosError::StringTooLong
             | SmbiosError::StringContainsNull
+            | SmbiosError::StringNotLatin1
             | SmbiosError::EmptyStringInPool
             | SmbiosError::MalformedRecordHeader
             | SmbiosError::InvalidStringPoolTermination
@@ -125,6 +128,7 @@ mod tests {
         let errors = vec![
             SmbiosError::StringTooLong,
             SmbiosError::StringContainsNull,
+            SmbiosError::StringNotLatin1,
             SmbiosError::EmptyStringInPool,
             SmbiosError::RecordTooSmall,
             SmbiosError::MalformedRecordHeader,

--- a/components/patina_smbios/src/manager/core.rs
+++ b/components/patina_smbios/src/manager/core.rs
@@ -172,7 +172,7 @@ impl SmbiosManager {
     /// Validate a string for use in SMBIOS records
     ///
     /// Ensures the string meets SMBIOS specification requirements:
-    /// - Does not exceed SMBIOS_STRING_MAX_LENGTH (64 bytes)
+    /// - Can be encoded as Latin-1 (CHAR8) and does not exceed SMBIOS_STRING_MAX_LENGTH (64 bytes)
     /// - Does not contain null terminators (they are added during serialization)
     ///
     /// # Arguments
@@ -183,14 +183,7 @@ impl SmbiosManager {
     ///
     /// Returns `Ok(())` if valid, or an appropriate error if validation fails
     pub(super) fn validate_string(s: &str) -> Result<(), SmbiosError> {
-        if s.len() > SMBIOS_STRING_MAX_LENGTH {
-            return Err(SmbiosError::StringTooLong);
-        }
-        // Strings must NOT contain null terminators - they are added during serialization
-        if s.bytes().any(|b| b == 0) {
-            return Err(SmbiosError::StringContainsNull);
-        }
-        Ok(())
+        crate::smbios_record::validate_smbios_string(s)
     }
 
     /// Efficiently validate string pool format and count strings in a single pass
@@ -261,7 +254,7 @@ impl SmbiosManager {
     /// # Errors
     ///
     /// Returns the same errors as `validate_and_count_strings` if the pool format is invalid.
-    pub(super) fn parse_strings_from_pool(string_pool_area: &[u8]) -> Result<Vec<&str>, SmbiosError> {
+    pub(super) fn parse_strings_from_pool(string_pool_area: &[u8]) -> Result<Vec<String>, SmbiosError> {
         // First validate the pool
         Self::validate_and_count_strings(string_pool_area)?;
 
@@ -275,13 +268,14 @@ impl SmbiosManager {
         // Remove the final double-null terminator and split by null bytes
         let data_without_terminator = &string_pool_area[..len - 2];
 
-        // Split by null bytes and convert to &str slices
-        let strings: Result<Vec<&str>, _> = data_without_terminator
+        // Split by null bytes and decode each segment so every byte maps directly onto its
+        // Unicode scalar value.
+        let strings = data_without_terminator
             .split(|&b| b == 0)
-            .map(|bytes| core::str::from_utf8(bytes).map_err(|_| SmbiosError::MalformedRecordHeader))
+            .map(|bytes| bytes.iter().map(|&b| b as char).collect())
             .collect();
 
-        strings
+        Ok(strings)
     }
 
     /// This function is called when the request handle is NOT FFFE.
@@ -661,10 +655,7 @@ impl SmbiosManager {
         // Extract existing strings from the string pool using the helper function
         let string_pool_start = header_length;
         let string_pool = &record.data[string_pool_start..];
-        let existing_strings_refs = Self::parse_strings_from_pool(string_pool)?;
-
-        // Convert to owned strings so we can modify them
-        let mut existing_strings: Vec<String> = existing_strings_refs.iter().map(|s| String::from(*s)).collect();
+        let mut existing_strings = Self::parse_strings_from_pool(string_pool)?;
 
         // Validate that we have enough strings
         if string_number > existing_strings.len() {
@@ -683,7 +674,7 @@ impl SmbiosManager {
 
         // Rebuild the string pool
         for s in &existing_strings {
-            new_data.extend_from_slice(s.as_bytes());
+            new_data.extend_from_slice(&crate::smbios_record::encode_smbios_string(s));
             new_data.push(0); // Null terminator
         }
 
@@ -868,12 +859,15 @@ mod tests {
         assert!(SmbiosManager::validate_string("Valid-String_With.Symbols").is_ok());
         let max_string = "a".repeat(SMBIOS_STRING_MAX_LENGTH);
         assert!(SmbiosManager::validate_string(&max_string).is_ok());
+        let max_latin1_string = "é".repeat(SMBIOS_STRING_MAX_LENGTH);
+        assert!(SmbiosManager::validate_string(&max_latin1_string).is_ok());
 
         // Error cases
         let long_string = "a".repeat(SMBIOS_STRING_MAX_LENGTH + 1);
         assert_eq!(SmbiosManager::validate_string(&long_string), Err(SmbiosError::StringTooLong));
         assert_eq!(SmbiosManager::validate_string("test\0string"), Err(SmbiosError::StringContainsNull));
         assert_eq!(SmbiosManager::validate_string("before\0after"), Err(SmbiosError::StringContainsNull));
+        assert_eq!(SmbiosManager::validate_string("emoji \u{1F600}"), Err(SmbiosError::StringNotLatin1));
     }
 
     #[test]
@@ -1117,6 +1111,32 @@ mod tests {
         manager.update_string(handle, 2, "new_second_string").expect("update failed");
         assert!(manager.update_string(handle, 1, "new_first").is_ok());
         assert!(manager.update_string(handle, 3, "new_third").is_ok());
+    }
+
+    #[test]
+    fn test_update_string_latin1_from_string_pool() {
+        // Strings containing Latin-1 supplement characters (U+0080..=U+00FF) must be encoded as
+        // a single byte each (not multi-byte UTF-8), and must be readable back from the string pool.
+        let manager = SmbiosManager::new(3, 9).expect("failed to create manager");
+        let mut record_data = vec![1u8, 4, 0, 0];
+        record_data.extend_from_slice(b"placeholder\0\0");
+        let handle = manager.add_from_bytes(None, &record_data).expect("add failed");
+
+        manager.update_string(handle, 1, "café").expect("update failed");
+
+        let pos = manager.records.borrow().iter().position(|r| r.header.handle == handle).unwrap();
+        let records = manager.records.borrow();
+        let header_length = records[pos].header.length as usize;
+        let string_pool = &records[pos].data[header_length..];
+
+        assert_eq!(string_pool, [b'c', b'a', b'f', 0xE9, 0, 0]);
+
+        // Reading the string backmust decode the extended character correctly.
+        let parsed = SmbiosManager::parse_strings_from_pool(string_pool).expect("parse failed");
+        assert_eq!(parsed, vec!["café"]);
+        drop(records);
+
+        assert!(manager.update_string(handle, 1, "resume").is_ok());
     }
 
     #[test]

--- a/components/patina_smbios/src/smbios_record.rs
+++ b/components/patina_smbios/src/smbios_record.rs
@@ -237,10 +237,11 @@
 extern crate alloc;
 use crate::{
     error::SmbiosError,
-    service::{SMBIOS_HANDLE_PI_RESERVED, SmbiosTableHeader},
+    service::{SMBIOS_HANDLE_PI_RESERVED, SMBIOS_STRING_MAX_LENGTH, SmbiosTableHeader},
     smbios_types::*,
 };
 use alloc::{string::String, vec::Vec};
+use patina::{Char8String, StringError};
 
 /// Base trait for SMBIOS record structures
 ///
@@ -269,6 +270,44 @@ pub trait SmbiosRecordStructure {
 
     /// Get mutable access to the string pool
     fn string_pool_mut(&mut self) -> &mut Vec<String>;
+}
+
+/// Validates a string for use in an SMBIOS string pool.
+///
+/// # Errors
+///
+/// Returns [`SmbiosError::StringContainsNull`] if `s` contains a NUL character,
+/// [`SmbiosError::StringNotLatin1`] if `s` contains a code point above `U+00FF`, or
+/// [`SmbiosError::StringTooLong`] if the encoded string exceeds [`SMBIOS_STRING_MAX_LENGTH`].
+pub fn validate_smbios_string(s: &str) -> Result<(), SmbiosError> {
+    let char8_str = Char8String::try_from_str(s).map_err(|error| match error {
+        StringError::InteriorNul { .. } => SmbiosError::StringContainsNull,
+        _ => SmbiosError::StringNotLatin1,
+    })?;
+
+    if char8_str.len() > SMBIOS_STRING_MAX_LENGTH {
+        return Err(SmbiosError::StringTooLong);
+    }
+
+    Ok(())
+}
+
+/// Encodes `s` as SMBIOS string-pool bytes (`CHAR8` without a NUL terminator).
+///
+/// Each character is encoded as a single byte via [`Char8String::try_from_str`]. Because
+/// [`SmbiosRecordStructure::to_bytes`] cannot fail, a character that can't be represented (a NUL, or a
+/// code point above `U+00FF`) is replaced with `?` instead of rejecting the whole string.
+pub fn encode_smbios_string(s: &str) -> Vec<u8> {
+    match Char8String::try_from_str(s) {
+        Ok(char8_str) => char8_str.as_bytes().to_vec(),
+        Err(_) => s
+            .chars()
+            .map(|c| {
+                let value = c as u32;
+                if value == 0 || value > 0xFF { b'?' } else { value as u8 }
+            })
+            .collect(),
+    }
 }
 
 /// Type 0: Platform Firmware Information (BIOS Information)

--- a/patina_dxe_core/src/filesystems.rs
+++ b/patina_dxe_core/src/filesystems.rs
@@ -8,8 +8,7 @@
 //!
 use alloc::{vec, vec::Vec};
 use core::{ffi::c_void, mem::size_of};
-use patina::error::EfiError;
-use patina::standard::efi;
+use patina::{Char16Str, error::EfiError, standard::efi};
 
 use crate::protocols::PROTOCOL_DB;
 
@@ -20,7 +19,7 @@ pub struct SimpleFile<'a> {
 
 impl SimpleFile<'_> {
     /// Opens the given filename with appropriate mode/attributes and returns a new instance of SimpleFile for it.
-    pub fn open(&mut self, filename: Vec<u16>, mode: u64, attributes: u64) -> Result<Self, EfiError> {
+    pub fn open(&mut self, filename: &Char16Str, mode: u64, attributes: u64) -> Result<Self, EfiError> {
         let mut file_ptr = core::ptr::null_mut();
         // SAFETY: self.file is a valid pointer to a file protocol instance
         // obtained from the protocol database during the construction of this

--- a/patina_dxe_core/src/misc_boot_services.rs
+++ b/patina_dxe_core/src/misc_boot_services.rs
@@ -319,6 +319,7 @@ mod tests {
         test_support,
     };
     use core::{ffi::c_void, ptr};
+    use patina::char16;
     use patina::pi::protocol::watchdog;
     use patina::standard::efi;
 
@@ -446,13 +447,15 @@ mod tests {
                 log::warn!("Disable watchdog timer returned unexpected status: {status}");
             }
 
-            let data: [efi::Char16; 6] = [b'H' as u16, b'e' as u16, b'l' as u16, b'l' as u16, b'o' as u16, 0];
+            let data = char16!("Hello");
             let data_ptr = data.as_ptr() as *mut efi::Char16;
 
             // Test case 3: Set the watchdog timer with non-null data - should return NOT_READY
             // SAFETY: The unsafe block is required because r-efi declares set_watchdog_timer as an
             // unsafe extern "efiapi" function pointer. The Patina implementation is fully safe.
-            let status = unsafe { (st.boot_services().get().set_watchdog_timer)(300, 0, data.len(), data_ptr) };
+            let status = unsafe {
+                (st.boot_services().get().set_watchdog_timer)(300, 0, data.as_units_with_nul().len(), data_ptr)
+            };
             if status == efi::Status::NOT_READY {
                 log::debug!("Set watchdog timer with data correctly returned NOT_READY");
             } else {
@@ -462,7 +465,9 @@ mod tests {
             // Test case 4: Disable the watchdog timer with non-null data - should return NOT_READY
             // SAFETY: The unsafe block is required because r-efi declares set_watchdog_timer as an
             // unsafe extern "efiapi" function pointer. The Patina implementation is fully safe.
-            let status = unsafe { (st.boot_services().get().set_watchdog_timer)(0, 0, data.len(), data_ptr) };
+            let status = unsafe {
+                (st.boot_services().get().set_watchdog_timer)(0, 0, data.as_units_with_nul().len(), data_ptr)
+            };
             if status == efi::Status::NOT_READY {
                 log::debug!("Disable watchdog timer with data correctly returned NOT_READY");
             } else {

--- a/patina_dxe_core/src/pi_dispatcher/image.rs
+++ b/patina_dxe_core/src/pi_dispatcher/image.rs
@@ -1426,7 +1426,7 @@ fn get_file_buffer_from_sfs(file_path: NonNull<Protocol>) -> Result<(Vec<u8>, ef
             .collect::<Result<Vec<_>, _>>()?;
         let filename = Char16Str::from_units_until_nul(&filename)?;
 
-        file = file.open(filename.as_units_with_nul().to_vec(), efi::protocols::file::MODE_READ, 0)?;
+        file = file.open(filename, efi::protocols::file::MODE_READ, 0)?;
     }
 
     // if execution comes here, the above loop was successfully able to open all the files on the remaining device path,

--- a/sdk/patina/src/performance/record.rs
+++ b/sdk/patina/src/performance/record.rs
@@ -10,7 +10,7 @@
 pub mod extended;
 pub mod known;
 
-use crate::{BinaryGuid, performance::error::Error, performance_debug_assert};
+use crate::{BinaryGuid, Char8Str, performance::error::Error, performance_debug_assert};
 use alloc::vec::Vec;
 use core::{fmt, fmt::Debug, mem};
 use zerocopy::{FromBytes, IntoBytes};
@@ -376,12 +376,11 @@ impl DynamicStringEventRecordData {
     pub const NAME: &'static str = "Dynamic String Event";
 
     /// Get the string portion from the full record data
-    pub fn extract_string(full_data: &[u8]) -> &str {
+    pub fn extract_string(full_data: &[u8]) -> &Char8Str {
         let Some(string_bytes) = full_data.get(core::mem::size_of::<Self>()..) else {
-            return "";
+            return Char8Str::EMPTY;
         };
-        let string_len = string_bytes.iter().position(|&b| b == 0).unwrap_or(string_bytes.len());
-        core::str::from_utf8(string_bytes.get(..string_len).unwrap_or(string_bytes)).unwrap_or("<invalid UTF-8>")
+        Char8Str::from_bytes_until_nul(string_bytes).unwrap_or(Char8Str::EMPTY)
     }
 }
 
@@ -420,12 +419,11 @@ impl DualGuidStringEventRecordData {
     pub const NAME: &'static str = "Dual GUID String Event";
 
     /// Get the string portion from the full record data
-    pub fn extract_string(full_data: &[u8]) -> &str {
+    pub fn extract_string(full_data: &[u8]) -> &Char8Str {
         let Some(string_bytes) = full_data.get(core::mem::size_of::<Self>()..) else {
-            return "";
+            return Char8Str::EMPTY;
         };
-        let string_len = string_bytes.iter().position(|&b| b == 0).unwrap_or(string_bytes.len());
-        core::str::from_utf8(string_bytes.get(..string_len).unwrap_or(string_bytes)).unwrap_or("<invalid UTF-8>")
+        Char8Str::from_bytes_until_nul(string_bytes).unwrap_or(Char8Str::EMPTY)
     }
 }
 
@@ -508,12 +506,11 @@ impl GuidQwordStringEventRecordData {
     pub const NAME: &'static str = "GUID QWORD String Event";
 
     /// Get the string portion from the full record data
-    pub fn extract_string(full_data: &[u8]) -> &str {
+    pub fn extract_string(full_data: &[u8]) -> &Char8Str {
         let Some(string_bytes) = full_data.get(core::mem::size_of::<Self>()..) else {
-            return "";
+            return Char8Str::EMPTY;
         };
-        let string_len = string_bytes.iter().position(|&b| b == 0).unwrap_or(string_bytes.len());
-        core::str::from_utf8(string_bytes.get(..string_len).unwrap_or(string_bytes)).unwrap_or("<invalid UTF-8>")
+        Char8Str::from_bytes_until_nul(string_bytes).unwrap_or(Char8Str::EMPTY)
     }
 }
 
@@ -902,12 +899,13 @@ mod tests {
     }
 
     #[test]
-    fn test_dynamic_string_event_record_data_extract_string_invalid_utf8() {
+    fn test_dynamic_string_event_record_data_extract_string_latin1_high_bytes() {
+        // Note: CHAR8 is ASCII/ISO-Latin-1, so bytes above 0x7F are valid characters rather than an error.
         let mut data = vec![0u8; core::mem::size_of::<DynamicStringEventRecordData>()];
-        data.extend_from_slice(&[0xFF, 0xFE, 0xFD, 0x00]); // Invalid UTF-8
+        data.extend_from_slice(&[0xFF, 0xFE, 0xFD, 0x00]);
 
         let extracted = DynamicStringEventRecordData::extract_string(&data);
-        assert_eq!(extracted, "<invalid UTF-8>");
+        assert_eq!(extracted, "\u{FF}\u{FE}\u{FD}");
     }
 
     #[test]
@@ -915,8 +913,10 @@ mod tests {
         let mut data = vec![0u8; core::mem::size_of::<DynamicStringEventRecordData>()];
         data.extend_from_slice(b"NoNull");
 
+        // Note: Unterminated data cannot be represented as a valid `Char8Str`, so extraction falls back
+        // to an empty string.
         let extracted = DynamicStringEventRecordData::extract_string(&data);
-        assert_eq!(extracted, "NoNull");
+        assert_eq!(extracted, "");
     }
 
     #[test]

--- a/sdk/patina/src/performance/record/extended.rs
+++ b/sdk/patina/src/performance/record/extended.rs
@@ -10,7 +10,7 @@
 use core::fmt::Debug;
 
 use super::PerformanceRecord;
-use crate::performance::error::Error;
+use crate::{Char8String, performance::error::Error};
 
 /// A performance string event record which includes a GUID.
 #[derive(Debug)]
@@ -105,8 +105,8 @@ impl PerformanceRecord for DynamicStringEventRecord<'_> {
         write_u32_le(buff, offset, self.acpi_id)?;
         write_u64_le(buff, offset, self.timestamp)?;
         write_bytes(buff, offset, self.guid.as_bytes())?;
-        write_bytes(buff, offset, self.string.as_bytes())?;
-        write_u8(buff, offset, 0)?; // terminator
+        let string = Char8String::try_from_str(self.string).map_err(|_| Error::Serialization)?;
+        write_bytes(buff, offset, string.as_bytes_with_nul())?;
         Ok(())
     }
 }
@@ -167,8 +167,8 @@ impl PerformanceRecord for DualGuidStringEventRecord<'_> {
         write_u64_le(buff, offset, self.timestamp)?;
         write_bytes(buff, offset, self.guid_1.as_bytes())?;
         write_bytes(buff, offset, self.guid_2.as_bytes())?;
-        write_bytes(buff, offset, self.string.as_bytes())?;
-        write_u8(buff, offset, 0)?;
+        let string = Char8String::try_from_str(self.string).map_err(|_| Error::Serialization)?;
+        write_bytes(buff, offset, string.as_bytes_with_nul())?;
         Ok(())
     }
 }
@@ -278,8 +278,8 @@ impl PerformanceRecord for GuidQwordStringEventRecord<'_> {
         write_u64_le(buff, offset, self.timestamp)?;
         write_bytes(buff, offset, self.guid.as_bytes())?;
         write_u64_le(buff, offset, self.qword)?;
-        write_bytes(buff, offset, self.string.as_bytes())?;
-        write_u8(buff, offset, 0)?;
+        let string = Char8String::try_from_str(self.string).map_err(|_| Error::Serialization)?;
+        write_bytes(buff, offset, string.as_bytes_with_nul())?;
         Ok(())
     }
 }
@@ -324,10 +324,6 @@ fn write_uint<T: IntoLeBytes>(dest: &mut [u8], offset: &mut usize, v: T) -> Resu
     write_bytes(dest, offset, bytes.as_ref())
 }
 
-fn write_u8(dest: &mut [u8], offset: &mut usize, v: u8) -> Result<(), Error> {
-    write_uint(dest, offset, v)
-}
-
 fn write_u16_le(dest: &mut [u8], offset: &mut usize, v: u16) -> Result<(), Error> {
     write_uint(dest, offset, v)
 }
@@ -338,4 +334,80 @@ fn write_u32_le(dest: &mut [u8], offset: &mut usize, v: u32) -> Result<(), Error
 
 fn write_u64_le(dest: &mut [u8], offset: &mut usize, v: u64) -> Result<(), Error> {
     write_uint(dest, offset, v)
+}
+
+#[cfg(test)]
+#[cfg_attr(coverage, coverage(off))]
+mod tests {
+    use super::*;
+
+    fn guid(byte: u8) -> crate::BinaryGuid {
+        crate::BinaryGuid::from_bytes(&[byte; 16])
+    }
+
+    #[test]
+    fn test_dynamic_string_event_record_write_data_into() {
+        let record = DynamicStringEventRecord::new(1, 2, 3, guid(1), "EFI");
+        let mut buf = [0u8; 64];
+        let mut offset = 0;
+        record.write_data_into(&mut buf, &mut offset).unwrap();
+        assert_eq!(offset, 34); // 2 + 4 + 8 + 16 + 3 chars + 1 nul
+        assert_eq!(&buf[30..34], b"EFI\0");
+    }
+
+    #[test]
+    fn test_dynamic_string_event_record_write_data_into_latin1_extended() {
+        // 'é' (U+00E9) is valid Latin-1 and must be encoded as a single byte (0xE9), not the
+        // two-byte UTF-8 sequence [0xC3, 0xA9].
+        let record = DynamicStringEventRecord::new(1, 2, 3, guid(1), "caf\u{e9}");
+        let mut buf = [0u8; 64];
+        let mut offset = 0;
+        record.write_data_into(&mut buf, &mut offset).unwrap();
+        assert_eq!(offset, 35); // 30 + 4 chars + 1 nul
+        assert_eq!(&buf[30..35], &[b'c', b'a', b'f', 0xE9, 0]);
+    }
+
+    #[test]
+    fn test_dynamic_string_event_record_write_data_into_rejects_non_latin1() {
+        let record = DynamicStringEventRecord::new(1, 2, 3, guid(1), "bad \u{1F600}");
+        let mut buf = [0u8; 64];
+        let mut offset = 0;
+        assert_eq!(record.write_data_into(&mut buf, &mut offset), Err(Error::Serialization));
+    }
+
+    #[test]
+    fn test_dual_guid_string_event_record_write_data_into() {
+        let record = DualGuidStringEventRecord::new(1, 2, 3, guid(1), guid(2), "EFI");
+        let mut buf = [0u8; 64];
+        let mut offset = 0;
+        record.write_data_into(&mut buf, &mut offset).unwrap();
+        assert_eq!(offset, 50); // 2 + 4 + 8 + 16 + 16 + 3 chars + 1 nul
+        assert_eq!(&buf[46..50], b"EFI\0");
+    }
+
+    #[test]
+    fn test_dual_guid_string_event_record_write_data_into_rejects_non_latin1() {
+        let record = DualGuidStringEventRecord::new(1, 2, 3, guid(1), guid(2), "bad \u{1F600}");
+        let mut buf = [0u8; 64];
+        let mut offset = 0;
+        assert_eq!(record.write_data_into(&mut buf, &mut offset), Err(Error::Serialization));
+    }
+
+    #[test]
+    fn test_guid_qword_string_event_record_write_data_into() {
+        let record = GuidQwordStringEventRecord::new(1, 2, 3, guid(1), 64, "EFI");
+        let mut buf = [0u8; 64];
+        let mut offset = 0;
+        record.write_data_into(&mut buf, &mut offset).unwrap();
+        assert_eq!(offset, 42); // 2 + 4 + 8 + 16 + 8 + 3 chars + 1 nul
+        assert_eq!(&buf[38..42], b"EFI\0");
+    }
+
+    #[test]
+    fn test_guid_qword_string_event_record_write_data_into_rejects_non_latin1() {
+        let record = GuidQwordStringEventRecord::new(1, 2, 3, guid(1), 64, "bad \u{1F600}");
+        let mut buf = [0u8; 64];
+        let mut offset = 0;
+        assert_eq!(record.write_data_into(&mut buf, &mut offset), Err(Error::Serialization));
+    }
 }

--- a/sdk/patina/src/uefi/runtime_services.rs
+++ b/sdk/patina/src/uefi/runtime_services.rs
@@ -28,6 +28,8 @@ use spin::Once;
 use crate::standard::efi;
 use variable_services::{GetVariableStatus, VariableInfo};
 
+use crate::{Char16Str, Char16String};
+
 /// The UEFI spec runtime services.
 /// Wrapper around [`efi::RuntimeServices`]
 ///
@@ -128,20 +130,22 @@ pub trait RuntimeServices {
     ///
     /// UEFI Spec Documentation: [8.2.3. EFI_RUNTIME_SERVICES.SetVariable()](https://uefi.org/specs/UEFI/2.10/08_Services_Runtime_Services.html#setvariable)
     ///
-    fn set_variable<T>(&self, name: &[u16], namespace: &efi::Guid, attributes: u32, data: &T) -> Result<(), efi::Status>
+    fn set_variable<T>(
+        &self,
+        name: &Char16Str,
+        namespace: &efi::Guid,
+        attributes: u32,
+        data: &T,
+    ) -> Result<(), efi::Status>
     where
         T: AsRef<[u8]> + 'static,
     {
-        if !name.contains(&0) {
-            debug_assert!(false, "Name passed into set_variable is not null-terminated.");
-            return Err(efi::Status::INVALID_PARAMETER);
-        }
-
         // Keep a local copy of name to unburden the caller of having to pass in a mutable slice
-        let mut name_vec = name.to_vec();
+        let mut name_vec = name.as_units_with_nul().to_vec();
 
-        // SAFETY: name_vec is a valid, null-terminated UTF-16 string as verified above.
-        // The unchecked variant is called with proper parameters that satisfy its preconditions.
+        // SAFETY: name_vec is a valid, null-terminated UCS-2 string because it was derived from a
+        // validated Char16Str. The unchecked variant is called with proper parameters that satisfy
+        // its preconditions.
         unsafe { self.set_variable_unchecked(name_vec.as_mut_slice(), namespace, attributes, data.as_ref()) }
     }
 
@@ -153,20 +157,15 @@ pub trait RuntimeServices {
     ///
     fn get_variable<T>(
         &self,
-        name: &[u16],
+        name: &Char16Str,
         namespace: &efi::Guid,
         size_hint: Option<usize>,
     ) -> Result<(T, u32), efi::Status>
     where
         T: TryFrom<Vec<u8>> + 'static,
     {
-        if !name.contains(&0) {
-            debug_assert!(false, "Name passed into get_variable is not null-terminated.");
-            return Err(efi::Status::INVALID_PARAMETER);
-        }
-
         // Keep a local copy of name to unburden the caller of having to pass in a mutable slice
-        let mut name_vec = name.to_vec();
+        let mut name_vec = name.as_units_with_nul().to_vec();
 
         // We can't simply allocate an empty buffer of size T because we can't assume
         // the TryFrom representation of T will be the same as T
@@ -182,7 +181,7 @@ pub trait RuntimeServices {
         // call.
         let mut first_attempt = true;
         loop {
-            // SAFETY: name_vec is a valid, null-terminated UTF-16 string. The data buffer, when provided,
+            // SAFETY: name_vec is a valid, null-terminated UCS-2 string. The data buffer, when provided,
             // is properly sized based on either the size_hint or the result from the first call.
             unsafe {
                 let status = self.get_variable_unchecked(
@@ -215,19 +214,14 @@ pub trait RuntimeServices {
     /// Helper function to get a UEFI variable's size and attributes
     fn get_variable_size_and_attributes(
         &self,
-        name: &[u16],
+        name: &Char16Str,
         namespace: &efi::Guid,
     ) -> Result<(usize, u32), efi::Status> {
-        if !name.contains(&0) {
-            debug_assert!(false, "Name passed into set_variable is not null-terminated.");
-            return Err(efi::Status::INVALID_PARAMETER);
-        }
-
         // Keep a local copy of name to unburden the caller of having to pass in a mutable slice
-        let mut name_vec = name.to_vec();
+        let mut name_vec = name.as_units_with_nul().to_vec();
 
-        // SAFETY: name_vec is a valid, null-terminated UTF-16 string as verified above.
-        // Calling with None buffer is safe and returns size/attributes only.
+        // SAFETY: name_vec is a valid, null-terminated UCS-2 string because it was derived from a
+        // validated Char16Str. Calling with None buffer is safe and returns size/attributes only.
         unsafe {
             match self.get_variable_unchecked(name_vec.as_mut_slice(), namespace, None) {
                 GetVariableStatus::BufferTooSmall { data_size, attributes } => Ok((data_size, attributes)),
@@ -250,22 +244,27 @@ pub trait RuntimeServices {
     ///
     fn get_next_variable_name(
         &self,
-        prev_name: &[u16],
+        prev_name: &Char16Str,
         prev_namespace: &efi::Guid,
-    ) -> Result<(Vec<u16>, efi::Guid), efi::Status> {
-        if prev_name.is_empty() {
-            debug_assert!(false, "Zero-length name passed into get_next_variable_name.");
-            return Err(efi::Status::INVALID_PARAMETER);
-        }
-
+    ) -> Result<(Char16String, efi::Guid), efi::Status> {
         let mut next_name = Vec::<u16>::new();
         let mut next_namespace: efi::Guid = efi::Guid::from_bytes(&[0x0; 16]);
 
-        // SAFETY: prev_name is validated to be non-empty above. The next_name and next_namespace
-        // are valid mutable references that will be populated by the unchecked call.
+        // SAFETY: prev_name is guaranteed non-empty and null-terminated by the Char16Str invariant.
+        // The next_name and next_namespace are valid mutable references that will be populated by
+        // the unchecked call.
         unsafe {
-            self.get_next_variable_name_unchecked(prev_name, prev_namespace, &mut next_name, &mut next_namespace)?;
+            self.get_next_variable_name_unchecked(
+                prev_name.as_units_with_nul(),
+                prev_namespace,
+                &mut next_name,
+                &mut next_namespace,
+            )?;
         };
+
+        // The firmware call above populates next_name as a valid, null-terminated UCS-2 buffer on
+        // success; treat anything else as a firmware error rather than panicking.
+        let next_name = Char16String::from_units_with_nul(next_name).map_err(|_| efi::Status::DEVICE_ERROR)?;
 
         Ok((next_name, next_namespace))
     }
@@ -534,9 +533,7 @@ pub(crate) mod test {
     pub(crate) use runtime_services;
 
     pub const DUMMY_FIRST_NAME: [u16; 3] = [0x1000, 0x1020, 0x0000];
-    pub const DUMMY_NON_NULL_TERMINATED_NAME: [u16; 3] = [0x1000, 0x1020, 0x1040];
     pub const DUMMY_EMPTY_NAME: [u16; 1] = [0x0000];
-    pub const DUMMY_ZERO_LENGTH_NAME: [u16; 0] = [];
     pub const DUMMY_SECOND_NAME: [u16; 5] = [0x1001, 0x1022, 0x1043, 0x1064, 0x0000];
     pub const DUMMY_UNKNOWN_NAME: [u16; 3] = [0x2000, 0x2020, 0x0000];
 
@@ -775,7 +772,8 @@ pub(crate) mod test {
     fn test_get_variable() {
         let rs = runtime_services!(get_variable = mock_efi_get_variable);
 
-        let status = rs.get_variable::<DummyVariableType>(&DUMMY_FIRST_NAME, &DUMMY_FIRST_NAMESPACE, None);
+        let name = Char16Str::from_units_with_nul(&DUMMY_FIRST_NAME).unwrap();
+        let status = rs.get_variable::<DummyVariableType>(name, &DUMMY_FIRST_NAMESPACE, None);
 
         assert!(status.is_ok());
         let (data, attributes) = status.unwrap();
@@ -784,21 +782,11 @@ pub(crate) mod test {
     }
 
     #[test]
-    fn test_get_variable_non_terminated() {
-        let rs = runtime_services!(get_variable = mock_efi_get_variable);
-
-        let status =
-            rs.get_variable::<DummyVariableType>(&DUMMY_NON_NULL_TERMINATED_NAME, &DUMMY_FIRST_NAMESPACE, None);
-
-        assert!(status.is_err());
-        assert_eq!(status.unwrap_err(), efi::Status::INVALID_PARAMETER);
-    }
-
-    #[test]
     fn test_get_variable_low_size_hint() {
         let rs = runtime_services!(get_variable = mock_efi_get_variable);
 
-        let status = rs.get_variable::<DummyVariableType>(&DUMMY_FIRST_NAME, &DUMMY_FIRST_NAMESPACE, Some(1));
+        let name = Char16Str::from_units_with_nul(&DUMMY_FIRST_NAME).unwrap();
+        let status = rs.get_variable::<DummyVariableType>(name, &DUMMY_FIRST_NAMESPACE, Some(1));
 
         assert!(status.is_ok());
         let (data, attributes) = status.unwrap();
@@ -810,7 +798,8 @@ pub(crate) mod test {
     fn test_get_variable_not_found() {
         let rs = runtime_services!(get_variable = mock_efi_get_variable);
 
-        let status = rs.get_variable::<DummyVariableType>(&DUMMY_UNKNOWN_NAME, &DUMMY_FIRST_NAMESPACE, Some(1));
+        let name = Char16Str::from_units_with_nul(&DUMMY_UNKNOWN_NAME).unwrap();
+        let status = rs.get_variable::<DummyVariableType>(name, &DUMMY_FIRST_NAMESPACE, Some(1));
 
         assert!(status.is_err());
         assert_eq!(status.unwrap_err(), efi::Status::NOT_FOUND);
@@ -820,7 +809,8 @@ pub(crate) mod test {
     fn test_get_variable_size_and_attributes() {
         let rs = runtime_services!(get_variable = mock_efi_get_variable);
 
-        let status = rs.get_variable_size_and_attributes(&DUMMY_FIRST_NAME, &DUMMY_FIRST_NAMESPACE);
+        let name = Char16Str::from_units_with_nul(&DUMMY_FIRST_NAME).unwrap();
+        let status = rs.get_variable_size_and_attributes(name, &DUMMY_FIRST_NAMESPACE);
 
         assert!(status.is_ok());
         let (size, attributes) = status.unwrap();
@@ -834,27 +824,10 @@ pub(crate) mod test {
 
         let data = DummyVariableType { value: DUMMY_DATA };
 
-        let status =
-            rs.set_variable::<DummyVariableType>(&DUMMY_FIRST_NAME, &DUMMY_FIRST_NAMESPACE, DUMMY_ATTRIBUTES, &data);
+        let name = Char16Str::from_units_with_nul(&DUMMY_FIRST_NAME).unwrap();
+        let status = rs.set_variable::<DummyVariableType>(name, &DUMMY_FIRST_NAMESPACE, DUMMY_ATTRIBUTES, &data);
 
         assert!(status.is_ok());
-    }
-
-    #[test]
-    fn test_set_variable_non_terminated() {
-        let rs = runtime_services!(set_variable = mock_efi_set_variable);
-
-        let data = DummyVariableType { value: DUMMY_DATA };
-
-        let status = rs.set_variable::<DummyVariableType>(
-            &DUMMY_NON_NULL_TERMINATED_NAME,
-            &DUMMY_FIRST_NAMESPACE,
-            DUMMY_ATTRIBUTES,
-            &data,
-        );
-
-        assert!(status.is_err());
-        assert_eq!(status.unwrap_err(), efi::Status::INVALID_PARAMETER);
     }
 
     #[test]
@@ -863,8 +836,8 @@ pub(crate) mod test {
 
         let data = DummyVariableType { value: DUMMY_DATA };
 
-        let status =
-            rs.set_variable::<DummyVariableType>(&DUMMY_EMPTY_NAME, &DUMMY_FIRST_NAMESPACE, DUMMY_ATTRIBUTES, &data);
+        let name = Char16Str::from_units_with_nul(&DUMMY_EMPTY_NAME).unwrap();
+        let status = rs.set_variable::<DummyVariableType>(name, &DUMMY_FIRST_NAMESPACE, DUMMY_ATTRIBUTES, &data);
 
         assert!(status.is_err());
         assert_eq!(status.unwrap_err(), efi::Status::INVALID_PARAMETER);
@@ -876,8 +849,8 @@ pub(crate) mod test {
 
         let data = DummyVariableType { value: DUMMY_DATA };
 
-        let status =
-            rs.set_variable::<DummyVariableType>(&DUMMY_UNKNOWN_NAME, &DUMMY_FIRST_NAMESPACE, DUMMY_ATTRIBUTES, &data);
+        let name = Char16Str::from_units_with_nul(&DUMMY_UNKNOWN_NAME).unwrap();
+        let status = rs.set_variable::<DummyVariableType>(name, &DUMMY_FIRST_NAMESPACE, DUMMY_ATTRIBUTES, &data);
 
         assert!(status.is_err());
         assert_eq!(status.unwrap_err(), efi::Status::NOT_FOUND);
@@ -890,41 +863,23 @@ pub(crate) mod test {
 
         let rs = runtime_services!(get_next_variable_name = mock_efi_get_next_variable_name);
 
-        let status = rs.get_next_variable_name(&DUMMY_FIRST_NAME, &DUMMY_FIRST_NAMESPACE);
+        let prev_name = Char16Str::from_units_with_nul(&DUMMY_FIRST_NAME).unwrap();
+        let status = rs.get_next_variable_name(prev_name, &DUMMY_FIRST_NAMESPACE);
 
         assert!(status.is_ok());
 
         let (next_name, next_guid) = status.unwrap();
 
-        assert_eq!(next_name, DUMMY_SECOND_NAME);
+        assert_eq!(next_name.as_units_with_nul(), DUMMY_SECOND_NAME);
         assert_eq!(next_guid, DUMMY_SECOND_NAMESPACE);
-    }
-
-    #[test]
-    fn test_get_next_variable_name_non_terminated() {
-        let rs = runtime_services!(get_next_variable_name = mock_efi_get_next_variable_name);
-
-        let status = rs.get_next_variable_name(&DUMMY_NON_NULL_TERMINATED_NAME, &DUMMY_FIRST_NAMESPACE);
-
-        assert!(status.is_err());
-        assert_eq!(status.unwrap_err(), efi::Status::INVALID_PARAMETER);
-    }
-
-    #[test]
-    fn test_get_next_variable_name_zero_length_name() {
-        let rs = runtime_services!(get_next_variable_name = mock_efi_get_next_variable_name);
-
-        let status = rs.get_next_variable_name(&DUMMY_ZERO_LENGTH_NAME, &DUMMY_FIRST_NAMESPACE);
-
-        assert!(status.is_err());
-        assert_eq!(status.unwrap_err(), efi::Status::INVALID_PARAMETER);
     }
 
     #[test]
     fn test_get_next_variable_name_not_found() {
         let rs = runtime_services!(get_next_variable_name = mock_efi_get_next_variable_name);
 
-        let status = rs.get_next_variable_name(&DUMMY_UNKNOWN_NAME, &DUMMY_FIRST_NAMESPACE);
+        let prev_name = Char16Str::from_units_with_nul(&DUMMY_UNKNOWN_NAME).unwrap();
+        let status = rs.get_next_variable_name(prev_name, &DUMMY_FIRST_NAMESPACE);
 
         assert!(status.is_err());
         assert_eq!(status.unwrap_err(), efi::Status::NOT_FOUND);

--- a/sdk/patina/src/uefi/runtime_services/variable_services.rs
+++ b/sdk/patina/src/uefi/runtime_services/variable_services.rs
@@ -11,6 +11,7 @@ use alloc::{vec, vec::Vec};
 use fallible_streaming_iterator::FallibleStreamingIterator;
 
 use super::RuntimeServices;
+use crate::Char16Str;
 
 /// Status information returned by [`RuntimeServices::get_variable_unchecked`]
 #[derive(Debug)]
@@ -112,10 +113,10 @@ impl<'a, R: RuntimeServices> VariableNameIterator<'a, R> {
     }
 
     /// Produce a new iterator, starting from a given variable
-    pub fn new_from_variable(name: &[u16], namespace: &efi::Guid, runtime_services: &'a R) -> Self {
+    pub fn new_from_variable(name: &Char16Str, namespace: &efi::Guid, runtime_services: &'a R) -> Self {
         Self {
             rs: runtime_services,
-            current: VariableIdentifier { name: name.to_vec(), namespace: *namespace },
+            current: VariableIdentifier { name: name.as_units_with_nul().to_vec(), namespace: *namespace },
             next: VariableIdentifier { name: Vec::<u16>::new(), namespace: Guid::from_bytes(&[0x0; 16]) },
             finished: false,
         }
@@ -205,7 +206,8 @@ mod test {
     fn test_variable_name_iterator_from_second() {
         let rs = runtime_services!(get_next_variable_name = mock_efi_get_next_variable_name);
 
-        let mut iter = VariableNameIterator::new_from_variable(&DUMMY_FIRST_NAME, &DUMMY_FIRST_NAMESPACE, &rs);
+        let name = Char16Str::from_units_with_nul(&DUMMY_FIRST_NAME).unwrap();
+        let mut iter = VariableNameIterator::new_from_variable(name, &DUMMY_FIRST_NAMESPACE, &rs);
 
         // Make sure the first result corresponds to DUMMY_SECOND_NAME
         let mut status = iter.next();

--- a/sdk/patina_macro/src/smbios_record_macro.rs
+++ b/sdk/patina_macro/src/smbios_record_macro.rs
@@ -186,9 +186,7 @@ pub(crate) fn smbios_record_derive(item: TokenStream) -> TokenStream {
             quote! {
                 fn validate(&self) -> core::result::Result<(), #crate_path::error::SmbiosError> {
                     for string in &self.#pool_field {
-                        if string.len() > #crate_path::service::SMBIOS_STRING_MAX_LENGTH {
-                            return Err(#crate_path::error::SmbiosError::StringTooLong);
-                        }
+                        #crate_path::smbios_record::validate_smbios_string(string)?;
                     }
                     Ok(())
                 }
@@ -212,7 +210,7 @@ pub(crate) fn smbios_record_derive(item: TokenStream) -> TokenStream {
             } else {
                 for string in &self.#pool_field {
                     if !string.is_empty() {
-                        string_bytes.extend_from_slice(string.as_bytes());
+                        string_bytes.extend_from_slice(&#crate_path::smbios_record::encode_smbios_string(string));
                     }
                     string_bytes.push(0);
                 }


### PR DESCRIPTION
## Description

Breaking changes to use the new [UEFI string](https://opendevicepartnership.github.io/patina/dev/principles/strings.html) types that have been deferred until this PR to the `major` branch.

---

**sdk: Use Patina SDK UEFI string types in public APIs**

This is a breaking change to public APIs in the SDK to use the new
UEFI string types where appropriate.

---

**patina_dxe_core: Use `Char16Str` in `filesystems::SimpleFile::open`**

This is a breaking change to use `&Char16Str` as the filename.

Some other minor integrating changes in patina_dxe_core for the new
Patina SDK UEFI string types are included.

---

**components: Integrate Patina SDK UEFI string changes**

Updates the code to use the new string types modified in public APIs
used by components that were made as breaking changes.

---

- [x] Impacts functionality?
- [ ] Impacts security?
- [x] Breaking change?
- [x] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

- `cargo make all`

## Integration Instructions

- Review the public API changes and adjust consuming code accordingly. Any callers in the `patina` repo are updated in this PR.

---

Note: Patina QEMU PR Validation is expected to fail since this PR is on the `major` branch which contains breaking changes for the patina-dxe-core-qemu build.