### PR TITLE
[major][Rebase & FF] Consolidate alloc crate usage and opt out of alloc feature for patina_internal_cpu's patina sdk dependency

### DIFF
--- a/components/patina_acpi/src/acpi.rs
+++ b/components/patina_acpi/src/acpi.rs
@@ -813,8 +813,6 @@ where
 
 #[cfg(test)]
 mod tests {
-    extern crate std;
-
     use crate::signature::MAX_INITIAL_ENTRIES;
 
     use super::*;

--- a/components/patina_acpi/src/service.rs
+++ b/components/patina_acpi/src/service.rs
@@ -168,9 +168,9 @@ pub(crate) trait AcpiProvider {
 #[cfg(test)]
 #[cfg_attr(coverage, coverage(off))]
 mod tests {
-    use alloc::boxed::Box;
     use core::mem;
     use patina::component::service::memory::StdMemoryManager;
+    use std::boxed::Box;
 
     use crate::acpi_table::AcpiFadt;
 

--- a/components/patina_adv_logger/src/lib.rs
+++ b/components/patina_adv_logger/src/lib.rs
@@ -8,7 +8,7 @@
 #![deny(missing_docs)]
 #![cfg_attr(coverage, feature(coverage_attribute))]
 
-#[cfg(any(feature = "alloc", test, doc))]
+#[cfg(any(feature = "alloc", doc))]
 extern crate alloc;
 
 mod memory_log;

--- a/components/patina_adv_logger/src/logger.rs
+++ b/components/patina_adv_logger/src/logger.rs
@@ -351,7 +351,6 @@ where
 mod tests {
     use core::{ffi::c_void, ptr};
 
-    use alloc::boxed::Box;
     use log::Log;
     use patina::standard::efi;
     use patina::{
@@ -360,6 +359,7 @@ mod tests {
         peripheral::serial::uart::UartNull,
         pi::hob::{GUID_EXTENSION, GuidHob, HobHeader},
     };
+    use std::boxed::Box;
 
     use crate::{
         logger::{AdvancedLogger, TargetFilter},

--- a/components/patina_adv_logger/src/memory_log.rs
+++ b/components/patina_adv_logger/src/memory_log.rs
@@ -423,9 +423,9 @@ impl AdvLoggerMessageEntry {
 const TEST_DATA_SIZE: usize = 128;
 
 #[cfg(test)]
-pub(crate) fn create_buffer_v5(timer_frequency: u64, hw_port_disabled: bool) -> alloc::boxed::Box<[u8]> {
+pub(crate) fn create_buffer_v5(timer_frequency: u64, hw_port_disabled: bool) -> std::boxed::Box<[u8]> {
     let header_size = size_of::<AdvLoggerInfoV5>();
-    let mut buffer = alloc::vec![0_u8; header_size + TEST_DATA_SIZE].into_boxed_slice();
+    let mut buffer = std::vec![0_u8; header_size + TEST_DATA_SIZE].into_boxed_slice();
     let header = AdvLoggerInfoV5 {
         signature: AdvLoggerInfo::SIGNATURE,
         version: ADV_LOGGER_INFO_VERSION_V5,
@@ -457,9 +457,9 @@ pub(crate) fn create_buffer_v5(timer_frequency: u64, hw_port_disabled: bool) -> 
 }
 
 #[cfg(test)]
-pub(crate) fn create_buffer_v6(timer_frequency: u64, new_address: u64) -> alloc::boxed::Box<[u8]> {
+pub(crate) fn create_buffer_v6(timer_frequency: u64, new_address: u64) -> std::boxed::Box<[u8]> {
     let header_size = size_of::<AdvLoggerInfoV6>();
-    let mut buffer = alloc::vec![0_u8; header_size + TEST_DATA_SIZE].into_boxed_slice();
+    let mut buffer = std::vec![0_u8; header_size + TEST_DATA_SIZE].into_boxed_slice();
     let header = AdvLoggerInfoV6 {
         v5: AdvLoggerInfoV5 {
             signature: AdvLoggerInfo::SIGNATURE,

--- a/components/patina_adv_logger/src/reader.rs
+++ b/components/patina_adv_logger/src/reader.rs
@@ -154,7 +154,6 @@ impl<'a> Iterator for AdvLogIterator<'a> {
 #[cfg(test)]
 #[cfg_attr(coverage, coverage(off))]
 mod tests {
-    extern crate std;
     use core::{mem::size_of, sync::atomic::Ordering};
 
     use super::*;

--- a/components/patina_adv_logger/src/writer.rs
+++ b/components/patina_adv_logger/src/writer.rs
@@ -192,9 +192,9 @@ impl AdvancedLogWriter {
 #[cfg(all(test, feature = "reader"))]
 #[cfg_attr(coverage, coverage(off))]
 mod tests {
-    use std::boxed::Box;
     use core::{mem::size_of, sync::atomic::Ordering};
     use efi::PhysicalAddress;
+    use std::boxed::Box;
 
     use super::*;
     use crate::{memory_log::*, reader::AdvancedLogReader};

--- a/components/patina_adv_logger/src/writer.rs
+++ b/components/patina_adv_logger/src/writer.rs
@@ -192,8 +192,7 @@ impl AdvancedLogWriter {
 #[cfg(all(test, feature = "reader"))]
 #[cfg_attr(coverage, coverage(off))]
 mod tests {
-    extern crate std;
-    use alloc::boxed::Box;
+    use std::boxed::Box;
     use core::{mem::size_of, sync::atomic::Ordering};
     use efi::PhysicalAddress;
 

--- a/components/patina_mm/src/component/communicator/comm_buffer_update.rs
+++ b/components/patina_mm/src/component/communicator/comm_buffer_update.rs
@@ -277,7 +277,7 @@ mod tests {
     };
     use patina::uefi::boot_services::StandardBootServices;
 
-    use alloc::boxed::Box;
+    use std::boxed::Box;
 
     /// Helper to create a test protocol notify context without boot services
     fn create_test_context(updatable_buffer_id: u8) -> Box<ProtocolNotifyContext> {

--- a/components/patina_mm/tests/patina_mm_integration/common/framework.rs
+++ b/components/patina_mm/tests/patina_mm_integration/common/framework.rs
@@ -12,8 +12,8 @@
 //! SPDX-License-Identifier: Apache-2.0
 use crate::patina_mm_integration::common::{constants::*, handlers::*, message_parser::*};
 
-use alloc::{boxed::Box, string::String, vec::Vec};
 use patina::BinaryGuid;
+use std::{boxed::Box, string::String, vec::Vec};
 use std::{
     collections::HashMap,
     sync::{

--- a/components/patina_mm/tests/patina_mm_integration/common/framework.rs
+++ b/components/patina_mm/tests/patina_mm_integration/common/framework.rs
@@ -12,7 +12,6 @@
 //! SPDX-License-Identifier: Apache-2.0
 use crate::patina_mm_integration::common::{constants::*, handlers::*, message_parser::*};
 
-extern crate alloc;
 use alloc::{boxed::Box, string::String, vec::Vec};
 use patina::BinaryGuid;
 use std::{

--- a/components/patina_mm/tests/patina_mm_integration/common/handlers.rs
+++ b/components/patina_mm/tests/patina_mm_integration/common/handlers.rs
@@ -19,7 +19,6 @@
 use crate::patina_mm_integration::common::constants::*;
 use patina::standard::efi;
 
-extern crate alloc;
 use alloc::{string::String, vec::Vec};
 pub use zerocopy::IntoBytes;
 

--- a/components/patina_mm/tests/patina_mm_integration/common/handlers.rs
+++ b/components/patina_mm/tests/patina_mm_integration/common/handlers.rs
@@ -19,7 +19,7 @@
 use crate::patina_mm_integration::common::constants::*;
 use patina::standard::efi;
 
-use alloc::{string::String, vec::Vec};
+use std::{string::String, vec::Vec};
 pub use zerocopy::IntoBytes;
 
 pub use patina::management_mode::protocol::{

--- a/components/patina_mm/tests/patina_mm_integration/common/message_parser.rs
+++ b/components/patina_mm/tests/patina_mm_integration/common/message_parser.rs
@@ -10,7 +10,6 @@
 //!
 //! SPDX-License-Identifier: Apache-2.0
 
-extern crate alloc;
 #[allow(unused_imports)] // Used in test module within this file
 use alloc::vec::Vec;
 use patina::BinaryGuid;

--- a/components/patina_mm/tests/patina_mm_integration/common/message_parser.rs
+++ b/components/patina_mm/tests/patina_mm_integration/common/message_parser.rs
@@ -10,8 +10,6 @@
 //!
 //! SPDX-License-Identifier: Apache-2.0
 
-#[allow(unused_imports)] // Used in test module within this file
-use alloc::vec::Vec;
 use patina::BinaryGuid;
 
 /// Error types for MM message parsing operations

--- a/components/patina_mm/tests/patina_mm_integration/common/real_component_framework.rs
+++ b/components/patina_mm/tests/patina_mm_integration/common/real_component_framework.rs
@@ -16,7 +16,6 @@
 
 use crate::patina_mm_integration::common::{constants::*, handlers::*};
 
-extern crate alloc;
 use alloc::{boxed::Box, vec::Vec};
 use patina::Guid;
 use std::{

--- a/components/patina_mm/tests/patina_mm_integration/common/real_component_framework.rs
+++ b/components/patina_mm/tests/patina_mm_integration/common/real_component_framework.rs
@@ -16,11 +16,12 @@
 
 use crate::patina_mm_integration::common::{constants::*, handlers::*};
 
-use alloc::{boxed::Box, vec::Vec};
 use patina::Guid;
 use std::{
+    boxed::Box,
     collections::BTreeMap,
     sync::{Arc, Mutex},
+    vec::Vec,
 };
 
 // Import the real patina_mm components and services

--- a/components/patina_mm/tests/patina_mm_integration/tests_root.rs
+++ b/components/patina_mm/tests/patina_mm_integration/tests_root.rs
@@ -31,8 +31,6 @@
 //!
 //! SPDX-License-Identifier: Apache-2.0
 
-extern crate alloc;
-
 // Common utilities available to all test modules
 mod common;
 

--- a/components/patina_performance/src/component/performance.rs
+++ b/components/patina_performance/src/component/performance.rs
@@ -525,7 +525,6 @@ mod tests {
     };
     use patina::standard::efi;
 
-    use alloc::sync::Arc;
     use patina::{
         c_ptr::{CMutPtr, CPtr},
         component::service::{IntoService, Service},
@@ -537,6 +536,7 @@ mod tests {
         uefi::{boot_services::MockBootServices, runtime_services::MockRuntimeServices},
     };
     use patina_mm::component::communicator::{MmCommunication, Status};
+    use std::sync::Arc;
 
     // Some constants shared between tests
     const TEST_EVENT_HANDLE: efi::Event = 1_usize as efi::Event;
@@ -760,7 +760,7 @@ mod tests {
         boot_services.expect_close_event().once().return_const(Ok(()));
 
         // The component allocates the publishing buffer itself; hand back a real leaked page-sized buffer.
-        let leaked_buffer = Box::leak(alloc::vec![0u8; UEFI_PAGE_SIZE].into_boxed_slice());
+        let leaked_buffer = Box::leak(std::vec![0u8; UEFI_PAGE_SIZE].into_boxed_slice());
         let leaked_buffer_addr = leaked_buffer.as_mut_ptr() as usize;
         boot_services.expect_allocate_pages().once().returning(move |_, _, _| Ok(leaked_buffer_addr));
 

--- a/components/patina_samples/src/lib.rs
+++ b/components/patina_samples/src/lib.rs
@@ -19,5 +19,7 @@
 #![deny(missing_docs)]
 #![cfg_attr(coverage, feature(coverage_attribute))]
 #![cfg_attr(coverage, coverage(off))] // Disable all coverage instrumentation for sample code
+extern crate alloc;
+
 pub mod component;
 pub mod smbios_platform;

--- a/components/patina_samples/src/lib.rs
+++ b/components/patina_samples/src/lib.rs
@@ -15,7 +15,7 @@
 //!
 //! SPDX-License-Identifier: Apache-2.0
 //!
-#![cfg_attr(not(feature = "std"), no_std)]
+#![cfg_attr(all(not(feature = "std"), not(test)), no_std)]
 #![deny(missing_docs)]
 #![cfg_attr(coverage, feature(coverage_attribute))]
 #![cfg_attr(coverage, coverage(off))] // Disable all coverage instrumentation for sample code

--- a/components/patina_samples/src/smbios_platform.rs
+++ b/components/patina_samples/src/smbios_platform.rs
@@ -28,8 +28,6 @@
 //!
 //! SPDX-License-Identifier: Apache-2.0
 
-extern crate alloc;
-
 use alloc::{string::String, vec};
 use patina::{
     component::{component, service::Service},

--- a/components/patina_smbios/src/component.rs
+++ b/components/patina_smbios/src/component.rs
@@ -142,7 +142,6 @@ impl SmbiosProvider {
 #[cfg(test)]
 mod tests {
     use super::*;
-    extern crate std;
 
     #[test]
     fn test_smbios_provider_new() {

--- a/components/patina_smbios/src/component.rs
+++ b/components/patina_smbios/src/component.rs
@@ -8,7 +8,6 @@
 //!
 //! SPDX-License-Identifier: Apache-2.0
 
-extern crate alloc;
 use crate::{
     error::SmbiosError,
     manager::SmbiosManager,

--- a/components/patina_smbios/src/error.rs
+++ b/components/patina_smbios/src/error.rs
@@ -121,7 +121,6 @@ mod tests {
 
     #[test]
     fn test_smbios_error_all_variants() {
-        extern crate std;
         use std::vec;
 
         // Test all error variants for completeness

--- a/components/patina_smbios/src/lib.rs
+++ b/components/patina_smbios/src/lib.rs
@@ -313,6 +313,8 @@
 #![deny(missing_docs)]
 #![cfg_attr(coverage, feature(coverage_attribute))]
 
+extern crate alloc;
+
 // SMBIOS tables require little-endian byte order. The SmbiosRecord derive macro
 // uses zerocopy::IntoBytes::as_bytes() which returns native byte order.
 #[cfg(not(target_endian = "little"))]

--- a/components/patina_smbios/src/manager.rs
+++ b/components/patina_smbios/src/manager.rs
@@ -12,8 +12,6 @@
 //! SPDX-License-Identifier: Apache-2.0
 //!
 
-extern crate alloc;
-
 use patina::protocol::ProtocolInterface;
 
 mod core;

--- a/components/patina_smbios/src/manager/core.rs
+++ b/components/patina_smbios/src/manager/core.rs
@@ -10,8 +10,6 @@
 //! SPDX-License-Identifier: Apache-2.0
 //!
 
-extern crate alloc;
-
 use alloc::{boxed::Box, collections::BTreeSet, string::String, vec::Vec};
 use core::cell::RefCell;
 use patina::standard::efi::{Handle, PhysicalAddress};

--- a/components/patina_smbios/src/manager/core.rs
+++ b/components/patina_smbios/src/manager/core.rs
@@ -753,14 +753,13 @@ impl SmbiosManager {
 #[cfg(test)]
 mod tests {
     use super::*;
-    extern crate std;
-    use std::{vec, vec::Vec};
-
     use crate::{
         error::SmbiosError,
         service::{SMBIOS_HANDLE_PI_RESERVED, SMBIOS_STRING_MAX_LENGTH, SmbiosHandle, SmbiosTableHeader},
     };
+    use patina::component::service::memory::StdMemoryManager;
     use patina::standard::efi;
+    use std::{boxed::Box, vec, vec::Vec};
     use zerocopy::IntoBytes;
 
     /// Test helper: Build a simple SMBIOS record with the given header and strings
@@ -1769,10 +1768,6 @@ mod tests {
 
     #[test]
     fn test_allocate_buffers() {
-        use patina::component::service::memory::StdMemoryManager;
-        extern crate std;
-        use std::boxed::Box;
-
         let manager = SmbiosManager::new(3, 9).expect("failed to create manager");
         let memory_manager: &'static dyn patina::component::service::memory::MemoryManager =
             Box::leak(Box::new(StdMemoryManager::new()));
@@ -1796,10 +1791,6 @@ mod tests {
 
     #[test]
     fn test_allocate_buffers_idempotent() {
-        use patina::component::service::memory::StdMemoryManager;
-        extern crate std;
-        use std::boxed::Box;
-
         let manager = SmbiosManager::new(3, 9).expect("failed to create manager");
         let memory_manager: &'static dyn patina::component::service::memory::MemoryManager =
             Box::leak(Box::new(StdMemoryManager::new()));
@@ -1820,10 +1811,6 @@ mod tests {
 
     #[test]
     fn test_build_table_data() {
-        use patina::component::service::memory::StdMemoryManager;
-        extern crate std;
-        use std::boxed::Box;
-
         let manager = SmbiosManager::new(3, 9).expect("failed to create manager");
         let memory_manager: &'static dyn patina::component::service::memory::MemoryManager =
             Box::leak(Box::new(StdMemoryManager::new()));
@@ -1863,10 +1850,6 @@ mod tests {
 
     #[test]
     fn test_build_table_data_copies_records_correctly() {
-        use patina::component::service::memory::StdMemoryManager;
-        extern crate std;
-        use std::boxed::Box;
-
         let manager = SmbiosManager::new(3, 9).expect("failed to create manager");
         let memory_manager: &'static dyn patina::component::service::memory::MemoryManager =
             Box::leak(Box::new(StdMemoryManager::new()));
@@ -1897,10 +1880,6 @@ mod tests {
 
     #[test]
     fn test_build_table_data_no_records_error() {
-        use patina::component::service::memory::StdMemoryManager;
-        extern crate std;
-        use std::boxed::Box;
-
         let manager = SmbiosManager::new(3, 9).expect("failed to create manager");
         let memory_manager: &'static dyn patina::component::service::memory::MemoryManager =
             Box::leak(Box::new(StdMemoryManager::new()));

--- a/components/patina_smbios/src/manager/protocol.rs
+++ b/components/patina_smbios/src/manager/protocol.rs
@@ -358,7 +358,6 @@ impl SmbiosProtocol {
 mod tests {
     use super::*;
     use crate::{error::SmbiosError, manager::SmbiosManager};
-    extern crate std;
     use std::vec::Vec;
 
     fn create_test_bios_info_record() -> Vec<u8> {

--- a/components/patina_smbios/src/manager/protocol.rs
+++ b/components/patina_smbios/src/manager/protocol.rs
@@ -13,8 +13,6 @@
 //! SPDX-License-Identifier: Apache-2.0
 //!
 
-extern crate alloc;
-
 use core::ffi::c_char;
 
 use alloc::string::ToString;

--- a/components/patina_smbios/src/manager/record.rs
+++ b/components/patina_smbios/src/manager/record.rs
@@ -38,7 +38,6 @@ impl SmbiosRecord {
 #[cfg(test)]
 mod tests {
     use super::*;
-    extern crate std;
     use std::vec;
 
     use patina::standard::efi;

--- a/components/patina_smbios/src/manager/record.rs
+++ b/components/patina_smbios/src/manager/record.rs
@@ -10,8 +10,6 @@
 //! SPDX-License-Identifier: Apache-2.0
 //!
 
-extern crate alloc;
-
 use alloc::vec::Vec;
 
 use crate::service::SmbiosTableHeader;

--- a/components/patina_smbios/src/service.rs
+++ b/components/patina_smbios/src/service.rs
@@ -413,8 +413,8 @@ mod tests {
     #[test]
     fn test_smbios_records_iter_basic() {
         use crate::manager::SmbiosRecord;
-        use alloc::vec;
         use core::cell::RefCell;
+        use std::vec;
 
         let records = RefCell::new(vec![
             SmbiosRecord::new(SmbiosTableHeader::new(0, 24, 0x0001), None, vec![], 0),
@@ -440,8 +440,8 @@ mod tests {
     #[test]
     fn test_smbios_records_iter_with_filter() {
         use crate::manager::SmbiosRecord;
-        use alloc::vec;
         use core::cell::RefCell;
+        use std::vec;
 
         let records = RefCell::new(vec![
             SmbiosRecord::new(SmbiosTableHeader::new(0, 24, 0x0001), None, vec![], 0),
@@ -468,8 +468,8 @@ mod tests {
     #[test]
     fn test_smbios_records_iter_empty() {
         use crate::manager::SmbiosRecord;
-        use alloc::vec;
         use core::cell::RefCell;
+        use std::vec;
 
         let records: RefCell<Vec<SmbiosRecord>> = RefCell::new(vec![]);
         let borrowed = records.borrow();
@@ -481,8 +481,8 @@ mod tests {
     #[test]
     fn test_smbios_records_iter_no_match_filter() {
         use crate::manager::SmbiosRecord;
-        use alloc::vec;
         use core::cell::RefCell;
+        use std::vec;
 
         let records = RefCell::new(vec![
             SmbiosRecord::new(SmbiosTableHeader::new(0, 24, 0x0001), None, vec![], 0),
@@ -584,8 +584,8 @@ mod tests {
 
     #[test]
     fn test_mock_smbios_service_add_record_integration() {
-        use alloc::vec;
         use patina::component::service::Service;
+        use std::vec;
 
         // Create a test record
         let record = Type127EndOfTable { header: SmbiosTableHeader::new(127, 4, 0xFFFE), string_pool: vec![] };
@@ -621,8 +621,8 @@ mod tests {
 
     #[test]
     fn test_mock_add_record_extension_trait_pattern() {
-        use alloc::vec;
         use patina::component::service::Service;
+        use std::vec;
 
         // Create a test record
         let record = Type127EndOfTable { header: SmbiosTableHeader::new(127, 4, 0xFFFE), string_pool: vec![] };
@@ -651,8 +651,8 @@ mod tests {
 
     #[test]
     fn test_mock_add_record_with_error() {
-        use alloc::vec;
         use patina::component::service::Service;
+        use std::vec;
 
         // Mock that returns an error
         let mock = MockSmbios {
@@ -673,8 +673,8 @@ mod tests {
 
     #[test]
     fn test_mock_multiple_record_types() {
-        use alloc::{string::String, vec};
         use patina::component::service::Service;
+        use std::{string::String, vec};
 
         // Test that mock can handle different record types
         let type0 = Type0PlatformFirmwareInformation {
@@ -720,8 +720,8 @@ mod tests {
 
     #[test]
     fn test_service_mock_pattern() {
-        use alloc::vec;
         use patina::component::service::Service;
+        use std::vec;
 
         // Create a mock service using the standard Service::mock pattern
         let mock = MockSmbios { version: (3, 6), add_from_bytes_result: Ok(0xBEEF), expected_bytes: None };
@@ -742,8 +742,8 @@ mod tests {
 
     #[test]
     fn test_service_mock_with_extension_trait() {
-        use alloc::vec;
         use patina::component::service::Service;
+        use std::vec;
 
         // Create test record
         let record = Type127EndOfTable { header: SmbiosTableHeader::new(127, 4, 0xFFFE), string_pool: vec![] };

--- a/components/patina_smbios/src/service.rs
+++ b/components/patina_smbios/src/service.rs
@@ -10,7 +10,6 @@
 //! SPDX-License-Identifier: Apache-2.0
 //!
 
-extern crate alloc;
 use alloc::vec::Vec;
 use core::cell::Ref;
 pub use patina::standard::efi::industry::smbios::{
@@ -343,9 +342,6 @@ impl SmbiosExt for patina::component::service::Service<dyn Smbios> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    extern crate alloc;
-    extern crate std;
-    use alloc::string::String;
     use std::format;
 
     use crate::{

--- a/components/patina_smbios/src/smbios_record.rs
+++ b/components/patina_smbios/src/smbios_record.rs
@@ -804,7 +804,7 @@ impl Default for Type127EndOfTable {
 mod tests {
     use super::*;
     use crate::{service::SMBIOS_STRING_MAX_LENGTH, smbios_types};
-    use alloc::vec;
+    use std::vec;
 
     #[test]
     fn test_type0_new() {

--- a/components/patina_smbios/src/smbios_record.rs
+++ b/components/patina_smbios/src/smbios_record.rs
@@ -234,7 +234,6 @@
 //!
 //! SPDX-License-Identifier: Apache-2.0
 
-extern crate alloc;
 use crate::{
     error::SmbiosError,
     service::{SMBIOS_HANDLE_PI_RESERVED, SMBIOS_STRING_MAX_LENGTH, SmbiosTableHeader},

--- a/components/patina_smbios/src/smbios_types.rs
+++ b/components/patina_smbios/src/smbios_types.rs
@@ -14,8 +14,6 @@
 //!
 //! SPDX-License-Identifier: Apache-2.0
 
-extern crate alloc;
-
 use bitfield_struct::bitfield;
 use zerocopy::{Immutable, IntoBytes, KnownLayout};
 

--- a/components/patina_test/src/__private_api.rs
+++ b/components/patina_test/src/__private_api.rs
@@ -170,8 +170,6 @@ where
 mod tests {
     use super::*;
 
-    extern crate std;
-
     #[test]
     fn test_should_run() {
         let test_case = TestCase {
@@ -183,10 +181,10 @@ mod tests {
             func: |_| Ok(true),
         };
 
-        std::assert!(test_case.should_run(&[Filter::include("test")]));
-        std::assert!(test_case.should_run(&[Filter::include("t")]));
-        std::assert!(test_case.should_run(&[]));
-        std::assert!(!test_case.should_run(&[Filter::include("not")]));
+        assert!(test_case.should_run(&[Filter::include("test")]));
+        assert!(test_case.should_run(&[Filter::include("t")]));
+        assert!(test_case.should_run(&[]));
+        assert!(!test_case.should_run(&[Filter::include("not")]));
     }
 
     #[test]
@@ -200,7 +198,7 @@ mod tests {
             func: |_| Ok(true),
         };
 
-        std::assert!(test_case.should_run(&[]));
+        assert!(test_case.should_run(&[]));
     }
 
     #[test]
@@ -215,13 +213,13 @@ mod tests {
         };
 
         // Exclude filter matches - should not run
-        std::assert!(!test_case.should_run(&[Filter::exclude("test_case")]));
+        assert!(!test_case.should_run(&[Filter::exclude("test_case")]));
         // Exclude filter does not match - should run
-        std::assert!(test_case.should_run(&[Filter::exclude("other")]));
+        assert!(test_case.should_run(&[Filter::exclude("other")]));
         // Include filter matches but exclude filter also matches - should not run
-        std::assert!(!test_case.should_run(&[Filter::include("my_crate"), Filter::exclude("test_case")]));
+        assert!(!test_case.should_run(&[Filter::include("my_crate"), Filter::exclude("test_case")]));
         // Include filter matches and exclude filter does not match - should run
-        std::assert!(test_case.should_run(&[Filter::include("my_crate"), Filter::exclude("other")]));
+        assert!(test_case.should_run(&[Filter::include("my_crate"), Filter::exclude("other")]));
     }
 
     #[test]
@@ -248,11 +246,11 @@ mod tests {
 
         // Test that a passing test passes
         let result = test_case_pass.run(&mut storage, true);
-        std::assert_eq!(result, Ok(()));
+        assert_eq!(result, Ok(()));
 
         // Test that a failing test fails
         let result = test_case_fail.run(&mut storage, true);
-        std::assert_eq!(result, Err("Failed to install protocol interface"));
+        assert_eq!(result, Err("Failed to install protocol interface"));
     }
 
     #[test]
@@ -278,11 +276,11 @@ mod tests {
 
         // Test that a test that passes, should fail because its expected to fail
         let result = test_case_pass.run(&mut storage, true);
-        std::assert_eq!(result, Err("Test passed when it should have failed"));
+        assert_eq!(result, Err("Test passed when it should have failed"));
 
         // Test that a test that fails, should pass because its expected to fail
         let result = test_case_fail.run(&mut storage, true);
-        std::assert_eq!(result, Ok(()));
+        assert_eq!(result, Ok(()));
     }
 
     #[test]
@@ -300,7 +298,7 @@ mod tests {
         };
 
         let result = test_case.run(&mut storage, false);
-        std::assert_eq!(result, Ok(()));
+        assert_eq!(result, Ok(()));
 
         // Test that a test that fails with an unexpected message, should fail
         let test_case = TestCase {
@@ -313,7 +311,7 @@ mod tests {
         };
 
         let result = test_case.run(&mut storage, false);
-        std::assert_eq!(result, Err("Failed to install protocol interface"));
+        assert_eq!(result, Err("Failed to install protocol interface"));
     }
 
     #[test]

--- a/components/patina_test/src/component.rs
+++ b/components/patina_test/src/component.rs
@@ -143,8 +143,6 @@ impl TestRunner {
 #[cfg(test)]
 #[cfg_attr(coverage, coverage(off))]
 pub(crate) mod tests {
-    extern crate std;
-
     use super::*;
 
     use crate::alloc::{boxed::Box, format};
@@ -354,7 +352,7 @@ pub(crate) mod tests {
         // This test is filtered out, so it should not even show up in the results.
         assert!(!output.contains("test_that_fails"));
         // This test is not filtered out, but never run, so should log as such.
-        std::println!("{output}");
+        println!("{output}");
         assert!(output.contains("event_triggered_test ... not triggered"));
     }
 }

--- a/components/patina_test/src/lib.rs
+++ b/components/patina_test/src/lib.rs
@@ -3,7 +3,7 @@
     "## License\n\n",
     " Copyright (c) Microsoft Corporation.\n\n",
 )]
-#![no_std]
+#![cfg_attr(not(test), no_std)]
 #![deny(missing_docs)]
 #![cfg_attr(coverage, feature(coverage_attribute))]
 extern crate alloc;

--- a/components/patina_test/src/service.rs
+++ b/components/patina_test/src/service.rs
@@ -309,12 +309,11 @@ impl Display for Recorder {
 #[cfg(test)]
 #[cfg_attr(coverage, coverage(off))]
 mod tests {
-    extern crate std;
-
     use core::mem::MaybeUninit;
 
     use super::*;
-    use crate::{alloc::format, component::tests::*};
+    use crate::component::tests::*;
+    use std::format;
 
     #[test]
     fn test_recorder_records_results() {
@@ -357,7 +356,7 @@ mod tests {
         recorder.update_record(test_data);
 
         let output = format!("{}", *recorder);
-        std::println!("{output}");
+        println!("{output}");
         assert!(output.contains("test ... ok (1 passes)"));
     }
 

--- a/core/patina_debugger/src/lib.rs
+++ b/core/patina_debugger/src/lib.rs
@@ -117,7 +117,7 @@ mod memory;
 mod system;
 mod transport;
 
-#[cfg(any(feature = "alloc", test))]
+#[cfg(feature = "alloc")]
 extern crate alloc;
 
 pub use debugger::PatinaDebugger;

--- a/core/patina_debugger/src/system/no_alloc.rs
+++ b/core/patina_debugger/src/system/no_alloc.rs
@@ -65,9 +65,6 @@ impl SystemStateTrait for SystemState {
 #[cfg(test)]
 #[cfg_attr(coverage, coverage(off))]
 mod tests {
-    extern crate alloc;
-    use alloc::string::String;
-
     use super::*;
 
     #[test]

--- a/core/patina_internal_core/src/collections/bst.rs
+++ b/core/patina_internal_core/src/collections/bst.rs
@@ -901,7 +901,6 @@ mod tests {
 #[cfg(test)]
 #[allow(clippy::undocumented_unsafe_blocks)]
 mod fuzz_tests {
-    extern crate std;
     use crate::collections::{Bst, node_size};
     use rand::{
         RngExt,

--- a/core/patina_internal_core/src/collections/rbt.rs
+++ b/core/patina_internal_core/src/collections/rbt.rs
@@ -919,8 +919,6 @@ where
 #[cfg_attr(coverage, coverage(off))]
 #[allow(clippy::undocumented_unsafe_blocks)]
 mod tests {
-    extern crate std;
-
     use super::*;
     use crate::collections::node_size;
 
@@ -1844,7 +1842,6 @@ mod tests {
 #[cfg(test)]
 #[allow(clippy::undocumented_unsafe_blocks)]
 mod fuzz_tests {
-    extern crate std;
     use crate::collections::{Rbt, node_size};
     use rand::{
         RngExt,

--- a/core/patina_internal_core/src/collections/sorted_slice.rs
+++ b/core/patina_internal_core/src/collections/sorted_slice.rs
@@ -209,9 +209,7 @@ where
 #[cfg(test)]
 #[cfg_attr(coverage, coverage(off))]
 mod tests {
-    extern crate std;
     use super::*;
-    extern crate alloc;
     use alloc::vec::Vec;
 
     #[test]

--- a/core/patina_internal_core/src/collections/sorted_slice.rs
+++ b/core/patina_internal_core/src/collections/sorted_slice.rs
@@ -210,7 +210,7 @@ where
 #[cfg_attr(coverage, coverage(off))]
 mod tests {
     use super::*;
-    use alloc::vec::Vec;
+    use std::vec::Vec;
 
     #[test]
     fn test_init_state_of_new_sorted_slice() {

--- a/core/patina_internal_core/src/depex.rs
+++ b/core/patina_internal_core/src/depex.rs
@@ -384,11 +384,10 @@ impl Iterator for DepexParser {
 #[cfg(test)]
 #[cfg_attr(coverage, coverage(off))]
 mod tests {
-    extern crate std;
-    use alloc::vec;
     use core::str::FromStr;
     use patina::standard::efi;
     use std::println;
+    use std::vec;
     use uuid::Uuid;
 
     use super::*;

--- a/core/patina_internal_core/src/lib.rs
+++ b/core/patina_internal_core/src/lib.rs
@@ -11,7 +11,7 @@
 //!
 //! SPDX-License-Identifier: Apache-2.0
 //!
-#![no_std]
+#![cfg_attr(not(test), no_std)]
 #![cfg_attr(coverage, feature(coverage_attribute))]
 
 extern crate alloc;

--- a/core/patina_internal_cpu/Cargo.toml
+++ b/core/patina_internal_cpu/Cargo.toml
@@ -17,7 +17,7 @@ features = ["std"]
 
 [dependencies]
 log = { workspace = true }
-patina = { workspace = true, features = ["alloc", "core"] }
+patina = { workspace = true, features = ["core"] }
 spin = { workspace = true, features = ["rwlock"] }
 patina_paging = { workspace = true }
 cfg-if = { workspace = true }

--- a/core/patina_internal_cpu/src/interrupts/exception_handling.rs
+++ b/core/patina_internal_cpu/src/interrupts/exception_handling.rs
@@ -119,8 +119,6 @@ extern "efiapi" fn exception_handler(exception_type: usize, context: &mut Except
 #[cfg(test)]
 #[cfg_attr(coverage, coverage(off))]
 mod tests {
-    extern crate std;
-
     use patina::pi::protocol::cpu_arch::EfiSystemContext;
 
     use super::*;

--- a/core/patina_internal_cpu/src/interrupts/x64/interrupt_manager.rs
+++ b/core/patina_internal_cpu/src/interrupts/x64/interrupt_manager.rs
@@ -241,8 +241,6 @@ fn dump_pte(cr2: u64) {
 #[cfg_attr(coverage, coverage(off))]
 #[cfg(test)]
 mod test {
-    extern crate std;
-
     use serial_test::serial;
 
     use super::*;

--- a/core/patina_internal_cpu/src/paging/null.rs
+++ b/core/patina_internal_cpu/src/paging/null.rs
@@ -8,7 +8,6 @@
 //!
 //! SPDX-License-Identifier: Apache-2.0
 //!
-use alloc::boxed::Box;
 use patina_paging::{CacheAttributeValue, MemoryAttributes, PtError};
 
 use crate::paging::PatinaPageTable;

--- a/patina_dxe_core/src/allocator.rs
+++ b/patina_dxe_core/src/allocator.rs
@@ -22,7 +22,6 @@ use core::{
     slice::{self, from_raw_parts_mut},
 };
 
-extern crate alloc;
 use alloc::{boxed::Box, collections::BTreeMap, vec::Vec};
 use patina::function;
 

--- a/patina_dxe_core/src/allocator/fixed_size_block_allocator.rs
+++ b/patina_dxe_core/src/allocator/fixed_size_block_allocator.rs
@@ -10,7 +10,6 @@
 //! SPDX-License-Identifier: Apache-2.0
 //!
 
-extern crate alloc;
 use super::{AllocationStatistics, AllocationStrategy, DEFAULT_ALLOCATION_STRATEGY, PageAllocator};
 
 use crate::{gcd::SpinLockedGcd, tpl_mutex};

--- a/patina_dxe_core/src/allocator/fixed_size_block_allocator.rs
+++ b/patina_dxe_core/src/allocator/fixed_size_block_allocator.rs
@@ -842,16 +842,15 @@ impl PageAllocator for SpinLockedFixedSizeBlockAllocator {
 #[cfg(test)]
 #[cfg_attr(coverage, coverage(off))]
 mod tests {
-    extern crate std;
     use crate::{
         allocator::{
             DEFAULT_ALLOCATION_STRATEGY, DEFAULT_PAGE_ALLOCATION_GRANULARITY, HIGH_TRAFFIC_ALLOC_MIN_EXPANSION,
         },
         gcd, test_support,
     };
-    use alloc::vec::Vec;
     use core::{alloc::GlobalAlloc, ffi::c_void, panic};
     use std::alloc::System;
+    use std::vec::Vec;
 
     use patina::{
         uefi_pages_to_size, {SIZE_64KB, UEFI_PAGE_SHIFT, UEFI_PAGE_SIZE},

--- a/patina_dxe_core/src/allocator/uefi_allocator.rs
+++ b/patina_dxe_core/src/allocator/uefi_allocator.rs
@@ -272,7 +272,6 @@ where
 #[cfg(test)]
 #[cfg_attr(coverage, coverage(off))]
 mod tests {
-    extern crate std;
     use core::cmp::max;
     use std::alloc::{GlobalAlloc, System};
 

--- a/patina_dxe_core/src/allocator/usage_tests/uefi_memory_map.rs
+++ b/patina_dxe_core/src/allocator/usage_tests/uefi_memory_map.rs
@@ -145,7 +145,6 @@ mod tests {
         allocator::{get_memory_map, init_memory_support, reset_allocators},
         test_support,
     };
-    use alloc::vec::Vec;
     use patina::standard::efi;
     use patina::{
         BinaryGuid,
@@ -158,6 +157,7 @@ mod tests {
     };
     use serial_test::serial;
     use std::panic::RefUnwindSafe;
+    use std::vec::Vec;
 
     const ZERO: BinaryGuid = BinaryGuid::ZERO;
 

--- a/patina_dxe_core/src/component_dispatcher.rs
+++ b/patina_dxe_core/src/component_dispatcher.rs
@@ -8,8 +8,6 @@
 //!
 //! SPDX-License-Identifier: Apache-2.0
 //!
-extern crate alloc;
-
 use crate::tpl_mutex::TplMutex;
 use patina::standard::efi;
 use patina::{

--- a/patina_dxe_core/src/config_tables/memory_attributes_table.rs
+++ b/patina_dxe_core/src/config_tables/memory_attributes_table.rs
@@ -6,7 +6,6 @@
 //!
 //! SPDX-License-Identifier: Apache-2.0
 //!
-extern crate alloc;
 use alloc::vec::Vec;
 
 #[cfg(not(test))]

--- a/patina_dxe_core/src/config_tables/memory_attributes_table.rs
+++ b/patina_dxe_core/src/config_tables/memory_attributes_table.rs
@@ -250,7 +250,6 @@ pub fn core_install_memory_attributes_table() {
 #[cfg(test)]
 #[cfg_attr(coverage, coverage(off))]
 mod tests {
-    extern crate std;
     use super::*;
 
     use crate::{

--- a/patina_dxe_core/src/decompress.rs
+++ b/patina_dxe_core/src/decompress.rs
@@ -6,8 +6,6 @@
 //!
 //! SPDX-License-Identifier: Apache-2.0
 //!
-extern crate alloc;
-
 use core::ffi::c_void;
 
 use alloc::boxed::Box;

--- a/patina_dxe_core/src/event_db.rs
+++ b/patina_dxe_core/src/event_db.rs
@@ -10,8 +10,6 @@
 //!
 #![warn(missing_docs)]
 
-extern crate alloc;
-
 use alloc::{
     collections::{BTreeMap, BTreeSet},
     vec::Vec,

--- a/patina_dxe_core/src/event_db.rs
+++ b/patina_dxe_core/src/event_db.rs
@@ -841,12 +841,11 @@ unsafe impl Sync for SpinLockedEventDb {}
 #[cfg(test)]
 #[cfg_attr(coverage, coverage(off))]
 mod tests {
-    extern crate std;
     use core::{iter, str::FromStr};
 
-    use alloc::{vec, vec::Vec};
     use patina::Guid;
     use patina::standard::efi;
+    use std::{vec, vec::Vec};
     use uuid::Uuid;
 
     use crate::test_support;

--- a/patina_dxe_core/src/gcd/spin_locked_gcd.rs
+++ b/patina_dxe_core/src/gcd/spin_locked_gcd.rs
@@ -3074,9 +3074,9 @@ mod tests {
     use crate::test_support::{self, MockPageTable, MockPageTableWrapper};
 
     use super::*;
-    use alloc::vec::Vec;
     use patina::pi::dxe_services::GcdMemoryType;
     use patina::standard::efi;
+    use std::vec::Vec;
     use std::{alloc::GlobalAlloc, cell::RefCell, rc::Rc};
 
     const DXE_CORE_PE_HEADER_DATA: [u8; 1057] = [

--- a/patina_dxe_core/src/pecoff.rs
+++ b/patina_dxe_core/src/pecoff.rs
@@ -6,8 +6,6 @@
 //!
 //! SPDX-License-Identifier: Apache-2.0
 //!
-extern crate alloc;
-
 use alloc::{
     format,
     string::{String, ToString},

--- a/patina_dxe_core/src/pecoff.rs
+++ b/patina_dxe_core/src/pecoff.rs
@@ -554,7 +554,6 @@ mod tests {
     use crate::test_support;
 
     use super::*;
-    extern crate std;
 
     use std::vec;
 

--- a/patina_dxe_core/src/pecoff/error.rs
+++ b/patina_dxe_core/src/pecoff/error.rs
@@ -46,12 +46,9 @@ impl From<goblin::error::Error> for Error {
 mod tests {
     use super::*;
 
-    extern crate alloc;
     extern crate scroll;
-    extern crate std;
-
-    use alloc::string::ToString;
     use std::format;
+    use std::string::ToString;
 
     #[test]
     fn test_convert_error() {

--- a/patina_dxe_core/src/performance.rs
+++ b/patina_dxe_core/src/performance.rs
@@ -809,7 +809,7 @@ mod tests {
             guid: efi::Guid,
         }
 
-        let node = alloc::boxed::Box::new(FwFilePathNode {
+        let node = std::boxed::Box::new(FwFilePathNode {
             header: efi::protocols::device_path::Protocol {
                 r#type: TYPE_MEDIA,
                 sub_type: Media::SUBTYPE_PIWG_FIRMWARE_FILE,
@@ -817,9 +817,9 @@ mod tests {
             },
             guid: file_guid,
         });
-        let node_ptr = alloc::boxed::Box::into_raw(node) as *mut efi::protocols::device_path::Protocol;
+        let node_ptr = std::boxed::Box::into_raw(node) as *mut efi::protocols::device_path::Protocol;
 
-        let loaded_image = alloc::boxed::Box::new(efi::protocols::loaded_image::Protocol {
+        let loaded_image = std::boxed::Box::new(efi::protocols::loaded_image::Protocol {
             revision: efi::protocols::loaded_image::REVISION,
             parent_handle: ptr::null_mut(),
             system_table: ptr::null_mut(),
@@ -834,7 +834,7 @@ mod tests {
             image_data_type: efi::BOOT_SERVICES_DATA,
             unload: None,
         });
-        let loaded_image_ptr = alloc::boxed::Box::into_raw(loaded_image) as *mut core::ffi::c_void;
+        let loaded_image_ptr = std::boxed::Box::into_raw(loaded_image) as *mut core::ffi::c_void;
 
         let (handle, _) = PROTOCOL_DB
             .install_protocol_interface(None, efi::protocols::loaded_image::PROTOCOL_GUID, loaded_image_ptr)
@@ -934,7 +934,7 @@ mod tests {
             // published_table_size reports a non-zero size, and publish_table writes into a large-enough buffer.
             let size = perf.published_table_size().unwrap();
             assert!(size > 0);
-            let buffer: &'static mut [u8] = alloc::boxed::Box::leak(alloc::vec![0u8; size].into_boxed_slice());
+            let buffer: &'static mut [u8] = std::boxed::Box::leak(std::vec![0u8; size].into_boxed_slice());
             perf.publish_table(buffer).unwrap();
         })
         .unwrap();
@@ -948,7 +948,7 @@ mod tests {
 
             assert_eq!(perf.published_table_size().unwrap_err(), Error::Efi(EfiError::AccessDenied));
 
-            let buffer: &'static mut [u8] = alloc::boxed::Box::leak(alloc::vec![0u8; 64].into_boxed_slice());
+            let buffer: &'static mut [u8] = std::boxed::Box::leak(std::vec![0u8; 64].into_boxed_slice());
             assert_eq!(perf.publish_table(buffer).unwrap_err(), Error::Efi(EfiError::AccessDenied));
 
             // A re-entrant record add cannot acquire the held table lock and drops the record.
@@ -1041,7 +1041,7 @@ mod tests {
             let image_handle = install_loaded_image_with_fw_path(node_length, file_guid);
 
             // A separate handle carries only a driver-binding protocol referencing the image handle above.
-            let driver_binding = alloc::boxed::Box::new(efi::protocols::driver_binding::Protocol {
+            let driver_binding = std::boxed::Box::new(efi::protocols::driver_binding::Protocol {
                 supported: stub_supported,
                 start: stub_start,
                 stop: stub_stop,
@@ -1049,7 +1049,7 @@ mod tests {
                 image_handle,
                 driver_binding_handle: ptr::null_mut(),
             });
-            let driver_binding_ptr = alloc::boxed::Box::into_raw(driver_binding) as *mut core::ffi::c_void;
+            let driver_binding_ptr = std::boxed::Box::into_raw(driver_binding) as *mut core::ffi::c_void;
             let (db_handle, _) = PROTOCOL_DB
                 .install_protocol_interface(None, efi::protocols::driver_binding::PROTOCOL_GUID, driver_binding_ptr)
                 .unwrap();

--- a/patina_dxe_core/src/performance/table.rs
+++ b/patina_dxe_core/src/performance/table.rs
@@ -224,7 +224,7 @@ mod tests {
 
     #[test]
     fn test_serialize_into() {
-        let buffer: &'static mut [u8] = alloc::boxed::Box::leak(alloc::vec![0u8; 1000].into_boxed_slice());
+        let buffer: &'static mut [u8] = std::boxed::Box::leak(std::vec![0u8; 1000].into_boxed_slice());
         let address = buffer.as_ptr() as usize;
 
         let mut fbpt = Fbpt::new();
@@ -275,7 +275,7 @@ mod tests {
 
     #[test]
     fn test_performance_table_well_written_in_memory() {
-        let buffer: &'static mut [u8] = alloc::boxed::Box::leak(alloc::vec![0u8; 1000].into_boxed_slice());
+        let buffer: &'static mut [u8] = std::boxed::Box::leak(std::vec![0u8; 1000].into_boxed_slice());
         let address = buffer.as_ptr() as usize;
 
         let mut fbpt = Fbpt::new();

--- a/patina_dxe_core/src/pi_dispatcher/debug_image_info_table.rs
+++ b/patina_dxe_core/src/pi_dispatcher/debug_image_info_table.rs
@@ -535,7 +535,7 @@ mod tests {
     fn test_grow_error_display_alloc_failed_msg() {
         with_locked_state(|| {
             let error = GrowError::AllocFailed;
-            let msg = alloc::format!("{error}");
+            let msg = std::format!("{error}");
             assert_eq!(msg, "allocation returned null");
         });
     }
@@ -546,7 +546,7 @@ mod tests {
             // Note: Zero alignment will result in a LayoutError.
             let layout_err = Layout::from_size_align(1, 0).unwrap_err();
             let error = GrowError::InvalidLayout(layout_err);
-            let msg = alloc::format!("{error}");
+            let msg = std::format!("{error}");
             assert!(msg.starts_with("invalid layout:"));
         });
     }
@@ -555,12 +555,12 @@ mod tests {
     fn test_grow_error_debug_msgs() {
         with_locked_state(|| {
             let error = GrowError::AllocFailed;
-            let msg = alloc::format!("{error:?}");
+            let msg = std::format!("{error:?}");
             assert_eq!(msg, "AllocFailed");
 
             let layout_err = Layout::from_size_align(1, 0).unwrap_err();
             let error = GrowError::from(layout_err);
-            let msg = alloc::format!("{error:?}");
+            let msg = std::format!("{error:?}");
             assert!(msg.starts_with("InvalidLayout("));
         });
     }

--- a/patina_dxe_core/src/pi_dispatcher/fv.rs
+++ b/patina_dxe_core/src/pi_dispatcher/fv.rs
@@ -899,14 +899,13 @@ pub fn device_path_bytes_for_fv_file(fv_handle: efi::Handle, file_name: efi::Gui
 #[cfg_attr(coverage, coverage(off))]
 mod tests {
     use super::*;
+    use crate::test_collateral;
     use crate::{MockComponentInfo, MockCpuInfo, MockMemoryInfo, test_support};
     use patina::pi::{
         BootMode,
         hob::{self, Hob, HobList},
     };
     use patina_ffs_extractors::CompositeSectionExtractor;
-    extern crate alloc;
-    use crate::test_collateral;
     use std::{
         alloc::{Layout, alloc, dealloc},
         ffi::c_void,

--- a/patina_dxe_core/src/pi_dispatcher/image.rs
+++ b/patina_dxe_core/src/pi_dispatcher/image.rs
@@ -1592,7 +1592,6 @@ impl Buffer {
 #[cfg(test)]
 #[cfg_attr(coverage, coverage(off))]
 mod tests {
-    extern crate std;
     use super::*;
     use crate::{
         Core, MockPlatformInfo,
@@ -1615,6 +1614,7 @@ mod tests {
             hob::{HobList, MemoryAllocationHeader, MemoryAllocationModule},
         },
     };
+    use std::alloc::{Layout, alloc};
     use std::{fs::File, io::Read, ptr::NonNull, slice::from_raw_parts};
 
     #[cfg(target_arch = "aarch64")]
@@ -2667,8 +2667,7 @@ mod tests {
             // Manually construct PrivateImageData with minimal required fields
             const LEN: usize = 0x2000;
             // SAFETY: Allocate a page-aligned test buffer and treat it as a raw image backing store.
-            let fake_buffer =
-                unsafe { alloc::alloc::alloc(alloc::alloc::Layout::from_size_align(LEN, 0x1000).unwrap()) };
+            let fake_buffer = unsafe { alloc(Layout::from_size_align(LEN, 0x1000).unwrap()) };
 
             // SAFETY: fake_buffer points to LEN bytes we just allocated and is valid for mutable slice creation.
             let slice = unsafe { core::slice::from_raw_parts_mut(fake_buffer, LEN) };

--- a/patina_dxe_core/src/pi_dispatcher/section_decompress.rs
+++ b/patina_dxe_core/src/pi_dispatcher/section_decompress.rs
@@ -1,7 +1,5 @@
 //! A section extractor that provides UEFI decompression functionality with an additional custom extractor
 //! implementation.
-extern crate alloc;
-
 use alloc::vec;
 use patina::{
     pi::fw_fs::{self, ffs},

--- a/patina_dxe_core/src/protocol_db.rs
+++ b/patina_dxe_core/src/protocol_db.rs
@@ -878,7 +878,6 @@ unsafe impl Sync for SpinLockedProtocolDb {}
 #[cfg(test)]
 #[cfg_attr(coverage, coverage(off))]
 mod tests {
-    extern crate std;
     use core::str::FromStr;
     use std::println;
 

--- a/patina_dxe_core/src/protocol_db.rs
+++ b/patina_dxe_core/src/protocol_db.rs
@@ -8,8 +8,6 @@
 //!
 //! SPDX-License-Identifier: Apache-2.0
 //!
-extern crate alloc;
-
 use alloc::{
     collections::{BTreeMap, BTreeSet},
     vec,

--- a/patina_dxe_core/src/runtime.rs
+++ b/patina_dxe_core/src/runtime.rs
@@ -239,10 +239,7 @@ mod tests {
         with_locked_state(|| {
             let block = RelocationBlock {
                 block_header: crate::pecoff::relocation::BaseRelocationBlockHeader { page_rva: 0, block_size: 0 },
-                relocations: alloc::vec![crate::pecoff::relocation::Relocation {
-                    type_and_offset: 0x1 << 12,
-                    value: 0
-                }],
+                relocations: std::vec![crate::pecoff::relocation::Relocation { type_and_offset: 0x1 << 12, value: 0 }],
             };
             let result = add_runtime_image(ptr::null_mut(), 0, &[block], 0x1 as efi::Handle);
             assert!(matches!(result, Err(EfiError::Unsupported)), "unexpected result: {result:?}");

--- a/sdk/patina/src/base/c_ptr.rs
+++ b/sdk/patina/src/base/c_ptr.rs
@@ -6,7 +6,7 @@
 //!
 //! SPDX-License-Identifier: Apache-2.0
 //!
-#[cfg(any(test, feature = "alloc"))]
+#[cfg(feature = "alloc")]
 use alloc::boxed::Box;
 use core::{
     ffi::c_void,

--- a/sdk/patina/src/base/error.rs
+++ b/sdk/patina/src/base/error.rs
@@ -195,8 +195,6 @@ impl core::error::Error for EfiError {}
 #[cfg(test)]
 mod tests {
     use super::*;
-    extern crate alloc;
-    use alloc::format;
 
     #[test]
     fn test_display_known_variant_matches_status() {

--- a/sdk/patina/src/base/string.rs
+++ b/sdk/patina/src/base/string.rs
@@ -246,7 +246,7 @@ macro_rules! char8 {
 #[cfg_attr(coverage, coverage(off))]
 mod tests {
     use super::*;
-    use alloc::string::ToString;
+    use std::string::ToString;
 
     #[test]
     fn test_string_error_display() {

--- a/sdk/patina/src/base/string/char16.rs
+++ b/sdk/patina/src/base/string/char16.rs
@@ -13,7 +13,7 @@ use zerocopy_derive::{FromBytes, Immutable, IntoBytes, KnownLayout};
 
 use super::char8::Char8Array;
 
-#[cfg(any(test, feature = "alloc"))]
+#[cfg(feature = "alloc")]
 use alloc::{string::String, vec::Vec};
 
 #[cfg(any(test, feature = "alloc"))]
@@ -760,7 +760,7 @@ impl<const N: usize> From<Char16Array<N>> for String {
 mod tests {
     use super::*;
     use crate::char16;
-    use alloc::string::ToString;
+    use std::string::ToString;
 
     #[test]
     fn test_char16_from_units_with_nul_valid() {
@@ -803,9 +803,9 @@ mod tests {
     fn test_char16_chars_and_iter() {
         let units = [0x0041u16, 0x00E9, 0x20AC, 0x0000]; // "Aé€"
         let s = Char16Str::from_units_with_nul(&units).unwrap();
-        let chars: alloc::vec::Vec<char> = s.chars().collect();
+        let chars: std::vec::Vec<char> = s.chars().collect();
         assert_eq!(chars, ['A', 'é', '€']);
-        let code_units: alloc::vec::Vec<u16> = s.iter().copied().collect();
+        let code_units: std::vec::Vec<u16> = s.iter().copied().collect();
         assert_eq!(code_units, [0x0041, 0x00E9, 0x20AC]);
     }
 
@@ -816,7 +816,7 @@ mod tests {
         let units = [0x0041u16, 0xD800, 0x0000];
         // SAFETY: This deliberately bypasses validation to exercise the lossy fallback path.
         let s = unsafe { Char16Str::from_units_with_nul_unchecked(&units) };
-        let chars: alloc::vec::Vec<char> = s.chars().collect();
+        let chars: std::vec::Vec<char> = s.chars().collect();
         assert_eq!(chars, ['A', char::REPLACEMENT_CHARACTER]);
     }
 
@@ -856,7 +856,7 @@ mod tests {
         let units = [0x0045u16, 0x0046, 0x0049, 0x0000];
         let s = Char16Str::from_units_with_nul(&units).unwrap();
         assert_eq!(s.to_string(), "EFI");
-        assert_eq!(alloc::format!("{s:?}"), "\"EFI\"");
+        assert_eq!(std::format!("{s:?}"), "\"EFI\"");
     }
 
     #[test]
@@ -926,7 +926,7 @@ mod tests {
         let s = Char16String::from_le_bytes_until_nul(&bytes).unwrap();
         assert_eq!(s.to_string(), "EFI");
         // The owned buffer is trimmed to exactly "EFI\0".
-        assert_eq!(s.into_units_with_nul(), alloc::vec![0x0045, 0x0046, 0x0049, 0x0000]);
+        assert_eq!(s.into_units_with_nul(), std::vec![0x0045, 0x0046, 0x0049, 0x0000]);
     }
 
     #[test]
@@ -971,12 +971,12 @@ mod tests {
         let b = Char16String::default();
         assert!(a.is_empty());
         assert_eq!(a, b);
-        assert_eq!(a.clone().into_units_with_nul(), alloc::vec![0]);
+        assert_eq!(a.clone().into_units_with_nul(), std::vec![0]);
     }
 
     #[test]
     fn test_char16string_to_owned_roundtrip() {
-        use alloc::borrow::ToOwned;
+        use std::borrow::ToOwned;
         let owned = Char16String::try_from_str("Test").unwrap();
         let borrowed: &Char16Str = &owned;
         let reowned = borrowed.to_owned();
@@ -1025,7 +1025,7 @@ mod tests {
     fn test_char16string_debug_borrow_and_display() {
         use core::borrow::Borrow;
         let s = Char16String::try_from_str("EFI").unwrap();
-        assert_eq!(alloc::format!("{s:?}"), "\"EFI\"");
+        assert_eq!(std::format!("{s:?}"), "\"EFI\"");
         assert_eq!(s.to_string(), "EFI");
         let borrowed: &Char16Str = s.borrow();
         assert_eq!(borrowed.len(), 3);
@@ -1071,7 +1071,7 @@ mod tests {
 
     #[test]
     fn test_char16string_from_units_with_nul() {
-        let units = alloc::vec![0x0045u16, 0x0046, 0x0049, 0x0000];
+        let units = std::vec![0x0045u16, 0x0046, 0x0049, 0x0000];
         let s = Char16String::from_units_with_nul(units).unwrap();
         assert_eq!(s.len(), 3);
         assert!(*s == *"EFI");
@@ -1079,25 +1079,25 @@ mod tests {
 
     #[test]
     fn test_char16string_from_units_with_nul_missing_terminator() {
-        let units = alloc::vec![0x0045u16, 0x0046];
+        let units = std::vec![0x0045u16, 0x0046];
         assert_eq!(Char16String::from_units_with_nul(units), Err(StringError::MissingNulTerminator));
     }
 
     #[test]
     fn test_char16string_from_units_with_nul_interior_nul() {
-        let units = alloc::vec![0x0045u16, 0x0000, 0x0049, 0x0000];
+        let units = std::vec![0x0045u16, 0x0000, 0x0049, 0x0000];
         assert_eq!(Char16String::from_units_with_nul(units), Err(StringError::InteriorNul { position: 1 }));
     }
 
     #[test]
     fn test_char16string_from_units_with_nul_surrogate_rejected() {
-        let units = alloc::vec![0x0045u16, 0xD800, 0x0000];
+        let units = std::vec![0x0045u16, 0xD800, 0x0000];
         assert_eq!(Char16String::from_units_with_nul(units), Err(StringError::NotUcs2 { position: 1, value: 0xD800 }));
     }
 
     #[test]
     fn test_char16string_from_units_with_nul_unchecked() {
-        let units = alloc::vec![0x0045u16, 0x0046, 0x0049, 0x0000];
+        let units = std::vec![0x0045u16, 0x0046, 0x0049, 0x0000];
         // SAFETY: `units` is a valid NUL-terminated UCS-2 sequence.
         let s = unsafe { Char16String::from_units_with_nul_unchecked(units) };
         assert!(*s == *"EFI");
@@ -1211,7 +1211,7 @@ mod tests {
     #[test]
     fn test_char16_array_to_string() {
         let array = Char16Array::<9>::from_str("Firmware");
-        let owned: alloc::string::String = array.into();
+        let owned: std::string::String = array.into();
         assert_eq!(owned, "Firmware");
     }
 

--- a/sdk/patina/src/base/string/char8.rs
+++ b/sdk/patina/src/base/string/char8.rs
@@ -13,7 +13,7 @@ use zerocopy_derive::{FromBytes, Immutable, IntoBytes, KnownLayout};
 
 use super::char16::Char16Array;
 
-#[cfg(any(test, feature = "alloc"))]
+#[cfg(feature = "alloc")]
 use alloc::{string::String, vec::Vec};
 
 #[cfg(any(test, feature = "alloc"))]
@@ -746,7 +746,7 @@ mod tests {
     fn test_char8_high_latin1_bytes_valid() {
         let bytes = [0xE9u8, 0xFF, 0x00]; // "éÿ"
         let s = Char8Str::from_bytes_with_nul(&bytes).unwrap();
-        let chars: alloc::vec::Vec<char> = s.chars().collect();
+        let chars: std::vec::Vec<char> = s.chars().collect();
         assert_eq!(chars, ['\u{00E9}', '\u{00FF}']);
     }
 
@@ -754,7 +754,7 @@ mod tests {
     fn test_char8_iter() {
         let bytes = *b"EFI\0";
         let s = Char8Str::from_bytes_with_nul(&bytes).unwrap();
-        let collected: alloc::vec::Vec<u8> = s.iter().copied().collect();
+        let collected: std::vec::Vec<u8> = s.iter().copied().collect();
         assert_eq!(collected, b"EFI");
     }
 
@@ -787,7 +787,7 @@ mod tests {
         let bytes = *b"EFI\0";
         let s = Char8Str::from_bytes_with_nul(&bytes).unwrap();
         assert_eq!(s.to_string(), "EFI");
-        assert_eq!(alloc::format!("{s:?}"), "\"EFI\"");
+        assert_eq!(std::format!("{s:?}"), "\"EFI\"");
     }
 
     #[test]
@@ -850,12 +850,12 @@ mod tests {
         let b = Char8String::default();
         assert!(a.is_empty());
         assert_eq!(a, b);
-        assert_eq!(a.clone().into_bytes_with_nul(), alloc::vec![0]);
+        assert_eq!(a.clone().into_bytes_with_nul(), std::vec![0]);
     }
 
     #[test]
     fn test_char8string_to_owned_roundtrip() {
-        use alloc::borrow::ToOwned;
+        use std::borrow::ToOwned;
         let owned = Char8String::try_from_str("Test").unwrap();
         let borrowed: &Char8Str = &owned;
         let reowned = borrowed.to_owned();
@@ -894,7 +894,7 @@ mod tests {
     fn test_char8string_debug_borrow_and_display() {
         use core::borrow::Borrow;
         let s = Char8String::try_from_str("EFI").unwrap();
-        assert_eq!(alloc::format!("{s:?}"), "\"EFI\"");
+        assert_eq!(std::format!("{s:?}"), "\"EFI\"");
         assert_eq!(s.to_string(), "EFI");
         let borrowed: &Char8Str = s.borrow();
         assert_eq!(borrowed.len(), 3);
@@ -933,7 +933,7 @@ mod tests {
 
     #[test]
     fn test_char8string_from_bytes_with_nul() {
-        let bytes = alloc::vec![b'E', b'F', b'I', 0];
+        let bytes = std::vec![b'E', b'F', b'I', 0];
         let s = Char8String::from_bytes_with_nul(bytes).unwrap();
         assert_eq!(s.len(), 3);
         assert!(*s == *"EFI");
@@ -941,19 +941,19 @@ mod tests {
 
     #[test]
     fn test_char8string_from_bytes_with_nul_missing_terminator() {
-        let bytes = alloc::vec![b'E', b'F', b'I'];
+        let bytes = std::vec![b'E', b'F', b'I'];
         assert_eq!(Char8String::from_bytes_with_nul(bytes), Err(StringError::MissingNulTerminator));
     }
 
     #[test]
     fn test_char8string_from_bytes_with_nul_interior_nul() {
-        let bytes = alloc::vec![b'E', 0, b'I', 0];
+        let bytes = std::vec![b'E', 0, b'I', 0];
         assert_eq!(Char8String::from_bytes_with_nul(bytes), Err(StringError::InteriorNul { position: 1 }));
     }
 
     #[test]
     fn test_char8string_from_bytes_with_nul_unchecked() {
-        let bytes = alloc::vec![b'E', b'F', b'I', 0];
+        let bytes = std::vec![b'E', b'F', b'I', 0];
         // SAFETY: `bytes` is a valid NUL-terminated Latin-1 sequence.
         let s = unsafe { Char8String::from_bytes_with_nul_unchecked(bytes) };
         assert!(*s == *"EFI");
@@ -1055,7 +1055,7 @@ mod tests {
     #[test]
     fn test_char8_array_to_string() {
         let array = Char8Array::<9>::from_str("Firmware");
-        let owned: alloc::string::String = array.into();
+        let owned: std::string::String = array.into();
         assert_eq!(owned, "Firmware");
     }
 

--- a/sdk/patina/src/component.rs
+++ b/sdk/patina/src/component.rs
@@ -214,8 +214,6 @@ pub mod prelude {
 #[cfg(test)]
 #[cfg_attr(coverage, coverage(off))]
 mod tests {
-    extern crate std;
-
     use super::*;
     use crate as patina;
     use crate::{

--- a/sdk/patina/src/component/metadata.rs
+++ b/sdk/patina/src/component/metadata.rs
@@ -182,7 +182,6 @@ impl fmt::Debug for PrettyFixedBitSet<'_> {
 #[cfg_attr(coverage, coverage(off))]
 mod tests {
     use super::*;
-    extern crate std;
 
     #[test]
     fn test_debug_view_calculates_config_reads_correctly() {

--- a/sdk/patina/src/component/service/memory.rs
+++ b/sdk/patina/src/component/service/memory.rs
@@ -48,7 +48,7 @@ use crate::{
 #[cfg(any(test, feature = "alloc"))]
 use core::alloc::Allocator;
 
-#[cfg(any(test, feature = "alloc"))]
+#[cfg(feature = "alloc")]
 use alloc::boxed::Box;
 
 #[cfg(any(test, feature = "mockall"))]
@@ -839,7 +839,6 @@ pub use mock::StdMemoryManager;
 #[cfg(any(test, feature = "mockall"))]
 #[cfg_attr(coverage, coverage(off))]
 mod mock {
-    extern crate std;
     use std::{
         alloc::{Layout, alloc, dealloc},
         collections::HashMap,

--- a/sdk/patina/src/component/service/performance.rs
+++ b/sdk/patina/src/component/service/performance.rs
@@ -191,9 +191,9 @@ pub trait PerformanceManager: Send + Sync {
 #[cfg_attr(coverage, coverage(off))]
 mod tests {
     use super::*;
-    use alloc::string::String;
-    use alloc::vec::Vec;
+    use std::string::String;
     use std::sync::Mutex;
+    use std::vec::Vec;
 
     struct Recorded {
         caller_guid: Option<efi::Guid>,

--- a/sdk/patina/src/component/struct_component.rs
+++ b/sdk/patina/src/component/struct_component.rs
@@ -122,7 +122,7 @@ mod tests {
         params::{Config, ConfigMut},
     };
 
-    use alloc::borrow::Cow;
+    use std::borrow::Cow;
 
     #[allow(dead_code)]
     pub struct TestStructSuccess {

--- a/sdk/patina/src/debug/log.rs
+++ b/sdk/patina/src/debug/log.rs
@@ -103,7 +103,7 @@ impl Format {
 #[cfg(test)]
 mod tests {
     use super::Format;
-    use alloc::string::String;
+    use std::string::String;
 
     /// Writes a log record through the given Format into a String buffer and returns it.
     fn format_record(format: &Format, level: log::Level, target: &str, message: &str) -> String {

--- a/sdk/patina/src/debug/log/serial_logger.rs
+++ b/sdk/patina/src/debug/log/serial_logger.rs
@@ -125,10 +125,10 @@ mod tests {
     use super::*;
     use crate::debug::log::Format;
     use crate::peripheral::serial::MockSerialIO;
-    use alloc::{string::String, sync::Arc, vec::Vec};
     use log::{Level, LevelFilter, Log, Metadata};
     use spin::Mutex;
     use std::thread;
+    use std::{string::String, sync::Arc, vec::Vec};
 
     fn metadata(level: Level, target: &str) -> Metadata<'_> {
         Metadata::builder().level(level).target(target).build()

--- a/sdk/patina/src/lib.rs
+++ b/sdk/patina/src/lib.rs
@@ -13,7 +13,7 @@
 #![cfg_attr(any(test, feature = "alloc"), feature(allocator_api))]
 #![cfg_attr(coverage, feature(coverage_attribute))]
 
-#[cfg(any(test, feature = "alloc"))]
+#[cfg(feature = "alloc")]
 extern crate alloc;
 
 // The base module gets republished from the root to flatten dependencies for common structures.

--- a/sdk/patina/src/performance/measurement.rs
+++ b/sdk/patina/src/performance/measurement.rs
@@ -186,8 +186,8 @@ impl PerformanceProperty {
 mod tests {
     use super::*;
 
-    use alloc::boxed::Box;
     use core::ptr;
+    use std::boxed::Box;
 
     use crate::performance::record::{
         PerformanceRecord,

--- a/sdk/patina/src/peripheral/serial/virtio.rs
+++ b/sdk/patina/src/peripheral/serial/virtio.rs
@@ -132,8 +132,8 @@ mod tests {
 
     use super::*;
     use crate::peripheral::serial::SerialIO;
-    use alloc::vec::Vec;
     use mmio::VirtioMmioRegs;
+    use std::vec::Vec;
 
     fn test_instance<const N: usize, const B: usize>(regs: &VirtioMmioRegs) -> VirtioSerial<N, B> {
         // SAFETY: `regs` outlives the returned `VirtioSerial`.

--- a/sdk/patina/src/peripheral/serial/virtio/queue.rs
+++ b/sdk/patina/src/peripheral/serial/virtio/queue.rs
@@ -279,8 +279,8 @@ impl<const N: usize, const B: usize> VirtQueue<N, B> {
 #[cfg(test)]
 #[cfg_attr(coverage, coverage(off))]
 impl<const N: usize, const B: usize> VirtQueue<N, B> {
-    pub(super) fn test_drain_tx(&mut self) -> alloc::vec::Vec<alloc::vec::Vec<u8>> {
-        use alloc::vec::Vec;
+    pub(super) fn test_drain_tx(&mut self) -> std::vec::Vec<std::vec::Vec<u8>> {
+        use std::vec::Vec;
         fence(Ordering::SeqCst);
         let mut out = Vec::new();
         while self.used.idx != self.avail.idx {

--- a/sdk/patina/src/pi/hob/hob_list.rs
+++ b/sdk/patina/src/pi/hob/hob_list.rs
@@ -1057,7 +1057,7 @@ mod tests {
 
     #[test]
     fn test_hoblist_debug_display() {
-        use alloc::format;
+        use std::format;
 
         let mut hoblist = HobList::new();
         let handoff = gen_phase_handoff_information_table();

--- a/sdk/patina/src/pi/serializable/serializable_hob.rs
+++ b/sdk/patina/src/pi/serializable/serializable_hob.rs
@@ -528,7 +528,7 @@ mod tests {
 
         assert_eq!(
             entries,
-            alloc::vec![
+            std::vec![
                 MemoryTypeInfoEntrySerDe { memory_type: 6, number_of_pages: 100 },
                 MemoryTypeInfoEntrySerDe { memory_type: 9, number_of_pages: 200 },
             ]

--- a/sdk/patina/src/uefi/decompress.rs
+++ b/sdk/patina/src/uefi/decompress.rs
@@ -724,7 +724,6 @@ impl Iterator for CodeIterator<'_> {
 
 #[cfg(test)]
 mod test {
-    extern crate std;
     use std::{fs::File, io::Read, iter::zip, println, time, vec, vec::Vec};
 
     use super::decompress_into_with_algo;

--- a/sdk/patina/src/uefi/device_path/helpers.rs
+++ b/sdk/patina/src/uefi/device_path/helpers.rs
@@ -125,7 +125,7 @@ mod tests {
         uefi::boot_services::MockBootServices,
         uefi::device_path::node_defs::{Acpi, EndEntire, FilePath, HardDrive, Pci},
     };
-    use alloc::boxed::Box;
+    use std::boxed::Box;
 
     /// Helper to build a partial device path starting with HD node.
     fn build_partial_hd_path(guid: [u8; 16]) -> DevicePathBuf {
@@ -195,11 +195,8 @@ mod tests {
         // Clone the device path bytes into a Vec and leak it so we can return a pointer
         let path_ref: &DevicePath = full_handle_path.as_ref();
         // SAFETY: path_ref is a valid DevicePath reference and size() returns its exact byte length.
-        let bytes: alloc::vec::Vec<u8> = unsafe {
-            alloc::vec::Vec::from(core::slice::from_raw_parts(
-                std::ptr::from_ref(path_ref) as *const u8,
-                path_ref.size(),
-            ))
+        let bytes: std::vec::Vec<u8> = unsafe {
+            std::vec::Vec::from(core::slice::from_raw_parts(std::ptr::from_ref(path_ref) as *const u8, path_ref.size()))
         };
         let leaked_bytes = Box::leak(bytes.into_boxed_slice());
         let full_path_ptr: usize = leaked_bytes.as_ptr() as usize;

--- a/sdk/patina/src/uefi/device_path/helpers.rs
+++ b/sdk/patina/src/uefi/device_path/helpers.rs
@@ -120,9 +120,6 @@ pub fn expand_device_path<B: BootServices>(boot_services: &B, partial_path: &mut
 
 #[cfg(test)]
 mod tests {
-    extern crate alloc;
-    extern crate std;
-
     use super::*;
     use crate::{
         uefi::boot_services::MockBootServices,

--- a/sdk/patina/src/uefi/device_path/node_defs.rs
+++ b/sdk/patina/src/uefi/device_path/node_defs.rs
@@ -906,8 +906,6 @@ impl TryFromCtx<'_, scroll::Endian> for FilePath {
 
 #[cfg(test)]
 mod tests {
-    extern crate std;
-
     use super::*;
     use scroll::{Pread, Pwrite};
 

--- a/sdk/patina_ffs_extractors/src/lib.rs
+++ b/sdk/patina_ffs_extractors/src/lib.rs
@@ -20,7 +20,7 @@
 //! SPDX-License-Identifier: Apache-2.0
 //!
 #![cfg_attr(coverage, feature(coverage_attribute))]
-#![cfg_attr(not(feature = "std"), no_std)]
+#![cfg_attr(all(not(feature = "std"), not(test)), no_std)]
 extern crate alloc;
 
 #[cfg(feature = "brotli")]
@@ -51,12 +51,12 @@ const DECOMPRESSION_MAX_MEMORY_LIMIT: u32 = patina::SIZE_512MB as u32;
 #[cfg(test)]
 #[cfg_attr(coverage, coverage(off))]
 mod tests {
-    use alloc::{vec, vec::Vec};
     use patina::pi::fw_fs::{
         ffs::section::header::GuidDefined,
         guid::{BROTLI_SECTION_GUID, CRC32_SECTION_GUID, LZMA_SECTION_GUID},
     };
     use patina_ffs::section::{Section, SectionHeader};
+    use std::{vec, vec::Vec};
 
     /// Constructs a section with the specified GUID and payload, prepending
     /// the required 16-byte header (`out_size` + `scratch_size`) for Brotli sections.

--- a/sdk/patina_ffs_extractors/src/lzma.rs
+++ b/sdk/patina_ffs_extractors/src/lzma.rs
@@ -81,9 +81,9 @@ mod tests {
     use crate::tests::create_lzma_section;
 
     use super::*;
-    use alloc::vec;
     use patina::pi::fw_fs::ffs::section::header::GuidDefined;
     use patina_ffs::section::Section;
+    use std::vec;
 
     #[test]
     fn test_lzma_extractor_valid() {

--- a/sdk/patina_macro/src/hob_macro.rs
+++ b/sdk/patina_macro/src/hob_macro.rs
@@ -227,7 +227,7 @@ mod tests {
 
         // Test that the hex string provided in the attribute matches the well known PCD Database HOB GUID
         let (f0, f1, f2, f3, f4, &[f5, f6, f7, f8, f9, f10]) = TEST_HOB_GUID.as_fields();
-        let name = alloc::format!(
+        let name = std::format!(
             "{f0:08x}-{f1:04x}-{f2:04x}-{f3:02x}{f4:02x}-{f5:02x}{f6:02x}{f7:02x}{f8:02x}{f9:02x}{f10:02x}"
         );
         assert_eq!(name, "ea296d92-0b69-423c-8c28-33b4e0a91268");

--- a/sdk/patina_macro/src/hob_macro.rs
+++ b/sdk/patina_macro/src/hob_macro.rs
@@ -153,8 +153,6 @@ mod tests {
     use super::*;
     use proc_macro2::TokenStream;
     use quote::quote;
-    extern crate alloc;
-    use alloc::format;
 
     #[test]
     fn test_config_basic() {

--- a/sdk/patina_macro/src/lib.rs
+++ b/sdk/patina_macro/src/lib.rs
@@ -9,6 +9,8 @@
 
 #![cfg_attr(coverage, feature(coverage_attribute))]
 
+extern crate alloc;
+
 mod device_path_encoder;
 mod device_path_macro;
 mod device_path_nodes;


### PR DESCRIPTION
## Description

This PR originally set out to consolidate and gate all `alloc` crate usage across the Patina repo behind an appropriate `alloc` feature flag. That turned out to be trickier and more fragile than expected, due to implicit assumptions about `alloc` crate usage baked in throughout Patina. This effort actually started while building the Rust MM supervisor, where the Patina crates it depends on should not implicitly opt into the `alloc` crate. After a few iterations, we deliberately narrowed the scope of this change to only the crates the supervisor relies on(`patina_internal_cpu`), gating those explicitly. As a result, this change is now trimmed down to the 3 commits below. The first two are good general cleanup/consolidation on their own, the third commit stops `patina_internal_cpu` from enabling the alloc feature on its patina SDK dependency, removing the unnecessary alloc requirement for the Rust MM supervisor's current dependency set.

[major] Consolidate extern crate alloc declarations to crate root(lib.rs/main.rs)

- This clean up will enable guarding alloc crate usage in a later PR

---
[major] Use `std` instead of `alloc` in tests

- Isolate alloc crate usage to non-test code
- Test code is always compiled for the host target with std, so alloc
  imports should not be conditionally guarded with test.
- Remove `extern crate std;` declaration from all tests.

---

[major] patina_internal_cpu: Do not enable "alloc" feature on patina sdk crate

- `alloc` feature on patina is not required to build patina_internal_cpu.
- This eliminates the dependency on alloc for rust mm_supervisor(with
  its current dependencies)
- explicitly validated by running below commands on `patina_internal_cpu`

```
cargo make all
cargo clippy -p patina_internal_cpu --all-targets --all-features -- -D warnings
cargo test -p patina_internal_cpu --no-run --no-default-features
```
---

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

`cargo make all` in patina and patina-dxe-core-qemu

## Integration Instructions

This does not change the interface between external consumers and patina crates. Hence not marking as breaking change.