### PR TITLE
[feature/supv] Extract intrinsics and data types into focused modules

### DIFF
--- a/patina_mm_supervisor/src/comm_buffer.rs
+++ b/patina_mm_supervisor/src/comm_buffer.rs
@@ -1,0 +1,66 @@
+//! Communication Buffer Configuration for the MM Supervisor Core
+//!
+//! Defines the communication buffer layout extracted from the MM Supervisor PassDown HOB
+//! and shared across the supervisor for routing user- and supervisor-targeted requests.
+//!
+//! ## License
+//!
+//! Copyright (c) Microsoft Corporation.
+//!
+//! SPDX-License-Identifier: Apache-2.0
+//!
+
+/// Communication buffer configuration extracted from PassDown HOB.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct CommBufferConfig {
+    /// MM Supervisor communication buffer (external interface).
+    pub supv_comm_buffer: u64,
+    /// MM Supervisor internal communication buffer.
+    pub supv_comm_buffer_internal: u64,
+    /// Size of supervisor communication buffer.
+    pub supv_comm_buffer_size: u64,
+    /// MM User communication buffer (external interface).
+    pub user_comm_buffer: u64,
+    /// MM User internal communication buffer.
+    pub user_comm_buffer_internal: u64,
+    /// Size of user communication buffer.
+    pub user_comm_buffer_size: u64,
+    /// `MmCommBufferStatus` mailbox for user-targeted requests.
+    pub user_status_buffer: u64,
+    /// `MmCommBufferStatus` mailbox for supervisor-targeted requests.
+    pub supv_status_buffer: u64,
+    /// MM Supervisor to User buffer.
+    pub supv_to_user_buffer: u64,
+    /// Size of Supervisor to User buffer.
+    pub supv_to_user_buffer_size: u64,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_comm_buffer_config_default_is_zeroed() {
+        let cfg = CommBufferConfig::default();
+        assert_eq!(cfg.supv_comm_buffer, 0);
+        assert_eq!(cfg.supv_comm_buffer_internal, 0);
+        assert_eq!(cfg.supv_comm_buffer_size, 0);
+        assert_eq!(cfg.user_comm_buffer, 0);
+        assert_eq!(cfg.user_comm_buffer_internal, 0);
+        assert_eq!(cfg.user_comm_buffer_size, 0);
+        assert_eq!(cfg.user_status_buffer, 0);
+        assert_eq!(cfg.supv_status_buffer, 0);
+        assert_eq!(cfg.supv_to_user_buffer, 0);
+        assert_eq!(cfg.supv_to_user_buffer_size, 0);
+    }
+
+    #[test]
+    fn test_comm_buffer_config_is_copy() {
+        let cfg = CommBufferConfig { supv_comm_buffer: 0x1000, user_comm_buffer: 0x2000, ..Default::default() };
+        let copied = cfg; // relies on `Copy`
+        assert_eq!(copied.supv_comm_buffer, 0x1000);
+        assert_eq!(copied.user_comm_buffer, 0x2000);
+        // `cfg` is still usable after the copy.
+        assert_eq!(cfg.supv_comm_buffer, 0x1000);
+    }
+}

--- a/patina_mm_supervisor/src/cpu.rs
+++ b/patina_mm_supervisor/src/cpu.rs
@@ -1,12 +1,12 @@
 //! CPU Management Module
 //!
-//! This module provides CPU identification and management for the MM Supervisor Core.
-//! It handles BSP/AP detection, CPU registration, and state tracking.
+//! This module provides CPU identification and management for the MM Supervisor
+//! Core. It handles BSP/AP detection, CPU registration, and state tracking.
 //!
 //! ## Memory Model
 //!
-//! This module does not perform heap allocation. All structures use fixed-size arrays
-//! with compile-time constants provided via const generics.
+//! This module does not perform heap allocation. All structures use fixed-size
+//! arrays with compile-time constants provided via const generics.
 //!
 //! ## License
 //!
@@ -15,19 +15,9 @@
 //! SPDX-License-Identifier: Apache-2.0
 //!
 
-use core::{
-    arch::x86_64::{__cpuid, CpuidResult},
-    sync::atomic::{AtomicU8, AtomicU32, Ordering},
-};
+use core::sync::atomic::{AtomicU8, AtomicU32, Ordering};
 
