### PR TITLE
Maintain r-efi under the patina/sdk Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,6 @@ patina_stacktrace = { version = "23.0.1", path = "core/patina_stacktrace" }
 patina_test = { version = "23.0.1", path = "components/patina_test" }
 proc-macro2 = { version = "1" }
 quote = { version = "1" }
-r-efi = { version = "7", default-features = false }
 scroll = { version = "0.13", default-features = false, features = ["derive"]}
 spin = { version = "0.12" }
 syn = { version = "3" }

--- a/sdk/patina/Cargo.toml
+++ b/sdk/patina/Cargo.toml
@@ -51,7 +51,7 @@ cfg-if = { workspace = true }
 compile-time = { workspace = true }
 goblin = { workspace = true, features = ["pe32", "pe64", "te", "alloc"], optional = true }
 log = { workspace = true }
-r-efi = { workspace = true }
+r-efi = { version = "7.1", default-features = false }
 mockall = { workspace = true, optional = true }
 num-traits = { workspace = true }
 indoc = { workspace = true }


### PR DESCRIPTION
## Description

The Patina SDK re-exports r-efi. The change moves the r-efi crate dependency under its Cargo.toml to clarify that is should only be directly depended on by the Patina SDK.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

- `cargo make all`

## Integration Instructions

- N/A