### PR TITLE
Unify TPL mutex implementation

### DIFF
--- a/docs/src/dxe_core/synchronization.md
+++ b/docs/src/dxe_core/synchronization.md
@@ -81,6 +81,17 @@ without blocking; this can be used for scenarios where a lock might be held by
 another agent in a lower TPL but the caller can handle not acquiring the lock,
 or in scenarios where a call is re-entrant at the same TPL.
 
+### TplMutex - Abstracting Access to TPL via TplController
+
+`TplMutex` is used by both the DXE Core and SDK consumers for general
+synchronization. The shared SDK implementation is parameterized by the
+`TplController` trait, which abstracts access to the TPL primitives. SDK
+consumers normally supply a `BootServices` implementation, which automatically
+implements `TplController`, but other environments may implement
+`TplController` directly. The DXE Core uses `CoreTplController` to provide its
+direct internal TPL operations, allowing the shared `TplMutex` implementation
+to be instantiated independently of Boot Services availability.
+
 ## TplGuard
 
 When `lock()` is called on `TplMutex` a `TplGuard` structure is returned that

--- a/patina_dxe_core/src/component_dispatcher.rs
+++ b/patina_dxe_core/src/component_dispatcher.rs
@@ -444,7 +444,7 @@ mod tests {
             with_global_lock(|| {
                 let dispatcher = ComponentDispatcher::new_locked();
                 let _lock = dispatcher.lock();
-                dispatcher.lock();
+                let _reentrant_lock = dispatcher.lock();
             })
             .is_err_and(|e| {
                 e.downcast::<String>().unwrap().contains("Re-entrant locks for \"ComponentDispatcher\" not permitted.")

--- a/patina_dxe_core/src/tpl_mutex.rs
+++ b/patina_dxe_core/src/tpl_mutex.rs
@@ -1,56 +1,52 @@
-//! TplMutex: Mutex implementation that also adjusts UEFI TPL levels.
+//! DXE Core adapter for the SDK TPL-aware mutex.
 //!
-//! This module raises and lowers the UEFI TPL level as the primary means of
-//! guarding the mutex critical section.
-//!
-//! This mutex guarantees that the critical section protected by the guard
-//! cannot be interrupted by code running at TPL equal to or lower than the
-//! lock's TPL level. At TPL_HIGH_LEVEL, interrupts are disabled, so that
-//! means that the critical section cannot be interrupted by anything.
+//! The mutex implementation is shared with the SDK. This module supplies the
+//! DXE Core's direct TPL routines and preserves the Core-facing API.
 //!
 //! ## License
 //!
 //! Copyright (c) Microsoft Corporation.
 //!
 //! SPDX-License-Identifier: Apache-2.0
-use core::{
-    cell::UnsafeCell,
-    fmt,
-    ops::{Deref, DerefMut},
-    sync::atomic::{AtomicBool, Ordering},
+use core::fmt;
+
+use patina::{
+    standard::efi,
+    uefi::{
+        boot_services::tpl::Tpl,
+        tpl_mutex::{TplController, TplMutex as SharedTplMutex, TplMutexGuard},
+    },
 };
 
-use patina::standard::efi;
-
 use crate::events::{raise_tpl, restore_tpl};
+
+#[derive(Clone, Copy)]
+pub(crate) struct CoreTplController;
+
+impl TplController for CoreTplController {
+    fn raise_tpl(&self, tpl: Tpl) -> Tpl {
+        raise_tpl(tpl.into()).into()
+    }
+
+    fn restore_tpl(&self, tpl: Tpl) {
+        restore_tpl(tpl.into());
+    }
+}
 
 /// Used to guard data with a locked MUTEX and TPL level.
 pub struct TplMutex<T: ?Sized> {
     tpl_lock_level: efi::Tpl,
-    lock: AtomicBool,
     name: &'static str,
-    data: UnsafeCell<T>,
+    inner: SharedTplMutex<T, CoreTplController>,
 }
+
 /// Wrapper for guarded data, which can be accessed by Deref or DerefMut on this object.
-pub struct TplGuard<'a, T: ?Sized + 'a> {
-    release_tpl: efi::Tpl,
-    mutex: &'a TplMutex<T>,
-}
-
-// SAFETY: TplMutex enforces mutual exclusion with atomic lock and TPL elevation.
-unsafe impl<T: ?Sized + Send> Sync for TplMutex<T> {}
-// SAFETY: TplMutex enforces mutual exclusion with atomic lock and TPL elevation.
-unsafe impl<T: ?Sized + Send> Send for TplMutex<T> {}
-
-// SAFETY: TplGuard grants exclusive access to the protected data while the lock is held.
-unsafe impl<T: ?Sized + Sync> Sync for TplGuard<'_, T> {}
-// SAFETY: TplGuard grants exclusive access to the protected data while the lock is held.
-unsafe impl<T: ?Sized + Send> Send for TplGuard<'_, T> {}
+pub type TplGuard<'a, T> = TplMutexGuard<'a, T, CoreTplController>;
 
 impl<T> TplMutex<T> {
     /// Instantiates a new TplMutex with the given TPL level, data object, and name string.
     pub const fn new(tpl_lock_level: efi::Tpl, data: T, name: &'static str) -> Self {
-        Self { tpl_lock_level, lock: AtomicBool::new(false), data: UnsafeCell::new(data), name }
+        Self { tpl_lock_level, name, inner: SharedTplMutex::new(CoreTplController, Tpl(tpl_lock_level), data) }
     }
 }
 
@@ -75,13 +71,7 @@ impl<T: ?Sized> TplMutex<T> {
     /// Attempting to acquire the lock while running at a TPL level higher than the lock's TPL level will panic due to
     /// TPL inversion.
     pub fn try_lock(&self) -> Option<TplGuard<'_, T>> {
-        let release_tpl = raise_tpl(self.tpl_lock_level);
-        if self.lock.compare_exchange(false, true, Ordering::Acquire, Ordering::Relaxed).is_ok() {
-            Some(TplGuard { release_tpl, mutex: self })
-        } else {
-            restore_tpl(release_tpl);
-            None
-        }
+        self.inner.try_lock().ok()
     }
 }
 
@@ -91,48 +81,13 @@ impl<T: ?Sized + fmt::Debug> fmt::Debug for TplMutex<T> {
             Some(guard) => write!(
                 f,
                 "TplMutex {{ lock_tpl: {:x?}, release_tpl: {:x?}, data: ",
-                self.tpl_lock_level, guard.release_tpl
+                self.tpl_lock_level,
+                usize::from(guard.release_tpl())
             )
             .and_then(|()| (*guard).fmt(f))
             .and_then(|()| write!(f, " }}")),
             None => write!(f, "TplMutex {{ lock_tpl: {:x?}, data: <locked> }}", self.tpl_lock_level),
         }
-    }
-}
-
-impl<T: ?Sized + fmt::Debug> fmt::Debug for TplGuard<'_, T> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        fmt::Debug::fmt(&**self, f)
-    }
-}
-
-impl<T: ?Sized + fmt::Display> fmt::Display for TplGuard<'_, T> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        fmt::Display::fmt(&**self, f)
-    }
-}
-
-impl<T: ?Sized> Deref for TplGuard<'_, T> {
-    type Target = T;
-    fn deref(&self) -> &T {
-        // SAFETY: data is only accessible through the guard, which guarantees mutual exclusion since no higher TPL can
-        // obtain the lock without panic, and no code at equal or lower TPL can interrupt while the lock is held.
-        unsafe { self.mutex.data.get().as_ref().expect("TplMutex data pointer should not be null") }
-    }
-}
-
-impl<T: ?Sized> DerefMut for TplGuard<'_, T> {
-    fn deref_mut(&mut self) -> &mut T {
-        // SAFETY: data is only accessible through the guard, which guarantees mutual exclusion since no higher TPL can
-        // obtain the lock without panic, and no code at equal or lower TPL can interrupt while the lock is held.
-        unsafe { self.mutex.data.get().as_mut().expect("TplMutex data pointer should not be null") }
-    }
-}
-
-impl<T: ?Sized> Drop for TplGuard<'_, T> {
-    fn drop(&mut self) {
-        self.mutex.lock.store(false, Ordering::Release);
-        restore_tpl(self.release_tpl);
     }
 }
 