-/// CPUID leaf 0x1: Version Information (Type, Family, Model, and Stepping ID).
-pub(crate) const CPUID_VERSION_INFO: u32 = 0x01;
-
-/// MSR index for IA32_APIC_BASE.
-const IA32_APIC_BASE_MSR_INDEX: u32 = 0x1B;
-
-/// BSP flag bit in IA32_APIC_BASE MSR (bit 8).
-const IA32_APIC_BSP: u64 = 1 << 8;
+use crate::semaphore::{sem_signal, sem_try_take, sem_wait};
 
 /// The state of an Application Processor (AP).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -92,38 +82,6 @@ impl CpuSlot {
         let id = self.cpu_id.load(Ordering::Acquire);
         if id == u32::MAX { None } else { Some(id) }
     }
-}
-
-/// Signals a counting rendezvous semaphore (atomic increment).
-#[inline]
-fn sem_signal(sem: &AtomicU32) {
-    sem.fetch_add(1, Ordering::AcqRel);
-}
-
-/// Blocks (spins, no timer) until the semaphore is positive, then consumes one count.
-#[inline]
-fn sem_wait(sem: &AtomicU32) {
-    loop {
-        let value = sem.load(Ordering::Acquire);
-        if value != 0 && sem.compare_exchange_weak(value, value - 1, Ordering::AcqRel, Ordering::Acquire).is_ok() {
-            return;
-        }
-        core::hint::spin_loop();
-    }
-}
-
-/// Consumes one count if the semaphore is positive. Non-blocking; returns whether a
-/// count was taken.
-#[inline]
-fn sem_try_take(sem: &AtomicU32) -> bool {
-    let mut value = sem.load(Ordering::Acquire);
-    while value != 0 {
-        match sem.compare_exchange_weak(value, value - 1, Ordering::AcqRel, Ordering::Acquire) {
-            Ok(_) => return true,
-            Err(current) => value = current,
-        }
-    }
-    false
 }
 
 /// Manager for CPU-related operations.
@@ -372,75 +330,6 @@ impl<const MAX_CPUS: usize> Default for CpuManager<MAX_CPUS> {
     fn default() -> Self {
         Self::new()
     }
-}
-
-/// Gets the current CPU's APIC ID.
-///
-/// On x86_64, this reads the APIC ID from the Local APIC or CPUID.
-pub fn get_current_cpu_id() -> u32 {
-    // Use CPUID to get the initial APIC ID
-    // CPUID function 0x01, EBX[31:24] contains the initial APIC ID
-
-    // CPUID is always available on x86_64 and `__cpuid` is a safe intrinsic.
-    let CpuidResult { ebx, .. } = __cpuid(CPUID_VERSION_INFO);
-
-    (ebx >> 24) & 0xff
-}
-
-/// Reads a Model-Specific Register (MSR) by index.
-///
-/// ## Safety
-///
-/// The caller must ensure the MSR index is valid and readable on the current platform.
-pub unsafe fn read_msr(msr: u32) -> u64 {
-    let lo: u32;
-    let hi: u32;
-    // SAFETY: Reading the MSR is memory safe as long as the caller ensures the MSR index is valid.
-    //         But this could also reveal the contents of the MSR, which is why we should guard this
-    //         behind the syscall gate and only allow access to certain MSRs.
-    unsafe {
-        core::arch::asm!(
-            "rdmsr",
-            in("ecx") msr,
-            out("eax") lo,
-            out("edx") hi,
-            options(nomem, nostack),
-        );
-    }
-    ((hi as u64) << 32) | (lo as u64)
-}
-
-/// Writes a 64-bit value to a Model-Specific Register (MSR).
-///
-/// ## Safety
-///
-/// The caller must ensure the MSR index is valid and writable on the current platform.
-pub unsafe fn write_msr(msr: u32, value: u64) {
-    let lo = value as u32;
-    let hi = (value >> 32) as u32;
-    // SAFETY: Writing the MSR is memory safe as long as the caller ensures the MSR index is valid
-    //         and writable (guaranteed by this function's `unsafe` contract). `wrmsr` writes only
-    //         the selected MSR from EDX:EAX and touches no memory (nomem, nostack).
-    unsafe {
-        core::arch::asm!(
-            "wrmsr",
-            in("ecx") msr,
-            in("eax") lo,
-            in("edx") hi,
-            options(nomem, nostack),
-        );
-    }
-}
-
-/// Checks if the current processor is the Bootstrap Processor (BSP).
-///
-/// This reads the IA32_APIC_BASE MSR and checks the BSP flag (bit 8).
-/// The BSP flag is set by hardware during reset and indicates which
-/// processor is the bootstrap processor.
-pub fn is_bsp() -> bool {
-    // SAFETY: The IA32_APIC_BASE MSR is safe to read on x86_64.
-    let apic_base = unsafe { read_msr(IA32_APIC_BASE_MSR_INDEX) };
-    (apic_base & IA32_APIC_BSP) != 0
 }
 
 #[cfg(test)]

