### PR TITLE
`--no-default-features` updates for tests [Rebase & FF]

### DIFF
--- a/components/patina_adv_logger/README.md
+++ b/components/patina_adv_logger/README.md
@@ -41,6 +41,8 @@ below.
 #### Example
 
 ```rust
+# #[cfg(feature = "component")]
+# {
 use patina_dxe_core::*;
 use patina::{debug::log::Format, peripheral::serial::uart::UartNull};
 use patina_adv_logger::{component::AdvancedLoggerComponent, logger::{AdvancedLogger, TargetFilter}};
@@ -75,6 +77,7 @@ pub extern "efiapi" fn _start(physical_hob_list: *const c_void) -> ! {
 
    # loop { }
 }
+# }
 ```
 
 ### Platform Integration

--- a/core/patina_internal_core/src/collections/bst.rs
+++ b/core/patina_internal_core/src/collections/bst.rs
@@ -706,8 +706,11 @@ mod tests {
         assert_eq!(bst.storage.len(), 8);
         assert!(bst.add(10).is_err()); // Can't add the same value twice
 
-        let values = bst.dfs();
-        assert_eq!(values, [2, 3, 5, 6, 7, 8, 9, 10]);
+        #[cfg(feature = "alloc")]
+        {
+            let values = bst.dfs();
+            assert_eq!(values, [2, 3, 5, 6, 7, 8, 9, 10]);
+        }
     }
 
     #[test]
@@ -934,8 +937,11 @@ mod fuzz_tests {
             assert!(bst.height() < 50);
             random_numbers.sort();
 
-            let ordered_numbers = bst.dfs();
-            assert_eq!(ordered_numbers, random_numbers);
+            #[cfg(feature = "alloc")]
+            {
+                let ordered_numbers = bst.dfs();
+                assert_eq!(ordered_numbers, random_numbers);
+            }
         }
     }
 

--- a/core/patina_internal_core/src/collections/rbt.rs
+++ b/core/patina_internal_core/src/collections/rbt.rs
@@ -948,8 +948,11 @@ mod tests {
         assert_eq!(rbt.storage.len(), 8);
         assert!(rbt.add(10).is_err()); // Can't add the same value twice
 
-        let values = rbt.dfs();
-        assert_eq!(values, [2, 3, 5, 6, 7, 8, 9, 10]);
+        #[cfg(feature = "alloc")]
+        {
+            let values = rbt.dfs();
+            assert_eq!(values, [2, 3, 5, 6, 7, 8, 9, 10]);
+        }
     }
 
     #[test]
@@ -1875,8 +1878,11 @@ mod fuzz_tests {
             assert!(rbt.height() < 25);
             random_numbers.sort();
 
-            let ordered_numbers = rbt.dfs();
-            assert_eq!(ordered_numbers, random_numbers);
+            #[cfg(feature = "alloc")]
+            {
+                let ordered_numbers = rbt.dfs();
+                assert_eq!(ordered_numbers, random_numbers);
+            }
         }
     }
 

--- a/sdk/patina/Cargo.toml
+++ b/sdk/patina/Cargo.toml
@@ -23,7 +23,24 @@ name = "bench_guid"
 harness = false
 
 [[example]]
+name = "basic_guid_usage"
+required-features = ["alloc"]
+
+[[example]]
 name = "basic_hob_usage"
+required-features = ["alloc"]
+
+[[example]]
+name = "brotli"
+required-features = ["alloc"]
+
+[[test]]
+name = "test_new_component_attr"
+required-features = ["alloc"]
+
+[[test]]
+name = "compile_fail_tests"
+required-features = ["alloc"]
 
 [dependencies]
 patina_macro = { workspace = true }

--- a/sdk/patina/src/base/c_ptr.rs
+++ b/sdk/patina/src/base/c_ptr.rs
@@ -6,6 +6,7 @@
 //!
 //! SPDX-License-Identifier: Apache-2.0
 //!
+#[cfg(any(test, feature = "alloc"))]
 use alloc::boxed::Box;
 use core::{
     ffi::c_void,
@@ -169,6 +170,7 @@ unsafe impl<'a, T> CMutPtr<'a> for &'a mut T {}
 unsafe impl<'a, T> CMutRef<'a> for &'a mut T {}
 
 // Box<T>
+#[cfg(any(test, feature = "alloc"))]
 // SAFETY: Memory layout and mutability are respected for these types.
 unsafe impl<T> CPtr<'_> for Box<T> {
     type Type = T;
@@ -177,10 +179,13 @@ unsafe impl<T> CPtr<'_> for Box<T> {
         AsRef::as_ref(self) as *const _
     }
 }
+#[cfg(any(test, feature = "alloc"))]
 // SAFETY: Memory layout and mutability are respected for these types.
 unsafe impl<T> CRef<'_> for Box<T> {}
+#[cfg(any(test, feature = "alloc"))]
 // SAFETY: Memory layout and mutability are respected for these types.
 unsafe impl<T> CMutPtr<'_> for Box<T> {}
+#[cfg(any(test, feature = "alloc"))]
 // SAFETY: Memory layout and mutability are respected for these types.
 unsafe impl<T> CMutRef<'_> for Box<T> {}
 

