### PR TITLE
[feature/supv] Add the support of programming MSEG during each core initialization

### DIFF
--- a/patina_mm_supervisor/src/entry_point.asm
+++ b/patina_mm_supervisor/src/entry_point.asm
@@ -12,6 +12,15 @@
 .global rust_main
 .global efi_main
 
+# Mark efi_main as an external function in the COFF symbol table (.scl 2 == external,
+# .type 32 == DT_FUNCTION). Without this the linker emits efi_main as an S_PUB32 record
+# with no function flag, and PDB consumers that only accept function publics (the SEA
+# gen_aux tool) cannot resolve it.
+.def efi_main
+    .scl 2
+    .type 32
+.endef
+
 .align 8
 # Shim layer that redefines the contract between runtime module and init.
 efi_main:

--- a/patina_mm_supervisor/src/init.rs
+++ b/patina_mm_supervisor/src/init.rs
@@ -31,6 +31,7 @@ use crate::{
     AllocationType, CommBufferConfig, MmSupervisorCore, PageOwnership, PlatformInfo, SharedPagingAllocator,
     intrinsics::read_cr3,
     is_buffer_inside_mmram,
+    mem::page_allocator::SmramDescriptor,
     mem::{self, page_allocator::coalesced_smrr_range},
     mm_policy::{self, MemDescriptorV1_0, dump_policy, gate::PolicyGate, walk_page_table},
     query_address_ownership,
@@ -69,6 +70,16 @@ pub enum PolicyInitError {
 
 /// Offset from SMBASE where the SMI handler code is located.
 const SMM_HANDLER_OFFSET: u64 = 0x8000;
+
+/// MSR index for `IA32_SMM_MONITOR_CTL`, which holds the MSEG base used to
+/// activate the dual-monitor treatment (Intel SDM Vol. 4).
+const IA32_SMM_MONITOR_CTL: u32 = 0x9b;
+
+/// `IA32_SMM_MONITOR_CTL.Valid` (bit 0). An STM may only be invoked when set.
+const SMM_MONITOR_CTL_VALID: u64 = 1;
+
+/// `IA32_SMM_MONITOR_CTL.MsegBase` (bits 31:12).
+const SMM_MONITOR_CTL_MSEG_BASE_MASK: u64 = 0xffff_f000;
 
 /// Index into the Fixup64 array for the SMI handler IDTR pointer.
 const FIXUP64_SMI_HANDLER_IDTR: usize = 5;
@@ -501,12 +512,36 @@ impl<P: PlatformInfo, const MAX_CPUS: usize> MmSupervisorCore<P, MAX_CPUS> {
         let core_type = if is_bsp { "BSP" } else { "AP" };
         log::trace!("{} (CPU {}) performing per-core initialization...", core_type, cpu_id);
 
+        // IA32_SMM_MONITOR_CTL is per-logical-processor, so every core programs it.
+        Self::program_mseg_base(cpu_id);
+
         let range =
             init_state().smrr_range().expect("SMRR range must be determined during BSP init before per-core init");
         smrr_initialize(range);
         configure_smm_code_access();
 
         log::trace!("{} (CPU {}) per-core initialization complete.", core_type, cpu_id);
+    }
+
+    /// Programs this logical processor's `IA32_SMM_MONITOR_CTL` with the MSEG base.
+    ///
+    /// The MSEG base discovered from the MSEG SMRAM HOB is written along with the
+    /// Valid bit so an STM can later be activated, and so software can read the region back.
+    ///
+    /// No-op when the platform publishes no MSEG SMRAM HOB.
+    fn program_mseg_base(cpu_id: u32) {
+        let Some(mseg_base) = init_state().mseg_base() else {
+            return;
+        };
+
+        let value = (mseg_base & SMM_MONITOR_CTL_MSEG_BASE_MASK) | SMM_MONITOR_CTL_VALID;
+
+        // SAFETY: IA32_SMM_MONITOR_CTL is an architectural MSR available whenever VMX is
+        // reported by CPUID.01H:ECX.VMX. Only the architecturally defined Valid and MsegBase
+        // fields are set; reserved bits are masked off above, so the write cannot #GP on a
+        // reserved-bit violation. The write affects only this logical processor's MSR.
+        unsafe { crate::cpu::write_msr(IA32_SMM_MONITOR_CTL, value) };
+        log::debug!("CPU {} programmed IA32_SMM_MONITOR_CTL = 0x{:x}", cpu_id, value);
     }
 
     /// Discovers the MM Supervisor User module entry point from the HOB list.
@@ -597,6 +632,18 @@ impl<P: PlatformInfo, const MAX_CPUS: usize> MmSupervisorCore<P, MAX_CPUS> {
             .ok_or(PolicyInitError::HobNotFound)?;
         security_state().set_save_state_info(SaveStateInfo { number_of_cpus, processor_info, sm_base });
         log::info!("Save-state metadata initialized for {} CPU(s)", number_of_cpus);
+
+        // 1b-ii. Process the MSEG SMRAM HOB (`gMsegSmramGuid`), if published. It carries the
+        //        MSEG region reserved for an STM. Each core programs the base into
+        //        IA32_SMM_MONITOR_CTL during per-core init. Platforms without STM/SEA
+        //        integration do not publish this HOB, so its absence is not an error.
+        match find_guid_hob(hob_list_info, crate::MSEG_SMRAM_HOB_GUID).and_then(parse_mseg_smram_hob) {
+            Some(mseg_base) => {
+                init_state().set_mseg_base(mseg_base);
+                log::info!("MSEG base 0x{:x} discovered from MSEG SMRAM HOB", mseg_base);
+            }
+            _ => panic!("No usable MSEG SMRAM HOB; IA32_SMM_MONITOR_CTL will not be programmed"),
+        }
 
         // 1c. Patch every core's SMI-handler IDT descriptor to the Rust IDT now that the
         //     CPU count is known (the SMI entry blocks were already copied per SMBASE, so
@@ -818,6 +865,33 @@ fn find_guid_hob(hob_list_info: &PhaseHandoffInformationTable, target_guid: pati
         }
     }
     None
+}
+
+/// Parses the MSEG SMRAM HOB payload (`gMsegSmramGuid`), a single
+/// [`SmramDescriptor`] describing the MSEG region carved out of SMRAM.
+///
+/// Returns the MSEG base address, or `None` if the region is empty.
+fn parse_mseg_smram_hob(data: &[u8]) -> Option<u64> {
+    // `read_from_prefix` validates the length and copies the bytes out, so it imposes no
+    // alignment or validity precondition on the HOB buffer and needs no `unsafe`.
+    let (descriptor, _) = SmramDescriptor::read_from_prefix(data)
+        .inspect_err(|_| {
+            log::error!("MSEG SMRAM HOB too small: {} < {}", data.len(), core::mem::size_of::<SmramDescriptor>())
+        })
+        .ok()?;
+
+    if descriptor.physical_size == 0 {
+        log::warn!("MSEG SMRAM HOB describes an empty region");
+        return None;
+    }
+
+    let base = descriptor.cpu_start;
+    if base & !SMM_MONITOR_CTL_MSEG_BASE_MASK != 0 {
+        log::error!("MSEG base 0x{:x} is not 4 KiB aligned or lies above 4 GiB", base);
+        return None;
+    }
+
+    Some(base)
 }
 
 /// Parses an `MP_INFORMATION_HOB_DATA` payload (`gMpInformationHobGuid`).

--- a/patina_mm_supervisor/src/init.rs
+++ b/patina_mm_supervisor/src/init.rs
@@ -1070,3 +1070,51 @@ unsafe fn init_user_comm_buffer(data: &[u8]) -> Result<(u64, u64, u64, u64), Pol
 
     Ok((user_comm_buffer, user_comm_buffer_size, user_comm_buffer_internal, status_buffer))
 }