--- a/patina_mm_supervisor/src/init.rs
+++ b/patina_mm_supervisor/src/init.rs
@@ -29,10 +29,11 @@ use patina_paging::{
 
 use crate::{
     AllocationType, CommBufferConfig, MmSupervisorCore, PageOwnership, PlatformInfo, SharedPagingAllocator,
+    intrinsics::read_cr3,
     is_buffer_inside_mmram,
     mem::{self, page_allocator::coalesced_smrr_range},
     mm_policy::{self, MemDescriptorV1_0, dump_policy, gate::PolicyGate, walk_page_table},
-    query_address_ownership, read_cr3,
+    query_address_ownership,
     save_state::SaveStateInfo,
     smrr::{configure_smm_code_access, smrr_initialize},
     state::{init_state, security_state},

--- a/patina_mm_supervisor/src/intrinsics.rs
+++ b/patina_mm_supervisor/src/intrinsics.rs
@@ -1,0 +1,127 @@
+//! Architectural Intrinsics for the MM Supervisor Core
+//!
+//! Provides thin, architecture-specific wrappers around low-level x86_64
+//! instructions used by the supervisor: `rdmsr`/`wrmsr` for Model-Specific
+//! Registers and `cpuid`/MSR reads for CPU identification (APIC ID and BSP
+//! detection). Access to individual MSRs is expected to be gated by the syscall
+//! policy layer.
+//!
+//! ## License
+//!
+//! Copyright (c) Microsoft Corporation.
+//!
+//! SPDX-License-Identifier: Apache-2.0
+//!
+
+use core::arch::x86_64::{__cpuid, CpuidResult};
+
+/// CPUID leaf 0x1: Version Information (Type, Family, Model, and Stepping ID).
+pub(crate) const CPUID_VERSION_INFO: u32 = 0x01;
+
+/// MSR index for IA32_APIC_BASE.
+const IA32_APIC_BASE_MSR_INDEX: u32 = 0x1B;
+
+/// BSP flag bit in IA32_APIC_BASE MSR (bit 8).
+const IA32_APIC_BSP: u64 = 1 << 8;
+
+/// Reads a Model-Specific Register (MSR) by index.
+///
+/// ## Safety
+///
+/// The caller must ensure the MSR index is valid and readable on the current
+/// platform.
+// Executes the privileged `rdmsr` instruction, which faults outside ring 0 and
+// cannot run in a host-based unit test.
+#[cfg_attr(coverage, coverage(off))]
+pub unsafe fn read_msr(msr: u32) -> u64 {
+    let lo: u32;
+    let hi: u32;
+    // SAFETY: Reading the MSR is memory safe as long as the caller ensures the
+    //         MSR index is valid. But this could also reveal the contents of
+    //         the MSR, which is why we should guard this behind the syscall
+    //         gate and only allow access to certain MSRs.
+    unsafe {
+        core::arch::asm!(
+            "rdmsr",
+            in("ecx") msr,
+            out("eax") lo,
+            out("edx") hi,
+            options(nomem, nostack),
+        );
+    }
+    ((hi as u64) << 32) | (lo as u64)
+}
+
+/// Writes a 64-bit value to a Model-Specific Register (MSR).
+///
+/// ## Safety
+///
+/// The caller must ensure the MSR index is valid and writable on the current
+/// platform.
+// Executes the privileged `wrmsr` instruction, which faults outside ring 0 and
+// cannot run in a host-based unit test.
+#[cfg_attr(coverage, coverage(off))]
+pub unsafe fn write_msr(msr: u32, value: u64) {
+    let lo = value as u32;
+    let hi = (value >> 32) as u32;
+    // SAFETY: Writing the MSR is memory safe as long as the caller ensures the
+    //         MSR index is valid and writable (guaranteed by this function's
+    //         `unsafe` contract). `wrmsr` writes only the selected MSR from
+    //         EDX:EAX and touches no memory (nomem, nostack).
+    unsafe {
+        core::arch::asm!(
+            "wrmsr",
+            in("ecx") msr,
+            in("eax") lo,
+            in("edx") hi,
+            options(nomem, nostack),
+        );
+    }
+}
+
+/// Gets the current CPU's APIC ID.
+///
+/// On x86_64, this reads the APIC ID from the Local APIC or CPUID.
+// Depends on the running processor's `cpuid` state, which cannot be exercised
+// deterministically in a host-based unit test.
+#[cfg_attr(coverage, coverage(off))]
+pub fn get_current_cpu_id() -> u32 {
+    // Use CPUID to get the initial APIC ID
+    // CPUID function 0x01, EBX[31:24] contains the initial APIC ID
+
+    // CPUID is always available on x86_64 and `__cpuid` is a safe intrinsic.
+    let CpuidResult { ebx, .. } = __cpuid(CPUID_VERSION_INFO);
+
+    (ebx >> 24) & 0xff
+}
+
+/// Checks if the current processor is the Bootstrap Processor (BSP).
+///
+/// This reads the IA32_APIC_BASE MSR and checks the BSP flag (bit 8).
+/// The BSP flag is set by hardware during reset and indicates which
+/// processor is the bootstrap processor.
+// Reads the IA32_APIC_BASE MSR via the privileged `rdmsr` instruction, which
+// faults outside ring 0 and cannot run in a host-based unit test.
+#[cfg_attr(coverage, coverage(off))]
+pub fn is_bsp() -> bool {
+    // SAFETY: The IA32_APIC_BASE MSR is safe to read on x86_64.
+    let apic_base = unsafe { read_msr(IA32_APIC_BASE_MSR_INDEX) };
+    (apic_base & IA32_APIC_BSP) != 0
+}
+
+/// Read CR3 register.
+#[cfg_attr(coverage, coverage(off))]
+pub(crate) fn read_cr3() -> u64 {
+    let mut _value = 0u64;
+
+    #[cfg(not(test))]
+    {
+        // SAFETY: inline asm is inherently unsafe because Rust can't reason about it.
+        // In this case we are reading the CR3 register, which is a safe operation.
+        unsafe {
+            core::arch::asm!("mov {}, cr3", out(reg) _value, options(nostack, preserves_flags));
+        }
+    }
+
+    _value
+}

--- a/patina_mm_supervisor/src/lib.rs
+++ b/patina_mm_supervisor/src/lib.rs
@@ -42,20 +42,26 @@
 #![cfg(target_arch = "x86_64")]
 #![cfg_attr(coverage, feature(coverage_attribute))]
 
+mod comm_buffer;
 mod cpu;
 mod init;
+mod intrinsics;
 mod mailbox;
 mod mem;
 mod mm_policy;
+mod page_ownership;
 mod perf_timer;
 mod privilege_mgmt;
+mod request_target;
 mod runtime;
 mod save_state;
+mod semaphore;
 mod smrr;
 mod state;
 mod supervisor_handlers;
 
-use cpu::{CpuManager, get_current_cpu_id, is_bsp};
+use cpu::CpuManager;
+use intrinsics::{get_current_cpu_id, is_bsp};
 use mailbox::MailboxManager;
 // Re-exported for use by descendant modules via `crate::` paths.
 use mem::{AllocationType, SharedPagingAllocator};
@@ -70,17 +76,18 @@ use core::{
     sync::atomic::{AtomicBool, Ordering},
 };
 
-use patina::{
-    UEFI_PAGE_SIZE, align_range, management_mode::MmCommBufferStatus, management_mode::supervisor::UserCommandType,
-};
-use patina_paging::{MemoryAttributes, PageTable};
+use patina::management_mode::supervisor::UserCommandType;
 
 use state::{init_state, security_state};
 
 // Publicly re-export the handler types since platform-specific handlers will need to reference these for
 // their function signatures and return types.
+pub use comm_buffer::CommBufferConfig;
 pub use init::PolicyInitError;
+pub use request_target::RequestTarget;
 pub use supervisor_handlers::SupervisorMmiHandler;
+
+pub(crate) use page_ownership::{PageOwnership, query_address_ownership};
 
 use crate::smrr::smrr_enable;
 
@@ -146,100 +153,6 @@ pub trait PlatformInfo: 'static {
     }
 }
 
