### PR TITLE
[major] Update the MSRV to 1.90.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,10 +6,13 @@ members = ["components/*", "core/*", "sdk/*", "patina_dxe_core"]
 version = "22.2.3"
 license = "Apache-2.0"
 edition = "2024"
-rust-version = "1.89"
+rust-version = "1.90"
 repository = "https://github.com/OpenDevicePartnership/patina"
 
 [workspace.dependencies]
+# alloc-no-stdlib is pinned to the 2.x because brotli-decompressor 5.0.3 (the latest release)
+# requires `alloc-no-stdlib = ">=2.0.4, <3"`. Bumping to 3.x causes two incompatible copies of
+# alloc-no-stdlib to appear in the dependency graph. Revisit once brotli-decompressor supports 3.x.
 alloc-no-stdlib = { version = "2.0" }
 arm-gic = { version = "0.8.1" }
 safe-mmio = { version = "0.3.0" }
@@ -50,7 +53,7 @@ quote = { version = "1" }
 r-efi = { version = "7", default-features = false }
 scroll = { version = "0.13", default-features = false, features = ["derive"]}
 spin = { version = "0.12" }
-syn = { version = "2" }
+syn = { version = "3" }
 uart_16550 = { version = "0.3.2" }
 corosensei = { version = "0.3.4", default-features = false }
 uuid = { version = "1.23", default-features = false }
@@ -60,11 +63,9 @@ zerocopy-derive = { version = "0.8" }
 # dev dependencies
 criterion = { version = "0.8" }
 env_logger = "0.11"
-mockall = { version = "0.14.0" }
+mockall = { version = "0.15.0" }
 rand = { version = "0.10" }
-# ruint ~1.17 is used right now because 1.18.0 has a MSRV of Rust 1.90.
-# This can be updated when the Patina MSRV is updated to 1.90+.
-ruint = { version = "~1.17" }
+ruint = { version = "1.20" }
 serial_test = { version = "3.5" }
 serde = { version = "1.0", default-features = false, features = ["derive"] }
 serde_yaml = { version = "0.9" }

--- a/deny.toml
+++ b/deny.toml
@@ -60,8 +60,7 @@ ignore = [
     #"a-crate-that-is-yanked@0.1.1", # you can also ignore yanked crate versions if you wish
     #{ crate = "a-crate-that-is-yanked@0.1.1", reason = "you can specify why you are ignoring the yanked crate" },
 
-    { id = "RUSTSEC-2024-0436", reason = "paste is unmaintained but is only pulled in transitively via arm-gic -> arm-sysregs. It is build-time only" },
-    { id = "RUSTSEC-2026-0220", reason = "ruint is a dev-only dependency (patina_internal_core benches) used solely as a fixed-width integer type with Uint::from(u32). No shift operations or string formatting are exercised. The fix requires ruint >=1.20.0, which has a Rust 1.90 MSRV, but Patina's MSRV is still 1.89. Revisit when the MSRV is raised to 1.90+" }
+    { id = "RUSTSEC-2024-0436", reason = "paste is unmaintained but is only pulled in transitively via arm-gic -> arm-sysregs. It is build-time only" }
 ]
 # If this is true, then cargo deny will use the git executable to fetch advisory database.
 # If this is false, then it uses a built-in git library.

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -23,4 +23,4 @@ mdbook-linkcheck = "0.7.7"
 mdbook-mermaid = "0.16.2"
 
 [msrv]
-channel = "1.89.0"
+channel = "1.90.0"

--- a/sdk/patina_macro/src/validate_params_macro.rs
+++ b/sdk/patina_macro/src/validate_params_macro.rs
@@ -9,7 +9,7 @@
 
 use proc_macro2::TokenStream;
 use quote::quote;
-use syn::{FnArg, ImplItem, ItemFn, ItemImpl, Pat, Type, TypePath, parse2, spanned::Spanned};
+use syn::{FnArg, FnModifiers, ImplItem, ItemFn, ItemImpl, Pat, Type, TypePath, parse2, spanned::Spanned};
 
 /// Validates component impl blocks with a unified `#[component]` attribute.
 ///
@@ -105,6 +105,7 @@ fn validate_component_impl_block(impl_block: ItemImpl) -> TokenStream {
     let item_fn = ItemFn {
         attrs: entry_point.attrs.clone(),
         vis: entry_point.vis.clone(),
+        modifiers: FnModifiers::default(),
         sig: entry_point.sig.clone(),
         block: Box::new(entry_point.block.clone()),
     };


### PR DESCRIPTION
## Description

Closes #1673

Updates the Minimum Supported Rust Version (MSRV) to 1.90.0. This update is being made at this time to allow dependencies with an MSRV of 1.90.0 that have security advisories to be updated.

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

- `cargo make all`

## Integration Instructions

- N/A