### PR TITLE
[major] Remove "alloc" feature from default feature list of all Patina crates

### DIFF
--- a/components/patina_acpi/Cargo.toml
+++ b/components/patina_acpi/Cargo.toml
@@ -21,7 +21,7 @@ patina_test = { workspace = true }
 
 [dev-dependencies]
 mockall = { workspace = true }
-patina = { workspace = true, features = ["mockall"] }
+patina = { workspace = true, features = ["alloc", "mockall"] }
 
 [features]
 mockall = ["dep:mockall", "std"]

--- a/components/patina_adv_logger/Cargo.toml
+++ b/components/patina_adv_logger/Cargo.toml
@@ -17,7 +17,7 @@ required-features = ['std']
 
 [dependencies]
 log = { workspace = true }
-patina = { workspace = true }
+patina = { workspace = true, features = ["alloc"] }
 patina_test = { workspace = true }
 spin = { workspace = true }
 zerocopy = { workspace = true }

--- a/components/patina_mm/Cargo.toml
+++ b/components/patina_mm/Cargo.toml
@@ -14,7 +14,7 @@ workspace = true
 cfg-if = { workspace = true }
 log = { workspace = true }
 mockall = { workspace = true, optional = true }
-patina = { workspace = true }
+patina = { workspace = true, features = ["alloc"] }
 zerocopy = { workspace = true }
 zerocopy-derive = { workspace = true }
 

--- a/components/patina_performance/Cargo.toml
+++ b/components/patina_performance/Cargo.toml
@@ -13,7 +13,7 @@ workspace = true
 [dependencies]
 log = { workspace = true }
 
-patina = { workspace = true }
+patina = { workspace = true, features = ["alloc"] }
 patina_mm = { workspace = true }
 zerocopy = { workspace = true }
 zerocopy-derive = { workspace = true }

--- a/components/patina_samples/Cargo.toml
+++ b/components/patina_samples/Cargo.toml
@@ -12,7 +12,7 @@ workspace = true
 
 [dependencies]
 log = { workspace = true }
-patina = { workspace = true }
+patina = { workspace = true, features = ["alloc"] }
 patina_macro = { workspace = true }
 patina_smbios = { workspace = true }
 

--- a/components/patina_smbios/Cargo.toml
+++ b/components/patina_smbios/Cargo.toml
@@ -10,7 +10,7 @@ description = "System Management BIOS (SMBIOS) support for Patina UEFI component
 [dependencies]
 log = { workspace = true }
 mockall = { workspace = true, optional = true }
-patina = { workspace = true }
+patina = { workspace = true, features = ["alloc"] }
 patina_macro = { workspace = true }
 zerocopy = { workspace = true }
 zerocopy-derive = { workspace = true }

--- a/components/patina_test/Cargo.toml
+++ b/components/patina_test/Cargo.toml
@@ -13,7 +13,7 @@ workspace = true
 [dependencies]
 linkme = { workspace = true }
 log = { workspace = true }
-patina = { workspace = true }
+patina = { workspace = true, features = ["alloc"] }
 patina_macro = { workspace = true }
 spin = { workspace = true }
 

--- a/core/patina_debugger/Cargo.toml
+++ b/core/patina_debugger/Cargo.toml
@@ -13,7 +13,7 @@ workspace = true
 [dependencies]
 cfg-if = { workspace = true }
 gdbstub = { workspace = true }
-patina = { workspace = true }
+patina = { workspace = true, features = ["alloc"] }
 patina_internal_cpu = { workspace = true }
 log = { workspace = true }
 spin = { workspace = true }
@@ -28,7 +28,6 @@ serial_test = { workspace = true }
 patina_mtrr = { workspace = true }
 
 [features]
-default = []
 alloc = []
 # All non-std features to test in CI
 ci_features = ["alloc"]

--- a/core/patina_internal_core/Cargo.toml
+++ b/core/patina_internal_core/Cargo.toml
@@ -13,14 +13,13 @@ workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [features]
-default = ["alloc"]
 alloc = []
 # All non-std features to test in CI
 ci_features = ["alloc"]
 
 [dependencies]
 log = { workspace=true }
-patina = { workspace = true }
+patina = { workspace = true, features = ["alloc"] }
 uuid = { workspace = true }
 
 [dev-dependencies]

--- a/core/patina_internal_cpu/Cargo.toml
+++ b/core/patina_internal_cpu/Cargo.toml
@@ -15,7 +15,7 @@ features = ["std"]
 
 [dependencies]
 log = { workspace = true }
-patina = { workspace = true, features = ["core"] }
+patina = { workspace = true, features = ["alloc", "core"] }
 spin = { workspace = true, features = ["rwlock"] }
 patina_paging = { workspace = true }
 cfg-if = { workspace = true }
@@ -32,7 +32,6 @@ mockall = { workspace = true }
 serial_test = { workspace = true }
 
 [features]
-default = []
 std = []
 # All non-std features to test in CI
 ci_features = []