@@ -170,27 +125,23 @@ mod tests {
     }
 
     #[test]
-    fn test_tpl_mutex_basic() {
+    fn test_tpl_mutex_basic_and_try_lock() {
         with_reset_state(|| {
             let lock = TplMutex::new(efi::TPL_NOTIFY, 42, "test_lock");
             {
-                let guard = lock.lock();
+                let mut guard = lock.try_lock().expect("Failed to acquire lock");
                 assert_eq!(*guard, 42);
-            }
-            {
-                let mut guard = lock.lock();
                 *guard = 43;
+                assert!(lock.try_lock().is_none(), "Should not acquire a lock while it is already held");
             }
-            {
-                let guard = lock.lock();
-                assert_eq!(*guard, 43);
-            }
+            let guard = lock.try_lock().expect("Failed to acquire lock after release");
+            assert_eq!(*guard, 43);
         });
     }
 
     #[test]
     #[should_panic(expected = "Re-entrant locks for \"test_lock\" not permitted.")]
-    fn test_tpl_mutex_reentrant() {
+    fn test_tpl_mutex_reentrant_lock_displays_name() {
         with_reset_state(|| {
             let lock = TplMutex::new(efi::TPL_NOTIFY, 42, "test_lock");
             let _guard1 = lock.lock();
@@ -199,23 +150,7 @@ mod tests {
     }
 
     #[test]
-    fn test_tpl_mutex_try_lock() {
-        with_reset_state(|| {
-            let lock = TplMutex::new(efi::TPL_NOTIFY, 42, "test_lock");
-            {
-                let guard1 = lock.try_lock().expect("Failed to acquire lock");
-                assert_eq!(*guard1, 42);
-                let guard2 = lock.try_lock();
-                assert!(guard2.is_none(), "Should not be able to acquire lock while already held");
-            }
-            {
-                let guard3 = lock.try_lock().expect("Failed to acquire lock after release");
-                assert_eq!(*guard3, 42);
-            }
-        });
-    }
-    #[test]
-    fn test_tpl_mutex_debug() {
+    fn test_tpl_mutex_preserves_core_debug_format() {
         with_reset_state(|| {
             let lock = TplMutex::new(efi::TPL_NOTIFY, 42, "test_lock");
             let debug_str = format!("{:?}", lock);
@@ -223,20 +158,6 @@ mod tests {
             let _guard = lock.lock();
             let debug_str_locked = format!("{:?}", lock);
             assert_eq!(debug_str_locked, "TplMutex { lock_tpl: 10, data: <locked> }");
-        });
-    }
-
-    #[test]
-    fn test_tpl_mutex_guard_debug_display() {
-        with_reset_state(|| {
-            let lock = TplMutex::new(efi::TPL_NOTIFY, 42, "test_lock");
-            {
-                let guard = lock.lock();
-                let debug_str = format!("{:?}", guard);
-                assert_eq!(debug_str, "42");
-                let display_str = format!("{}", guard);
-                assert_eq!(display_str, "42");
-            }
         });
     }
 }

--- a/sdk/patina/src/uefi/tpl_mutex.rs
+++ b/sdk/patina/src/uefi/tpl_mutex.rs
@@ -6,6 +6,73 @@
 //!
 //! SPDX-License-Identifier: Apache-2.0
 //!
+//! ## Examples
+//!
+//! SDK consumers normally construct a [`TplMutex`] with an owned or cloned Boot
+//! Services implementation and access the protected data through the guard
+//! returned by [`TplMutex::lock`].
+//!
+//! ```
+//! use patina::uefi::{
+//!     boot_services::{StandardBootServices, tpl::Tpl},
+//!     tpl_mutex::TplMutex,
+//! };
+//!
+//! struct SharedState {
+//!     value: usize,
+//! }
+//!
+//! struct Consumer {
+//!     state: TplMutex<SharedState>,
+//!     boot_services: StandardBootServices,
+//! }
+//!
+//! impl Consumer {
+//!     fn new(boot_services: StandardBootServices) -> Self {
+//!         Self {
+//!             state: TplMutex::new(
+//!                 boot_services.clone(),
+//!                 Tpl::NOTIFY,
+//!                 SharedState { value: 0 },
+//!             ),
+//!             boot_services,
+//!         }
+//!     }
+//!
+//!     fn increment(&self) {
+//!         self.state.lock().value += 1;
+//!     }
+//! }
+//! ```
+//!
+//! ### Delayed initialization
+//!
+//! A static mutex can be constructed before Boot Services are available and
+//! initialized later. [`TplMutex::init`] must be called exactly once before the
+//! mutex is locked.
+//!
+//! ```
+//! use patina::uefi::{
+//!     boot_services::{StandardBootServices, tpl::Tpl},
+//!     tpl_mutex::TplMutex,
+//! };
+//!
+//! struct SharedState {
+//!     value: usize,
+//! }
+//!
+//! static STATE: TplMutex<SharedState> =
+//!     TplMutex::new_uninit(Tpl::NOTIFY, SharedState { value: 0 });
+//!
+//! fn initialize(boot_services: StandardBootServices) {
+//!     STATE.init(boot_services);
+//! }
+//!
+//! fn increment() {
+//!     STATE.lock().value += 1;
+//! }
+//! ```
+//!
 use core::{
     cell::{OnceCell, UnsafeCell},
     fmt::{self, Debug, Display},
@@ -17,8 +84,12 @@ use crate::uefi::boot_services::{BootServices, StandardBootServices, tpl::Tpl};
 
 /// Provides the TPL operations required by [`TplMutex`].
 ///
-/// Boot services implementations automatically implement this trait. Other
-/// environments, such as the DXE Core, can provide TPL operations directly.
+/// [`BootServices`] implementations automatically implement this trait. Other
+/// execution environments, such as the DXE Core, may implement this trait to
+/// provide TPL operations without depending on Boot Services. This abstraction
+/// is intended to support execution environments with different requirements
+/// for accessing TPL primitives; SDK consumers should normally use the blanket
+/// implementation provided for [`BootServices`].
 pub trait TplController {
     /// Raises the current TPL and returns the previous TPL.
     fn raise_tpl(&self, tpl: Tpl) -> Tpl;

--- a/sdk/patina/src/uefi/tpl_mutex.rs
+++ b/sdk/patina/src/uefi/tpl_mutex.rs
@@ -15,13 +15,45 @@ use core::{
 
 use crate::uefi::boot_services::{BootServices, StandardBootServices, tpl::Tpl};
 
+/// Provides the TPL operations required by [`TplMutex`].
+///
+/// Boot services implementations automatically implement this trait. Other
+/// environments, such as the DXE Core, can provide TPL operations directly.
+pub trait TplController {
+    /// Raises the current TPL and returns the previous TPL.
+    fn raise_tpl(&self, tpl: Tpl) -> Tpl;
+
+    /// Restores the current TPL to a previously returned value.
+    fn restore_tpl(&self, tpl: Tpl);
+}
+
+impl<B: BootServices> TplController for B {
+    fn raise_tpl(&self, tpl: Tpl) -> Tpl {
+        BootServices::raise_tpl(self, tpl)
+    }
+
+    fn restore_tpl(&self, tpl: Tpl) {
+        BootServices::restore_tpl(self, tpl);
+    }
+}
+
+// `OnceCell::from` and `OnceCell::set` are not `const`. This enumeration
+// allows `const` construction of TplMutex by bypassing the need for non-const
+// `OnceCell` APIs using the `Ready` variant in the case where TplController is
+// available at construction.
+enum TplControllerStorage<C> {
+    Ready(C),
+    Deferred(OnceCell<C>),
+}
+
 /// Type use for mutual exclusion of data across Tpl (task priority level)
 ///
 /// This mutex will raise the TPL to the specified level when locked, and restore it when the lock is released.
 ///
-/// The mutex owns the BootServices instance. Callers pass an owned instance or clone if needed.
-pub struct TplMutex<T: ?Sized, B: BootServices = StandardBootServices> {
-    boot_services: OnceCell<B>,
+/// The mutex owns its TPL controller. SDK callers normally provide an owned
+/// BootServices instance or a clone if they need to retain a copy.
+pub struct TplMutex<T: ?Sized, B: TplController = StandardBootServices> {
+    tpl_controller: TplControllerStorage<B>,
     tpl_lock_level: Tpl,
     lock: AtomicBool,
     data: UnsafeCell<T>,
@@ -29,45 +61,56 @@ pub struct TplMutex<T: ?Sized, B: BootServices = StandardBootServices> {
 
 /// RAII implementation of a [TplMutex] lock. When this structure is dropped, the lock will be unlocked.
 #[must_use = "if unused the TplMutex will immediately unlock"]
-pub struct TplMutexGuard<'a, T: ?Sized, B: BootServices> {
+pub struct TplMutexGuard<'a, T: ?Sized, B: TplController> {
     tpl_mutex: &'a TplMutex<T, B>,
     release_tpl: Tpl,
 }
 
-impl<T, B: BootServices> TplMutex<T, B> {
+impl<T, B: TplController> TplMutex<T, B> {
     /// Create a new TplMutex in an unlocked state.
-    /// Takes ownership of the boot_services instance. Callers can pass an owned
-    /// instance directly or clone if they need to retain a copy.
-    ///
-    /// # Panics
-    /// This call will panic if the mutex is already initialized (should not be possible here).
-    pub fn new(boot_services: B, tpl_lock_level: Tpl, data: T) -> Self {
-        let bs_cell = OnceCell::new();
-        bs_cell.set(boot_services).map_err(|_| "Boot services already initialized!").unwrap();
-        Self { boot_services: bs_cell, tpl_lock_level, lock: AtomicBool::new(false), data: UnsafeCell::new(data) }
-    }
-
-    /// Create a new TplMutex in an unlocked, uninitialized state.
-    /// The resulting TplMutex will not be usable until `boot_services` is initialized.
-    pub const fn new_uninit(tpl_lock_level: Tpl, data: T) -> Self {
+    /// Takes ownership of the TPL controller.
+    pub const fn new(tpl_controller: B, tpl_lock_level: Tpl, data: T) -> Self {
         Self {
-            boot_services: OnceCell::new(),
+            tpl_controller: TplControllerStorage::Ready(tpl_controller),
             tpl_lock_level,
             lock: AtomicBool::new(false),
             data: UnsafeCell::new(data),
         }
     }
 
-    /// Initialize the boot services for this TplMutex. This must be called before the mutex can be used.
+    /// Create a new TplMutex in an unlocked, uninitialized state.
+    /// The resulting TplMutex will not be usable until its TPL controller is initialized.
+    pub const fn new_uninit(tpl_lock_level: Tpl, data: T) -> Self {
+        Self {
+            tpl_controller: TplControllerStorage::Deferred(OnceCell::new()),
+            tpl_lock_level,
+            lock: AtomicBool::new(false),
+            data: UnsafeCell::new(data),
+        }
+    }
+
+    /// Initialize the TPL controller for this TplMutex. This must be called before the mutex can be used.
     ///
     /// # Panics
     /// This call will panic if the mutex is already initialized.
-    pub fn init(&self, boot_services: B) {
-        self.boot_services.set(boot_services).map_err(|_| "Boot services already initialized!").unwrap();
+    pub fn init(&self, tpl_controller: B) {
+        match &self.tpl_controller {
+            TplControllerStorage::Ready(_) => Err(tpl_controller),
+            TplControllerStorage::Deferred(controller) => controller.set(tpl_controller),
+        }
+        .map_err(|_| "TPL controller already initialized!")
+        .unwrap();
     }
 }
 
-impl<T: ?Sized, B: BootServices> TplMutex<T, B> {
+impl<T: ?Sized, B: TplController> TplMutex<T, B> {
+    fn tpl_controller(&self) -> &B {
+        match &self.tpl_controller {
+            TplControllerStorage::Ready(controller) => controller,
+            TplControllerStorage::Deferred(controller) => controller.get().expect("TPL controller not initialized!"),
+        }
+    }
+
     /// Attempt to lock the mutex and return a [TplMutexGuard] if the mutex was not locked.
     ///
     /// # Panics
@@ -85,28 +128,37 @@ impl<T: ?Sized, B: BootServices> TplMutex<T, B> {
     /// This call will panic if the mutex is not initialized.
     #[allow(clippy::result_unit_err)]
     pub fn try_lock(&self) -> Result<TplMutexGuard<'_, T, B>, ()> {
-        self.lock
-            .compare_exchange(false, true, Ordering::Acquire, Ordering::Relaxed)
-            .map(|_| TplMutexGuard {
-                release_tpl: self
-                    .boot_services
-                    .get()
-                    .expect("BootServices not initialized!")
-                    .raise_tpl(self.tpl_lock_level),
-                tpl_mutex: self,
-            })
-            .map_err(|_| ())
+        if self.lock.load(Ordering::Relaxed) {
+            return Err(());
+        }
+
+        let tpl_controller = self.tpl_controller();
+        let release_tpl = tpl_controller.raise_tpl(self.tpl_lock_level);
+
+        if self.lock.compare_exchange(false, true, Ordering::Acquire, Ordering::Relaxed).is_ok() {
+            Ok(TplMutexGuard { release_tpl, tpl_mutex: self })
+        } else {
+            tpl_controller.restore_tpl(release_tpl);
+            Err(())
+        }
     }
 }
 
-impl<T: ?Sized, B: BootServices> Drop for TplMutexGuard<'_, T, B> {
+impl<T: ?Sized, B: TplController> TplMutexGuard<'_, T, B> {
+    /// Returns the TPL that will be restored when this guard is dropped.
+    pub fn release_tpl(&self) -> Tpl {
+        self.release_tpl
+    }
+}
+
+impl<T: ?Sized, B: TplController> Drop for TplMutexGuard<'_, T, B> {
     fn drop(&mut self) {
-        self.tpl_mutex.boot_services.get().expect("BootServices not initialized!").restore_tpl(self.release_tpl);
         self.tpl_mutex.lock.store(false, Ordering::Release);
+        self.tpl_mutex.tpl_controller().restore_tpl(self.release_tpl);
     }
 }
 
-impl<T: ?Sized, B: BootServices> Deref for TplMutexGuard<'_, T, B> {
+impl<T: ?Sized, B: TplController> Deref for TplMutexGuard<'_, T, B> {
     type Target = T;
     fn deref(&self) -> &T {
         // SAFETY:
@@ -116,7 +168,7 @@ impl<T: ?Sized, B: BootServices> Deref for TplMutexGuard<'_, T, B> {
     }
 }
 
-impl<T: ?Sized, B: BootServices> DerefMut for TplMutexGuard<'_, T, B> {
+impl<T: ?Sized, B: TplController> DerefMut for TplMutexGuard<'_, T, B> {
     fn deref_mut(&mut self) -> &mut T {
         // SAFETY:
         // `as_ref` is guarantee to have a valid pointer because it come from a UnsafeCell.
@@ -125,7 +177,7 @@ impl<T: ?Sized, B: BootServices> DerefMut for TplMutexGuard<'_, T, B> {
     }
 }
 
-impl<T: ?Sized + fmt::Debug, B: BootServices> fmt::Debug for TplMutex<T, B> {
+impl<T: ?Sized + fmt::Debug, B: TplController> fmt::Debug for TplMutex<T, B> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let mut dbg = f.debug_struct("TplMutex");
         match self.try_lock() {
@@ -136,13 +188,13 @@ impl<T: ?Sized + fmt::Debug, B: BootServices> fmt::Debug for TplMutex<T, B> {
     }
 }
 
-impl<T: ?Sized + fmt::Debug, B: BootServices> fmt::Debug for TplMutexGuard<'_, T, B> {
+impl<T: ?Sized + fmt::Debug, B: TplController> fmt::Debug for TplMutexGuard<'_, T, B> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         Debug::fmt(self.deref(), f)
     }
 }
 
-impl<T: ?Sized + fmt::Display, B: BootServices> fmt::Display for TplMutexGuard<'_, T, B> {
+impl<T: ?Sized + fmt::Display, B: TplController> fmt::Display for TplMutexGuard<'_, T, B> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         Display::fmt(self.deref(), f)
     }
@@ -151,14 +203,14 @@ impl<T: ?Sized + fmt::Display, B: BootServices> fmt::Display for TplMutexGuard<'
 // SAFETY: TplMutex is Sync because it ensures exclusive access to T through TPL-based locking.
 // The lock/unlock operations at TPL_HIGH_LEVEL prevent concurrent access. T must be Send to
 // allow transfer between threads, and the mutex ensures only one thread accesses T at a time.
-unsafe impl<T: ?Sized + Send, B: BootServices + Send> Sync for TplMutex<T, B> {}
+unsafe impl<T: ?Sized + Send, B: TplController + Send> Sync for TplMutex<T, B> {}
 // SAFETY: TplMutex is Send because it owns T (which is Send) and uses TPL locking to ensure
 // thread-safe access. The mutex can be safely transferred between threads.
-unsafe impl<T: ?Sized + Send, B: BootServices + Send> Send for TplMutex<T, B> {}
+unsafe impl<T: ?Sized + Send, B: TplController + Send> Send for TplMutex<T, B> {}
 
 // SAFETY: TplMutexGuard is Sync when T is Sync because the guard represents exclusive access
 // to T through the TPL mutex. The guard can be shared across threads safely.
-unsafe impl<T: ?Sized + Sync, B: BootServices> Sync for TplMutexGuard<'_, T, B> {}
+unsafe impl<T: ?Sized + Sync, B: TplController> Sync for TplMutexGuard<'_, T, B> {}
 
 #[cfg(test)]
 #[cfg_attr(coverage, coverage(off))]
@@ -186,7 +238,10 @@ mod tests {
 
     #[test]
     fn test_try_lock() {
-        let mutex = TplMutex::new(boot_services(), Tpl::NOTIFY, 0);
+        let mut boot_services = MockBootServices::new();
+        boot_services.expect_raise_tpl().with(eq(Tpl::NOTIFY)).times(2).return_const(Tpl::APPLICATION);
+        boot_services.expect_restore_tpl().with(eq(Tpl::APPLICATION)).times(2).return_const(());
+        let mutex = TplMutex::new(boot_services, Tpl::NOTIFY, 0);
 
         let guard_result = mutex.try_lock();
         assert!(guard_result.is_ok(), "First lock should work.");
@@ -201,6 +256,20 @@ mod tests {
         drop(guard_result);
         let guard_result = mutex.try_lock();
         assert!(guard_result.is_ok(), "Lock should work after the guard has been dropped.");
+    }
+
+    #[test]
+    #[should_panic(expected = "TPL controller already initialized!")]
+    fn test_init_panics_when_tpl_controller_is_already_initialized() {
+        let mutex = TplMutex::new(MockBootServices::new(), Tpl::NOTIFY, 0);
+        mutex.init(MockBootServices::new());
+    }
+
+    #[test]
+    #[should_panic(expected = "TPL controller not initialized!")]
+    fn test_lock_panics_when_tpl_controller_is_not_initialized() {
+        let mutex = TplMutex::<_, MockBootServices>::new_uninit(Tpl::NOTIFY, 0);
+        let _guard = mutex.lock();
     }
 
     #[test]


### PR DESCRIPTION
## Description

Unifies TPL mutex implementation and address incorrect ordering of atomic lock flag vs. TPL raise/restore in SDK. 

All the business logic for the mutex now lives in the SDK, with a trait that abstracts the TPL operations. SDK version implements this trait via BootServices, whereas the core TplMutex has a trait implementation that wraps the core TPL routines directly.

Existing TplMutex APIs are maintained and there is no breaking change for downstream consumers of either TplMutex implementation.

Addresses #1667 

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [x] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Passes existing unit tests; testing on hardware platforms with components that have extensive use of TplMutex in progrss.

## Integration Instructions

N/A - API is maintained.