-/// Result of a page table ownership query.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(crate) enum PageOwnership {
-    /// The page is user-accessible (U/S = 1, SpecialPurpose clear).
-    User,
-    /// The page is supervisor-only (U/S = 0, SpecialPurpose set).
-    Supervisor,
-}
-
-/// Queries the page table to determine the ownership (user vs supervisor) of an address.
-///
-/// The address and size are page-aligned before querying (rounded down / up respectively).
-///
-/// Checks the `Supervisor` attribute which maps to the U/S bit on X64:
-///   - `Supervisor` set  => `PageOwnership::Supervisor` (U/S = 0)
-///   - `Supervisor` clear => `PageOwnership::User` (U/S = 1)
-///
-/// Returns `None` if the page table is not initialized or the address is unmapped.
-pub(crate) fn query_address_ownership(address: u64, size: u64) -> Option<PageOwnership> {
-    let (aligned_addr, aligned_size) = align_range(address, size, UEFI_PAGE_SIZE as u64).ok()?;
-    let page_table = security_state().lock_page_table();
-    let pt = page_table.as_ref()?;
-    let attrs = pt.query_memory_region(aligned_addr, aligned_size).ok()?;
-    log::trace!(
-        "Queried page ownership for address range 0x{:016x}-0x{:016x}: attributes={:?}",
-        aligned_addr,
-        aligned_addr + aligned_size,
-        attrs
-    );
-    if attrs.contains(MemoryAttributes::Supervisor) {
-        Some(PageOwnership::Supervisor)
-    } else {
-        Some(PageOwnership::User)
-    }
-}
-
-/// Communication buffer configuration extracted from PassDown HOB.
-#[derive(Debug, Clone, Copy, Default)]
-pub struct CommBufferConfig {
-    /// MM Supervisor communication buffer (external interface).
-    pub supv_comm_buffer: u64,
-    /// MM Supervisor internal communication buffer.
-    pub supv_comm_buffer_internal: u64,
-    /// Size of supervisor communication buffer.
-    pub supv_comm_buffer_size: u64,
-    /// MM User communication buffer (external interface).
-    pub user_comm_buffer: u64,
-    /// MM User internal communication buffer.
-    pub user_comm_buffer_internal: u64,
-    /// Size of user communication buffer.
-    pub user_comm_buffer_size: u64,
-    /// `MmCommBufferStatus` mailbox for user-targeted requests.
-    pub user_status_buffer: u64,
-    /// `MmCommBufferStatus` mailbox for supervisor-targeted requests.
-    pub supv_status_buffer: u64,
-    /// MM Supervisor to User buffer.
-    pub supv_to_user_buffer: u64,
-    /// Size of Supervisor to User buffer.
-    pub supv_to_user_buffer_size: u64,
-}
-
-/// Request target derived from the user and supervisor `MmCommBufferStatus`
-/// mailboxes.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum RequestTarget {
-    /// No pending request (neither mailbox is valid).
-    None,
-    /// Request targets the Supervisor.
-    Supervisor,
-    /// Request targets the User module.
-    User,
-}
-
-impl RequestTarget {
-    /// Selects the dispatch target based on the two parallel status mailboxes.
-    ///
-    /// The user mailbox is checked first — if its `is_comm_buffer_valid` flag
-    /// is set, the request belongs to the user module. Otherwise the
-    /// supervisor mailbox is consulted. When neither mailbox is valid the
-    /// request is treated as an asynchronous MMI, which is still dispatched
-    /// through the user path so the user-core's async handler chain can run.
-    pub fn select(user_status: &MmCommBufferStatus, supv_status: &MmCommBufferStatus) -> Self {
-        if user_status.is_comm_buffer_valid != 0 {
-            RequestTarget::User
-        } else if supv_status.is_comm_buffer_valid != 0 {
-            RequestTarget::Supervisor
-        } else {
-            // Async MMI — user-core's async dispatcher runs unconditionally
-            // once we demote, so route through the user path.
-            RequestTarget::User
-        }
-    }
-}
-
 /// The MM Supervisor Core responsible for managing the standalone MM environment.
 ///
 /// This struct is generic over the [`PlatformInfo`] trait, which provides platform-specific
