### PR TITLE
patina: Fix dropped re-export fix from major merge conflict

### DIFF
--- a/sdk/patina/src/lib.rs
+++ b/sdk/patina/src/lib.rs
@@ -21,7 +21,10 @@ extern crate alloc;
 mod base;
 pub use base::*;
 pub use guid::{BinaryGuid, Guid, GuidError, OwnedGuid};
-pub use string::{Char8Array, Char8Str, Char8String, Char16Array, Char16Str, Char16String, StringError};
+pub use string::{Char8Array, Char8Str, Char16Array, Char16Str, StringError};
+
+#[cfg(any(test, feature = "alloc"))]
+pub use base::string::{Char8String, Char16String};
 
 pub mod arch;
 #[cfg(any(test, feature = "alloc"))]


### PR DESCRIPTION
## Description

The merge of the major branch SDK refactor dropped the change to re-export of Char8String and Char16String only when the `alloc` feature is enabled.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Cargo make all

## Integration Instructions

N/A
