### PR TITLE
deny.toml: Temporarily ignore RUSTSEC-2026-0220 (until MSRV is 1.90+)

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -60,7 +60,8 @@ ignore = [
     #"a-crate-that-is-yanked@0.1.1", # you can also ignore yanked crate versions if you wish
     #{ crate = "a-crate-that-is-yanked@0.1.1", reason = "you can specify why you are ignoring the yanked crate" },
 
-    { id = "RUSTSEC-2024-0436", reason = "paste is unmaintained but is only pulled in transitively via arm-gic -> arm-sysregs. It is build-time only" }
+    { id = "RUSTSEC-2024-0436", reason = "paste is unmaintained but is only pulled in transitively via arm-gic -> arm-sysregs. It is build-time only" },
+    { id = "RUSTSEC-2026-0220", reason = "ruint is a dev-only dependency (patina_internal_core benches) used solely as a fixed-width integer type with Uint::from(u32). No shift operations or string formatting are exercised. The fix requires ruint >=1.20.0, which has a Rust 1.90 MSRV, but Patina's MSRV is still 1.89. Revisit when the MSRV is raised to 1.90+" }
 ]
 # If this is true, then cargo deny will use the git executable to fetch advisory database.
 # If this is false, then it uses a built-in git library.


### PR DESCRIPTION
## Description

Advisory: [RUSTSEC-2026-0220](https://rustsec.org/advisories/RUSTSEC-2026-0220.html)

ruint is used as a dev-dependency for patina_internal_core for benchmarks. The three bench files using ruint only use `Uint::from(u32)` as a fixed-width benchmark key, so they do not exercise the shift operations or string formatting that are affected by the advisory.

Patina will be moving its MSRV to Rust 1.90+ and the exception can be dropped then. This allows CI to pass in the meantime.

Searching for the affected functions in the security advisory, shown below returns no results in the Patina repo:

- ruint::Uint::checked_shl
- ruint::Uint::checked_shr
- ruint::Uint::overflowing_shl
- ruint::Uint::overflowing_shr
- ruint::Uint::saturating_shl
- ruint::Uint::saturating_shr
- ruint::Uint::wrapping_shl
- ruint::Uint::wrapping_shr

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

- `cargo make deny` fails before and passes after

## Integration Instructions

- N/A