--- a/patina_dxe_core/Cargo.toml
+++ b/patina_dxe_core/Cargo.toml
@@ -22,9 +22,9 @@ scroll = { workspace = true, features = ["derive"] }
 spin = { workspace = true }
 corosensei = { workspace = true  }
 uuid = { workspace = true  }
-patina = { workspace = true, features = ["core"] }
+patina = { workspace = true, features = ["alloc", "core"] }
 patina_ffs = { workspace = true }
-patina_internal_core = { workspace = true }
+patina_internal_core = { workspace = true, features = ["alloc"] }
 patina_internal_cpu = { workspace = true }
 patina_debugger = { workspace = true, features = ["alloc"] }
 patina_test = { workspace = true }
@@ -35,9 +35,9 @@ patina_test = { workspace = true }
 # local to the workspace should be added via `path` instead of `workspace = true` so that that it does not fail to
 # compile due to the dev-dependency not being published yet.
 patina_samples = { path = "../components/patina_samples" }
-patina = { path = "../sdk/patina", features = ["core", "mockall"] }
+patina = { path = "../sdk/patina", features = ["alloc", "core", "mockall"] }
 patina_ffs_extractors = { path = "../sdk/patina_ffs_extractors" }
-patina_internal_core = { path = "../core/patina_internal_core" }
+patina_internal_core = { path = "../core/patina_internal_core", features = ["alloc"] }
 env_logger = { workspace = true }
 mockall = { workspace = true }
 serial_test = { workspace = true }
@@ -48,7 +48,6 @@ zerocopy-derive = { workspace = true }
 arm-gic = { workspace = true }
 
 [features]
-default = []
 std = ["patina/std"]
 compatibility_mode_allowed = []
 v1_resource_descriptor_support = []

--- a/sdk/patina/Cargo.toml
+++ b/sdk/patina/Cargo.toml
@@ -87,7 +87,6 @@ std = ['alloc']
 alloc = ["dep:goblin", "dep:fixedbitset"]
 mockall = ["dep:mockall", "std"]
 global_allocator = []
-default = ['alloc']
 serde = ["alloc", "dep:serde", "serde/alloc", "dep:serde_json"]
 serde-with-yaml = ["serde", "dep:serde_yaml"]
 

--- a/sdk/patina/src/base/c_ptr.rs
+++ b/sdk/patina/src/base/c_ptr.rs
@@ -172,6 +172,7 @@ unsafe impl<'a, T> CMutRef<'a> for &'a mut T {}
 // Box<T>
 #[cfg(any(test, feature = "alloc"))]
 // SAFETY: Memory layout and mutability are respected for these types.
+#[cfg(any(test, feature = "alloc"))]
 unsafe impl<T> CPtr<'_> for Box<T> {
     type Type = T;
 
@@ -181,12 +182,15 @@ unsafe impl<T> CPtr<'_> for Box<T> {
 }
 #[cfg(any(test, feature = "alloc"))]
 // SAFETY: Memory layout and mutability are respected for these types.
+#[cfg(any(test, feature = "alloc"))]
 unsafe impl<T> CRef<'_> for Box<T> {}
 #[cfg(any(test, feature = "alloc"))]
 // SAFETY: Memory layout and mutability are respected for these types.
+#[cfg(any(test, feature = "alloc"))]
 unsafe impl<T> CMutPtr<'_> for Box<T> {}
 #[cfg(any(test, feature = "alloc"))]
 // SAFETY: Memory layout and mutability are respected for these types.
+#[cfg(any(test, feature = "alloc"))]
 unsafe impl<T> CMutRef<'_> for Box<T> {}
 
 // ()

--- a/sdk/patina_ffs/Cargo.toml
+++ b/sdk/patina_ffs/Cargo.toml
@@ -11,7 +11,7 @@ description = "Support for Firmware File System as described in the UEFI Platfor
 workspace = true
 
 [dependencies]
-patina = {workspace = true}
+patina = {workspace = true, features = ["alloc"]}
 log = {workspace = true}
 
 [dev-dependencies]

--- a/sdk/patina_ffs_extractors/Cargo.toml
+++ b/sdk/patina_ffs_extractors/Cargo.toml
@@ -11,7 +11,7 @@ description = "UEFI section extractor implementations."
 workspace = true
 
 [dependencies]
-patina = { workspace = true }
+patina = { workspace = true, features = ["alloc"] }
 patina_ffs = { workspace = true }
 brotli-decompressor = { workspace = true, optional = true }
 alloc-no-stdlib = { workspace = true, optional = true }

--- a/sdk/patina_macro/Cargo.toml
+++ b/sdk/patina_macro/Cargo.toml
@@ -24,11 +24,10 @@ proc-macro2 = { workspace = true }
 # cargo-release, however they are still used when verifying the package is compileable. Any dev-dependency that is
 # local to the workspace should be added via `path` instead of `workspace = true` so that that it does not fail to
 # compile due to the dev-dependency not being published yet.
-patina = { path="../../sdk/patina" }
+patina = { path="../../sdk/patina", features = ["alloc"] }
 
 
 [features]