+
+#[cfg(test)]
+#[cfg_attr(coverage, coverage(off))]
+mod tests {
+    use super::*;
+
+    fn mseg_smram_hob_data(
+        physical_start: u64,
+        cpu_start: u64,
+        physical_size: u64,
+    ) -> [u8; core::mem::size_of::<SmramDescriptor>()] {
+        let mut data = [0; core::mem::size_of::<SmramDescriptor>()];
+        data[0..8].copy_from_slice(&physical_start.to_ne_bytes());
+        data[8..16].copy_from_slice(&cpu_start.to_ne_bytes());
+        data[16..24].copy_from_slice(&physical_size.to_ne_bytes());
+        data
+    }
+
+    #[test]
+    fn test_parse_mseg_smram_hob_returns_cpu_start() {
+        let data = mseg_smram_hob_data(0x0080_0000, 0x0040_0000, 0x0002_0000);
+
+        assert_eq!(parse_mseg_smram_hob(&data), Some(0x0040_0000));
+    }
+
+    #[test]
+    fn test_parse_mseg_smram_hob_rejects_truncated_descriptor() {
+        let data = mseg_smram_hob_data(0x0040_0000, 0x0040_0000, 0x0002_0000);
+
+        assert_eq!(parse_mseg_smram_hob(&data[..data.len() - 1]), None);
+    }
+
+    #[test]
+    fn test_parse_mseg_smram_hob_rejects_empty_region() {
+        let data = mseg_smram_hob_data(0x0040_0000, 0x0040_0000, 0);
+
+        assert_eq!(parse_mseg_smram_hob(&data), None);
+    }
+
+    #[test]
+    fn test_parse_mseg_smram_hob_rejects_invalid_base() {
+        for invalid_base in [0x0040_0001, 0x1_0000_0000] {
+            let data = mseg_smram_hob_data(invalid_base, invalid_base, 0x0002_0000);
+
+            assert_eq!(parse_mseg_smram_hob(&data), None);
+        }
+    }
+}