@@ -297,22 +210,6 @@ pub struct MmSupervisorCore<P: PlatformInfo, const MAX_CPUS: usize> {
 pub(crate) fn is_buffer_inside_mmram(base: u64, size: u64) -> bool {
     // we will go over the page allocator to see if this region falls inside any of the MMRAM regions
     security_state().page_allocator().is_region_inside_mmram(base, size)
-}
-
-/// Read CR3 register.
-pub(crate) fn read_cr3() -> u64 {
-    let mut _value = 0u64;
-
-    #[cfg(not(test))]
-    {
-        // SAFETY: inline asm is inherently unsafe because Rust can't reason about it.
-        // In this case we are reading the CR3 register, which is a safe operation.
-        unsafe {
-            core::arch::asm!("mov {}, cr3", out(reg) _value, options(nostack, preserves_flags));
-        }
-    }
-
-    _value
 }
 
 /// Checks if a specific core has completed initialization.

--- a/patina_mm_supervisor/src/page_ownership.rs
+++ b/patina_mm_supervisor/src/page_ownership.rs
@@ -1,0 +1,73 @@
+//! Page Table Ownership Queries for the MM Supervisor Core
+//!
+//! Provides helpers to determine whether a memory range is owned by the supervisor
+//! (CPL0) or the user module (CPL3), based on the page table's `Supervisor` attribute
+//! (the X64 U/S bit).
+//!
+//! ## License
+//!
+//! Copyright (c) Microsoft Corporation.
+//!
+//! SPDX-License-Identifier: Apache-2.0
+//!
+
+use patina::{UEFI_PAGE_SIZE, align_range};
+use patina_paging::{MemoryAttributes, PageTable};
+
+use crate::state::security_state;
+
+/// Result of a page table ownership query.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum PageOwnership {
+    /// The page is user-accessible (U/S = 1, SpecialPurpose clear).
+    User,
+    /// The page is supervisor-only (U/S = 0, SpecialPurpose set).
+    Supervisor,
+}
+
+/// Queries the page table to determine the ownership (user vs supervisor) of an address.
+///
+/// The address and size are page-aligned before querying (rounded down / up respectively).
+///
+/// Checks the `Supervisor` attribute which maps to the U/S bit on X64:
+///   - `Supervisor` set  => `PageOwnership::Supervisor` (U/S = 0)
+///   - `Supervisor` clear => `PageOwnership::User` (U/S = 1)
+///
+/// Returns `None` if the page table is not initialized or the address is unmapped.
+pub(crate) fn query_address_ownership(address: u64, size: u64) -> Option<PageOwnership> {
+    let (aligned_addr, aligned_size) = align_range(address, size, UEFI_PAGE_SIZE as u64).ok()?;
+    let page_table = security_state().lock_page_table();
+    let pt = page_table.as_ref()?;
+    let attrs = pt.query_memory_region(aligned_addr, aligned_size).ok()?;
+    log::trace!(
+        "Queried page ownership for address range 0x{:016x}-0x{:016x}: attributes={:?}",
+        aligned_addr,
+        aligned_addr + aligned_size,
+        attrs
+    );
+    if attrs.contains(MemoryAttributes::Supervisor) {
+        Some(PageOwnership::Supervisor)
+    } else {
+        Some(PageOwnership::User)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_page_ownership_is_copy_and_comparable() {
+        let owner = PageOwnership::Supervisor;
+        let copied = owner; // relies on `Copy`
+        assert_eq!(owner, copied);
+        assert_ne!(PageOwnership::Supervisor, PageOwnership::User);
+    }
+
+    #[test]
+    fn test_query_address_ownership_none_when_page_table_uninitialized() {
+        // With no page table installed, ownership cannot be determined.
+        *security_state().lock_page_table() = None;
+        assert_eq!(query_address_ownership(0x1000, 0x1000), None);
+    }
+}

--- a/patina_mm_supervisor/src/privilege_mgmt/syscall_dispatcher.rs
+++ b/patina_mm_supervisor/src/privilege_mgmt/syscall_dispatcher.rs
@@ -277,7 +277,7 @@ impl SyscallDispatcher {
         // Policy allows - execute the MSR read
         // SAFETY: the policy gate authorized reading this MSR above; `read_msr` only issues
         // `rdmsr` for `msr_index` and returns its value.
-        let value = unsafe { crate::cpu::read_msr(msr_index) };
+        let value = unsafe { crate::intrinsics::read_msr(msr_index) };
         log::debug!("RDMSR: MSR 0x{:x} = 0x{:x}", msr_index, value);
         Ok(value)
     }
@@ -309,7 +309,7 @@ impl SyscallDispatcher {
         // Policy allows - execute the MSR write
         // SAFETY: the policy gate authorized writing this MSR above; `write_msr` only issues
         // `wrmsr` for `msr_index` with the requested value.
-        unsafe { crate::cpu::write_msr(msr_index, value) };
+        unsafe { crate::intrinsics::write_msr(msr_index, value) };
         log::debug!("WRMSR: MSR 0x{:x} written with 0x{:x}", msr_index, value);
         Ok(0)
     }

--- a/patina_mm_supervisor/src/request_target.rs
+++ b/patina_mm_supervisor/src/request_target.rs
@@ -1,0 +1,80 @@
+//! Request Target Selection for the MM Supervisor Core
+//!
+//! Derives the dispatch target (user vs supervisor) for an incoming request from the two
+//! parallel `MmCommBufferStatus` mailboxes.
+//!
+//! ## License
+//!
+//! Copyright (c) Microsoft Corporation.
+//!
+//! SPDX-License-Identifier: Apache-2.0
+//!
+
+use patina::management_mode::MmCommBufferStatus;
+
+/// Request target derived from the user and supervisor `MmCommBufferStatus`
+/// mailboxes.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RequestTarget {
+    /// No pending request (neither mailbox is valid).
+    None,
+    /// Request targets the Supervisor.
+    Supervisor,
+    /// Request targets the User module.
+    User,
+}
+
+impl RequestTarget {
+    /// Selects the dispatch target based on the two parallel status mailboxes.
+    ///
+    /// The user mailbox is checked first — if its `is_comm_buffer_valid` flag
+    /// is set, the request belongs to the user module. Otherwise the
+    /// supervisor mailbox is consulted. When neither mailbox is valid the
+    /// request is treated as an asynchronous MMI, which is still dispatched
+    /// through the user path so the user-core's async handler chain can run.
+    pub fn select(user_status: &MmCommBufferStatus, supv_status: &MmCommBufferStatus) -> Self {
+        if user_status.is_comm_buffer_valid != 0 {
+            RequestTarget::User
+        } else if supv_status.is_comm_buffer_valid != 0 {
+            RequestTarget::Supervisor
+        } else {
+            // Async MMI — user-core's async dispatcher runs unconditionally
+            // once we demote, so route through the user path.
+            RequestTarget::User
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Builds a status mailbox with the given validity flag.
+    fn status(valid: bool) -> MmCommBufferStatus {
+        let mut s = MmCommBufferStatus::new();
+        s.is_comm_buffer_valid = valid as u8;
+        s
+    }
+
+    #[test]
+    fn test_request_target_user_when_user_valid() {
+        assert_eq!(RequestTarget::select(&status(true), &status(false)), RequestTarget::User);
+    }
+
+    #[test]
+    fn test_request_target_supervisor_when_only_supervisor_valid() {
+        assert_eq!(RequestTarget::select(&status(false), &status(true)), RequestTarget::Supervisor);
+    }
+
+    #[test]
+    fn test_request_target_user_takes_priority_when_both_valid() {
+        // The user mailbox is consulted first, so it wins even when both are valid.
+        assert_eq!(RequestTarget::select(&status(true), &status(true)), RequestTarget::User);
+    }
+
+    #[test]
+    fn test_request_target_async_routes_to_user_when_none_valid() {
+        // Neither mailbox valid => async MMI, dispatched through the user path.
+        assert_eq!(RequestTarget::select(&status(false), &status(false)), RequestTarget::User);
+    }
+}

--- a/patina_mm_supervisor/src/runtime.rs
+++ b/patina_mm_supervisor/src/runtime.rs
@@ -19,7 +19,8 @@ use r_efi::efi;
 
 use crate::{
     AP_ARRIVAL_TIMEOUT_US, AP_TIMEOUT_US, CommBufferConfig, MmSupervisorCore, PageOwnership, PlatformInfo,
-    cpu::{ApState, is_bsp},
+    cpu::ApState,
+    intrinsics::is_bsp,
     mailbox::{ApCommand, ApResponse},
     privilege_mgmt::invoke_demoted_routine,
     query_address_ownership,

--- a/patina_mm_supervisor/src/semaphore.rs
+++ b/patina_mm_supervisor/src/semaphore.rs
@@ -1,0 +1,103 @@
+//! Counting Rendezvous Semaphores for the MM Supervisor Core
+//!
+//! Provides lightweight, allocation-free counting semaphore primitives built on
+//! a single [`AtomicU32`]. These are used to coordinate the BSP/AP SMI exit
+//! barrier: the BSP signals a release count and APs consume it, and vice versa
+//! for exit acknowledgements.
+//!
+//! ## License
+//!
+//! Copyright (c) Microsoft Corporation.
+//!
+//! SPDX-License-Identifier: Apache-2.0
+//!
+
+use core::sync::atomic::{AtomicU32, Ordering};
+
+/// Signals a counting rendezvous semaphore (atomic increment).
+pub(crate) fn sem_signal(sem: &AtomicU32) {
+    sem.fetch_add(1, Ordering::AcqRel);
+}
+
+/// Blocks (spins, no timer) until the semaphore is positive, then consumes one count.
+pub(crate) fn sem_wait(sem: &AtomicU32) {
+    loop {
+        let value = sem.load(Ordering::Acquire);
+        if value != 0 && sem.compare_exchange_weak(value, value - 1, Ordering::AcqRel, Ordering::Acquire).is_ok() {
+            return;
+        }
+        core::hint::spin_loop();
+    }
+}
+
+/// Consumes one count if the semaphore is positive. Non-blocking; returns whether a
+/// count was taken.
+pub(crate) fn sem_try_take(sem: &AtomicU32) -> bool {
+    let mut value = sem.load(Ordering::Acquire);
+    while value != 0 {
+        match sem.compare_exchange_weak(value, value - 1, Ordering::AcqRel, Ordering::Acquire) {
+            Ok(_) => return true,
+            Err(current) => value = current,
+        }
+    }
+    false
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_sem_signal_increments_count() {
+        let sem = AtomicU32::new(0);
+        sem_signal(&sem);
+        assert_eq!(sem.load(Ordering::Acquire), 1);
+        sem_signal(&sem);
+        assert_eq!(sem.load(Ordering::Acquire), 2);
+    }
+
+    #[test]
+    fn test_sem_try_take_returns_false_when_zero() {
+        let sem = AtomicU32::new(0);
+        assert!(!sem_try_take(&sem));
+        assert_eq!(sem.load(Ordering::Acquire), 0);
+    }
+
+    #[test]
+    fn test_sem_try_take_consumes_one_count() {
+        let sem = AtomicU32::new(2);
+        assert!(sem_try_take(&sem));
+        assert_eq!(sem.load(Ordering::Acquire), 1);
+        assert!(sem_try_take(&sem));
+        assert_eq!(sem.load(Ordering::Acquire), 0);
+        // Exhausted: no more counts to take.
+        assert!(!sem_try_take(&sem));
+    }
+
+    #[test]
+    fn test_sem_wait_consumes_available_count() {
+        // With a positive count already available, `sem_wait` returns immediately and
+        // consumes exactly one count without blocking.
+        let sem = AtomicU32::new(0);
+        sem_signal(&sem);
+        sem_signal(&sem);
+        sem_wait(&sem);
+        assert_eq!(sem.load(Ordering::Acquire), 1);
+        sem_wait(&sem);
+        assert_eq!(sem.load(Ordering::Acquire), 0);
+    }
+
+    #[test]
+    fn test_signal_wait_round_trip_is_balanced() {
+        // Signaling N times and waiting N times leaves the semaphore balanced at zero.
+        let sem = AtomicU32::new(0);
+        for _ in 0..5 {
+            sem_signal(&sem);
+        }
+        for _ in 0..5 {
+            sem_wait(&sem);
+        }
+        assert_eq!(sem.load(Ordering::Acquire), 0);
+        assert!(!sem_try_take(&sem));
+    }
+}

--- a/patina_mm_supervisor/src/smrr.rs
+++ b/patina_mm_supervisor/src/smrr.rs
@@ -13,9 +13,9 @@
 //! SPDX-License-Identifier: Apache-2.0
 //!
 
-use crate::cpu::CPUID_VERSION_INFO;
-use crate::cpu::read_msr;
-use crate::cpu::write_msr;
+use crate::intrinsics::CPUID_VERSION_INFO;
+use crate::intrinsics::read_msr;
+use crate::intrinsics::write_msr;
 use core::arch::x86_64::__cpuid;
 
 const SIZE_4KB: u32 = 0x0000_1000;

--- a/patina_mm_supervisor/src/supervisor_handlers/supv_request/fetch_policy.rs
+++ b/patina_mm_supervisor/src/supervisor_handlers/supv_request/fetch_policy.rs
@@ -14,9 +14,9 @@ use patina::{
 };
 
 use crate::{
+    intrinsics::read_cr3,
     is_buffer_inside_mmram,
     mm_policy::{MemDescriptorV1_0, PolicyError, PolicyGate},
-    read_cr3,
     state::security_state,
 };
 

--- a/patina_mm_supervisor/src/supervisor_handlers/system_handlers.rs
+++ b/patina_mm_supervisor/src/supervisor_handlers/system_handlers.rs
@@ -12,7 +12,8 @@
 use r_efi::efi;
 
 use crate::{
-    is_buffer_inside_mmram, read_cr3,
+    intrinsics::read_cr3,
+    is_buffer_inside_mmram,
     state::{init_state, security_state},
 };
 


### PR DESCRIPTION
## Description

Break up lib.rs and cpu.rs into single responsibility modules and consolidate
low-level architectural helpers:

- Add intrinsics.rs for x86_64 wrappers
- Extract comm_buffer.rs/request_target.rs/page_ownership.rs.
- Extract semaphore.rs out of cpu.rs.
- No functional changes
----
- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

`cargo make build-supervisor`

## Integration Instructions

NA