### PR TITLE
.github: Skip Patina QEMU PR Validation on unsupported branches

### DIFF
--- a/.github/workflows/patina-qemu-pr-validation-pending.yml
+++ b/.github/workflows/patina-qemu-pr-validation-pending.yml
@@ -19,7 +19,6 @@ on:
     types: [opened, synchronize, reopened]
     branches:
       - main
-      - major
       - feature/**/*
 
 concurrency:

--- a/.github/workflows/patina-qemu-pr-validation.yml
+++ b/.github/workflows/patina-qemu-pr-validation.yml
@@ -45,9 +45,10 @@ jobs:
           HEAD_REPO: ${{ github.event.workflow_run.head_repository.full_name }}
         run: |
           owner="${HEAD_REPO%%/*}"
-          pr_number=$(gh api "repos/${GITHUB_REPOSITORY}/pulls" \
+          pr_json=$(gh api "repos/${GITHUB_REPOSITORY}/pulls" \
             --method GET -f state=open -f head="${owner}:${HEAD_REF}" \
-            --jq '.[0].number')
+            --jq '.[0]')
+          pr_number=$(echo "$pr_json" | jq -r '.number')
 
           if [[ -z "$pr_number" || "$pr_number" == "null" ]]; then
             echo "::notice::No open PR found for head $owner:$HEAD_REF. Checking for closed/merged PRs."
@@ -80,12 +81,24 @@ jobs:
             exit 0
           fi
 
+          base_ref=$(echo "$pr_json" | jq -r '.base.ref')
+
+          # Only run QEMU validation for PRs targeting `main` or a `feature/**/*` branch.
+          if [[ "$base_ref" != "main" && "$base_ref" != feature/* ]]; then
+            echo "::notice::PR #$pr_number targets '$base_ref', which is not a supported branch for QEMU validation. Skipping."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            echo "skip_reason=unsupported_target_branch" >> "$GITHUB_OUTPUT"
+            echo "pr_number=$pr_number" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
           echo "skip=false" >> "$GITHUB_OUTPUT"
 
           echo "::group::PR Information"
           echo "  - PR Number: $pr_number"
           echo "  - Head SHA:  $HEAD_SHA"
           echo "  - Head Ref:  $HEAD_REF"
+          echo "  - Base Ref:  $base_ref"
           echo "  - Source:    $HEAD_REPO"
           echo "::endgroup::"
 


### PR DESCRIPTION
## Description

The Patina QEMU PR Validation workflow is running on all branches today. In particular, the major branch is expected to have breaking changes that will prevent building the Patina QEMU DXE Core binary.

This change only runs the workflow on the main and feature branches. Some feature branches may also not build due to breaking changes but that is not universal, and the workflow results can be ignored in cases where failure is expected.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

- Verify Patina QEMU PR Validation runs on expected branches.
- Verify Patina QEMU PR Validation is skipped on an unexpected branch:

  <img width="1434" height="856" alt="image" src="https://github.com/user-attachments/assets/89300bad-9d0d-4e66-b68f-8e71c7d81727" />

## Integration Instructions

- N/A