### PR TITLE
smbios: use r-efi constants

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,7 @@ patina_stacktrace = { version = "23.0.1", path = "core/patina_stacktrace" }
 patina_test = { version = "23.0.1", path = "components/patina_test" }
 proc-macro2 = { version = "1" }
 quote = { version = "1" }
-r-efi = { version = "7", default-features = false }
+r-efi = { version = "7.1", default-features = false }
 scroll = { version = "0.13", default-features = false, features = ["derive"]}
 spin = { version = "0.12" }
 syn = { version = "3" }

--- a/components/patina_smbios/src/manager/protocol.rs
+++ b/components/patina_smbios/src/manager/protocol.rs
@@ -50,7 +50,7 @@ pub(super) struct SmbiosProtocolInternal {
 // SAFETY: SmbiosProtocol implements the SMBIOS protocol interface. The struct layout
 // must match the SMBIOS protocol interface with function pointers in the correct order.
 unsafe impl ProtocolInterface for SmbiosProtocol {
-    const PROTOCOL_GUID: patina::BinaryGuid = patina::BinaryGuid::from_string("03583FF6-CB36-4940-947E-B9B39F4AFAF7");
+    const PROTOCOL_GUID: patina::BinaryGuid = patina::BinaryGuid(efi::protocols::smbios::PROTOCOL_GUID);
 }
 
 type SmbiosAdd =

--- a/components/patina_smbios/src/service.rs
+++ b/components/patina_smbios/src/service.rs
@@ -13,6 +13,9 @@
 extern crate alloc;
 use alloc::vec::Vec;
 use core::cell::Ref;
+pub use patina::standard::efi::industry::smbios::{
+    HANDLE_PI_RESERVED as SMBIOS_HANDLE_PI_RESERVED, STRING_MAX_LENGTH as SMBIOS_STRING_MAX_LENGTH,
+};
 use patina::standard::efi::{self, Handle, SMBIOS3_TABLE_GUID};
 use patina::uefi::boot_services::{BootServices, StandardBootServices};
 use zerocopy_derive::*;
@@ -25,12 +28,6 @@ pub type SmbiosHandle = u16;
 
 /// SMBIOS record type
 pub type SmbiosType = u8;
-
-/// Special handle value for automatic assignment
-pub const SMBIOS_HANDLE_PI_RESERVED: SmbiosHandle = 0xFFFE;
-
-/// SMBIOS string maximum length per specification
-pub const SMBIOS_STRING_MAX_LENGTH: usize = 64;
 
 /// SMBIOS table header structure
 ///


### PR DESCRIPTION
## Description

Require `r-efi` 7.1 and replace the remaining Patina-owned SMBIOS constants with the definitions released upstream in r-efi/r-efi#102.

The existing `SMBIOS_HANDLE_PI_RESERVED` and `SMBIOS_STRING_MAX_LENGTH` public names remain available as re-exports, so downstream Patina users do not need to change imports. The SMBIOS protocol GUID now comes directly from `r_efi::efi::protocols::smbios::PROTOCOL_GUID`.

Tracking: #1457

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [x] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

- `cargo make fmt`
- `cargo make test -p patina_smbios`
- `cargo make check`

## Integration Instructions

N/A
