### PR TITLE
[feature/supv][Rebase & FF] Remove CpuTrait from MM supervisor platform configuration

### DIFF
--- a/components/patina_acpi/src/acpi.rs
+++ b/components/patina_acpi/src/acpi.rs
@@ -10,6 +10,7 @@
 //!
 
 use alloc::collections::btree_map::BTreeMap;
+use alloc::{vec, vec::Vec};
 use core::{
     any::TypeId,
     cell::OnceCell,
@@ -33,7 +34,6 @@ use patina::{
 
 use crate::{
     acpi_table::{AcpiDsdt, AcpiFacs, AcpiFadt, AcpiRsdp, AcpiTable, AcpiTableHeader, AcpiXsdt, AcpiXsdtMetadata},
-    alloc::{vec, vec::Vec},
     error::AcpiError,
     hob::AcpiMemoryHob,
     service::{AcpiNotifyFn, AcpiProvider, TableKey},

--- a/components/patina_acpi/src/acpi.rs
+++ b/components/patina_acpi/src/acpi.rs
@@ -812,8 +812,6 @@ where
 
 #[cfg(test)]
 mod tests {
-    extern crate std;
-
     use crate::signature::MAX_INITIAL_ENTRIES;
 
     use super::*;

--- a/components/patina_acpi/src/acpi_table.rs
+++ b/components/patina_acpi/src/acpi_table.rs
@@ -14,7 +14,7 @@ use crate::{
     error::AcpiError,
     signature::{self, ACPI_CHECKSUM_OFFSET},
 };
-use alloc::{boxed::Box, vec::Vec};
+use alloc::{alloc::Allocator, boxed::Box, vec::Vec};
 use patina::{
     SIZE_4GB,
     component::service::{
@@ -225,7 +225,7 @@ pub struct AcpiXsdt {
 pub(crate) struct AcpiXsdtMetadata {
     pub(crate) n_entries: usize,
     pub(crate) max_capacity: usize,
-    pub(crate) slice: Box<[u8], &'static dyn alloc::alloc::Allocator>,
+    pub(crate) slice: Box<[u8], &'static dyn Allocator>,
 }
 
 impl AcpiXsdtMetadata {

--- a/components/patina_acpi/src/component.rs
+++ b/components/patina_acpi/src/component.rs
@@ -8,10 +8,11 @@
 
 use crate::{
     acpi_table::{AcpiTableHeader, AcpiXsdtMetadata},
-    alloc::boxed::Box,
     hob::AcpiMemoryHob,
     service::{AcpiProvider, AcpiTableManager},
 };
+
+use alloc::boxed::Box;
 use alloc::vec::Vec;
 
 use core::mem;

--- a/components/patina_acpi/src/service.rs
+++ b/components/patina_acpi/src/service.rs
@@ -168,9 +168,9 @@ pub(crate) trait AcpiProvider {
 #[cfg(test)]
 #[cfg_attr(coverage, coverage(off))]
 mod tests {
-    use alloc::boxed::Box;
     use core::mem;
     use patina::component::service::memory::StdMemoryManager;
+    use std::boxed::Box;
 
     use crate::acpi_table::AcpiFadt;
 

--- a/components/patina_adv_logger/src/lib.rs
+++ b/components/patina_adv_logger/src/lib.rs
@@ -8,7 +8,7 @@
 #![deny(missing_docs)]
 #![cfg_attr(coverage, feature(coverage_attribute))]
 
-#[cfg(any(feature = "alloc", test, doc))]
+#[cfg(any(feature = "alloc", doc))]
 extern crate alloc;
 
 mod memory_log;

--- a/components/patina_adv_logger/src/logger.rs
+++ b/components/patina_adv_logger/src/logger.rs
@@ -352,7 +352,6 @@ where
 mod tests {
     use core::{ffi::c_void, ptr};
 
-    use alloc::boxed::Box;
     use log::Log;
     use patina::standard::efi;
     use patina::{
@@ -361,6 +360,7 @@ mod tests {
         peripheral::serial::uart::UartNull,
         pi::hob::{GUID_EXTENSION, GuidHob, HobHeader},
     };
+    use std::boxed::Box;
 
     use crate::{
         logger::{AdvancedLogger, TargetFilter},

--- a/components/patina_adv_logger/src/memory_log.rs
+++ b/components/patina_adv_logger/src/memory_log.rs
@@ -423,9 +423,9 @@ impl AdvLoggerMessageEntry {
 const TEST_DATA_SIZE: usize = 128;
 
 #[cfg(test)]
-pub(crate) fn create_buffer_v5(timer_frequency: u64, hw_port_disabled: bool) -> alloc::boxed::Box<[u8]> {
+pub(crate) fn create_buffer_v5(timer_frequency: u64, hw_port_disabled: bool) -> std::boxed::Box<[u8]> {
     let header_size = size_of::<AdvLoggerInfoV5>();
-    let mut buffer = alloc::vec![0_u8; header_size + TEST_DATA_SIZE].into_boxed_slice();
+    let mut buffer = std::vec![0_u8; header_size + TEST_DATA_SIZE].into_boxed_slice();
     let header = AdvLoggerInfoV5 {
         signature: AdvLoggerInfo::SIGNATURE,
         version: ADV_LOGGER_INFO_VERSION_V5,
@@ -457,9 +457,9 @@ pub(crate) fn create_buffer_v5(timer_frequency: u64, hw_port_disabled: bool) -> 
 }
 
 #[cfg(test)]
-pub(crate) fn create_buffer_v6(timer_frequency: u64, new_address: u64) -> alloc::boxed::Box<[u8]> {
+pub(crate) fn create_buffer_v6(timer_frequency: u64, new_address: u64) -> std::boxed::Box<[u8]> {
     let header_size = size_of::<AdvLoggerInfoV6>();
-    let mut buffer = alloc::vec![0_u8; header_size + TEST_DATA_SIZE].into_boxed_slice();
+    let mut buffer = std::vec![0_u8; header_size + TEST_DATA_SIZE].into_boxed_slice();
     let header = AdvLoggerInfoV6 {
         v5: AdvLoggerInfoV5 {
             signature: AdvLoggerInfo::SIGNATURE,

--- a/components/patina_adv_logger/src/reader.rs
+++ b/components/patina_adv_logger/src/reader.rs
@@ -154,7 +154,6 @@ impl<'a> Iterator for AdvLogIterator<'a> {
 #[cfg(test)]
 #[cfg_attr(coverage, coverage(off))]
 mod tests {
-    extern crate std;
     use core::{mem::size_of, sync::atomic::Ordering};
 
     use super::*;

--- a/components/patina_adv_logger/src/writer.rs
+++ b/components/patina_adv_logger/src/writer.rs
@@ -192,9 +192,9 @@ impl AdvancedLogWriter {
 #[cfg(all(test, feature = "reader"))]
 #[cfg_attr(coverage, coverage(off))]
 mod tests {
-    use std::boxed::Box;
     use core::{mem::size_of, sync::atomic::Ordering};
     use efi::PhysicalAddress;
+    use std::boxed::Box;
 
     use super::*;
     use crate::{memory_log::*, reader::AdvancedLogReader};

--- a/components/patina_adv_logger/src/writer.rs
+++ b/components/patina_adv_logger/src/writer.rs
@@ -192,8 +192,7 @@ impl AdvancedLogWriter {
 #[cfg(all(test, feature = "reader"))]
 #[cfg_attr(coverage, coverage(off))]
 mod tests {
-    extern crate std;
-    use alloc::boxed::Box;
+    use std::boxed::Box;
     use core::{mem::size_of, sync::atomic::Ordering};
     use efi::PhysicalAddress;
 

--- a/components/patina_mm/src/component/communicator.rs
+++ b/components/patina_mm/src/component/communicator.rs
@@ -15,6 +15,8 @@
 
 mod comm_buffer_update;
 
+use alloc::vec::Vec;
+
 use crate::{
     config::{CommunicateBuffer, MmCommunicationConfiguration},
     service::SwMmiTrigger,
@@ -29,8 +31,6 @@ use patina::{
     uefi::boot_services::StandardBootServices,
     writelncrlf,
 };
-
-use alloc::vec::Vec;
 
 use core::{
     cell::RefCell,
@@ -386,6 +386,7 @@ mod tests {
     };
 
     use core::{cell::RefCell, pin::Pin};
+    use std::alloc::{Layout, alloc, dealloc};
 
     use std::vec::Vec;
 
@@ -795,8 +796,6 @@ mod tests {
 
     #[test]
     fn test_communicate_non_zero_mm_return_status() {
-        use std::alloc::{Layout, alloc, dealloc};
-
         // Create a buffer with a mailbox using from_firmware_region
         let buffer_size = 4096;
         let page_align = 4096;
@@ -876,8 +875,6 @@ mod tests {
 
     #[test]
     fn test_communicate_get_message_fails_after_mm() {
-        use std::alloc::{Layout, alloc, dealloc};
-
         // Create a buffer with a mailbox using from_firmware_region
         let buffer_size = 4096;
         let page_align = 4096;

--- a/components/patina_mm/src/component/communicator/comm_buffer_update.rs
+++ b/components/patina_mm/src/component/communicator/comm_buffer_update.rs
@@ -282,7 +282,7 @@ mod tests {
     };
     use patina::uefi::boot_services::StandardBootServices;
 
-    use alloc::boxed::Box;
+    use std::boxed::Box;
 
     /// Helper to create a test protocol notify context without boot services
     fn create_test_context(updatable_buffer_id: u8) -> Box<ProtocolNotifyContext> {

--- a/components/patina_mm/src/component/communicator/comm_buffer_update.rs
+++ b/components/patina_mm/src/component/communicator/comm_buffer_update.rs
@@ -11,6 +11,8 @@
 //! SPDX-License-Identifier: Apache-2.0
 
 use crate::config::CommunicateBuffer;
+use alloc::boxed::Box;
+use alloc::vec::Vec;
 use patina::{
     UEFI_PAGE_SIZE,
     management_mode::protocol::mm_comm_buffer_update::{self, MmCommBufferUpdateProtocol},
@@ -21,8 +23,6 @@ use patina::{
 use zerocopy::FromBytes;
 
 use core::sync::atomic::{AtomicBool, AtomicPtr, Ordering};
-
-use alloc::boxed::Box;
 
 /// Context for the MM Comm Buffer Update Protocol notify callback
 ///
@@ -101,7 +101,7 @@ pub(super) fn register_buffer_update_notify(
 /// - `false` if no update was pending
 pub(super) fn apply_pending_buffer_update(
     context: &ProtocolNotifyContext,
-    comm_buffers: &mut alloc::vec::Vec<CommunicateBuffer>,
+    comm_buffers: &mut Vec<CommunicateBuffer>,
 ) -> bool {
     if !context.has_pending_update.load(Ordering::Acquire) {
         return false;

--- a/components/patina_mm/tests/patina_mm_integration/common/framework.rs
+++ b/components/patina_mm/tests/patina_mm_integration/common/framework.rs
@@ -12,8 +12,8 @@
 //! SPDX-License-Identifier: Apache-2.0
 use crate::patina_mm_integration::common::{constants::*, handlers::*, message_parser::*};
 
-use alloc::{boxed::Box, string::String, vec::Vec};
 use patina::BinaryGuid;
+use std::{boxed::Box, string::String, vec::Vec};
 use std::{
     collections::HashMap,
     sync::{

--- a/components/patina_mm/tests/patina_mm_integration/common/framework.rs
+++ b/components/patina_mm/tests/patina_mm_integration/common/framework.rs
@@ -12,7 +12,6 @@
 //! SPDX-License-Identifier: Apache-2.0
 use crate::patina_mm_integration::common::{constants::*, handlers::*, message_parser::*};
 
-extern crate alloc;
 use alloc::{boxed::Box, string::String, vec::Vec};
 use patina::BinaryGuid;
 use std::{

--- a/components/patina_mm/tests/patina_mm_integration/common/handlers.rs
+++ b/components/patina_mm/tests/patina_mm_integration/common/handlers.rs
@@ -19,7 +19,6 @@
 use crate::patina_mm_integration::common::constants::*;
 use patina::standard::efi;
 
-extern crate alloc;
 use alloc::{string::String, vec::Vec};
 pub use zerocopy::IntoBytes;
 

--- a/components/patina_mm/tests/patina_mm_integration/common/handlers.rs
+++ b/components/patina_mm/tests/patina_mm_integration/common/handlers.rs
@@ -19,7 +19,7 @@
 use crate::patina_mm_integration::common::constants::*;
 use patina::standard::efi;
 
-use alloc::{string::String, vec::Vec};
+use std::{string::String, vec::Vec};
 pub use zerocopy::IntoBytes;
 
 pub use patina::management_mode::protocol::{

--- a/components/patina_mm/tests/patina_mm_integration/common/message_parser.rs
+++ b/components/patina_mm/tests/patina_mm_integration/common/message_parser.rs
@@ -10,7 +10,6 @@
 //!
 //! SPDX-License-Identifier: Apache-2.0
 
-extern crate alloc;
 #[allow(unused_imports)] // Used in test module within this file
 use alloc::vec::Vec;
 use patina::BinaryGuid;

--- a/components/patina_mm/tests/patina_mm_integration/common/message_parser.rs
+++ b/components/patina_mm/tests/patina_mm_integration/common/message_parser.rs
@@ -10,8 +10,6 @@
 //!
 //! SPDX-License-Identifier: Apache-2.0
 
-#[allow(unused_imports)] // Used in test module within this file
-use alloc::vec::Vec;
 use patina::BinaryGuid;
 
 /// Error types for MM message parsing operations

--- a/components/patina_mm/tests/patina_mm_integration/common/real_component_framework.rs
+++ b/components/patina_mm/tests/patina_mm_integration/common/real_component_framework.rs
@@ -16,7 +16,6 @@
 
 use crate::patina_mm_integration::common::{constants::*, handlers::*};
 
-extern crate alloc;
 use alloc::{boxed::Box, vec::Vec};
 use patina::Guid;
 use std::{

--- a/components/patina_mm/tests/patina_mm_integration/common/real_component_framework.rs
+++ b/components/patina_mm/tests/patina_mm_integration/common/real_component_framework.rs
@@ -16,11 +16,12 @@
 
 use crate::patina_mm_integration::common::{constants::*, handlers::*};
 
-use alloc::{boxed::Box, vec::Vec};
 use patina::Guid;
 use std::{
+    boxed::Box,
     collections::BTreeMap,
     sync::{Arc, Mutex},
+    vec::Vec,
 };
 
 // Import the real patina_mm components and services

--- a/components/patina_mm/tests/patina_mm_integration/tests_root.rs
+++ b/components/patina_mm/tests/patina_mm_integration/tests_root.rs
@@ -31,8 +31,6 @@
 //!
 //! SPDX-License-Identifier: Apache-2.0
 
-extern crate alloc;
-
 // Common utilities available to all test modules
 mod common;
 

--- a/components/patina_performance/src/component/performance.rs
+++ b/components/patina_performance/src/component/performance.rs
@@ -18,7 +18,7 @@ use crate::{
     },
     mm,
 };
-use alloc::{boxed::Box, string::String, vec::Vec};
+use alloc::{boxed::Box, format, string::String, vec, vec::Vec};
 use core::ffi::c_void;
 use patina::standard::efi::EVENT_GROUP_READY_TO_BOOT;
 use patina::{
@@ -223,7 +223,7 @@ fn fetch_mm_record_chunk(
     data_req.boot_record_data_size = chunk_size;
 
     let buffer_size = mm::SMM_COMM_HEADER_SIZE + chunk_size;
-    let mut data_req_buf = alloc::vec![0u8; buffer_size];
+    let mut data_req_buf = vec![0u8; buffer_size];
 
     data_req
         .write_into(&mut data_req_buf)
@@ -304,7 +304,7 @@ impl<'a> Iterator for PerformanceRecordIterator<'a> {
         let rec_len = header.length as usize;
         if rec_len < PerformanceRecordHeader::SIZE {
             self.bytes = self.bytes.get(PerformanceRecordHeader::SIZE..).unwrap_or(&[]);
-            return Some(Err(MmPerformanceError::RecordError(alloc::format!(
+            return Some(Err(MmPerformanceError::RecordError(format!(
                 "Record reports too small length {} (< {})",
                 rec_len,
                 PerformanceRecordHeader::SIZE
@@ -314,10 +314,9 @@ impl<'a> Iterator for PerformanceRecordIterator<'a> {
         if rec_len > self.bytes.len() {
             let available = self.bytes.len();
             self.bytes = &[];
-            return Some(Err(MmPerformanceError::RecordError(alloc::format!(
+            return Some(Err(MmPerformanceError::RecordError(format!(
                 "Truncated record (needed {}, had {})",
-                rec_len,
-                available
+                rec_len, available
             ))));
         }
 
@@ -326,7 +325,7 @@ impl<'a> Iterator for PerformanceRecordIterator<'a> {
             Ok(record) => record,
             Err(err) => {
                 self.bytes = &[];
-                return Some(Err(MmPerformanceError::RecordError(alloc::format!("Failed to parse record: {:?}", err))));
+                return Some(Err(MmPerformanceError::RecordError(format!("Failed to parse record: {:?}", err))));
             }
         };
 

--- a/components/patina_performance/src/component/performance.rs
+++ b/components/patina_performance/src/component/performance.rs
@@ -530,7 +530,6 @@ mod tests {
     };
     use patina::standard::efi;
 
-    use alloc::sync::Arc;
     use patina::{
         c_ptr::{CMutPtr, CPtr},
         component::service::{IntoService, Service},
@@ -542,6 +541,7 @@ mod tests {
         uefi::{boot_services::MockBootServices, runtime_services::MockRuntimeServices},
     };
     use patina_mm::component::communicator::{MmCommunication, Status};
+    use std::sync::Arc;
 
     // Some constants shared between tests
     const TEST_EVENT_HANDLE: efi::Event = 1_usize as efi::Event;
@@ -765,7 +765,7 @@ mod tests {
         boot_services.expect_close_event().once().return_const(Ok(()));
 
         // The component allocates the publishing buffer itself; hand back a real leaked page-sized buffer.
-        let leaked_buffer = Box::leak(alloc::vec![0u8; UEFI_PAGE_SIZE].into_boxed_slice());
+        let leaked_buffer = Box::leak(std::vec![0u8; UEFI_PAGE_SIZE].into_boxed_slice());
         let leaked_buffer_addr = leaked_buffer.as_mut_ptr() as usize;
         boot_services.expect_allocate_pages().once().returning(move |_, _, _| Ok(leaked_buffer_addr));
 

--- a/components/patina_performance/src/component/protocol.rs
+++ b/components/patina_performance/src/component/protocol.rs
@@ -11,13 +11,14 @@
 //! SPDX-License-Identifier: Apache-2.0
 //!
 
+use alloc::string::ToString;
+
 use core::{
     cell::OnceCell,
     ffi::{c_char, c_void},
     sync::atomic::{AtomicBool, Ordering},
 };
 
-use alloc::string::ToString;
 use patina::standard::efi;
 use patina::{
     BinaryGuid, Char8Str,

--- a/components/patina_samples/src/lib.rs
+++ b/components/patina_samples/src/lib.rs
@@ -19,5 +19,7 @@
 #![deny(missing_docs)]
 #![cfg_attr(coverage, feature(coverage_attribute))]
 #![cfg_attr(coverage, coverage(off))] // Disable all coverage instrumentation for sample code
+extern crate alloc;
+
 pub mod component;
 pub mod smbios_platform;

--- a/components/patina_samples/src/lib.rs
+++ b/components/patina_samples/src/lib.rs
@@ -15,7 +15,7 @@
 //!
 //! SPDX-License-Identifier: Apache-2.0
 //!
-#![cfg_attr(not(feature = "std"), no_std)]
+#![cfg_attr(all(not(feature = "std"), not(test)), no_std)]
 #![deny(missing_docs)]
 #![cfg_attr(coverage, feature(coverage_attribute))]
 #![cfg_attr(coverage, coverage(off))] // Disable all coverage instrumentation for sample code

--- a/components/patina_samples/src/smbios_platform.rs
+++ b/components/patina_samples/src/smbios_platform.rs
@@ -28,7 +28,7 @@
 //!
 //! SPDX-License-Identifier: Apache-2.0
 
-use alloc::{string::String, vec};
+use alloc::{string::String, vec, vec::Vec};
 use patina::{
     component::{component, service::Service},
     error::Result,
@@ -57,7 +57,7 @@ pub struct VendorOemRecord {
     pub oem_field: u32,
     /// String pool containing vendor and platform data strings
     #[string_pool]
-    pub string_pool: alloc::vec::Vec<String>,
+    pub string_pool: Vec<String>,
 }
 
 /// Example Platform SMBIOS Component

--- a/components/patina_samples/src/smbios_platform.rs
+++ b/components/patina_samples/src/smbios_platform.rs
@@ -28,8 +28,6 @@
 //!
 //! SPDX-License-Identifier: Apache-2.0
 
-extern crate alloc;
-
 use alloc::{string::String, vec};
 use patina::{
     component::{component, service::Service},

--- a/components/patina_smbios/src/component.rs
+++ b/components/patina_smbios/src/component.rs
@@ -142,7 +142,6 @@ impl SmbiosProvider {
 #[cfg(test)]
 mod tests {
     use super::*;
-    extern crate std;
 
     #[test]
     fn test_smbios_provider_new() {

--- a/components/patina_smbios/src/component.rs
+++ b/components/patina_smbios/src/component.rs
@@ -8,7 +8,6 @@
 //!
 //! SPDX-License-Identifier: Apache-2.0
 
-extern crate alloc;
 use crate::{
     error::SmbiosError,
     manager::SmbiosManager,

--- a/components/patina_smbios/src/error.rs
+++ b/components/patina_smbios/src/error.rs
@@ -121,7 +121,6 @@ mod tests {
 
     #[test]
     fn test_smbios_error_all_variants() {
-        extern crate std;
         use std::vec;
 
         // Test all error variants for completeness

--- a/components/patina_smbios/src/lib.rs
+++ b/components/patina_smbios/src/lib.rs
@@ -313,6 +313,8 @@
 #![deny(missing_docs)]
 #![cfg_attr(coverage, feature(coverage_attribute))]
 
+extern crate alloc;
+
 // SMBIOS tables require little-endian byte order. The SmbiosRecord derive macro
 // uses zerocopy::IntoBytes::as_bytes() which returns native byte order.
 #[cfg(not(target_endian = "little"))]

--- a/components/patina_smbios/src/manager.rs
+++ b/components/patina_smbios/src/manager.rs
@@ -12,8 +12,6 @@
 //! SPDX-License-Identifier: Apache-2.0
 //!
 
-extern crate alloc;
-
 use patina::protocol::ProtocolInterface;
 
 mod core;

--- a/components/patina_smbios/src/manager/core.rs
+++ b/components/patina_smbios/src/manager/core.rs
@@ -10,8 +10,6 @@
 //! SPDX-License-Identifier: Apache-2.0
 //!
 
-extern crate alloc;
-
 use alloc::{boxed::Box, collections::BTreeSet, string::String, vec::Vec};
 use core::cell::RefCell;
 use patina::standard::efi::{Handle, PhysicalAddress};

--- a/components/patina_smbios/src/manager/core.rs
+++ b/components/patina_smbios/src/manager/core.rs
@@ -757,14 +757,13 @@ impl SmbiosManager {
 #[cfg(test)]
 mod tests {
     use super::*;
-    extern crate std;
-    use std::{vec, vec::Vec};
-
     use crate::{
         error::SmbiosError,
         service::{SMBIOS_HANDLE_PI_RESERVED, SMBIOS_STRING_MAX_LENGTH, SmbiosHandle, SmbiosTableHeader},
     };
+    use patina::component::service::memory::StdMemoryManager;
     use patina::standard::efi;
+    use std::{boxed::Box, vec, vec::Vec};
     use zerocopy::IntoBytes;
 
     /// Test helper: Build a simple SMBIOS record with the given header and strings
@@ -1773,10 +1772,6 @@ mod tests {
 
     #[test]
     fn test_allocate_buffers() {
-        use patina::component::service::memory::StdMemoryManager;
-        extern crate std;
-        use std::boxed::Box;
-
         let manager = SmbiosManager::new(3, 9).expect("failed to create manager");
         let memory_manager: &'static dyn patina::component::service::memory::MemoryManager =
             Box::leak(Box::new(StdMemoryManager::new()));
@@ -1800,10 +1795,6 @@ mod tests {
 
     #[test]
     fn test_allocate_buffers_idempotent() {
-        use patina::component::service::memory::StdMemoryManager;
-        extern crate std;
-        use std::boxed::Box;
-
         let manager = SmbiosManager::new(3, 9).expect("failed to create manager");
         let memory_manager: &'static dyn patina::component::service::memory::MemoryManager =
             Box::leak(Box::new(StdMemoryManager::new()));
@@ -1824,10 +1815,6 @@ mod tests {
 
     #[test]
     fn test_build_table_data() {
-        use patina::component::service::memory::StdMemoryManager;
-        extern crate std;
-        use std::boxed::Box;
-
         let manager = SmbiosManager::new(3, 9).expect("failed to create manager");
         let memory_manager: &'static dyn patina::component::service::memory::MemoryManager =
             Box::leak(Box::new(StdMemoryManager::new()));
@@ -1867,10 +1854,6 @@ mod tests {
 
     #[test]
     fn test_build_table_data_copies_records_correctly() {
-        use patina::component::service::memory::StdMemoryManager;
-        extern crate std;
-        use std::boxed::Box;
-
         let manager = SmbiosManager::new(3, 9).expect("failed to create manager");
         let memory_manager: &'static dyn patina::component::service::memory::MemoryManager =
             Box::leak(Box::new(StdMemoryManager::new()));
@@ -1901,10 +1884,6 @@ mod tests {
 
     #[test]
     fn test_build_table_data_no_records_error() {
-        use patina::component::service::memory::StdMemoryManager;
-        extern crate std;
-        use std::boxed::Box;
-
         let manager = SmbiosManager::new(3, 9).expect("failed to create manager");
         let memory_manager: &'static dyn patina::component::service::memory::MemoryManager =
             Box::leak(Box::new(StdMemoryManager::new()));

--- a/components/patina_smbios/src/manager/protocol.rs
+++ b/components/patina_smbios/src/manager/protocol.rs
@@ -358,7 +358,6 @@ impl SmbiosProtocol {
 mod tests {
     use super::*;
     use crate::{error::SmbiosError, manager::SmbiosManager};
-    extern crate std;
     use std::vec::Vec;
 
     fn create_test_bios_info_record() -> Vec<u8> {

--- a/components/patina_smbios/src/manager/protocol.rs
+++ b/components/patina_smbios/src/manager/protocol.rs
@@ -13,8 +13,6 @@
 //! SPDX-License-Identifier: Apache-2.0
 //!
 
-extern crate alloc;
-
 use core::ffi::c_char;
 
 use alloc::string::ToString;

--- a/components/patina_smbios/src/manager/protocol.rs
+++ b/components/patina_smbios/src/manager/protocol.rs
@@ -13,9 +13,10 @@
 //! SPDX-License-Identifier: Apache-2.0
 //!
 
+use alloc::string::ToString;
+
 use core::ffi::c_char;
 
-use alloc::string::ToString;
 use patina::{Char8Str, protocol::ProtocolInterface, standard::efi, uefi::tpl_mutex::TplMutex};
 
 use crate::service::{SMBIOS_HANDLE_PI_RESERVED, SmbiosHandle, SmbiosTableHeader, SmbiosType};

--- a/components/patina_smbios/src/manager/record.rs
+++ b/components/patina_smbios/src/manager/record.rs
@@ -38,7 +38,6 @@ impl SmbiosRecord {
 #[cfg(test)]
 mod tests {
     use super::*;
-    extern crate std;
     use std::vec;
 
     use patina::standard::efi;

--- a/components/patina_smbios/src/manager/record.rs
+++ b/components/patina_smbios/src/manager/record.rs
@@ -10,8 +10,6 @@
 //! SPDX-License-Identifier: Apache-2.0
 //!
 
-extern crate alloc;
-
 use alloc::vec::Vec;
 
 use crate::service::SmbiosTableHeader;

--- a/components/patina_smbios/src/service.rs
+++ b/components/patina_smbios/src/service.rs
@@ -416,8 +416,8 @@ mod tests {
     #[test]
     fn test_smbios_records_iter_basic() {
         use crate::manager::SmbiosRecord;
-        use alloc::vec;
         use core::cell::RefCell;
+        use std::vec;
 
         let records = RefCell::new(vec![
             SmbiosRecord::new(SmbiosTableHeader::new(0, 24, 0x0001), None, vec![], 0),
@@ -443,8 +443,8 @@ mod tests {
     #[test]
     fn test_smbios_records_iter_with_filter() {
         use crate::manager::SmbiosRecord;
-        use alloc::vec;
         use core::cell::RefCell;
+        use std::vec;
 
         let records = RefCell::new(vec![
             SmbiosRecord::new(SmbiosTableHeader::new(0, 24, 0x0001), None, vec![], 0),
@@ -471,8 +471,8 @@ mod tests {
     #[test]
     fn test_smbios_records_iter_empty() {
         use crate::manager::SmbiosRecord;
-        use alloc::vec;
         use core::cell::RefCell;
+        use std::vec;
 
         let records: RefCell<Vec<SmbiosRecord>> = RefCell::new(vec![]);
         let borrowed = records.borrow();
@@ -484,8 +484,8 @@ mod tests {
     #[test]
     fn test_smbios_records_iter_no_match_filter() {
         use crate::manager::SmbiosRecord;
-        use alloc::vec;
         use core::cell::RefCell;
+        use std::vec;
 
         let records = RefCell::new(vec![
             SmbiosRecord::new(SmbiosTableHeader::new(0, 24, 0x0001), None, vec![], 0),
@@ -587,8 +587,8 @@ mod tests {
 
     #[test]
     fn test_mock_smbios_service_add_record_integration() {
-        use alloc::vec;
         use patina::component::service::Service;
+        use std::vec;
 
         // Create a test record
         let record = Type127EndOfTable { header: SmbiosTableHeader::new(127, 4, 0xFFFE), string_pool: vec![] };
@@ -624,8 +624,8 @@ mod tests {
 
     #[test]
     fn test_mock_add_record_extension_trait_pattern() {
-        use alloc::vec;
         use patina::component::service::Service;
+        use std::vec;
 
         // Create a test record
         let record = Type127EndOfTable { header: SmbiosTableHeader::new(127, 4, 0xFFFE), string_pool: vec![] };
@@ -654,8 +654,8 @@ mod tests {
 
     #[test]
     fn test_mock_add_record_with_error() {
-        use alloc::vec;
         use patina::component::service::Service;
+        use std::vec;
 
         // Mock that returns an error
         let mock = MockSmbios {
@@ -676,8 +676,8 @@ mod tests {
 
     #[test]
     fn test_mock_multiple_record_types() {
-        use alloc::{string::String, vec};
         use patina::component::service::Service;
+        use std::{string::String, vec};
 
         // Test that mock can handle different record types
         let type0 = Type0PlatformFirmwareInformation {
@@ -723,8 +723,8 @@ mod tests {
 
     #[test]
     fn test_service_mock_pattern() {
-        use alloc::vec;
         use patina::component::service::Service;
+        use std::vec;
 
         // Create a mock service using the standard Service::mock pattern
         let mock = MockSmbios { version: (3, 6), add_from_bytes_result: Ok(0xBEEF), expected_bytes: None };
@@ -745,8 +745,8 @@ mod tests {
 
     #[test]
     fn test_service_mock_with_extension_trait() {
-        use alloc::vec;
         use patina::component::service::Service;
+        use std::vec;
 
         // Create test record
         let record = Type127EndOfTable { header: SmbiosTableHeader::new(127, 4, 0xFFFE), string_pool: vec![] };

--- a/components/patina_smbios/src/service.rs
+++ b/components/patina_smbios/src/service.rs
@@ -10,7 +10,6 @@
 //! SPDX-License-Identifier: Apache-2.0
 //!
 
-extern crate alloc;
 use alloc::vec::Vec;
 use core::cell::Ref;
 use patina::standard::efi::{self, Handle, SMBIOS3_TABLE_GUID};
@@ -346,9 +345,6 @@ impl SmbiosExt for patina::component::service::Service<dyn Smbios> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    extern crate alloc;
-    extern crate std;
-    use alloc::string::String;
     use std::format;
 
     use crate::{

--- a/components/patina_smbios/src/smbios_record.rs
+++ b/components/patina_smbios/src/smbios_record.rs
@@ -804,7 +804,7 @@ impl Default for Type127EndOfTable {
 mod tests {
     use super::*;
     use crate::{service::SMBIOS_STRING_MAX_LENGTH, smbios_types};
-    use alloc::vec;
+    use std::vec;
 
     #[test]
     fn test_type0_new() {

--- a/components/patina_smbios/src/smbios_record.rs
+++ b/components/patina_smbios/src/smbios_record.rs
@@ -234,7 +234,6 @@
 //!
 //! SPDX-License-Identifier: Apache-2.0
 
-extern crate alloc;
 use crate::{
     error::SmbiosError,
     service::{SMBIOS_HANDLE_PI_RESERVED, SMBIOS_STRING_MAX_LENGTH, SmbiosTableHeader},

--- a/components/patina_smbios/src/smbios_types.rs
+++ b/components/patina_smbios/src/smbios_types.rs
@@ -14,8 +14,6 @@
 //!
 //! SPDX-License-Identifier: Apache-2.0
 
-extern crate alloc;
-
 use bitfield_struct::bitfield;
 use zerocopy::{Immutable, IntoBytes, KnownLayout};
 

--- a/components/patina_test/src/__private_api.rs
+++ b/components/patina_test/src/__private_api.rs
@@ -170,8 +170,6 @@ where
 mod tests {
     use super::*;
 
-    extern crate std;
-
     #[test]
     fn test_should_run() {
         let test_case = TestCase {
@@ -183,10 +181,10 @@ mod tests {
             func: |_| Ok(true),
         };
 
-        std::assert!(test_case.should_run(&[Filter::include("test")]));
-        std::assert!(test_case.should_run(&[Filter::include("t")]));
-        std::assert!(test_case.should_run(&[]));
-        std::assert!(!test_case.should_run(&[Filter::include("not")]));
+        assert!(test_case.should_run(&[Filter::include("test")]));
+        assert!(test_case.should_run(&[Filter::include("t")]));
+        assert!(test_case.should_run(&[]));
+        assert!(!test_case.should_run(&[Filter::include("not")]));
     }
 
     #[test]
@@ -200,7 +198,7 @@ mod tests {
             func: |_| Ok(true),
         };
 
-        std::assert!(test_case.should_run(&[]));
+        assert!(test_case.should_run(&[]));
     }
 
     #[test]
@@ -215,13 +213,13 @@ mod tests {
         };
 
         // Exclude filter matches - should not run
-        std::assert!(!test_case.should_run(&[Filter::exclude("test_case")]));
+        assert!(!test_case.should_run(&[Filter::exclude("test_case")]));
         // Exclude filter does not match - should run
-        std::assert!(test_case.should_run(&[Filter::exclude("other")]));
+        assert!(test_case.should_run(&[Filter::exclude("other")]));
         // Include filter matches but exclude filter also matches - should not run
-        std::assert!(!test_case.should_run(&[Filter::include("my_crate"), Filter::exclude("test_case")]));
+        assert!(!test_case.should_run(&[Filter::include("my_crate"), Filter::exclude("test_case")]));
         // Include filter matches and exclude filter does not match - should run
-        std::assert!(test_case.should_run(&[Filter::include("my_crate"), Filter::exclude("other")]));
+        assert!(test_case.should_run(&[Filter::include("my_crate"), Filter::exclude("other")]));
     }
 
     #[test]
@@ -248,11 +246,11 @@ mod tests {
 
         // Test that a passing test passes
         let result = test_case_pass.run(&mut storage, true);
-        std::assert_eq!(result, Ok(()));
+        assert_eq!(result, Ok(()));
 
         // Test that a failing test fails
         let result = test_case_fail.run(&mut storage, true);
-        std::assert_eq!(result, Err("Failed to install protocol interface"));
+        assert_eq!(result, Err("Failed to install protocol interface"));
     }
 
     #[test]
@@ -278,11 +276,11 @@ mod tests {
 
         // Test that a test that passes, should fail because its expected to fail
         let result = test_case_pass.run(&mut storage, true);
-        std::assert_eq!(result, Err("Test passed when it should have failed"));
+        assert_eq!(result, Err("Test passed when it should have failed"));
 
         // Test that a test that fails, should pass because its expected to fail
         let result = test_case_fail.run(&mut storage, true);
-        std::assert_eq!(result, Ok(()));
+        assert_eq!(result, Ok(()));
     }
 
     #[test]
@@ -300,7 +298,7 @@ mod tests {
         };
 
         let result = test_case.run(&mut storage, false);
-        std::assert_eq!(result, Ok(()));
+        assert_eq!(result, Ok(()));
 
         // Test that a test that fails with an unexpected message, should fail
         let test_case = TestCase {
@@ -313,7 +311,7 @@ mod tests {
         };
 
         let result = test_case.run(&mut storage, false);
-        std::assert_eq!(result, Err("Failed to install protocol interface"));
+        assert_eq!(result, Err("Failed to install protocol interface"));
     }
 
     #[test]

--- a/components/patina_test/src/component.rs
+++ b/components/patina_test/src/component.rs
@@ -13,9 +13,9 @@
 //!
 use crate::{
     __private_api,
-    alloc::vec::Vec,
     service::{Recorder, TestRecord},
 };
+use alloc::vec::Vec;
 
 use patina::component::{Storage, component};
 
@@ -142,16 +142,14 @@ impl TestRunner {
 #[cfg_attr(coverage, coverage(off))]
 pub(crate) mod tests {
     use super::*;
-    use crate::{
-        __private_api::TestCase,
-        alloc::{boxed::Box, format},
-    };
+    use crate::__private_api::TestCase;
     use core::mem::MaybeUninit;
     use patina::{
         BinaryGuid,
         component::{IntoComponent, Storage, params::Config},
         uefi::boot_services::StandardBootServices,
     };
+    use std::{boxed::Box, format};
 
     // A test function where we mock DxeComponentInterface to return what we want for the test.
     fn test_function(config: Config<i32>) -> crate::error::Result {

--- a/components/patina_test/src/component.rs
+++ b/components/patina_test/src/component.rs
@@ -141,8 +141,6 @@ impl TestRunner {
 #[cfg(test)]
 #[cfg_attr(coverage, coverage(off))]
 pub(crate) mod tests {
-    extern crate std;
-
     use super::*;
     use crate::{
         __private_api::TestCase,
@@ -399,7 +397,7 @@ pub(crate) mod tests {
         // This test is filtered out, so it should not even show up in the results.
         assert!(!output.contains("test_that_fails"));
         // This test is not filtered out, but never run, so should log as such.
-        std::println!("{}", output);
+        println!("{}", output);
         assert!(output.contains("event_triggered_test ... not triggered"));
     }
 }

--- a/components/patina_test/src/lib.rs
+++ b/components/patina_test/src/lib.rs
@@ -3,7 +3,7 @@
     "## License\n\n",
     " Copyright (c) Microsoft Corporation.\n\n",
 )]
-#![no_std]
+#![cfg_attr(not(test), no_std)]
 #![deny(missing_docs)]
 #![cfg_attr(coverage, feature(coverage_attribute))]
 extern crate alloc;

--- a/components/patina_test/src/service.rs
+++ b/components/patina_test/src/service.rs
@@ -13,10 +13,8 @@
 //!
 //! SPDX-License-Identifier: Apache-2.0
 //!
-use crate::{
-    __private_api::{TestCase, TestTrigger},
-    alloc::{boxed::Box, collections::BTreeMap, fmt::Display, string::String, vec::Vec},
-};
+use crate::__private_api::{TestCase, TestTrigger};
+use alloc::{boxed::Box, collections::BTreeMap, fmt::Display, format, string::String, vec::Vec};
 
 use core::{ops::DerefMut, ptr::NonNull};
 
@@ -139,12 +137,12 @@ impl TestRecord {
 
     /// Serializes the test record to a JSON string for logging or reporting purposes.
     fn json(&self) -> String {
-        alloc::format!(
+        format!(
             r#"{{"name":"{}","pass":{},"fail":{},"err_msg":{}}}"#,
             self.test_case.name,
             self.pass,
             self.fail,
-            self.err_msg.map_or(String::from("null"), |msg| alloc::format!(r#""{}""#, msg))
+            self.err_msg.map_or(String::from("null"), |msg| format!(r#""{}""#, msg))
         )
     }
 

--- a/components/patina_test/src/service.rs
+++ b/components/patina_test/src/service.rs
@@ -308,12 +308,11 @@ impl Display for Recorder {
 #[cfg(test)]
 #[cfg_attr(coverage, coverage(off))]
 mod tests {
-    extern crate std;
-
     use core::mem::MaybeUninit;
 
     use super::*;
-    use crate::{alloc::format, component::tests::*};
+    use crate::component::tests::*;
+    use std::format;
 
     #[test]
     fn test_recorder_records_results() {
@@ -356,7 +355,7 @@ mod tests {
         recorder.update_record(test_data);
 
         let output = format!("{}", *recorder);
-        std::println!("{}", output);
+        println!("{}", output);
         assert!(output.contains("test ... ok (1 passes)"));
     }
 

--- a/core/patina_debugger/src/lib.rs
+++ b/core/patina_debugger/src/lib.rs
@@ -120,6 +120,7 @@ mod transport;
 #[cfg(feature = "alloc")]
 extern crate alloc;
 
+use alloc::boxed::Box;
 pub use debugger::PatinaDebugger;
 
 #[cfg(not(test))]
@@ -181,7 +182,7 @@ trait Debugger: Sync {
         &'static self,
         command: &'static str,
         description: Option<&'static str>,
-        callback: alloc::boxed::Box<MonitorCommandFn>,
+        callback: Box<MonitorCommandFn>,
     );
 }
 
@@ -312,7 +313,7 @@ where
     F: Fn(&mut core::str::SplitWhitespace<'_>, &mut dyn core::fmt::Write) + Send + Sync + 'static,
 {
     if let Some(debugger) = DEBUGGER.get() {
-        debugger.add_monitor_command(cmd, description, alloc::boxed::Box::new(function));
+        debugger.add_monitor_command(cmd, description, Box::new(function));
     }
 }
 

--- a/core/patina_debugger/src/lib.rs
+++ b/core/patina_debugger/src/lib.rs
@@ -117,7 +117,7 @@ mod memory;
 mod system;
 mod transport;
 
-#[cfg(any(feature = "alloc", test))]
+#[cfg(feature = "alloc")]
 extern crate alloc;
 
 pub use debugger::PatinaDebugger;

--- a/core/patina_debugger/src/memory.rs
+++ b/core/patina_debugger/src/memory.rs
@@ -175,14 +175,13 @@ fn check_paging_range<P: PatinaPageTable>(page_table: &P, start_address: u64, le
 #[cfg(test)]
 #[cfg_attr(coverage, coverage(off))]
 mod tests {
-
     use super::*;
-
     use crate::*;
     use gdbstub::target::ext::breakpoints;
     use mockall::{predicate::*, *};
     use patina_internal_cpu::paging::CacheAttributeValue;
     use patina_paging::{MemoryAttributes, PtError};
+    use std::alloc::{Layout, alloc_zeroed, dealloc};
 
     mock! {
         pub MemPageTable {}
@@ -348,9 +347,9 @@ mod tests {
         // Write a pattern across the page boundary and verify all bytes land
         // at the correct addresses.
         const SIZE: usize = PAGE_SIZE as usize * 2;
-        let layout = std::alloc::Layout::from_size_align(SIZE, PAGE_SIZE as usize).unwrap();
+        let layout = Layout::from_size_align(SIZE, PAGE_SIZE as usize).unwrap();
         // SAFETY: layout has non-zero size and power-of-two alignment.
-        let dest = unsafe { std::alloc::alloc_zeroed(layout) };
+        let dest = unsafe { alloc_zeroed(layout) };
         assert!(!dest.is_null());
 
         // Start the write halfway into the first page so it crosses the boundary.
@@ -382,7 +381,7 @@ mod tests {
         }
 
         // SAFETY: dest was allocated with this layout.
-        unsafe { std::alloc::dealloc(dest, layout) };
+        unsafe { dealloc(dest, layout) };
     }
 
     #[test]

--- a/core/patina_debugger/src/system/no_alloc.rs
+++ b/core/patina_debugger/src/system/no_alloc.rs
@@ -65,9 +65,6 @@ impl SystemStateTrait for SystemState {
 #[cfg(test)]
 #[cfg_attr(coverage, coverage(off))]
 mod tests {
-    extern crate alloc;
-    use alloc::string::String;
-
     use super::*;
 
     #[test]

--- a/core/patina_internal_core/src/collections/bst.rs
+++ b/core/patina_internal_core/src/collections/bst.rs
@@ -899,7 +899,6 @@ mod tests {
 #[cfg(test)]
 #[allow(clippy::undocumented_unsafe_blocks)]
 mod fuzz_tests {
-    extern crate std;
     use crate::collections::{Bst, node_size};
     use rand::{
         RngExt,

--- a/core/patina_internal_core/src/collections/bst.rs
+++ b/core/patina_internal_core/src/collections/bst.rs
@@ -6,6 +6,8 @@
 //!
 //! SPDX-License-Identifier: Apache-2.0
 //!
+#[cfg(feature = "alloc")]
+use alloc::vec::Vec;
 use core::{cell::Cell, cmp::Ordering};
 
 use crate::collections::{
@@ -643,8 +645,8 @@ where
     #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
     #[allow(dead_code)]
     /// Performs a depth-first search on the tree, returning the ordered values.
-    pub fn dfs(&self) -> alloc::vec::Vec<D> {
-        let mut values = alloc::vec::Vec::new();
+    pub fn dfs(&self) -> Vec<D> {
+        let mut values = Vec::new();
         Self::_dfs(self.root(), &mut values);
         values
     }
@@ -652,7 +654,7 @@ where
     #[cfg(feature = "alloc")]
     #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
     #[allow(dead_code)]
-    fn _dfs(node: Option<&Node<D>>, values: &mut alloc::vec::Vec<D>) {
+    fn _dfs(node: Option<&Node<D>>, values: &mut Vec<D>) {
         if let Some(node) = node {
             Self::_dfs(node.left(), values);
             // SAFETY: Nodes in the tree always have initialized data

--- a/core/patina_internal_core/src/collections/rbt.rs
+++ b/core/patina_internal_core/src/collections/rbt.rs
@@ -10,6 +10,8 @@ use crate::collections::{
     SliceKey,
     node::{Node, NodeTrait, Storage},
 };
+#[cfg(feature = "alloc")]
+use alloc::vec::Vec;
 
 use super::{Error, Result};
 use core::{cell::Cell, cmp::Ordering, ptr};
@@ -872,8 +874,8 @@ where
     #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
     #[allow(dead_code)]
     /// Performs a depth-first search on the tree, returning the ordered values.
-    pub fn dfs(&self) -> alloc::vec::Vec<D> {
-        let mut values = alloc::vec::Vec::new();
+    pub fn dfs(&self) -> Vec<D> {
+        let mut values = Vec::new();
         Self::_dfs(self.root(), &mut values);
         values
     }
@@ -881,7 +883,7 @@ where
     #[cfg(feature = "alloc")]
     #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
     #[allow(dead_code)]
-    fn _dfs(node: Option<&Node<D>>, values: &mut alloc::vec::Vec<D>) {
+    fn _dfs(node: Option<&Node<D>>, values: &mut Vec<D>) {
         if let Some(node) = node {
             Self::_dfs(node.left(), values);
             // SAFETY: Nodes in the tree always have initialized data

--- a/core/patina_internal_core/src/collections/rbt.rs
+++ b/core/patina_internal_core/src/collections/rbt.rs
@@ -917,8 +917,6 @@ where
 #[cfg_attr(coverage, coverage(off))]
 #[allow(clippy::undocumented_unsafe_blocks)]
 mod tests {
-    extern crate std;
-
     use super::*;
     use crate::collections::node_size;
 
@@ -1842,7 +1840,6 @@ mod tests {
 #[cfg(test)]
 #[allow(clippy::undocumented_unsafe_blocks)]
 mod fuzz_tests {
-    extern crate std;
     use crate::collections::{Rbt, node_size};
     use rand::{
         RngExt,

--- a/core/patina_internal_core/src/collections/sorted_slice.rs
+++ b/core/patina_internal_core/src/collections/sorted_slice.rs
@@ -206,7 +206,7 @@ where
 #[cfg_attr(coverage, coverage(off))]
 mod tests {
     use super::*;
-    use alloc::vec::Vec;
+    use std::vec::Vec;
 
     #[test]
     fn test_init_state_of_new_sorted_slice() {

--- a/core/patina_internal_core/src/collections/sorted_slice.rs
+++ b/core/patina_internal_core/src/collections/sorted_slice.rs
@@ -205,9 +205,7 @@ where
 #[cfg(test)]
 #[cfg_attr(coverage, coverage(off))]
 mod tests {
-    extern crate std;
     use super::*;
-    extern crate alloc;
     use alloc::vec::Vec;
 
     #[test]

--- a/core/patina_internal_core/src/depex.rs
+++ b/core/patina_internal_core/src/depex.rs
@@ -384,11 +384,10 @@ impl Iterator for DepexParser {
 #[cfg(test)]
 #[cfg_attr(coverage, coverage(off))]
 mod tests {
-    extern crate std;
-    use alloc::vec;
     use core::str::FromStr;
     use patina::standard::efi;
     use std::println;
+    use std::vec;
     use uuid::Uuid;
 
     use super::*;

--- a/core/patina_internal_core/src/lib.rs
+++ b/core/patina_internal_core/src/lib.rs
@@ -11,7 +11,7 @@
 //!
 //! SPDX-License-Identifier: Apache-2.0
 //!
-#![no_std]
+#![cfg_attr(not(test), no_std)]
 #![cfg_attr(coverage, feature(coverage_attribute))]
 
 extern crate alloc;

--- a/core/patina_internal_cpu/Cargo.toml
+++ b/core/patina_internal_cpu/Cargo.toml
@@ -15,7 +15,7 @@ features = ["std"]
 
 [dependencies]
 log = { workspace = true }
-patina = { workspace = true, features = ["alloc", "core"] }
+patina = { workspace = true, features = ["core"] }
 spin = { workspace = true, features = ["rwlock"] }
 patina_paging = { workspace = true }
 cfg-if = { workspace = true }

--- a/core/patina_internal_cpu/src/interrupts/exception_handling.rs
+++ b/core/patina_internal_cpu/src/interrupts/exception_handling.rs
@@ -119,8 +119,6 @@ extern "efiapi" fn exception_handler(exception_type: usize, context: &mut Except
 #[cfg(test)]
 #[cfg_attr(coverage, coverage(off))]
 mod tests {
-    extern crate std;
-
     use patina::pi::protocol::cpu_arch::EfiSystemContext;
 
     use super::*;

--- a/core/patina_internal_cpu/src/interrupts/x64/interrupt_manager.rs
+++ b/core/patina_internal_cpu/src/interrupts/x64/interrupt_manager.rs
@@ -241,8 +241,6 @@ fn dump_pte(cr2: u64) {
 #[cfg_attr(coverage, coverage(off))]
 #[cfg(test)]
 mod test {
-    extern crate std;
-
     use serial_test::serial;
 
     use super::*;

--- a/core/patina_internal_cpu/src/paging/null.rs
+++ b/core/patina_internal_cpu/src/paging/null.rs
@@ -8,7 +8,6 @@
 //!
 //! SPDX-License-Identifier: Apache-2.0
 //!
-use alloc::boxed::Box;
 use patina_paging::{CacheAttributeValue, MemoryAttributes, PtError};
 
 use crate::paging::PatinaPageTable;

--- a/patina_dxe_core/src/allocator.rs
+++ b/patina_dxe_core/src/allocator.rs
@@ -13,6 +13,11 @@ mod uefi_allocator;
 #[cfg_attr(coverage, coverage(off))]
 mod usage_tests;
 
+use alloc::{
+    boxed::Box,
+    collections::BTreeMap,
+    vec::{IntoIter, Vec},
+};
 use core::{
     ffi::c_void,
     fmt::Debug,
@@ -22,7 +27,6 @@ use core::{
     slice::{self, from_raw_parts_mut},
 };
 
-use alloc::{boxed::Box, collections::BTreeMap, vec::Vec};
 use patina::function;
 
 use crate::{
@@ -166,7 +170,7 @@ pub trait PageAllocator {
     fn set_reserved_range(&self, range: Range<efi::PhysicalAddress>) -> Result<(), EfiError>;
 
     /// Returns an iterator over the memory ranges managed by this allocator.
-    fn get_memory_ranges(&self) -> alloc::vec::IntoIter<Range<usize>>;
+    fn get_memory_ranges(&self) -> IntoIter<Range<usize>>;
 
     /// Indicates whether the given pointer falls within a memory region managed by this allocator.
     fn contains(&self, ptr: NonNull<u8>) -> bool;
@@ -1632,17 +1636,17 @@ pub(crate) unsafe fn reset_allocators() {
 #[cfg_attr(coverage, coverage(off))]
 mod tests {
 
+    use super::*;
     use crate::{
         gcd,
         test_support::{self, build_test_hob_list},
     };
-
-    use super::*;
     use patina::pi::{
         dxe_services, guid as pi_guids,
         hob::{GUID_EXTENSION, GuidHob, Hob, HobHeader},
     };
     use patina::standard::efi;
+    use std::alloc::Allocator;
 
     enum GcdInit {
         /// Initializes a simple test GCD (via init_test_gcd()) with the given size.
@@ -2393,7 +2397,7 @@ mod tests {
                 assert!(!buffer_ptr.is_null());
                 assert!(allocator.get_memory_ranges().next().is_some());
 
-                let _alloc_trait: &dyn core::alloc::Allocator = allocator;
+                let _alloc_trait: &dyn Allocator = allocator;
 
                 assert!(allocator.free_pool(buffer_ptr).is_ok());
             }
@@ -2413,7 +2417,7 @@ mod tests {
                 assert!(!buffer_ptr.is_null());
                 assert!(allocator.get_memory_ranges().next().is_some());
 
-                let _alloc_trait: &dyn core::alloc::Allocator = allocator;
+                let _alloc_trait: &dyn Allocator = allocator;
 
                 assert!(allocator.free_pool(buffer_ptr).is_ok());
             }

--- a/patina_dxe_core/src/allocator.rs
+++ b/patina_dxe_core/src/allocator.rs
@@ -22,7 +22,6 @@ use core::{
     slice::{self, from_raw_parts_mut},
 };
 
-extern crate alloc;
 use alloc::{boxed::Box, collections::BTreeMap, vec::Vec};
 use patina::function;
 

--- a/patina_dxe_core/src/allocator/fixed_size_block_allocator.rs
+++ b/patina_dxe_core/src/allocator/fixed_size_block_allocator.rs
@@ -14,7 +14,7 @@ use super::{AllocationStatistics, AllocationStrategy, DEFAULT_ALLOCATION_STRATEG
 
 use crate::{gcd::SpinLockedGcd, tpl_mutex};
 
-use alloc::vec::Vec;
+use alloc::vec::{IntoIter, Vec};
 use core::{
     alloc::{AllocError, Allocator, GlobalAlloc, Layout},
     cmp::max,
@@ -656,7 +656,7 @@ impl SpinLockedFixedSizeBlockAllocator {
 
     /// Returns an iterator of the ranges of memory owned by this allocator
     /// Returns an empty iterator if the allocator does not own any memory.
-    pub fn get_memory_ranges(&self) -> alloc::vec::IntoIter<Range<usize>> {
+    pub fn get_memory_ranges(&self) -> IntoIter<Range<usize>> {
         let ranges: Vec<_> = self.lock().get_memory_ranges().collect();
         ranges.into_iter()
     }
@@ -816,7 +816,7 @@ impl PageAllocator for SpinLockedFixedSizeBlockAllocator {
         Self::set_reserved_range(self, range)
     }
 
-    fn get_memory_ranges(&self) -> alloc::vec::IntoIter<Range<usize>> {
+    fn get_memory_ranges(&self) -> IntoIter<Range<usize>> {
         Self::get_memory_ranges(self)
     }
 

--- a/patina_dxe_core/src/allocator/fixed_size_block_allocator.rs
+++ b/patina_dxe_core/src/allocator/fixed_size_block_allocator.rs
@@ -10,7 +10,6 @@
 //! SPDX-License-Identifier: Apache-2.0
 //!
 
-extern crate alloc;
 use super::{AllocationStatistics, AllocationStrategy, DEFAULT_ALLOCATION_STRATEGY, PageAllocator};
 
 use crate::{gcd::SpinLockedGcd, tpl_mutex};

--- a/patina_dxe_core/src/allocator/fixed_size_block_allocator.rs
+++ b/patina_dxe_core/src/allocator/fixed_size_block_allocator.rs
@@ -845,16 +845,15 @@ impl PageAllocator for SpinLockedFixedSizeBlockAllocator {
 #[cfg(test)]
 #[cfg_attr(coverage, coverage(off))]
 mod tests {
-    extern crate std;
     use crate::{
         allocator::{
             DEFAULT_ALLOCATION_STRATEGY, DEFAULT_PAGE_ALLOCATION_GRANULARITY, HIGH_TRAFFIC_ALLOC_MIN_EXPANSION,
         },
         gcd, test_support,
     };
-    use alloc::vec::Vec;
     use core::{alloc::GlobalAlloc, ffi::c_void, panic};
     use std::alloc::System;
+    use std::vec::Vec;
 
     use patina::{
         uefi_pages_to_size, {SIZE_64KB, UEFI_PAGE_SHIFT, UEFI_PAGE_SIZE},

--- a/patina_dxe_core/src/allocator/uefi_allocator.rs
+++ b/patina_dxe_core/src/allocator/uefi_allocator.rs
@@ -13,13 +13,12 @@ use patina::{error::EfiError, writelncrlf};
 
 use super::{AllocationStatistics, AllocationStrategy, PageAllocator};
 use core::{
-    alloc::{Allocator, GlobalAlloc, Layout},
+    alloc::{AllocError, Allocator, GlobalAlloc, Layout},
     ffi::c_void,
     fmt::{self, Display},
     ops::Range,
     ptr::NonNull,
 };
-
 const POOL_SIG: u32 = 0x04151980; //arbitrary number.
 const UEFI_POOL_ALIGN: usize = 8; //per UEFI spec.
 
@@ -221,11 +220,11 @@ unsafe impl<A> GlobalAlloc for UefiAllocator<A>
 where
     A: PageAllocator + GlobalAlloc + Allocator + Display + Sync + Send,
 {
-    unsafe fn alloc(&self, layout: core::alloc::Layout) -> *mut u8 {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
         // SAFETY: layout comes from the global allocator contract.
         unsafe { self.allocator.alloc(layout) }
     }
-    unsafe fn dealloc(&self, ptr: *mut u8, layout: core::alloc::Layout) {
+    unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
         // SAFETY: ptr was returned by alloc with the same layout.
         unsafe { self.allocator.dealloc(ptr, layout) }
     }
@@ -236,10 +235,10 @@ unsafe impl<A> Allocator for UefiAllocator<A>
 where
     A: PageAllocator + GlobalAlloc + Allocator + Display + Sync + Send,
 {
-    fn allocate(&self, layout: core::alloc::Layout) -> Result<core::ptr::NonNull<[u8]>, core::alloc::AllocError> {
+    fn allocate(&self, layout: Layout) -> Result<core::ptr::NonNull<[u8]>, AllocError> {
         self.allocator.allocate(layout)
     }
-    unsafe fn deallocate(&self, ptr: core::ptr::NonNull<u8>, layout: core::alloc::Layout) {
+    unsafe fn deallocate(&self, ptr: core::ptr::NonNull<u8>, layout: Layout) {
         // SAFETY: ptr was returned by allocate with the same layout.
         unsafe { self.allocator.deallocate(ptr, layout) }
     }

--- a/patina_dxe_core/src/allocator/uefi_allocator.rs
+++ b/patina_dxe_core/src/allocator/uefi_allocator.rs
@@ -272,7 +272,6 @@ where
 #[cfg(test)]
 #[cfg_attr(coverage, coverage(off))]
 mod tests {
-    extern crate std;
     use core::cmp::max;
     use std::alloc::{GlobalAlloc, System};
 

--- a/patina_dxe_core/src/allocator/usage_tests/uefi_memory_map.rs
+++ b/patina_dxe_core/src/allocator/usage_tests/uefi_memory_map.rs
@@ -145,7 +145,6 @@ mod tests {
         allocator::{get_memory_map, init_memory_support, reset_allocators},
         test_support,
     };
-    use alloc::vec::Vec;
     use patina::standard::efi;
     use patina::{
         BinaryGuid,
@@ -158,6 +157,7 @@ mod tests {
     };
     use serial_test::serial;
     use std::panic::RefUnwindSafe;
+    use std::vec::Vec;
 
     const ZERO: BinaryGuid = BinaryGuid::ZERO;
 

--- a/patina_dxe_core/src/component_dispatcher.rs
+++ b/patina_dxe_core/src/component_dispatcher.rs
@@ -9,6 +9,7 @@
 //! SPDX-License-Identifier: Apache-2.0
 //!
 use crate::tpl_mutex::TplMutex;
+use alloc::{borrow::Cow, boxed::Box, format, vec::Vec};
 use patina::standard::efi;
 use patina::{
     component::{IntoComponent, Storage, service::IntoService},
@@ -17,8 +18,6 @@ use patina::{
     uefi::boot_services::StandardBootServices,
     uefi::runtime_services::StandardRuntimeServices,
 };
-
-use alloc::{borrow::Cow, boxed::Box, vec::Vec};
 
 /// A trait to be implemented by the platform to register additional components, configurations, and services.
 ///
@@ -197,7 +196,7 @@ impl ComponentDispatcher {
                 let parser_funcs = self.storage.get_hob_parsers(&guid.name);
                 if parser_funcs.is_empty() {
                     let (f0, f1, f2, f3, f4, &[f5, f6, f7, f8, f9, f10]) = guid.name.as_fields();
-                    let name = alloc::format!(
+                    let name = format!(
                         "{f0:08x}-{f1:04x}-{f2:04x}-{f3:02x}{f4:02x}-{f5:02x}{f6:02x}{f7:02x}{f8:02x}{f9:02x}{f10:02x}"
                     );
                     log::warn!(

--- a/patina_dxe_core/src/component_dispatcher.rs
+++ b/patina_dxe_core/src/component_dispatcher.rs
@@ -8,8 +8,6 @@
 //!
 //! SPDX-License-Identifier: Apache-2.0
 //!
-extern crate alloc;
-
 use crate::tpl_mutex::TplMutex;
 use patina::standard::efi;
 use patina::{

--- a/patina_dxe_core/src/config_tables/memory_attributes_table.rs
+++ b/patina_dxe_core/src/config_tables/memory_attributes_table.rs
@@ -6,7 +6,6 @@
 //!
 //! SPDX-License-Identifier: Apache-2.0
 //!
-extern crate alloc;
 use alloc::vec::Vec;
 
 #[cfg(not(test))]

--- a/patina_dxe_core/src/config_tables/memory_attributes_table.rs
+++ b/patina_dxe_core/src/config_tables/memory_attributes_table.rs
@@ -250,7 +250,6 @@ pub fn core_install_memory_attributes_table() {
 #[cfg(test)]
 #[cfg_attr(coverage, coverage(off))]
 mod tests {
-    extern crate std;
     use super::*;
 
     use crate::{

--- a/patina_dxe_core/src/debugger_reload.rs
+++ b/patina_dxe_core/src/debugger_reload.rs
@@ -11,9 +11,9 @@
 //! SPDX-License-Identifier: Apache-2.0
 //!
 
+use alloc::{boxed::Box, vec, vec::Vec};
 use core::ffi::c_void;
 
-use alloc::vec::Vec;
 use patina::{
     component::service::memory::{AllocationOptions, MemoryManager, PageAllocationStrategy},
     guid as base_guids,
@@ -176,7 +176,7 @@ fn decompress_image(compressed_image: &[u8], out: &mut dyn core::fmt::Write) -> 
         u32::from_le_bytes(bytes) as usize
     };
 
-    let decompressed_image = alloc::boxed::Box::leak(alloc::vec![0u8; decompressed_size].into_boxed_slice());
+    let decompressed_image = Box::leak(vec![0u8; decompressed_size].into_boxed_slice());
     if let Err(error) =
         decompress_into_with_algo(compressed_image, decompressed_image, DecompressionAlgorithm::UefiDecompress)
     {

--- a/patina_dxe_core/src/decompress.rs
+++ b/patina_dxe_core/src/decompress.rs
@@ -6,8 +6,6 @@
 //!
 //! SPDX-License-Identifier: Apache-2.0
 //!
-extern crate alloc;
-
 use core::ffi::c_void;
 
 use alloc::boxed::Box;

--- a/patina_dxe_core/src/decompress.rs
+++ b/patina_dxe_core/src/decompress.rs
@@ -6,9 +6,9 @@
 //!
 //! SPDX-License-Identifier: Apache-2.0
 //!
+use alloc::boxed::Box;
 use core::ffi::c_void;
 
-use alloc::boxed::Box;
 use patina::{
     component::{Storage, component},
     error::EfiError,

--- a/patina_dxe_core/src/event_db.rs
+++ b/patina_dxe_core/src/event_db.rs
@@ -10,8 +10,6 @@
 //!
 #![warn(missing_docs)]
 
-extern crate alloc;
-
 use alloc::{
     collections::{BTreeMap, BTreeSet},
     vec::Vec,

--- a/patina_dxe_core/src/event_db.rs
+++ b/patina_dxe_core/src/event_db.rs
@@ -843,12 +843,11 @@ unsafe impl Sync for SpinLockedEventDb {}
 #[cfg(test)]
 #[cfg_attr(coverage, coverage(off))]
 mod tests {
-    extern crate std;
     use core::{iter, str::FromStr};
 
-    use alloc::{vec, vec::Vec};
     use patina::Guid;
     use patina::standard::efi;
+    use std::{vec, vec::Vec};
     use uuid::Uuid;
 
     use crate::test_support;

--- a/patina_dxe_core/src/gcd/spin_locked_gcd.rs
+++ b/patina_dxe_core/src/gcd/spin_locked_gcd.rs
@@ -3083,9 +3083,9 @@ mod tests {
     use crate::test_support::{self, MockPageTable, MockPageTableWrapper};
 
     use super::*;
-    use alloc::vec::Vec;
     use patina::pi::dxe_services::GcdMemoryType;
     use patina::standard::efi;
+    use std::vec::Vec;
     use std::{alloc::GlobalAlloc, cell::RefCell, rc::Rc};
 
     const DXE_CORE_PE_HEADER_DATA: [u8; 1057] = [

--- a/patina_dxe_core/src/gcd/spin_locked_gcd.rs
+++ b/patina_dxe_core/src/gcd/spin_locked_gcd.rs
@@ -3076,17 +3076,17 @@ mod tests {
     //! ## Global State (`GCD.reset()`)
     //! - Tests reset global GCD state to ensure test isolation
     //! - The test lock prevents concurrent access during reset operations
-    extern crate std;
-    use core::{alloc::Layout, sync::atomic::AtomicBool};
-    use patina::align_up;
-
     use crate::test_support::{self, MockPageTable, MockPageTableWrapper};
+    use core::sync::atomic::AtomicBool;
+    use patina::align_up;
+    use std::alloc::System;
+    use std::alloc::{Layout, alloc};
+    use std::vec::Vec;
+    use std::{alloc::GlobalAlloc, cell::RefCell, rc::Rc};
 
     use super::*;
     use patina::pi::dxe_services::GcdMemoryType;
     use patina::standard::efi;
-    use std::vec::Vec;
-    use std::{alloc::GlobalAlloc, cell::RefCell, rc::Rc};
 
     const DXE_CORE_PE_HEADER_DATA: [u8; 1057] = [
         0x4D, 0x5A, 0x78, 0x00, 0x01, 0x00, 0x00, 0x00, 0x04, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
@@ -4744,7 +4744,7 @@ mod tests {
     unsafe fn get_memory(size: usize) -> &'static mut [u8] {
         // SAFETY: Allocates memory from the system allocator with UEFI page alignment.
         // The returned slice is intentionally leaked for test simplicity and valid for 'static lifetime.
-        let addr = unsafe { alloc::alloc::alloc(alloc::alloc::Layout::from_size_align(size, UEFI_PAGE_SIZE).unwrap()) };
+        let addr = unsafe { alloc(Layout::from_size_align(size, UEFI_PAGE_SIZE).unwrap()) };
         // SAFETY: The allocated pointer is valid for `size` bytes and properly aligned.
         unsafe { core::slice::from_raw_parts_mut(addr, size) }
     }
@@ -4888,7 +4888,7 @@ mod tests {
 
             let layout = Layout::from_size_align(GCD_SIZE, 0x1000).unwrap();
             // SAFETY: The allocator returns a test buffer aligned to pages for GCD initialization.
-            let base = unsafe { std::alloc::System.alloc(layout) as u64 };
+            let base = unsafe { System.alloc(layout) as u64 };
             // SAFETY: base/size come from the test allocation and are valid for initializing memory blocks.
             unsafe {
                 GCD.init_memory_blocks(
@@ -4935,7 +4935,7 @@ mod tests {
 
             let layout = Layout::from_size_align(GCD_SIZE, 0x1000).unwrap();
             // SAFETY: The allocator returns a test buffer aligned to pages for GCD initialization.
-            let base = unsafe { std::alloc::System.alloc(layout) as u64 };
+            let base = unsafe { System.alloc(layout) as u64 };
             // SAFETY: base/size come from the test allocation and are valid for initializing memory blocks.
             unsafe {
                 GCD.init_memory_blocks(
@@ -5140,7 +5140,7 @@ mod tests {
 
             let layout = Layout::from_size_align(GCD_SIZE, 0x1000).unwrap();
             // SAFETY: The allocator is set up to return an aligned and available test buffer for GCD initialization.
-            let base = unsafe { std::alloc::System.alloc(layout) as u64 };
+            let base = unsafe { System.alloc(layout) as u64 };
             // SAFETY: base points to the test allocation and GCD_SIZE defines the initialized range.
             unsafe {
                 GCD.init_memory_blocks(
@@ -5194,7 +5194,7 @@ mod tests {
 
             let layout = Layout::from_size_align(GCD_SIZE, 0x1000).unwrap();
             // SAFETY: The allocator is set up to return an aligned and available test buffer for GCD initialization.
-            let base = unsafe { std::alloc::System.alloc(layout) as u64 };
+            let base = unsafe { System.alloc(layout) as u64 };
             // SAFETY: base/size correspond to the test allocation and are safe to register with the GCD.
             unsafe {
                 GCD.init_memory_blocks(

--- a/patina_dxe_core/src/memory_bin.rs
+++ b/patina_dxe_core/src/memory_bin.rs
@@ -25,14 +25,13 @@
 //!
 
 use crate::allocator::{DEFAULT_PAGE_ALLOCATION_GRANULARITY, RUNTIME_PAGE_ALLOCATION_GRANULARITY};
+use alloc::vec::Vec;
 use patina::standard::efi;
 use patina::{
     pi::hob::{self, EFiMemoryTypeInformation, Hob, HobList, MEMORY_TYPE_INFO_HOB_GUID},
     uefi::memory::{EFI_MAX_MEMORY_TYPE, INVALID_INFORMATION_INDEX},
     uefi_pages_to_size, uefi_size_to_pages, {UEFI_PAGE_SHIFT, align_up},
 };
-
-use alloc::vec::Vec;
 
 /// Maximum number of entries in the memory type information array.
 const MAX_MEMORY_TYPE_INFO_ENTRIES: usize = EFI_MAX_MEMORY_TYPE + 1;

--- a/patina_dxe_core/src/memory_manager.rs
+++ b/patina_dxe_core/src/memory_manager.rs
@@ -7,6 +7,7 @@
 //! SPDX-License-Identifier: Apache-2.0
 //!
 use alloc::boxed::Box;
+use core::alloc::Allocator;
 use patina::standard::efi;
 use patina::{
     component::service::{
@@ -91,10 +92,10 @@ impl MemoryManager for CoreMemoryManager {
     // Coverage is turned off since this is a simple wrapper function that would necessitate
     // complex mocking to test.
     #[cfg_attr(coverage, coverage(off))]
-    fn get_allocator(&self, memory_type: EfiMemoryType) -> Result<&'static dyn core::alloc::Allocator, MemoryError> {
+    fn get_allocator(&self, memory_type: EfiMemoryType) -> Result<&'static dyn Allocator, MemoryError> {
         let allocator =
             crate::allocator::core_get_allocator(memory_type.into()).map_err(|_| MemoryError::UnsupportedMemoryType)?;
-        Ok(allocator as &dyn core::alloc::Allocator)
+        Ok(allocator as &dyn Allocator)
     }
 
     /// # Safety

--- a/patina_dxe_core/src/pecoff.rs
+++ b/patina_dxe_core/src/pecoff.rs
@@ -6,8 +6,6 @@
 //!
 //! SPDX-License-Identifier: Apache-2.0
 //!
-extern crate alloc;
-
 use alloc::{
     format,
     string::{String, ToString},

--- a/patina_dxe_core/src/pecoff.rs
+++ b/patina_dxe_core/src/pecoff.rs
@@ -552,7 +552,6 @@ mod tests {
     use crate::test_support;
 
     use super::*;
-    extern crate std;
 
     use std::vec;
 

--- a/patina_dxe_core/src/pecoff/error.rs
+++ b/patina_dxe_core/src/pecoff/error.rs
@@ -46,12 +46,9 @@ impl From<goblin::error::Error> for Error {
 mod tests {
     use super::*;
 
-    extern crate alloc;
     extern crate scroll;
-    extern crate std;
-
-    use alloc::string::ToString;
     use std::format;
+    use std::string::ToString;
 
     #[test]
     fn test_convert_error() {

--- a/patina_dxe_core/src/performance.rs
+++ b/patina_dxe_core/src/performance.rs
@@ -809,7 +809,7 @@ mod tests {
             guid: efi::Guid,
         }
 
-        let node = alloc::boxed::Box::new(FwFilePathNode {
+        let node = std::boxed::Box::new(FwFilePathNode {
             header: efi::protocols::device_path::Protocol {
                 r#type: TYPE_MEDIA,
                 sub_type: Media::SUBTYPE_PIWG_FIRMWARE_FILE,
@@ -817,9 +817,9 @@ mod tests {
             },
             guid: file_guid,
         });
-        let node_ptr = alloc::boxed::Box::into_raw(node) as *mut efi::protocols::device_path::Protocol;
+        let node_ptr = std::boxed::Box::into_raw(node) as *mut efi::protocols::device_path::Protocol;
 
-        let loaded_image = alloc::boxed::Box::new(efi::protocols::loaded_image::Protocol {
+        let loaded_image = std::boxed::Box::new(efi::protocols::loaded_image::Protocol {
             revision: efi::protocols::loaded_image::REVISION,
             parent_handle: ptr::null_mut(),
             system_table: ptr::null_mut(),
@@ -834,7 +834,7 @@ mod tests {
             image_data_type: efi::BOOT_SERVICES_DATA,
             unload: None,
         });
-        let loaded_image_ptr = alloc::boxed::Box::into_raw(loaded_image) as *mut core::ffi::c_void;
+        let loaded_image_ptr = std::boxed::Box::into_raw(loaded_image) as *mut core::ffi::c_void;
 
         let (handle, _) = PROTOCOL_DB
             .install_protocol_interface(None, efi::protocols::loaded_image::PROTOCOL_GUID, loaded_image_ptr)
@@ -934,7 +934,7 @@ mod tests {
             // published_table_size reports a non-zero size, and publish_table writes into a large-enough buffer.
             let size = perf.published_table_size().unwrap();
             assert!(size > 0);
-            let buffer: &'static mut [u8] = alloc::boxed::Box::leak(alloc::vec![0u8; size].into_boxed_slice());
+            let buffer: &'static mut [u8] = std::boxed::Box::leak(std::vec![0u8; size].into_boxed_slice());
             perf.publish_table(buffer).unwrap();
         })
         .unwrap();
@@ -948,7 +948,7 @@ mod tests {
 
             assert_eq!(perf.published_table_size().unwrap_err(), Error::Efi(EfiError::AccessDenied));
 
-            let buffer: &'static mut [u8] = alloc::boxed::Box::leak(alloc::vec![0u8; 64].into_boxed_slice());
+            let buffer: &'static mut [u8] = std::boxed::Box::leak(std::vec![0u8; 64].into_boxed_slice());
             assert_eq!(perf.publish_table(buffer).unwrap_err(), Error::Efi(EfiError::AccessDenied));
 
             // A re-entrant record add cannot acquire the held table lock and drops the record.
@@ -1041,7 +1041,7 @@ mod tests {
             let image_handle = install_loaded_image_with_fw_path(node_length, file_guid);
 
             // A separate handle carries only a driver-binding protocol referencing the image handle above.
-            let driver_binding = alloc::boxed::Box::new(efi::protocols::driver_binding::Protocol {
+            let driver_binding = std::boxed::Box::new(efi::protocols::driver_binding::Protocol {
                 supported: stub_supported,
                 start: stub_start,
                 stop: stub_stop,
@@ -1049,7 +1049,7 @@ mod tests {
                 image_handle,
                 driver_binding_handle: ptr::null_mut(),
             });
-            let driver_binding_ptr = alloc::boxed::Box::into_raw(driver_binding) as *mut core::ffi::c_void;
+            let driver_binding_ptr = std::boxed::Box::into_raw(driver_binding) as *mut core::ffi::c_void;
             let (db_handle, _) = PROTOCOL_DB
                 .install_protocol_interface(None, efi::protocols::driver_binding::PROTOCOL_GUID, driver_binding_ptr)
                 .unwrap();

--- a/patina_dxe_core/src/performance.rs
+++ b/patina_dxe_core/src/performance.rs
@@ -5,12 +5,11 @@
 //!
 //! SPDX-License-Identifier: Apache-2.0
 //!
+use alloc::vec::Vec;
 use core::{
     mem, ptr,
     sync::atomic::{AtomicBool, AtomicU32, Ordering},
 };
-
-use alloc::vec::Vec;
 
 use patina::{
     BinaryGuid,

--- a/patina_dxe_core/src/performance/table.rs
+++ b/patina_dxe_core/src/performance/table.rs
@@ -224,7 +224,7 @@ mod tests {
 
     #[test]
     fn test_serialize_into() {
-        let buffer: &'static mut [u8] = alloc::boxed::Box::leak(alloc::vec![0u8; 1000].into_boxed_slice());
+        let buffer: &'static mut [u8] = std::boxed::Box::leak(std::vec![0u8; 1000].into_boxed_slice());
         let address = buffer.as_ptr() as usize;
 
         let mut fbpt = Fbpt::new();
@@ -275,7 +275,7 @@ mod tests {
 
     #[test]
     fn test_performance_table_well_written_in_memory() {
-        let buffer: &'static mut [u8] = alloc::boxed::Box::leak(alloc::vec![0u8; 1000].into_boxed_slice());
+        let buffer: &'static mut [u8] = std::boxed::Box::leak(std::vec![0u8; 1000].into_boxed_slice());
         let address = buffer.as_ptr() as usize;
 
         let mut fbpt = Fbpt::new();

--- a/patina_dxe_core/src/pi_dispatcher/debug_image_info_table.rs
+++ b/patina_dxe_core/src/pi_dispatcher/debug_image_info_table.rs
@@ -6,6 +6,11 @@
 //!
 //! SPDX-License-Identifier: Apache-2.0
 //!
+use alloc::alloc::LayoutError;
+use alloc::{
+    alloc::{alloc_zeroed, dealloc, realloc},
+    boxed::Box,
+};
 use core::{
     alloc::Layout,
     fmt,
@@ -22,7 +27,7 @@ const _: () = assert!(DEFAULT_CAPACITY > 0);
 #[derive(Debug)]
 enum GrowError {
     /// The requested layout was invalid.
-    InvalidLayout(alloc::alloc::LayoutError),
+    InvalidLayout(LayoutError),
     /// The allocator returned a null pointer.
     AllocFailed,
 }
@@ -36,8 +41,8 @@ impl fmt::Display for GrowError {
     }
 }
 
-impl From<alloc::alloc::LayoutError> for GrowError {
-    fn from(e: alloc::alloc::LayoutError) -> Self {
+impl From<LayoutError> for GrowError {
+    fn from(e: LayoutError) -> Self {
         GrowError::InvalidLayout(e)
     }
 }
@@ -248,7 +253,7 @@ impl DebugImageInfoData {
             let layout = Layout::array::<efi::DebugImageInfo>(DEFAULT_CAPACITY)?;
 
             // SAFETY: layout is non-zero sized due to DEFAULT_CAPACITY being non-zero
-            let data = unsafe { alloc::alloc::alloc_zeroed(layout) };
+            let data = unsafe { alloc_zeroed(layout) };
             (data, DEFAULT_CAPACITY)
         } else {
             let old_layout = Layout::array::<efi::DebugImageInfo>(self.capacity)?;
@@ -258,7 +263,7 @@ impl DebugImageInfoData {
             //   of this struct.
             // SAFETY: new_size is greater than zero due to the if branch above ensuring capacity is non-zero.
             // SAFETY: new_size does not exceed isize::MAX as the `Layout` call would have failed.
-            let data = unsafe { alloc::alloc::realloc(self.table_mut().cast::<u8>(), old_layout, new_layout.size()) };
+            let data = unsafe { realloc(self.table_mut().cast::<u8>(), old_layout, new_layout.size()) };
             (data, new_capacity)
         };
 
@@ -288,7 +293,7 @@ impl Drop for DebugImageInfoData {
             let layout = Layout::array::<efi::DebugImageInfo>(self.capacity).unwrap();
             // SAFETY: Invariants of this struct ensure that `data` was allocated with this layout.
             unsafe {
-                alloc::alloc::dealloc(self.table_mut().cast::<u8>(), layout);
+                dealloc(self.table_mut().cast::<u8>(), layout);
             }
         }
     }
@@ -302,7 +307,7 @@ fn new_debug_image_info(
     handle: efi::Handle,
 ) -> efi::DebugImageInfo {
     efi::DebugImageInfo {
-        normal_image: alloc::boxed::Box::into_raw(alloc::boxed::Box::new(efi::DebugImageInfoNormal {
+        normal_image: Box::into_raw(Box::new(efi::DebugImageInfoNormal {
             image_info_type: image_info_type.into(),
             loaded_image_protocol_instance: protocol.as_ptr(),
             image_handle: handle,
@@ -321,7 +326,7 @@ fn debug_image_info_handle(info: &efi::DebugImageInfo) -> Option<efi::Handle> {
 /// Frees the heap allocation backing a debug image info entry.
 fn drop_debug_image_info(info: &mut efi::DebugImageInfo) {
     // SAFETY: `normal_image` was produced by `Box::into_raw` in `new_debug_image_info` and has not yet been freed.
-    let normal = unsafe { alloc::boxed::Box::from_raw(info.normal_image) };
+    let normal = unsafe { Box::from_raw(info.normal_image) };
     drop(normal);
 }
 

--- a/patina_dxe_core/src/pi_dispatcher/debug_image_info_table.rs
+++ b/patina_dxe_core/src/pi_dispatcher/debug_image_info_table.rs
@@ -535,7 +535,7 @@ mod tests {
     fn test_grow_error_display_alloc_failed_msg() {
         with_locked_state(|| {
             let error = GrowError::AllocFailed;
-            let msg = alloc::format!("{error}");
+            let msg = std::format!("{error}");
             assert_eq!(msg, "allocation returned null");
         });
     }
@@ -546,7 +546,7 @@ mod tests {
             // Note: Zero alignment will result in a LayoutError.
             let layout_err = Layout::from_size_align(1, 0).unwrap_err();
             let error = GrowError::InvalidLayout(layout_err);
-            let msg = alloc::format!("{error}");
+            let msg = std::format!("{error}");
             assert!(msg.starts_with("invalid layout:"));
         });
     }
@@ -555,12 +555,12 @@ mod tests {
     fn test_grow_error_debug_msgs() {
         with_locked_state(|| {
             let error = GrowError::AllocFailed;
-            let msg = alloc::format!("{error:?}");
+            let msg = std::format!("{error:?}");
             assert_eq!(msg, "AllocFailed");
 
             let layout_err = Layout::from_size_align(1, 0).unwrap_err();
             let error = GrowError::from(layout_err);
-            let msg = alloc::format!("{error:?}");
+            let msg = std::format!("{error:?}");
             assert!(msg.starts_with("InvalidLayout("));
         });
     }

--- a/patina_dxe_core/src/pi_dispatcher/fv.rs
+++ b/patina_dxe_core/src/pi_dispatcher/fv.rs
@@ -902,14 +902,13 @@ pub fn device_path_bytes_for_fv_file(fv_handle: efi::Handle, file_name: efi::Gui
 #[cfg_attr(coverage, coverage(off))]
 mod tests {
     use super::*;
+    use crate::test_collateral;
     use crate::{MockComponentInfo, MockCpuInfo, MockMemoryInfo, test_support};
     use patina::pi::{
         BootMode,
         hob::{self, Hob, HobList},
     };
     use patina_ffs_extractors::CompositeSectionExtractor;
-    extern crate alloc;
-    use crate::test_collateral;
     use std::{
         alloc::{Layout, alloc, dealloc},
         ffi::c_void,

--- a/patina_dxe_core/src/pi_dispatcher/image.rs
+++ b/patina_dxe_core/src/pi_dispatcher/image.rs
@@ -1593,7 +1593,6 @@ impl Buffer {
 #[cfg(test)]
 #[cfg_attr(coverage, coverage(off))]
 mod tests {
-    extern crate std;
     use super::*;
     use crate::{
         Core, MockPlatformInfo,
@@ -1616,6 +1615,7 @@ mod tests {
             hob::{HobList, MemoryAllocationHeader, MemoryAllocationModule},
         },
     };
+    use std::alloc::{Layout, alloc};
     use std::{fs::File, io::Read, ptr::NonNull, slice::from_raw_parts};
 
     #[cfg(target_arch = "aarch64")]
@@ -2671,8 +2671,7 @@ mod tests {
             // Manually construct PrivateImageData with minimal required fields
             const LEN: usize = 0x2000;
             // SAFETY: Allocate a page-aligned test buffer and treat it as a raw image backing store.
-            let fake_buffer =
-                unsafe { alloc::alloc::alloc(alloc::alloc::Layout::from_size_align(LEN, 0x1000).unwrap()) };
+            let fake_buffer = unsafe { alloc(Layout::from_size_align(LEN, 0x1000).unwrap()) };
 
             // SAFETY: fake_buffer points to LEN bytes we just allocated and is valid for mutable slice creation.
             let slice = unsafe { core::slice::from_raw_parts_mut(fake_buffer, LEN) };

--- a/patina_dxe_core/src/pi_dispatcher/section_decompress.rs
+++ b/patina_dxe_core/src/pi_dispatcher/section_decompress.rs
@@ -1,7 +1,5 @@
 //! A section extractor that provides UEFI decompression functionality with an additional custom extractor
 //! implementation.
-extern crate alloc;
-
 use alloc::vec;
 use patina::{
     pi::fw_fs::{self, ffs},

--- a/patina_dxe_core/src/protocol_db.rs
+++ b/patina_dxe_core/src/protocol_db.rs
@@ -883,7 +883,6 @@ unsafe impl Sync for SpinLockedProtocolDb {}
 #[cfg(test)]
 #[cfg_attr(coverage, coverage(off))]
 mod tests {
-    extern crate std;
     use core::str::FromStr;
     use std::println;
 

--- a/patina_dxe_core/src/protocol_db.rs
+++ b/patina_dxe_core/src/protocol_db.rs
@@ -8,8 +8,6 @@
 //!
 //! SPDX-License-Identifier: Apache-2.0
 //!
-extern crate alloc;
-
 use alloc::{
     collections::{BTreeMap, BTreeSet},
     vec,

--- a/patina_dxe_core/src/protocols.rs
+++ b/patina_dxe_core/src/protocols.rs
@@ -6,9 +6,9 @@
 //!
 //! SPDX-License-Identifier: Apache-2.0
 //!
+use alloc::{slice, vec, vec::Vec};
 use core::{ffi::c_void, mem::size_of, ptr::NonNull};
 
-use alloc::{slice, vec, vec::Vec};
 use patina::standard::efi::{self, protocols::device_path::Protocol};
 use patina::{
     OwnedGuid,

--- a/patina_dxe_core/src/runtime.rs
+++ b/patina_dxe_core/src/runtime.rs
@@ -237,10 +237,7 @@ mod tests {
         with_locked_state(|| {
             let block = RelocationBlock {
                 block_header: crate::pecoff::relocation::BaseRelocationBlockHeader { page_rva: 0, block_size: 0 },
-                relocations: alloc::vec![crate::pecoff::relocation::Relocation {
-                    type_and_offset: 0x1 << 12,
-                    value: 0
-                }],
+                relocations: std::vec![crate::pecoff::relocation::Relocation { type_and_offset: 0x1 << 12, value: 0 }],
             };
             let result = add_runtime_image(ptr::null_mut(), 0, &[block], 0x1 as efi::Handle);
             assert!(matches!(result, Err(EfiError::Unsupported)), "unexpected result: {result:?}");

--- a/patina_dxe_core/src/runtime.rs
+++ b/patina_dxe_core/src/runtime.rs
@@ -7,9 +7,9 @@
 //! SPDX-License-Identifier: Apache-2.0
 //!
 
+use alloc::collections::LinkedList;
 use core::{ffi::c_void, ptr};
 
-use alloc::collections::LinkedList;
 use patina::error::EfiError;
 use patina::standard::efi;
 use spin::Mutex;

--- a/patina_dxe_core/src/systemtables.rs
+++ b/patina_dxe_core/src/systemtables.rs
@@ -8,9 +8,9 @@
 //!
 //! SPDX-License-Identifier: Apache-2.0
 //!
+use alloc::boxed::Box;
 use core::{ffi::c_void, mem::size_of, slice::from_raw_parts};
 
-use alloc::boxed::Box;
 use patina::standard::efi;
 use patina::{component::component, pi::error_codes::EFI_NOT_AVAILABLE_YET, uefi::boot_services::BootServices};
 

--- a/patina_dxe_core/src/test_support.rs
+++ b/patina_dxe_core/src/test_support.rs
@@ -9,6 +9,7 @@
 //! SPDX-License-Identifier: Apache-2.0
 //!
 use crate::{GCD, allocator::DEFAULT_PAGE_ALLOCATION_GRANULARITY, protocols::PROTOCOL_DB};
+use alloc::alloc::{Layout, alloc};
 use core::ffi::c_void;
 use patina::standard::efi;
 use patina::{
@@ -311,7 +312,7 @@ pub(crate) fn with_clean_global_lock<F: Fn() + std::panic::RefUnwindSafe>(f: F) 
 pub(crate) unsafe fn get_memory(size: usize) -> &'static mut [u8] {
     // SAFETY: Test code - allocates memory from the system allocator with UEFI page alignment.
     // The returned slice is intentionally leaked for test simplicity and valid for 'static lifetime.
-    let addr = unsafe { alloc::alloc::alloc(alloc::alloc::Layout::from_size_align(size, 0x10000).unwrap()) };
+    let addr = unsafe { alloc(Layout::from_size_align(size, 0x10000).unwrap()) };
     // SAFETY: The allocated pointer is valid for `size` bytes and properly aligned.
     unsafe { core::slice::from_raw_parts_mut(addr, size) }
 }
@@ -331,7 +332,7 @@ const TEST_GCD_MEM_SIZE: usize = 0x1000000;
 pub(crate) unsafe fn init_test_gcd(size: Option<usize>) {
     let size = size.unwrap_or(TEST_GCD_MEM_SIZE);
     // SAFETY: Allocates memory from the system allocator with UEFI page alignment for GCD memory blocks.
-    let addr = unsafe { alloc::alloc::alloc(alloc::alloc::Layout::from_size_align(size, 0x1000).unwrap()) };
+    let addr = unsafe { alloc(Layout::from_size_align(size, 0x1000).unwrap()) };
     // SAFETY: Resetting the global GCD state in test context - called with test lock held.
     unsafe { GCD.reset() };
     GCD.init(48, 16);

--- a/patina_mm_supervisor/Cargo.toml
+++ b/patina_mm_supervisor/Cargo.toml
@@ -28,7 +28,6 @@ zerocopy = { workspace = true }
 zerocopy-derive = { workspace = true }
 
 [dev-dependencies]
-mockall = { workspace = true }
 serial_test = { workspace = true }
 
 [features]

--- a/patina_mm_supervisor/README.md
+++ b/patina_mm_supervisor/README.md
@@ -108,13 +108,7 @@ use patina_mm_supervisor::*;
 
 struct MyPlatform;
 
-impl CpuInfo for MyPlatform {
-    fn ap_poll_timeout_us() -> u64 { 1000 }
-}
-
-impl PlatformInfo for MyPlatform {
-    type CpuInfo = Self;
-}
+impl PlatformInfo for MyPlatform {}
 
 // Static instance - no heap allocation required.
 // The const generic argument is the maximum CPU count used to size internal arrays.
@@ -153,8 +147,6 @@ static MY_HANDLERS: &[SupervisorMmiHandler] = &[SupervisorMmiHandler {
 }];
 
 impl PlatformInfo for MyPlatform {
-    type CpuInfo = Self;
-
     fn mmi_handlers() -> &'static [SupervisorMmiHandler] {
         MY_HANDLERS
     }

--- a/patina_mm_supervisor/src/cpu.rs
+++ b/patina_mm_supervisor/src/cpu.rs
@@ -29,44 +29,6 @@ const IA32_APIC_BASE_MSR_INDEX: u32 = 0x1B;
 /// BSP flag bit in IA32_APIC_BASE MSR (bit 8).
 const IA32_APIC_BSP: u64 = 1 << 8;
 
-/// A trait to be implemented by the platform to provide CPU-related configuration.
-///
-/// ## Examples
-///
-/// ```rust,no_run
-/// # #[cfg(target_arch = "x86_64")]
-/// # mod example {
-/// use patina_mm_supervisor::CpuInfo;
-///
-/// struct ExamplePlatform;
-///
-/// impl CpuInfo for ExamplePlatform {
-///     fn ap_poll_timeout_us() -> u64 { 500 }
-/// }
-/// # }
-/// ```
-#[cfg_attr(test, mockall::automock)]
-pub trait CpuInfo {
-    /// Returns the timeout in microseconds for AP mailbox polling.
-    ///
-    /// By default, this returns 1000 (1ms) which is a reasonable polling interval.
-    #[inline(always)]
-    fn ap_poll_timeout_us() -> u64 {
-        1000
-    }
-
-    /// Returns the performance counter frequency in Hz, if known by the platform.
-    ///
-    /// For example, on QEMU Q35 the platform can calibrate the TSC frequency
-    /// from the ACPI PM Timer and return it here.
-    ///
-    /// If `None` is returned (the default), the supervisor will attempt
-    /// auto-detection via CPUID.
-    fn perf_timer_frequency() -> Option<u64> {
-        None
-    }
-}
-
 /// The state of an Application Processor (AP).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]

--- a/patina_mm_supervisor/src/lib.rs
+++ b/patina_mm_supervisor/src/lib.rs
@@ -25,13 +25,7 @@
 //!
 //! struct MyPlatform;
 //!
-//! impl CpuInfo for MyPlatform {
-//!     fn ap_poll_timeout_us() -> u64 { 1000 }
-//! }
-//!
-//! impl PlatformInfo for MyPlatform {
-//!     type CpuInfo = Self;
-//! }
+//! impl PlatformInfo for MyPlatform {}
 //!
 //! // The const generic argument is the maximum CPU count used to size internal arrays.
 //! static SUPERVISOR: MmSupervisorCore<MyPlatform, 8> = MmSupervisorCore::new();
@@ -82,9 +76,6 @@ use patina::{
 use patina_paging::{MemoryAttributes, PageTable};
 
 use state::{init_state, security_state};
-
-// Public API: traits that platform binaries must implement.
-pub use cpu::CpuInfo;
 
 // Publicly re-export the handler types since platform-specific handlers will need to reference these for
 // their function signatures and return types.
@@ -139,19 +130,10 @@ const AP_TIMEOUT_US: u64 = 10_000_000;
 ///
 /// struct ExamplePlatform;
 ///
-/// impl CpuInfo for ExamplePlatform {
-///     fn ap_poll_timeout_us() -> u64 { 1000 }
-/// }
-///
-/// impl PlatformInfo for ExamplePlatform {
-///     type CpuInfo = Self;
-/// }
+/// impl PlatformInfo for ExamplePlatform {}
 /// # }
 /// ```
 pub trait PlatformInfo: 'static {
-    /// The platform's CPU information and configuration.
-    type CpuInfo: CpuInfo;
-
     /// Returns the platform-specific supervisor MMI handlers.
     ///
     /// The supervisor dispatch loop iterates the core's built-in handlers first and then
@@ -285,13 +267,7 @@ impl RequestTarget {
 ///
 /// struct MyPlatform;
 ///
-/// impl CpuInfo for MyPlatform {
-///     fn ap_poll_timeout_us() -> u64 { 1000 }
-/// }
-///
-/// impl PlatformInfo for MyPlatform {
-///     type CpuInfo = Self;
-/// }
+/// impl PlatformInfo for MyPlatform {}
 ///
 /// // The const generic argument is the maximum CPU count used to size internal arrays.
 /// static SUPERVISOR: MmSupervisorCore<MyPlatform, 8> = MmSupervisorCore::new();
@@ -307,7 +283,7 @@ pub struct MmSupervisorCore<P: PlatformInfo, const MAX_CPUS: usize> {
     /// Manager for CPU-related operations.
     cpu_manager: CpuManager<MAX_CPUS>,
     /// Manager for AP mailboxes.
-    mailbox_manager: MailboxManager<MAX_CPUS, P::CpuInfo>,
+    mailbox_manager: MailboxManager<MAX_CPUS>,
     /// Syscall interface for privilege transitions.
     syscall_interface: SyscallInterface<MAX_CPUS>,
     /// Flag indicating if the core has been initialized.
@@ -559,7 +535,7 @@ impl<P: PlatformInfo, const MAX_CPUS: usize> MmSupervisorCore<P, MAX_CPUS> {
     }
 
     /// Get the mailbox manager.
-    pub fn mailbox_manager(&self) -> &MailboxManager<MAX_CPUS, P::CpuInfo> {
+    pub fn mailbox_manager(&self) -> &MailboxManager<MAX_CPUS> {
         &self.mailbox_manager
     }
 }
@@ -576,16 +552,7 @@ mod tests {
 
     struct TestPlatform;
 
-    impl CpuInfo for TestPlatform {}
-
-    impl PlatformInfo for TestPlatform {
-        type CpuInfo = Self;
-    }
-
-    #[test]
-    fn test_cpu_info_defaults() {
-        assert_eq!(<TestPlatform as CpuInfo>::ap_poll_timeout_us(), 1000);
-    }
+    impl PlatformInfo for TestPlatform {}
 
     #[test]
     fn test_supervisor_creation() {

--- a/patina_mm_supervisor/src/mailbox.rs
+++ b/patina_mm_supervisor/src/mailbox.rs
@@ -25,7 +25,7 @@
 
 use core::sync::atomic::{AtomicU32, AtomicU64, Ordering};
 
-use crate::{CpuInfo, perf_timer};
+use crate::perf_timer;
 
 /// Commands that can be sent from BSP to APs via the mailbox.
 ///
@@ -230,19 +230,17 @@ impl Default for ApMailbox {
 /// ## Const Generic Parameters
 ///
 /// * `MAX_APS` - The maximum number of APs that can be managed.
-pub struct MailboxManager<const MAX_APS: usize, C: CpuInfo> {
+pub struct MailboxManager<const MAX_APS: usize> {
     /// Mailboxes - fixed size array.
     mailboxes: [ApMailbox; MAX_APS],
-    /// Phantom data for the CpuInfo type.
-    _cpu_info: core::marker::PhantomData<fn() -> C>,
 }
 
-impl<const MAX_APS: usize, C: CpuInfo> MailboxManager<MAX_APS, C> {
+impl<const MAX_APS: usize> MailboxManager<MAX_APS> {
     /// Creates a new mailbox manager.
     ///
     /// This is a const fn and performs no heap allocation.
     pub const fn new() -> Self {
-        Self { mailboxes: [const { ApMailbox::new() }; MAX_APS], _cpu_info: core::marker::PhantomData }
+        Self { mailboxes: [const { ApMailbox::new() }; MAX_APS] }
     }
 
     /// Sends a command to a specific AP.
@@ -278,7 +276,7 @@ impl<const MAX_APS: usize, C: CpuInfo> MailboxManager<MAX_APS, C> {
         let mailbox = self.mailboxes.get(cpu_index)?;
         let mut result = None;
 
-        perf_timer::spin_until::<C, _>(timeout_us, || {
+        perf_timer::spin_until(timeout_us, || {
             if let Some(response) = mailbox.get_response() {
                 result = Some(response);
                 true
@@ -291,7 +289,7 @@ impl<const MAX_APS: usize, C: CpuInfo> MailboxManager<MAX_APS, C> {
     }
 }
 
-impl<const MAX_APS: usize, C: CpuInfo> Default for MailboxManager<MAX_APS, C> {
+impl<const MAX_APS: usize> Default for MailboxManager<MAX_APS> {
     fn default() -> Self {
         Self::new()
     }
@@ -300,10 +298,6 @@ impl<const MAX_APS: usize, C: CpuInfo> Default for MailboxManager<MAX_APS, C> {
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    /// Minimal `CpuInfo` implementation for tests (all methods use defaults).
-    struct TestCpuInfo;
-    impl CpuInfo for TestCpuInfo {}
 
     #[test]
     fn test_mailbox_creation() {
@@ -351,12 +345,12 @@ mod tests {
     #[test]
     fn test_mailbox_manager_is_const() {
         // Verify we can create a static manager
-        static _MANAGER: MailboxManager<8, TestCpuInfo> = MailboxManager::new();
+        static _MANAGER: MailboxManager<8> = MailboxManager::new();
     }
 
     #[test]
     fn test_mailbox_manager() {
-        let manager: MailboxManager<4, TestCpuInfo> = MailboxManager::new();
+        let manager: MailboxManager<4> = MailboxManager::new();
 
         // Send a command to the AP occupying slot index 1.
         let command = ApCommand::RunProcedure { procedure: 0x1000, argument: 0x2000 };
@@ -393,7 +387,7 @@ mod tests {
 
     #[test]
     fn test_manager_reset_all_scrubs_every_mailbox() {
-        let manager: MailboxManager<4, TestCpuInfo> = MailboxManager::new();
+        let manager: MailboxManager<4> = MailboxManager::new();
 
         // Leave two different slots' mailboxes stuck in non-empty states.
         assert!(manager.send_command(1, ApCommand::RunProcedure { procedure: 0x10, argument: 0 }).is_ok());

--- a/patina_mm_supervisor/src/perf_timer.rs
+++ b/patina_mm_supervisor/src/perf_timer.rs
@@ -13,8 +13,6 @@
 use core::arch::x86_64;
 use core::arch::x86_64::{__cpuid, CpuidResult};
 
-use crate::CpuInfo;
-
 const CPUID_TIME_STAMP_COUNTER: u32 = 0x15;
 const CPUID_PROCESSOR_FREQUENCY: u32 = 0x16;
 
@@ -28,23 +26,11 @@ fn ticks() -> u64 {
     unsafe { x86_64::_rdtsc() }
 }
 
-/// Returns the frequency in Hz from the platform's CpuInfo, or `0` if
-/// not determinable.
+/// Converts a duration in microseconds to the equivalent tick count using the
+/// CPU's detected performance-counter frequency (via CPUID).
 #[inline]
-pub fn frequency<C: CpuInfo>() -> u64 {
-    C::perf_timer_frequency().unwrap_or(0)
-}
-
-/// Converts a duration in microseconds to the equivalent tick count using
-/// the given CpuInfo's frequency.
-///
-/// Returns `None` if the frequency is unknown (0).
-#[inline]
-pub fn us_to_ticks<C: CpuInfo>(us: u64) -> Option<u64> {
-    let mut freq = frequency::<C>();
-    if freq == 0 {
-        freq = arch_perf_frequency();
-    }
+pub fn us_to_ticks(us: u64) -> Option<u64> {
+    let freq = arch_perf_frequency();
     Some(((freq as u128 * us as u128) / 1_000_000) as u64)
 }
 
@@ -78,11 +64,11 @@ pub(crate) fn arch_perf_frequency() -> u64 {
 ///
 /// If the performance frequency is unknown, falls back to a conservative
 /// iteration-count heuristic (`timeout_us * 10` loops).
-pub fn spin_until<C: CpuInfo, F>(timeout_us: u64, mut condition: F) -> bool
+pub fn spin_until<F>(timeout_us: u64, mut condition: F) -> bool
 where
     F: FnMut() -> bool,
 {
-    if let Some(deadline_ticks) = us_to_ticks::<C>(timeout_us) {
+    if let Some(deadline_ticks) = us_to_ticks(timeout_us) {
         let start = ticks();
         loop {
             if condition() {
@@ -110,30 +96,16 @@ where
 mod tests {
     use super::*;
 
-    struct TestCpu;
-    impl CpuInfo for TestCpu {
-        fn perf_timer_frequency() -> Option<u64> {
-            None
-        }
-    }
-
-    /// A CPU to make timer test happy.
-    struct FixedFreqCpu;
-    impl CpuInfo for FixedFreqCpu {
-        fn perf_timer_frequency() -> Option<u64> {
-            Some(1_000_000)
-        }
-    }
-
     #[test]
-    fn test_us_to_ticks_basic() {
-        // With a known 1 MHz frequency, 1000 us converts to exactly 1000 ticks.
-        assert_eq!(us_to_ticks::<FixedFreqCpu>(1000), Some(1000));
+    fn test_us_to_ticks_returns_some() {
+        // The exact value depends on the CPU's detected frequency, but a conversion is
+        // always produced.
+        assert!(us_to_ticks(1000).is_some());
     }
 
     #[test]
     fn test_spin_until_immediate_true() {
-        let result = spin_until::<TestCpu, _>(1_000, || true);
+        let result = spin_until(1_000, || true);
         assert!(result);
     }
 }

--- a/patina_mm_supervisor/src/runtime.rs
+++ b/patina_mm_supervisor/src/runtime.rs
@@ -143,7 +143,7 @@ impl<P: PlatformInfo, const MAX_CPUS: usize> MmSupervisorCore<P, MAX_CPUS> {
             return;
         }
 
-        let all_arrived = crate::perf_timer::spin_until::<P::CpuInfo, _>(AP_ARRIVAL_TIMEOUT_US, || {
+        let all_arrived = crate::perf_timer::spin_until(AP_ARRIVAL_TIMEOUT_US, || {
             self.cpu_manager.count_aps_in_state(ApState::InHoldingPen) >= expected_aps
         });
 

--- a/patina_mm_supervisor/src/supervisor_handlers.rs
+++ b/patina_mm_supervisor/src/supervisor_handlers.rs
@@ -18,7 +18,7 @@
 //! ```rust,no_run
 //! # #[cfg(target_arch = "x86_64")]
 //! # mod example {
-//! use patina_mm_supervisor::{CpuInfo, PlatformInfo, SupervisorMmiHandler};
+//! use patina_mm_supervisor::{PlatformInfo, SupervisorMmiHandler};
 //! use r_efi::efi;
 //!
 //! struct MyPlatform;
@@ -34,13 +34,7 @@
 //!     handle: my_handler,
 //! }];
 //!
-//! impl CpuInfo for MyPlatform {
-//!     fn ap_poll_timeout_us() -> u64 { 1000 }
-//! }
-//!
 //! impl PlatformInfo for MyPlatform {
-//!     type CpuInfo = Self;
-//!
 //!     fn mmi_handlers() -> &'static [SupervisorMmiHandler] {
 //!         MY_HANDLERS
 //!     }

--- a/sdk/patina/src/base/c_ptr.rs
+++ b/sdk/patina/src/base/c_ptr.rs
@@ -6,7 +6,7 @@
 //!
 //! SPDX-License-Identifier: Apache-2.0
 //!
-#[cfg(any(test, feature = "alloc"))]
+#[cfg(feature = "alloc")]
 use alloc::boxed::Box;
 use core::{
     ffi::c_void,

--- a/sdk/patina/src/base/error.rs
+++ b/sdk/patina/src/base/error.rs
@@ -195,8 +195,6 @@ impl core::error::Error for EfiError {}
 #[cfg(test)]
 mod tests {
     use super::*;
-    extern crate alloc;
-    use alloc::format;
 
     #[test]
     fn test_display_known_variant_matches_status() {

--- a/sdk/patina/src/base/string.rs
+++ b/sdk/patina/src/base/string.rs
@@ -246,7 +246,7 @@ macro_rules! char8 {
 #[cfg_attr(coverage, coverage(off))]
 mod tests {
     use super::*;
-    use alloc::string::ToString;
+    use std::string::ToString;
 
     #[test]
     fn test_string_error_display() {

--- a/sdk/patina/src/base/string/char16.rs
+++ b/sdk/patina/src/base/string/char16.rs
@@ -13,7 +13,7 @@ use zerocopy_derive::{FromBytes, Immutable, IntoBytes, KnownLayout};
 
 use super::char8::Char8Array;
 
-#[cfg(any(test, feature = "alloc"))]
+#[cfg(feature = "alloc")]
 use alloc::{string::String, vec::Vec};
 
 #[cfg(any(test, feature = "alloc"))]
@@ -760,7 +760,7 @@ impl<const N: usize> From<Char16Array<N>> for String {
 mod tests {
     use super::*;
     use crate::char16;
-    use alloc::string::ToString;
+    use std::string::ToString;
 
     #[test]
     fn test_char16_from_units_with_nul_valid() {
@@ -803,9 +803,9 @@ mod tests {
     fn test_char16_chars_and_iter() {
         let units = [0x0041u16, 0x00E9, 0x20AC, 0x0000]; // "Aé€"
         let s = Char16Str::from_units_with_nul(&units).unwrap();
-        let chars: alloc::vec::Vec<char> = s.chars().collect();
+        let chars: std::vec::Vec<char> = s.chars().collect();
         assert_eq!(chars, ['A', 'é', '€']);
-        let code_units: alloc::vec::Vec<u16> = s.iter().copied().collect();
+        let code_units: std::vec::Vec<u16> = s.iter().copied().collect();
         assert_eq!(code_units, [0x0041, 0x00E9, 0x20AC]);
     }
 
@@ -816,7 +816,7 @@ mod tests {
         let units = [0x0041u16, 0xD800, 0x0000];
         // SAFETY: This deliberately bypasses validation to exercise the lossy fallback path.
         let s = unsafe { Char16Str::from_units_with_nul_unchecked(&units) };
-        let chars: alloc::vec::Vec<char> = s.chars().collect();
+        let chars: std::vec::Vec<char> = s.chars().collect();
         assert_eq!(chars, ['A', char::REPLACEMENT_CHARACTER]);
     }
 
@@ -856,7 +856,7 @@ mod tests {
         let units = [0x0045u16, 0x0046, 0x0049, 0x0000];
         let s = Char16Str::from_units_with_nul(&units).unwrap();
         assert_eq!(s.to_string(), "EFI");
-        assert_eq!(alloc::format!("{s:?}"), "\"EFI\"");
+        assert_eq!(std::format!("{s:?}"), "\"EFI\"");
     }
 
     #[test]
@@ -926,7 +926,7 @@ mod tests {
         let s = Char16String::from_le_bytes_until_nul(&bytes).unwrap();
         assert_eq!(s.to_string(), "EFI");
         // The owned buffer is trimmed to exactly "EFI\0".
-        assert_eq!(s.into_units_with_nul(), alloc::vec![0x0045, 0x0046, 0x0049, 0x0000]);
+        assert_eq!(s.into_units_with_nul(), std::vec![0x0045, 0x0046, 0x0049, 0x0000]);
     }
 
     #[test]
@@ -971,12 +971,12 @@ mod tests {
         let b = Char16String::default();
         assert!(a.is_empty());
         assert_eq!(a, b);
-        assert_eq!(a.clone().into_units_with_nul(), alloc::vec![0]);
+        assert_eq!(a.clone().into_units_with_nul(), std::vec![0]);
     }
 
     #[test]
     fn test_char16string_to_owned_roundtrip() {
-        use alloc::borrow::ToOwned;
+        use std::borrow::ToOwned;
         let owned = Char16String::try_from_str("Test").unwrap();
         let borrowed: &Char16Str = &owned;
         let reowned = borrowed.to_owned();
@@ -1025,7 +1025,7 @@ mod tests {
     fn test_char16string_debug_borrow_and_display() {
         use core::borrow::Borrow;
         let s = Char16String::try_from_str("EFI").unwrap();
-        assert_eq!(alloc::format!("{s:?}"), "\"EFI\"");
+        assert_eq!(std::format!("{s:?}"), "\"EFI\"");
         assert_eq!(s.to_string(), "EFI");
         let borrowed: &Char16Str = s.borrow();
         assert_eq!(borrowed.len(), 3);
@@ -1071,7 +1071,7 @@ mod tests {
 
     #[test]
     fn test_char16string_from_units_with_nul() {
-        let units = alloc::vec![0x0045u16, 0x0046, 0x0049, 0x0000];
+        let units = std::vec![0x0045u16, 0x0046, 0x0049, 0x0000];
         let s = Char16String::from_units_with_nul(units).unwrap();
         assert_eq!(s.len(), 3);
         assert!(*s == *"EFI");
@@ -1079,25 +1079,25 @@ mod tests {
 
     #[test]
     fn test_char16string_from_units_with_nul_missing_terminator() {
-        let units = alloc::vec![0x0045u16, 0x0046];
+        let units = std::vec![0x0045u16, 0x0046];
         assert_eq!(Char16String::from_units_with_nul(units), Err(StringError::MissingNulTerminator));
     }
 
     #[test]
     fn test_char16string_from_units_with_nul_interior_nul() {
-        let units = alloc::vec![0x0045u16, 0x0000, 0x0049, 0x0000];
+        let units = std::vec![0x0045u16, 0x0000, 0x0049, 0x0000];
         assert_eq!(Char16String::from_units_with_nul(units), Err(StringError::InteriorNul { position: 1 }));
     }
 
     #[test]
     fn test_char16string_from_units_with_nul_surrogate_rejected() {
-        let units = alloc::vec![0x0045u16, 0xD800, 0x0000];
+        let units = std::vec![0x0045u16, 0xD800, 0x0000];
         assert_eq!(Char16String::from_units_with_nul(units), Err(StringError::NotUcs2 { position: 1, value: 0xD800 }));
     }
 
     #[test]
     fn test_char16string_from_units_with_nul_unchecked() {
-        let units = alloc::vec![0x0045u16, 0x0046, 0x0049, 0x0000];
+        let units = std::vec![0x0045u16, 0x0046, 0x0049, 0x0000];
         // SAFETY: `units` is a valid NUL-terminated UCS-2 sequence.
         let s = unsafe { Char16String::from_units_with_nul_unchecked(units) };
         assert!(*s == *"EFI");
@@ -1211,7 +1211,7 @@ mod tests {
     #[test]
     fn test_char16_array_to_string() {
         let array = Char16Array::<9>::from_str("Firmware");
-        let owned: alloc::string::String = array.into();
+        let owned: std::string::String = array.into();
         assert_eq!(owned, "Firmware");
     }
 

--- a/sdk/patina/src/base/string/char8.rs
+++ b/sdk/patina/src/base/string/char8.rs
@@ -13,7 +13,7 @@ use zerocopy_derive::{FromBytes, Immutable, IntoBytes, KnownLayout};
 
 use super::char16::Char16Array;
 
-#[cfg(any(test, feature = "alloc"))]
+#[cfg(feature = "alloc")]
 use alloc::{string::String, vec::Vec};
 
 #[cfg(any(test, feature = "alloc"))]
@@ -746,7 +746,7 @@ mod tests {
     fn test_char8_high_latin1_bytes_valid() {
         let bytes = [0xE9u8, 0xFF, 0x00]; // "éÿ"
         let s = Char8Str::from_bytes_with_nul(&bytes).unwrap();
-        let chars: alloc::vec::Vec<char> = s.chars().collect();
+        let chars: std::vec::Vec<char> = s.chars().collect();
         assert_eq!(chars, ['\u{00E9}', '\u{00FF}']);
     }
 
@@ -754,7 +754,7 @@ mod tests {
     fn test_char8_iter() {
         let bytes = *b"EFI\0";
         let s = Char8Str::from_bytes_with_nul(&bytes).unwrap();
-        let collected: alloc::vec::Vec<u8> = s.iter().copied().collect();
+        let collected: std::vec::Vec<u8> = s.iter().copied().collect();
         assert_eq!(collected, b"EFI");
     }
 
@@ -787,7 +787,7 @@ mod tests {
         let bytes = *b"EFI\0";
         let s = Char8Str::from_bytes_with_nul(&bytes).unwrap();
         assert_eq!(s.to_string(), "EFI");
-        assert_eq!(alloc::format!("{s:?}"), "\"EFI\"");
+        assert_eq!(std::format!("{s:?}"), "\"EFI\"");
     }
 
     #[test]
@@ -850,12 +850,12 @@ mod tests {
         let b = Char8String::default();
         assert!(a.is_empty());
         assert_eq!(a, b);
-        assert_eq!(a.clone().into_bytes_with_nul(), alloc::vec![0]);
+        assert_eq!(a.clone().into_bytes_with_nul(), std::vec![0]);
     }
 
     #[test]
     fn test_char8string_to_owned_roundtrip() {
-        use alloc::borrow::ToOwned;
+        use std::borrow::ToOwned;
         let owned = Char8String::try_from_str("Test").unwrap();
         let borrowed: &Char8Str = &owned;
         let reowned = borrowed.to_owned();
@@ -894,7 +894,7 @@ mod tests {
     fn test_char8string_debug_borrow_and_display() {
         use core::borrow::Borrow;
         let s = Char8String::try_from_str("EFI").unwrap();
-        assert_eq!(alloc::format!("{s:?}"), "\"EFI\"");
+        assert_eq!(std::format!("{s:?}"), "\"EFI\"");
         assert_eq!(s.to_string(), "EFI");
         let borrowed: &Char8Str = s.borrow();
         assert_eq!(borrowed.len(), 3);
@@ -933,7 +933,7 @@ mod tests {
 
     #[test]
     fn test_char8string_from_bytes_with_nul() {
-        let bytes = alloc::vec![b'E', b'F', b'I', 0];
+        let bytes = std::vec![b'E', b'F', b'I', 0];
         let s = Char8String::from_bytes_with_nul(bytes).unwrap();
         assert_eq!(s.len(), 3);
         assert!(*s == *"EFI");
@@ -941,19 +941,19 @@ mod tests {
 
     #[test]
     fn test_char8string_from_bytes_with_nul_missing_terminator() {
-        let bytes = alloc::vec![b'E', b'F', b'I'];
+        let bytes = std::vec![b'E', b'F', b'I'];
         assert_eq!(Char8String::from_bytes_with_nul(bytes), Err(StringError::MissingNulTerminator));
     }
 
     #[test]
     fn test_char8string_from_bytes_with_nul_interior_nul() {
-        let bytes = alloc::vec![b'E', 0, b'I', 0];
+        let bytes = std::vec![b'E', 0, b'I', 0];
         assert_eq!(Char8String::from_bytes_with_nul(bytes), Err(StringError::InteriorNul { position: 1 }));
     }
 
     #[test]
     fn test_char8string_from_bytes_with_nul_unchecked() {
-        let bytes = alloc::vec![b'E', b'F', b'I', 0];
+        let bytes = std::vec![b'E', b'F', b'I', 0];
         // SAFETY: `bytes` is a valid NUL-terminated Latin-1 sequence.
         let s = unsafe { Char8String::from_bytes_with_nul_unchecked(bytes) };
         assert!(*s == *"EFI");
@@ -1055,7 +1055,7 @@ mod tests {
     #[test]
     fn test_char8_array_to_string() {
         let array = Char8Array::<9>::from_str("Firmware");
-        let owned: alloc::string::String = array.into();
+        let owned: std::string::String = array.into();
         assert_eq!(owned, "Firmware");
     }
 

--- a/sdk/patina/src/component.rs
+++ b/sdk/patina/src/component.rs
@@ -145,6 +145,7 @@ mod struct_component;
 mod type_name;
 
 use crate::base::error::Result;
+use alloc::boxed::Box;
 
 pub use metadata::MetaData;
 pub use storage::{Storage, UnsafeStorageCell};
@@ -195,7 +196,7 @@ pub trait IntoComponent<Input> {
     /// Converts a non-[Component] struct into an object that does implement [Component].
     ///
     /// Returns a boxed trait object that implements [Component].
-    fn into_component(self) -> alloc::boxed::Box<dyn Component>;
+    fn into_component(self) -> Box<dyn Component>;
 }
 
 /// A prelude module that re-exports commonly used items from the `component` module.

--- a/sdk/patina/src/component.rs
+++ b/sdk/patina/src/component.rs
@@ -214,8 +214,6 @@ pub mod prelude {
 #[cfg(test)]
 #[cfg_attr(coverage, coverage(off))]
 mod tests {
-    extern crate std;
-
     use super::*;
     use crate as patina;
     use crate::{

--- a/sdk/patina/src/component/metadata.rs
+++ b/sdk/patina/src/component/metadata.rs
@@ -181,7 +181,6 @@ impl fmt::Debug for PrettyFixedBitSet<'_> {
 #[cfg_attr(coverage, coverage(off))]
 mod tests {
     use super::*;
-    extern crate std;
 
     #[test]
     fn test_debug_view_calculates_config_reads_correctly() {

--- a/sdk/patina/src/component/params.rs
+++ b/sdk/patina/src/component/params.rs
@@ -100,7 +100,7 @@ use core::{
     ops::{Deref, DerefMut},
 };
 
-use alloc::{borrow::Cow, boxed::Box};
+use alloc::{borrow::Cow, boxed::Box, format};
 
 use crate::{
     component::{
@@ -154,7 +154,7 @@ pub unsafe trait Param {
         if Self::validate(state, storage) {
             Ok(())
         } else {
-            Err(Cow::from(alloc::format!("{} not available.", super::type_name::normalized::<Self>())))
+            Err(Cow::from(format!("{} not available.", super::type_name::normalized::<Self>())))
         }
     }
 
@@ -431,14 +431,14 @@ unsafe impl<T: Default + 'static> Param for Config<'_, T> {
         let id = storage.add_config_default_if_not_present::<T>();
 
         if meta.access().has_writes_all_configs() {
-            return Err(Cow::from(alloc::format!(
+            return Err(Cow::from(format!(
                 "Config<{}> conflicts with a previous &mut Storage access.",
                 super::type_name::normalized::<T>()
             )));
         }
 
         if meta.access().has_config_write(id) {
-            return Err(Cow::from(alloc::format!(
+            return Err(Cow::from(format!(
                 "Config<{0}> conflicts with a previous ConfigMut<{0}> access.",
                 super::type_name::normalized::<T>()
             )));
@@ -543,28 +543,28 @@ unsafe impl<T: Default + 'static> Param for ConfigMut<'_, T> {
         storage.unlock_config(id);
 
         if meta.access().has_writes_all_configs() {
-            return Err(Cow::from(alloc::format!(
+            return Err(Cow::from(format!(
                 "ConfigMut<{}> conflicts with a previous &mut Storage access.",
                 super::type_name::normalized::<T>()
             )));
         }
 
         if meta.access().has_reads_all_configs() {
-            return Err(Cow::from(alloc::format!(
+            return Err(Cow::from(format!(
                 "ConfigMut<{}> conflicts with a previous &Storage access.",
                 super::type_name::normalized::<T>()
             )));
         }
 
         if meta.access().has_config_write(id) {
-            return Err(Cow::from(alloc::format!(
+            return Err(Cow::from(format!(
                 "ConfigMut<{0}> conflicts with a previous ConfigMut<{0}> access.",
                 super::type_name::normalized::<T>()
             )));
         }
 
         if meta.access().has_config_read(id) {
-            return Err(Cow::from(alloc::format!(
+            return Err(Cow::from(format!(
                 "ConfigMut<{0}> conflicts with a previous Config<{0}> access.",
                 super::type_name::normalized::<T>()
             )));

--- a/sdk/patina/src/component/service/memory.rs
+++ b/sdk/patina/src/component/service/memory.rs
@@ -31,12 +31,13 @@
 //!
 //! SPDX-License-Identifier: Apache-2.0
 //!
+use crate::standard::efi;
+use core::alloc::AllocError;
+use core::alloc::Layout;
 use core::{
     mem::{ManuallyDrop, MaybeUninit},
     ptr::{NonNull, with_exposed_provenance_mut},
 };
-
-use crate::standard::efi;
 
 use crate::{
     base::{UEFI_PAGE_SIZE, error::EfiError},
@@ -668,11 +669,11 @@ pub struct PageFree {
 // allocate() always fails. deallocate() frees the specific pages tracked by this struct.
 // The caller must ensure the memory was allocated using the same MemoryManager.
 unsafe impl Allocator for PageFree {
-    fn allocate(&self, _layout: core::alloc::Layout) -> Result<NonNull<[u8]>, core::alloc::AllocError> {
-        Err(core::alloc::AllocError)
+    fn allocate(&self, _layout: Layout) -> Result<NonNull<[u8]>, AllocError> {
+        Err(AllocError)
     }
 
-    unsafe fn deallocate(&self, ptr: NonNull<u8>, _layout: core::alloc::Layout) {
+    unsafe fn deallocate(&self, ptr: NonNull<u8>, _layout: Layout) {
         if self.blob != ptr {
             log_debug_assert!(
                 "PageFree was not used to free the correct memory! Leaking memory at {:?}!",
@@ -923,13 +924,13 @@ mod mock {
 #[cfg(test)]
 #[cfg_attr(coverage, coverage(off))]
 mod tests {
+    use super::*;
+    use crate::component::service::Service;
+    use core::alloc::AllocError;
     use core::{
         alloc::Layout,
         sync::atomic::{AtomicBool, AtomicUsize},
     };
-
-    use super::*;
-    use crate::component::service::Service;
 
     #[test]
     fn test_custom_mock_with_failing() {
@@ -1054,7 +1055,7 @@ mod tests {
             memory_manager: Box::leak(Box::new(StdMemoryManager::new())),
         };
 
-        assert!(pf.allocate(Layout::new::<u8>()).is_err_and(|e| matches!(e, core::alloc::AllocError)));
+        assert!(pf.allocate(Layout::new::<u8>()).is_err_and(|e| matches!(e, AllocError)));
     }
 
     #[test]

--- a/sdk/patina/src/component/service/memory.rs
+++ b/sdk/patina/src/component/service/memory.rs
@@ -48,7 +48,7 @@ use crate::{
 #[cfg(any(test, feature = "alloc"))]
 use core::alloc::Allocator;
 
-#[cfg(any(test, feature = "alloc"))]
+#[cfg(feature = "alloc")]
 use alloc::boxed::Box;
 
 #[cfg(any(test, feature = "mockall"))]
@@ -836,7 +836,6 @@ pub use mock::StdMemoryManager;
 #[cfg(any(test, feature = "mockall"))]
 #[cfg_attr(coverage, coverage(off))]
 mod mock {
-    extern crate std;
     use std::{
         alloc::{Layout, alloc, dealloc},
         collections::HashMap,

--- a/sdk/patina/src/component/service/performance.rs
+++ b/sdk/patina/src/component/service/performance.rs
@@ -191,9 +191,9 @@ pub trait PerformanceManager: Send + Sync {
 #[cfg_attr(coverage, coverage(off))]
 mod tests {
     use super::*;
-    use alloc::string::{String, ToString};
-    use alloc::vec::Vec;
+    use std::string::{String, ToString};
     use std::sync::Mutex;
+    use std::vec::Vec;
 
     struct Recorded {
         caller_guid: Option<efi::Guid>,

--- a/sdk/patina/src/component/struct_component.rs
+++ b/sdk/patina/src/component/struct_component.rs
@@ -122,7 +122,7 @@ mod tests {
         params::{Config, ConfigMut},
     };
 
-    use alloc::borrow::Cow;
+    use std::borrow::Cow;
 
     #[allow(dead_code)]
     pub struct TestStructSuccess {

--- a/sdk/patina/src/debug/log.rs
+++ b/sdk/patina/src/debug/log.rs
@@ -103,7 +103,7 @@ impl Format {
 #[cfg(test)]
 mod tests {
     use super::Format;
-    use alloc::string::String;
+    use std::string::String;
 
     /// Writes a log record through the given Format into a String buffer and returns it.
     fn format_record(format: &Format, level: log::Level, target: &str, message: &str) -> String {

--- a/sdk/patina/src/debug/log/serial_logger.rs
+++ b/sdk/patina/src/debug/log/serial_logger.rs
@@ -93,9 +93,9 @@ mod tests {
     use super::*;
     use crate::debug::log::Format;
     use crate::peripheral::serial::MockSerialIO;
-    use alloc::{string::String, sync::Arc, vec::Vec};
     use log::{Level, LevelFilter, Log, Metadata};
     use spin::Mutex;
+    use std::{string::String, sync::Arc, vec::Vec};
 
     fn metadata(level: Level, target: &str) -> Metadata<'_> {
         Metadata::builder().level(level).target(target).build()

--- a/sdk/patina/src/lib.rs
+++ b/sdk/patina/src/lib.rs
@@ -13,7 +13,7 @@
 #![cfg_attr(any(test, feature = "alloc"), feature(allocator_api))]
 #![cfg_attr(coverage, feature(coverage_attribute))]
 
-#[cfg(any(test, feature = "alloc"))]
+#[cfg(feature = "alloc")]
 extern crate alloc;
 
 // The base module gets republished from the root to flatten dependencies for common structures.

--- a/sdk/patina/src/performance/measurement.rs
+++ b/sdk/patina/src/performance/measurement.rs
@@ -186,8 +186,8 @@ impl PerformanceProperty {
 mod tests {
     use super::*;
 
-    use alloc::boxed::Box;
     use core::ptr;
+    use std::boxed::Box;
 
     use crate::performance::record::{
         PerformanceRecord,

--- a/sdk/patina/src/peripheral/serial/virtio.rs
+++ b/sdk/patina/src/peripheral/serial/virtio.rs
@@ -132,8 +132,8 @@ mod tests {
 
     use super::*;
     use crate::peripheral::serial::SerialIO;
-    use alloc::vec::Vec;
     use mmio::VirtioMmioRegs;
+    use std::vec::Vec;
 
     fn test_instance<const N: usize, const B: usize>(regs: &VirtioMmioRegs) -> VirtioSerial<N, B> {
         // SAFETY: `regs` outlives the returned `VirtioSerial`.

--- a/sdk/patina/src/peripheral/serial/virtio/queue.rs
+++ b/sdk/patina/src/peripheral/serial/virtio/queue.rs
@@ -279,8 +279,8 @@ impl<const N: usize, const B: usize> VirtQueue<N, B> {
 #[cfg(test)]
 #[cfg_attr(coverage, coverage(off))]
 impl<const N: usize, const B: usize> VirtQueue<N, B> {
-    pub(super) fn test_drain_tx(&mut self) -> alloc::vec::Vec<alloc::vec::Vec<u8>> {
-        use alloc::vec::Vec;
+    pub(super) fn test_drain_tx(&mut self) -> std::vec::Vec<std::vec::Vec<u8>> {
+        use std::vec::Vec;
         fence(Ordering::SeqCst);
         let mut out = Vec::new();
         while self.used.idx != self.avail.idx {

--- a/sdk/patina/src/pi/fw_fs.rs
+++ b/sdk/patina/src/pi/fw_fs.rs
@@ -14,12 +14,13 @@
 //!
 //! SPDX-License-Identifier: Apache-2.0
 //!
-use core::{fmt, mem, num::Wrapping, ptr, slice};
 
 pub mod ffs;
 pub mod fv;
 pub mod fvb;
 
+use alloc::{boxed::Box, collections::VecDeque, vec::Vec};
+use core::{fmt, mem, num::Wrapping, ptr, slice};
 use ffs::{attributes::raw::LARGE_FILE, file, section};
 pub use ffs::{
     attributes::{Attribute as FfsAttribute, raw as FfsRawAttribute},
@@ -40,11 +41,8 @@ pub use fv::{
 pub use fvb::attributes::{EfiFvbAttributes2, Fvb2 as Fvb2Attributes, raw::fvb2 as Fvb2RawAttributes};
 use zerocopy::FromBytes;
 
-#[cfg(test)]
-use crate::Char16String;
 use crate::standard::efi;
 use crate::{BinaryGuid, base::align_up};
-use alloc::{boxed::Box, collections::VecDeque, vec::Vec};
 use num_traits::WrappingSub;
 
 /// Well-known GUIDs for firmware file system encapsulation and compression section types.
@@ -1004,14 +1002,14 @@ mod unit_tests {
         path::Path,
     };
 
+    use crate::Char16String;
+    use crate::pi::fw_fs::{SectionMetaData, guid};
     use crate::standard::efi;
     use core::{mem, sync::atomic::AtomicBool};
     use serde::Deserialize;
     use uuid::Uuid;
 
-    use crate::pi::fw_fs::{SectionMetaData, guid};
-
-    use super::{Char16String, FfsSectionType, FirmwareVolume, NullSectionExtractor, Section, SectionExtractor, fv};
+    use super::{FfsSectionType, FirmwareVolume, NullSectionExtractor, Section, SectionExtractor, fv};
 
     #[derive(Debug, Deserialize)]
     struct TargetValues {

--- a/sdk/patina/src/pi/hob/hob_list.rs
+++ b/sdk/patina/src/pi/hob/hob_list.rs
@@ -20,15 +20,13 @@ use crate::pi::hob::{
     PhaseHandoffInformationTable, RESOURCE_DESCRIPTOR, RESOURCE_DESCRIPTOR2, ResourceDescriptor, ResourceDescriptorV2,
     UEFI_CAPSULE,
 };
+use alloc::{boxed::Box, vec::Vec};
 use core::{ffi::c_void, mem, slice};
 
 use indoc::indoc;
 
 use crate::base::{align_down, align_up};
 use core::fmt;
-
-// Expectation is someone will provide alloc
-use alloc::{boxed::Box, vec::Vec};
 
 /// Represents a HOB list.
 ///

--- a/sdk/patina/src/pi/hob/hob_list.rs
+++ b/sdk/patina/src/pi/hob/hob_list.rs
@@ -1104,7 +1104,7 @@ mod tests {
 
     #[test]
     fn test_hoblist_debug_display() {
-        use alloc::format;
+        use std::format;
 
         let mut hoblist = HobList::new();
         let handoff = gen_phase_handoff_information_table();

--- a/sdk/patina/src/pi/serializable/serializable_hob.rs
+++ b/sdk/patina/src/pi/serializable/serializable_hob.rs
@@ -528,7 +528,7 @@ mod tests {
 
         assert_eq!(
             entries,
-            alloc::vec![
+            std::vec![
                 MemoryTypeInfoEntrySerDe { memory_type: 6, number_of_pages: 100 },
                 MemoryTypeInfoEntrySerDe { memory_type: 9, number_of_pages: 200 },
             ]

--- a/sdk/patina/src/uefi/decompress.rs
+++ b/sdk/patina/src/uefi/decompress.rs
@@ -724,7 +724,6 @@ impl Iterator for CodeIterator<'_> {
 
 #[cfg(test)]
 mod test {
-    extern crate std;
     use std::{fs::File, io::Read, iter::zip, println, time, vec, vec::Vec};
 
     use super::decompress_into_with_algo;

--- a/sdk/patina/src/uefi/device_path/helpers.rs
+++ b/sdk/patina/src/uefi/device_path/helpers.rs
@@ -123,7 +123,7 @@ mod tests {
         uefi::boot_services::MockBootServices,
         uefi::device_path::node_defs::{Acpi, EndEntire, FilePath, HardDrive, Pci},
     };
-    use alloc::boxed::Box;
+    use std::boxed::Box;
 
     /// Helper to build a partial device path starting with HD node.
     fn build_partial_hd_path(guid: [u8; 16]) -> DevicePathBuf {
@@ -193,8 +193,8 @@ mod tests {
         // Clone the device path bytes into a Vec and leak it so we can return a pointer
         let path_ref: &DevicePath = full_handle_path.as_ref();
         // SAFETY: path_ref is a valid DevicePath reference and size() returns its exact byte length.
-        let bytes: alloc::vec::Vec<u8> = unsafe {
-            alloc::vec::Vec::from(core::slice::from_raw_parts(path_ref as *const _ as *const u8, path_ref.size()))
+        let bytes: std::vec::Vec<u8> = unsafe {
+            std::vec::Vec::from(core::slice::from_raw_parts(path_ref as *const _ as *const u8, path_ref.size()))
         };
         let leaked_bytes = Box::leak(bytes.into_boxed_slice());
         let full_path_ptr: usize = leaked_bytes.as_ptr() as usize;

--- a/sdk/patina/src/uefi/device_path/helpers.rs
+++ b/sdk/patina/src/uefi/device_path/helpers.rs
@@ -118,9 +118,6 @@ pub fn expand_device_path<B: BootServices>(boot_services: &B, partial_path: &mut
 
 #[cfg(test)]
 mod tests {
-    extern crate alloc;
-    extern crate std;
-
     use super::*;
     use crate::{
         uefi::boot_services::MockBootServices,

--- a/sdk/patina/src/uefi/device_path/node_defs.rs
+++ b/sdk/patina/src/uefi/device_path/node_defs.rs
@@ -905,8 +905,6 @@ impl TryFromCtx<'_, scroll::Endian> for FilePath {
 
 #[cfg(test)]
 mod tests {
-    extern crate std;
-
     use super::*;
     use scroll::{Pread, Pwrite};
 

--- a/sdk/patina_ffs_extractors/src/composite.rs
+++ b/sdk/patina_ffs_extractors/src/composite.rs
@@ -6,6 +6,7 @@
 //!
 //! SPDX-License-Identifier: Apache-2.0
 //!
+use alloc::vec::Vec;
 use patina_ffs::{
     FirmwareFileSystemError,
     section::{Section, SectionExtractor},
@@ -50,7 +51,7 @@ impl CompositeSectionExtractor {
 }
 
 impl SectionExtractor for CompositeSectionExtractor {
-    fn extract(&self, _section: &Section) -> Result<alloc::vec::Vec<u8>, FirmwareFileSystemError> {
+    fn extract(&self, _section: &Section) -> Result<Vec<u8>, FirmwareFileSystemError> {
         #[cfg(feature = "brotli")]
         {
             match self.brotli.extract(_section) {

--- a/sdk/patina_ffs_extractors/src/crc32.rs
+++ b/sdk/patina_ffs_extractors/src/crc32.rs
@@ -6,6 +6,7 @@
 //!
 //! SPDX-License-Identifier: Apache-2.0
 //!
+use alloc::vec::Vec;
 use patina::pi::fw_fs;
 use patina_ffs::{
     FirmwareFileSystemError,
@@ -25,7 +26,7 @@ impl Crc32SectionExtractor {
 }
 
 impl SectionExtractor for Crc32SectionExtractor {
-    fn extract(&self, section: &patina_ffs::section::Section) -> Result<alloc::vec::Vec<u8>, FirmwareFileSystemError> {
+    fn extract(&self, section: &patina_ffs::section::Section) -> Result<Vec<u8>, FirmwareFileSystemError> {
         if let SectionHeader::GuidDefined(guid_header, crc_header, _) = section.header()
             && guid_header.section_definition_guid == fw_fs::guid::CRC32_SECTION_GUID
         {

--- a/sdk/patina_ffs_extractors/src/lib.rs
+++ b/sdk/patina_ffs_extractors/src/lib.rs
@@ -20,7 +20,7 @@
 //! SPDX-License-Identifier: Apache-2.0
 //!
 #![cfg_attr(coverage, feature(coverage_attribute))]
-#![cfg_attr(not(feature = "std"), no_std)]
+#![cfg_attr(all(not(feature = "std"), not(test)), no_std)]
 extern crate alloc;
 
 #[cfg(feature = "brotli")]
@@ -51,12 +51,12 @@ const DECOMPRESSION_MAX_MEMORY_LIMIT: u32 = patina::SIZE_512MB as u32;
 #[cfg(test)]
 #[cfg_attr(coverage, coverage(off))]
 mod tests {
-    use alloc::{vec, vec::Vec};
     use patina::pi::fw_fs::{
         ffs::section::header::GuidDefined,
         guid::{BROTLI_SECTION_GUID, CRC32_SECTION_GUID, LZMA_SECTION_GUID},
     };
     use patina_ffs::section::{Section, SectionHeader};
+    use std::{vec, vec::Vec};
 
     /// Constructs a section with the specified GUID and payload, prepending
     /// the required 16-byte header (out_size + scratch_size) for Brotli sections.

--- a/sdk/patina_ffs_extractors/src/lzma.rs
+++ b/sdk/patina_ffs_extractors/src/lzma.rs
@@ -81,9 +81,9 @@ mod tests {
     use crate::tests::create_lzma_section;
 
     use super::*;
-    use alloc::vec;
     use patina::pi::fw_fs::ffs::section::header::GuidDefined;
     use patina_ffs::section::Section;
+    use std::vec;
 
     #[test]
     fn test_lzma_extractor_valid() {

--- a/sdk/patina_macro/src/hob_macro.rs
+++ b/sdk/patina_macro/src/hob_macro.rs
@@ -227,7 +227,7 @@ mod tests {
 
         // Test that the hex string provided in the attribute matches the well known PCD Database HOB GUID
         let (f0, f1, f2, f3, f4, &[f5, f6, f7, f8, f9, f10]) = TEST_HOB_GUID.as_fields();
-        let name = alloc::format!(
+        let name = std::format!(
             "{f0:08x}-{f1:04x}-{f2:04x}-{f3:02x}{f4:02x}-{f5:02x}{f6:02x}{f7:02x}{f8:02x}{f9:02x}{f10:02x}"
         );
         assert_eq!(name, "ea296d92-0b69-423c-8c28-33b4e0a91268");

--- a/sdk/patina_macro/src/hob_macro.rs
+++ b/sdk/patina_macro/src/hob_macro.rs
@@ -153,8 +153,6 @@ mod tests {
     use super::*;
     use proc_macro2::TokenStream;
     use quote::quote;
-    extern crate alloc;
-    use alloc::format;
 
     #[test]
     fn test_config_basic() {

--- a/sdk/patina_macro/src/lib.rs
+++ b/sdk/patina_macro/src/lib.rs
@@ -9,6 +9,8 @@
 
 #![cfg_attr(coverage, feature(coverage_attribute))]
 
+extern crate alloc;
+
 mod hob_macro;
 mod service_macro;
 mod smbios_record_macro;


### PR DESCRIPTION
## Description

Remove the CpuInfo traits and configure MmSupervisorCore directly with
performance timer frequency.

Simplify the supervisor and mailbox generics, update timeout handling
to use value based timer configuration.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [x] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

validate on physical platform.

## Integration Instructions

NA