--- a/patina_mm_supervisor/src/init.rs
+++ b/patina_mm_supervisor/src/init.rs
@@ -29,7 +29,7 @@ use patina_paging::{
 
 use crate::{
     AllocationType, CommBufferConfig, MmSupervisorCore, PageOwnership, PlatformInfo, SharedPagingAllocator,
-    intrinsics::read_cr3,
+    intrinsics::{read_cr3, write_msr},
     is_buffer_inside_mmram,
     mem::page_allocator::SmramDescriptor,
     mem::{self, page_allocator::coalesced_smrr_range},
@@ -540,7 +540,7 @@ impl<P: PlatformInfo, const MAX_CPUS: usize> MmSupervisorCore<P, MAX_CPUS> {
         // reported by CPUID.01H:ECX.VMX. Only the architecturally defined Valid and MsegBase
         // fields are set; reserved bits are masked off above, so the write cannot #GP on a
         // reserved-bit violation. The write affects only this logical processor's MSR.
-        unsafe { crate::cpu::write_msr(IA32_SMM_MONITOR_CTL, value) };
+        unsafe { write_msr(IA32_SMM_MONITOR_CTL, value) };
         log::debug!("CPU {} programmed IA32_SMM_MONITOR_CTL = 0x{:x}", cpu_id, value);
     }
 

--- a/patina_mm_supervisor/src/init.rs
+++ b/patina_mm_supervisor/src/init.rs
@@ -12,6 +12,7 @@
 //!
 
 use core::ffi::c_void;
+use core::arch::x86_64::{__cpuid, CpuidResult};
 
 use patina::{
     UEFI_PAGE_SIZE, align_range,
@@ -29,7 +30,7 @@ use patina_paging::{
 
 use crate::{
     AllocationType, CommBufferConfig, MmSupervisorCore, PageOwnership, PlatformInfo, SharedPagingAllocator,
-    intrinsics::{read_cr3, write_msr},
+    intrinsics::{CPUID_VERSION_INFO, read_cr3, write_msr},
     is_buffer_inside_mmram,
     mem::page_allocator::SmramDescriptor,
     mem::{self, page_allocator::coalesced_smrr_range},
@@ -536,10 +537,20 @@ impl<P: PlatformInfo, const MAX_CPUS: usize> MmSupervisorCore<P, MAX_CPUS> {
 
         let value = (mseg_base & SMM_MONITOR_CTL_MSEG_BASE_MASK) | SMM_MONITOR_CTL_VALID;
 
+        let CpuidResult { ecx, .. } = __cpuid(CPUID_VERSION_INFO);
+        if (ecx & (1 << 5)) == 0 {
+            log::warn!(
+                "CPU {} does not support VMX (CPUID.01H:ECX.VMX=0), cannot program IA32_SMM_MONITOR_CTL",
+                cpu_id
+            );
+            return;
+        }
+
         // SAFETY: IA32_SMM_MONITOR_CTL is an architectural MSR available whenever VMX is
-        // reported by CPUID.01H:ECX.VMX. Only the architecturally defined Valid and MsegBase
-        // fields are set; reserved bits are masked off above, so the write cannot #GP on a
-        // reserved-bit violation. The write affects only this logical processor's MSR.
+        // reported by CPUID.01H:ECX.VMX. After the check above, only the architecturally
+        // defined Valid and MsegBase fields are set; reserved bits are masked off above,
+        // so the write cannot #GP on a reserved-bit violation. The write affects only this
+        // logical processor's MSR.
         unsafe { write_msr(IA32_SMM_MONITOR_CTL_MSR, value) };
         log::debug!("CPU {} programmed IA32_SMM_MONITOR_CTL = 0x{:x}", cpu_id, value);
     }
@@ -642,7 +653,7 @@ impl<P: PlatformInfo, const MAX_CPUS: usize> MmSupervisorCore<P, MAX_CPUS> {
                 init_state().set_mseg_base(mseg_base);
                 log::info!("MSEG base 0x{:x} discovered from MSEG SMRAM HOB", mseg_base);
             }
-            _ => panic!("No usable MSEG SMRAM HOB; IA32_SMM_MONITOR_CTL will not be programmed"),
+            _ => log::warn!("No usable MSEG SMRAM HOB; IA32_SMM_MONITOR_CTL will not be programmed"),
         }
 
         // 1c. Patch every core's SMI-handler IDT descriptor to the Rust IDT now that the

--- a/patina_mm_supervisor/src/init.rs
+++ b/patina_mm_supervisor/src/init.rs
@@ -73,7 +73,7 @@ const SMM_HANDLER_OFFSET: u64 = 0x8000;
 
 /// MSR index for `IA32_SMM_MONITOR_CTL`, which holds the MSEG base used to
 /// activate the dual-monitor treatment (Intel SDM Vol. 4).
-const IA32_SMM_MONITOR_CTL: u32 = 0x9b;
+const IA32_SMM_MONITOR_CTL_MSR: u32 = 0x9b;
 
 /// `IA32_SMM_MONITOR_CTL.Valid` (bit 0). An STM may only be invoked when set.
 const SMM_MONITOR_CTL_VALID: u64 = 1;
@@ -540,7 +540,7 @@ impl<P: PlatformInfo, const MAX_CPUS: usize> MmSupervisorCore<P, MAX_CPUS> {
         // reported by CPUID.01H:ECX.VMX. Only the architecturally defined Valid and MsegBase
         // fields are set; reserved bits are masked off above, so the write cannot #GP on a
         // reserved-bit violation. The write affects only this logical processor's MSR.
-        unsafe { write_msr(IA32_SMM_MONITOR_CTL, value) };
+        unsafe { write_msr(IA32_SMM_MONITOR_CTL_MSR, value) };
         log::debug!("CPU {} programmed IA32_SMM_MONITOR_CTL = 0x{:x}", cpu_id, value);
     }
 

--- a/patina_mm_supervisor/src/init.rs
+++ b/patina_mm_supervisor/src/init.rs
@@ -12,7 +12,6 @@
 //!
 
 use core::ffi::c_void;
-use core::arch::x86_64::{__cpuid, CpuidResult};
 
 use patina::{
     UEFI_PAGE_SIZE, align_range,
@@ -30,7 +29,7 @@ use patina_paging::{
 
 use crate::{
     AllocationType, CommBufferConfig, MmSupervisorCore, PageOwnership, PlatformInfo, SharedPagingAllocator,
-    intrinsics::{CPUID_VERSION_INFO, read_cr3, write_msr},
+    intrinsics::{get_current_cpu_id, read_cr3, write_msr},
     is_buffer_inside_mmram,
     mem::page_allocator::SmramDescriptor,
     mem::{self, page_allocator::coalesced_smrr_range},
@@ -537,8 +536,7 @@ impl<P: PlatformInfo, const MAX_CPUS: usize> MmSupervisorCore<P, MAX_CPUS> {
 
         let value = (mseg_base & SMM_MONITOR_CTL_MSEG_BASE_MASK) | SMM_MONITOR_CTL_VALID;
 
-        let CpuidResult { ecx, .. } = __cpuid(CPUID_VERSION_INFO);
-        if (ecx & (1 << 5)) == 0 {
+        if (get_current_cpu_id().ecx & (1 << 5)) == 0 {
             log::warn!(
                 "CPU {} does not support VMX (CPUID.01H:ECX.VMX=0), cannot program IA32_SMM_MONITOR_CTL",
                 cpu_id

--- a/patina_mm_supervisor/src/intrinsics.rs
+++ b/patina_mm_supervisor/src/intrinsics.rs
@@ -85,14 +85,12 @@ pub unsafe fn write_msr(msr: u32, value: u64) {
 // Depends on the running processor's `cpuid` state, which cannot be exercised
 // deterministically in a host-based unit test.
 #[cfg_attr(coverage, coverage(off))]
-pub fn get_current_cpu_id() -> u32 {
+pub fn get_current_cpu_id() -> CpuidResult {
     // Use CPUID to get the initial APIC ID
-    // CPUID function 0x01, EBX[31:24] contains the initial APIC ID
+    // CPUID function 0x01
 
     // CPUID is always available on x86_64 and `__cpuid` is a safe intrinsic.
-    let CpuidResult { ebx, .. } = __cpuid(CPUID_VERSION_INFO);
-
-    (ebx >> 24) & 0xff
+    __cpuid(CPUID_VERSION_INFO)
 }
 
 /// Checks if the current processor is the Bootstrap Processor (BSP).

--- a/patina_mm_supervisor/src/lib.rs
+++ b/patina_mm_supervisor/src/lib.rs
@@ -116,6 +116,14 @@ pub const MM_SUPV_PASS_DOWN_HOB_GUID: patina::BinaryGuid =
 pub const MP_INFORMATION_HOB_GUID: patina::BinaryGuid =
     patina::BinaryGuid::from_string("ba33f15d-4000-45c1-8e88-f91692d457e3");
 
+// GUID for gMsegSmramGuid (UefiCpuPkg/UefiCpuPkg.dec)
+// { 0x5802bce4, 0xeeee, 0x4e33, { 0xa1, 0x30, 0xeb, 0xad, 0x27, 0xf0, 0xe4, 0x39 } }
+/// GUID for the MSEG SMRAM HOB, which carries the `EFI_SMRAM_DESCRIPTOR` for the
+/// MSEG region carved out of SMRAM for an STM. Only published by platforms that
+/// integrate STM/SEA support.
+pub const MSEG_SMRAM_HOB_GUID: patina::BinaryGuid =
+    patina::BinaryGuid::from_string("5802bce4-eeee-4e33-a130-ebad27f0e439");
+
 /// MM Supervisor PassDown HOB Revision
 pub const MM_SUPV_PASS_DOWN_HOB_REVISION: u32 = 2;
 

--- a/patina_mm_supervisor/src/lib.rs
+++ b/patina_mm_supervisor/src/lib.rs
@@ -321,8 +321,8 @@ impl<P: PlatformInfo, const MAX_CPUS: usize> MmSupervisorCore<P, MAX_CPUS> {
     /// is properly set up. The function will perform basic sanity checks against the incoming parameters
     /// but does not validate the entire system state.
     pub unsafe fn entry_point(&'static self, cpu_index: usize, hob_list: *const c_void) {
-        // Get the current CPU's APIC ID
-        let cpu_id = get_current_cpu_id();
+        // Get the current CPU's APIC ID, EBX[31:24] contains the initial APIC ID
+        let cpu_id = (get_current_cpu_id().ebx >> 24) & 0xff;
 
         // Determine if we're BSP by checking IA32_APIC_BASE MSR
         let is_bsp = is_bsp();

--- a/patina_mm_supervisor/src/mem/page_allocator.rs
+++ b/patina_mm_supervisor/src/mem/page_allocator.rs
@@ -96,7 +96,7 @@ pub enum AllocationType {
 
 /// SMRAM descriptor structure matching EFI_SMRAM_DESCRIPTOR.
 #[repr(C)]
-#[derive(Clone, Copy, Debug, Default)]
+#[derive(Clone, Copy, Debug, Default, zerocopy_derive::FromBytes, zerocopy_derive::Immutable)]
 pub struct SmramDescriptor {
     /// Physical start address of the SMRAM region.
     pub physical_start: efi::PhysicalAddress,

--- a/patina_mm_supervisor/src/state.rs
+++ b/patina_mm_supervisor/src/state.rs
@@ -56,6 +56,9 @@ pub(crate) struct InitState {
     per_core_init_count: AtomicU32,
     /// User module entry point discovered from the HOB list.
     user_entry_point: Once<u64>,
+    /// MSEG base address discovered from the MSEG SMRAM HOB, if the platform
+    /// publishes one. Programmed into `IA32_SMM_MONITOR_CTL` during per-core init.
+    mseg_base: Once<u64>,
     /// Type-erased AP startup dispatch function (conformed for the platform).
     ap_startup_fn: Once<fn(u64, u64, u64) -> u64>,
     /// Set once ExitBootServices has been signaled.
@@ -73,6 +76,7 @@ impl InitState {
             mm_initialized_buffer: Once::new(),
             per_core_init_count: AtomicU32::new(0),
             user_entry_point: Once::new(),
+            mseg_base: Once::new(),
             ap_startup_fn: Once::new(),
             at_runtime: Once::new(),
             smrr_range: Once::new(),
@@ -130,6 +134,16 @@ impl InitState {
     /// Returns the user module entry point, if set.
     pub(crate) fn user_entry_point(&self) -> Option<u64> {
         self.user_entry_point.get().copied()
+    }
+
+    /// Stores the MSEG base address discovered from the MSEG SMRAM HOB (one-time).
+    pub(crate) fn set_mseg_base(&self, base: u64) {
+        self.mseg_base.call_once(|| base);
+    }
+
+    /// Returns the MSEG base address, if the platform published an MSEG SMRAM HOB.
+    pub(crate) fn mseg_base(&self) -> Option<u64> {
+        self.mseg_base.get().copied()
     }
 
     /// Stores the type-erased AP startup function (one-time).


### PR DESCRIPTION
## Description

This change adds a parser for the `MSEG_SMRAM_HOB` so that the SMM can program the MSEG MSR during the first MMI entry.

This change also exposed the `efi_main` to make it discoverable in the PDB file.

- [x] Impacts functionality?
- [x] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

This was tested on a customized QEMU Q35 platform and booted to UEFI shell.

## Integration Instructions

For platforms elect to support SEA, integrate the MSEG prepare PEI into the platform and link the STM based CPU feature library into the MM initializer.