--- a/sdk/patina/src/lib.rs
+++ b/sdk/patina/src/lib.rs
@@ -27,11 +27,11 @@ pub use string::{Char8Array, Char8Str, Char16Array, Char16Str, StringError};
 pub use base::string::{Char8String, Char16String};
 
 pub mod arch;
-#[cfg(any(test, feature = "alloc"))]
+#[cfg(feature = "alloc")]
 pub mod component;
 pub mod debug;
 pub mod management_mode;
-#[cfg(any(test, feature = "alloc"))]
+#[cfg(feature = "alloc")]
 pub mod performance;
 pub mod peripheral;
 pub mod pi;

--- a/sdk/patina/src/pi/protocol/status_code.rs
+++ b/sdk/patina/src/pi/protocol/status_code.rs
@@ -11,7 +11,11 @@
 //! SPDX-License-Identifier: Apache-2.0
 //!
 
-use core::{mem, ptr, slice};
+#[cfg(feature = "alloc")]
+use core::mem;
+use core::ptr;
+#[cfg(feature = "alloc")]
+use core::slice;
 
 use crate::standard::efi;
 
@@ -67,6 +71,7 @@ unsafe impl crate::base::protocol::ProtocolInterface for StatusCodeProtocol {
 // Non-spec defined wrappers on top of the StatusCodeProtocol to make it easier to use in Rust.
 impl StatusCodeProtocol {
     /// Reports a status code to the platform firmware with data.
+    #[cfg(feature = "alloc")]
     pub fn report_status_code_with_data<T>(
         &self,
         status_code_type: EfiStatusCodeType,
@@ -107,6 +112,7 @@ impl StatusCodeProtocol {
     }
 }
 
+#[cfg(feature = "alloc")]
 fn any_as_u8_slice<T: Sized>(p: &T) -> &[u8] {
     // SAFETY: P is a ref thus a valid pointer and since the type is sized, the memory boundary of this type is known.
     unsafe { slice::from_raw_parts((p as *const T) as *const u8, mem::size_of::<T>()) }


### PR DESCRIPTION
## Description

Includes fixes for issues found while running `test --no-default-features` against individual crates.

---

**sdk/patina: Uncouple test and alloc**

Fixes failures running: `cargo test -p patina --no-run --no-default-features`

component/metadata.rs uses `fixedbitset` which is an optional crate
dependency:

  `fixedbitset = { workspace = true, optional = true }`

It will only be pulled in when the `alloc` feature is active:

  `alloc = ["dep:goblin", "dep:fixedbitset"]`

The decision on whether which features are enabled and dependencies
included is made before `rustc` runs for tests.

This made `test` in `#[cfg(any(test, feature = "alloc"))]` not work
when `--no-default-features` is used as `alloc` is not enabled and
`fixedbitset` is therefore not linked.

Since `alloc` is enabled by default, this does not change the normal
`cargo test` build. This will cause `component` to not be included on
`--no-default-features` test invocations which was already the case
for commands like `cargo make check --no-default-features`.

`cargo test -p patina --no-run --no-default-features` was run to
filter the modules down what could be enabled.

---

**core: Gate `dfs()` method calls in tests on alloc**

The `dfs()` method on the `Bst` and `Rbt` types is gated on the alloc
feature, so the calls to the methods in tests need to be as well.

Allows running tests with `--no-default-features` to succeed.

---

**sdk: Gate c_ptr and status_code**

sdk/patina/src/lib.rs gates the alloc crate:

```rust
#![cfg_attr(any(test, feature = "alloc"), feature(allocator_api))]
```

Code in sdk/patina/src/base/c_ptr.rs was using `alloc::boxed::Box`
without applying a similar gate. This change applies the gate on
usage there so the crate can be built without the alloc feature.

A similar fix in the sdk is made in status_code.rs. When built with
`cargo hack check --workspace --no-default-features` the following
error was seen:

```
error[E0599]: no method named `concat` found for array `[&[u8]; 2]` in the current scope
    let mut data_buffer = [any_as_u8_slice(&header), any_as_u8_slice(&data)].concat();
```

`[T]::concat()` on an array of slices returns `Vec<u8>` with alloc's
`Concat` trait.

Three changes were made for this:

1. Splitting the import block, so `use core::{mem, ptr, slice}` so
   `mem` and `slice` are gated on `alloc`.
2. Updating `pub fn report_status_code_with_data<T>` to be gated on
   the `alloc` feature.
3. Updating `fn any_as_u8_slice<T: Sized>(p: &T) -> &[u8]` to be
   gated on the `alloc` feature as well to avoid a dead code warning
   since it was only called by `report_status_code_with_data<T>`.

---

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

- `cargo test --no-default-features`
- `cargo hack check --workspace --no-default-features`
- `cargo hack test --no-run --workspace --no-default-features`
- `cargo make test`

Note: https://github.com/OpenDevicePartnership/patina/issues/1680 tracks potentially using `cargo-hack` to perform no default testing on each crate in the future.

## Integration Instructions

- N/A