### PR TITLE
Export Char8String and Char16String only if alloc feature is enabled

### DIFF
--- a/sdk/patina/src/base/string.rs
+++ b/sdk/patina/src/base/string.rs
@@ -65,8 +65,13 @@ use crate::error::EfiError;
 pub mod char16;
 pub mod char8;
 
-pub use char8::{Char8Array, Char8Str, Char8String};
-pub use char16::{Char16Array, Char16Str, Char16String};
+pub use char8::{Char8Array, Char8Str};
+pub use char16::{Char16Array, Char16Str};
+
+#[cfg(any(test, feature = "alloc"))]
+pub use char8::Char8String;
+#[cfg(any(test, feature = "alloc"))]
+pub use char16::Char16String;
 
 #[doc(hidden)]
 pub use char8::latin1_capacity;

--- a/sdk/patina/src/lib.rs
+++ b/sdk/patina/src/lib.rs
@@ -23,7 +23,10 @@
 extern crate alloc;
 
 pub use base::guid::{BinaryGuid, Guid, GuidError, OwnedGuid};
-pub use base::string::{Char8Array, Char8Str, Char8String, Char16Array, Char16Str, Char16String, StringError};
+pub use base::string::{Char8Array, Char8Str, Char16Array, Char16Str, StringError};
+
+#[cfg(any(test, feature = "alloc"))]
+pub use base::string::{Char8String, Char16String};
 
 /// Common GUID constants
 pub mod guid_constants {


### PR DESCRIPTION
## Description

Export Char8String and Char16String only if alloc feature is enabled

- Found when rebasing rust mm supervisor feature branch with latest main
---
- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

`cargo make all`

## Integration Instructions

NA