-default = []
 # Opting in to the `enable_patina_tests` feature requires registering at least one test
 # with the `#[patina_test]` attribute. Otherwise, a linker crash or failure will
 # occur!


### PR DESCRIPTION
## Description

**Background:** Behavior of `--all-features` with explicit package vs without explicit package:
```
cargo clippy --all-features --tests
workspace
  crate a(feature fa)           <--- all features defined in crate_a are enabled and built as a test binary
    crate b(feature fb)         <--- all features defined in crate_b are enabled and built as a lib

cargo clippy -p crate_a --all-features --tests
workspace
  crate a(feature fa)           <--- all features defined in crate_a are enabled and built as a test binary
    crate b(feature fb)         <--- only features selected when specifying crate_b as dependency are enabled(if non selected, default features are applied) and built as a lib
```
**NOTE:** `--tests` is nothing special here any target can be picked

**Problem:** Rust MM Supervisor avoids hidden heap allocations from dependencies
by ensuring the "alloc" feature is not enabled. Since Patina currently includes
"alloc" in its default feature set, the MM Supervisor branch had to explicitly
remove it from its default features(`default = []`) and also by not defining an
explicit `#[global_allocator]`. Because `default-features = false` only affects
a direct dependency, not transitive dependencies

Now with `default=[]` in place on patina sdk in feature/supv branch,

Before the SDK refactor, c_ptr.rs is gated as shown below. Which means trying to
run `cargo clippy --tests` did not break the build with or without
--all-features because in both cases c_ptr.rs is fully stubbed out as patina
sdk is neither built with test feature(remember this is a dependency to whatever
crate is being built) nor alloc(since we have set default=[]).

```
sdk\patina\src\lib.rs
#[cfg(any(test, feature = "alloc"))]        <----- stubbed out because patina sdk is a dependency for whatever test crate is being built right now
extern crate alloc;

#[cfg(any(test, feature = "alloc"))]        <----- stubbed out because patina sdk is a dependency for whatever test crate is being built right now
pub mod boot_services;

sdk\patina\src\boot_services\c_ptr.rs       <----- stubbed out because patina sdk is a dependency for whatever test crate is being built right now
use alloc::boxed::Box;
```

After the SDK refactor, c_ptr.rs is NOT gated. Which means trying to run 
`cargo clippy --tests` will break the build with or without `--all-features` because in
both the cases c_ptr.rs is always present and `extern crate alloc` is always
absent as neither test feature(again remember this is a dependency to whatever
crate is being built) nor alloc(since we have set default=[]).

```
sdk\patina\src\lib.rs
#[cfg(any(test, feature = "alloc"))]        <----- stubbed out because patina sdk is a dependency for whatever test crate is being built right now
extern crate alloc;

pub mod base;                               <----- NOT STUBBED OUT

sdk\patina\src\base\c_ptr.rs                <----- NOT STUBBED OUT
use alloc::boxed::Box;
```

Resulting in below error:

  ```
  error[E0433]: cannot find module or crate `alloc` in this scope
 --> sdk\patina\src\base\c_ptr.rs:9:5
  |
9 | use alloc::boxed::Box;
  |     ^^^^^ use of unresolved module or unlinked crate `alloc`
  ```

While restoring the feature gate on `c_ptr` fixes this immediate issue(also done
in https://github.com/OpenDevicePartnership/patina/pull/1677), debugging "feature"
related failures like this is not a very pleasant experience. In particular,
`--all-features` only applies to the package being built and does not propagate
to dependencies. To some extent `cargo hack` makes it easier to run failing
command on individual packages but that brings in its own set of new challenges.
After spending a considerable amount of time untangling the dependencies and
finding the root cause, it seems that removing "alloc" from the default feature set
across all Patina crates would alleviate some of the debugging pain.

**Benefits:**
1. Patina crates no longer assume the presence of the `alloc` feature.
2. Crates within Patina repo are nothing special and they have to explicitly
   declare the required feature set, making feature usage easier to audit and
   maintain.

    ```
    E:\repos\patina>cargo tree -e features -p patina_ffs_extractors -e=no-dev
    patina_ffs_extractors v23.0.1 (E:\repos\patina\sdk\patina_ffs_extractors)
    ...
    ├── patina feature "default"  <----

    vs

    E:\repos\patina>cargo tree -e features -p patina_ffs_extractors -e=no-dev
    patina_ffs_extractors v23.0.1 (E:\repos\patina\sdk\patina_ffs_extractors)
    ...
    ├── patina feature "alloc"    <----
    ```
3. Rust MM Supervisor can now opt out of `alloc` without requiring any hacks.
   Please note that #[global_allocator] should still be avoided so that the
   compiler can flag any dependent code paths that require heap allocations.

This is a breaking change because existing consumers relying on Patina's default
feature set will need to explicitly enable the required features. Most existing
crates have already been updated as part of this commit.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [x] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

`cargo make all` and validated on hardware platform.

## Integration Instructions

All external crates relying on patina crates will need to add "alloc" to the features list like below
`patina = { workspace = true, features = ["alloc"] }`
