### PR TITLE
Ignore slow tests [Rebase & FF]

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -235,6 +235,12 @@ clear = true
 command = "cargo"
 args = ["test", "@@split(CARGO_MAKE_TASK_ARGS,;)"]
 
+[tasks.test-ignored]
+description = "Runs ignored tests with native cargo test behavior. Example `cargo make test-ignored` or `cargo make test-ignored -p package_name"
+clear = true
+command = "cargo"
+args = ["test", "@@split(CARGO_MAKE_TASK_ARGS,;)", "--lib", "--tests", "--examples", "--", "--ignored"]
+
 [tasks.test-cov]
 description = "Run tests and collect coverage data without generating reports."
 install_crate = false
@@ -487,5 +493,6 @@ dependencies = [
     "coverage",
     "doc-test",
     "doc",
+    "test-ignored",
     "test-mdbook",
 ]

--- a/components/patina_test/src/component.rs
+++ b/components/patina_test/src/component.rs
@@ -144,10 +144,8 @@ pub(crate) mod tests {
     extern crate std;
 
     use super::*;
-    use crate::{
-        __private_api::TestCase,
-        alloc::{boxed::Box, format},
-    };
+
+    use crate::alloc::{boxed::Box, format};
     use core::mem::MaybeUninit;
     use patina::{
         BinaryGuid,
@@ -228,51 +226,6 @@ pub(crate) mod tests {
         fail_msg: None,
         func: |storage| crate::__private_api::FunctionTest::new(test_function_invalid).run(storage.into()),
     };
-
-    #[test]
-    #[ignore = "Skipping test until the service for UEFI services is out, so we can mock it."]
-    fn test_we_can_initialize_the_component() {
-        let mut storage = Storage::new();
-
-        let mut component = super::TestRunner::default().into_component();
-        component.initialize(&mut storage);
-    }
-
-    #[test]
-    #[ignore = "Skipping test until the service for UEFI services is out, so we can mock it."]
-    fn test_we_can_collect_and_execute_tests() {
-        assert_eq!(TEST_TESTS.len(), 2);
-        let mut storage = Storage::new();
-        storage.add_config(1_i32);
-
-        let component = super::TestRunner::default();
-        let result = component.register_tests(&TEST_TESTS, &mut storage);
-        assert!(result.is_ok());
-    }
-
-    #[test]
-    #[ignore = "Skipping test until the service for UEFI services is out, so we can mock it."]
-    fn test_handle_different_test_counts() {
-        let mut storage = Storage::new();
-        storage.add_config(1_i32);
-
-        let test_cases: &'static [TestCase] = Box::leak(Box::new([]));
-        let component = super::TestRunner::default();
-        let result = component.register_tests(test_cases, &mut storage);
-        assert!(result.is_ok());
-
-        let test_cases: &'static [TestCase] = Box::leak(Box::new([TEST_CASE1]));
-        let result = component.register_tests(test_cases, &mut storage);
-        assert!(result.is_ok());
-
-        let test_cases: &'static [TestCase] = Box::leak(Box::new([TEST_CASE1, TEST_CASE2]));
-        let result = component.register_tests(test_cases, &mut storage);
-        assert!(result.is_ok());
-
-        let test_cases: &'static [TestCase] = Box::leak(Box::new([TEST_CASE1, TEST_CASE2, TEST_CASE3]));
-        let result = component.register_tests(test_cases, &mut storage);
-        assert!(result.is_ok());
-    }
 
     #[test]
     fn test_func_implements_into_component() {

--- a/sdk/patina/tests/compile_fail_tests.rs
+++ b/sdk/patina/tests/compile_fail_tests.rs
@@ -10,6 +10,7 @@
 //! SPDX-License-Identifier: Apache-2.0
 
 #[test]
+#[ignore = "Ignore compilation tests by default since they are slow."]
 fn compile_fail_tests() {
     let t = trybuild::TestCases::new();
     t.compile_fail("tests/ui/duplicate_config_mut.rs");


### PR DESCRIPTION
## Description

Since a small set of unit tests increase time significantly, this follows the guidance in the [Rust Programming Language book](https://doc.rust-lang.org/book/ch11-02-running-tests.html#ignoring-tests-unless-specifically-requested) to ignore them during normal test runs.

- `cargo make test` before avg (after clean): 192 seconds
- `cargo make test` after avg (after clean): 105 seconds

This does not include ignored tests in test coverage, though that's possible if preferred.

---


**Ignore long-running tests by default**

Excluding `compile_fail_tests` reduces "cargo make test" reduces the
test run time by about 45% (after clean). Since it is common to run
`cargo make test` throughout development, this has a significant
impact on iterative development.

This change marks these tests as ignored by default, so that they will
only run when explicitly requested with `cargo test --ignored`.

A few tests in `components\patina_test\src\component.rs` were
already using the `#[ignore]` attribute but don't successfully run.
The `storage::new()` calls initialize `StandardBootServices`. This
code ends up registering a Ready to Boot notification, but
`create_event_ex()` is not initialized in the Boot Services table and
panics with a message.

This change removes these tests for now with a tracking issue filed
to add them back when the UEFI services are available to mock.

---

**Makefile.toml: Add test-ignored task**

Adds a new task to run ignored tests excluding those in doctests.

- `cargo make test` - Runs all tests excluding ignored tests.
- `cargo make test-ignored` - Runs ignored tests excluding those in
  doctests.

`cargo make all` runs both sets.

This allows `cargo make test` to run much faster by ignoring a small
set of slow tests.

---

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

- `cargo make test`
- `cargo make test-ignored`
- `cargo make all`

## Integration Instructions

- N/A