### PR TITLE
[CHERRY-PICK] SerialLogger: Add opt-in blocking, uncorrupted serial logging (#1702)

### DIFF
--- a/sdk/patina/src/debug/log/serial_logger.rs
+++ b/sdk/patina/src/debug/log/serial_logger.rs
@@ -8,6 +8,7 @@
 //!
 use crate::peripheral::serial::{SerialIO, shared::SharedSerial};
 use core::marker::Send;
+use spin::Mutex;
 
 use super::Format;
 
@@ -25,6 +26,11 @@ where
     target_filters: &'a [(&'a str, log::LevelFilter)],
     max_level: log::LevelFilter,
     format: Format,
+    /// When `true`, [`write_lock`](Self::write_lock) is engaged to serialize each record.
+    blocking: bool,
+    /// Serializes an entire record so the multiple `write_str` fragments of a single message
+    /// cannot interleave with another core's message. Only taken when `blocking` is set.
+    write_lock: Mutex<()>,
 }
 
 impl<'a, S> Logger<'a, S>
@@ -32,13 +38,36 @@ where
     S: SerialIO + Send,
 {
     /// Creates a new logger instance.
+    ///
+    /// Serial acquisition is non-blocking by default: on contention a write fails fast rather
+    /// than waiting. Call [`Logger::with_blocking`] to switch to blocking (lossless) output.
     pub const fn new(
         format: Format,
         target_filters: &'a [(&'a str, log::LevelFilter)],
         max_level: log::LevelFilter,
         serial_port: S,
     ) -> Self {
-        Self { serial_port: SharedSerial::new(serial_port), target_filters, max_level, format }
+        Self {
+            serial_port: SharedSerial::new(serial_port),
+            target_filters,
+            max_level,
+            format,
+            blocking: false,
+            write_lock: Mutex::new(()),
+        }
+    }
+
+    /// Switches the logger to blocking (spinning) serial acquisition, consuming and returning `self`.
+    ///
+    /// In blocking mode, each record is written under a logger-level lock so concurrent cores
+    /// cannot interleave the individual `write_str` fragments of a single message, and the serial
+    /// port itself spins until free instead of failing fast on contention. This guarantees lossless,
+    /// uncorrupted output at the cost of a self deadlock hazard if the same core re-enters the
+    /// logger while already writing a record (e.g. logging from a panic handler mid record).
+    pub fn with_blocking(mut self) -> Self {
+        self.serial_port = self.serial_port.with_blocking();
+        self.blocking = true;
+        self
     }
 }
 
@@ -59,6 +88,9 @@ where
     fn log(&self, record: &log::Record) {
         if self.enabled(record.metadata()) {
             let mut writer = LogWriter { serial_port: &self.serial_port };
+            // In blocking mode, hold the logger-level lock for the whole record so concurrent
+            // cores cannot interleave the multiple `write_str` fragments of a single message.
+            let _guard = self.blocking.then(|| self.write_lock.lock());
             self.format.write(&mut writer, record);
         }
     }
@@ -96,6 +128,7 @@ mod tests {
     use log::{Level, LevelFilter, Log, Metadata};
     use spin::Mutex;
     use std::{string::String, sync::Arc, vec::Vec};
+    use std::thread;
 
     fn metadata(level: Level, target: &str) -> Metadata<'_> {
         Metadata::builder().level(level).target(target).build()
@@ -148,5 +181,59 @@ mod tests {
         let args = format_args!("should be filtered out");
         logger.log(&log::Record::builder().args(args).level(Level::Info).target("test").build());
         logger.flush();
+    }
+
+    #[test]
+    fn test_serial_logger_blocking_writes_intact_record() {
+        let (mock, buffer) = recording_serial();
+        let logger = Logger::new(Format::Standard, &[], LevelFilter::Trace, mock).with_blocking();
+        assert!(logger.blocking);
+
+        let args = format_args!("hello");
+        logger.log(&log::Record::builder().args(args).level(Level::Info).target("test").build());
+        assert_eq!(String::from_utf8(buffer.lock().clone()).expect("valid utf8"), "INFO - hello\r\n");
+    }
+
+    #[test]
+    #[ignore = "Stress test: spawns threads and logs many records; run explicitly with --ignored."]
+    fn test_serial_logger_blocking_concurrent_records_not_interleaved() {
+        // Each record is emitted as several `write_str` fragments (level, separator, message,
+        // terminator). In blocking mode the logger-level `write_lock` must hold for the whole
+        // record so two threads writing concurrently cannot interleave those fragments. We log
+        // two distinct messages from two threads and assert every rendered record is intact -
+        // i.e. the stream is a sequence of whole "A" or "B" records, never a garbled mix.
+        const ITERATIONS: usize = 500;
+
+        let (mock, buffer) = recording_serial();
+        let logger = Logger::new(Format::Standard, &[], LevelFilter::Trace, mock).with_blocking();
+
+        thread::scope(|scope| {
+            for message in ["aaaa", "bbbb"] {
+                let logger = &logger;
+                scope.spawn(move || {
+                    for _ in 0..ITERATIONS {
+                        logger.log(
+                            &log::Record::builder()
+                                .args(format_args!("{message}"))
+                                .level(Level::Info)
+                                .target("test")
+                                .build(),
+                        );
+                    }
+                });
+            }
+        });
+
+        let output = String::from_utf8(buffer.lock().clone()).expect("valid utf8");
+        let (mut a_count, mut b_count) = (0usize, 0usize);
+        for record in output.split_terminator("\r\n") {
+            match record {
+                "INFO - aaaa" => a_count += 1,
+                "INFO - bbbb" => b_count += 1,
+                garbled => panic!("interleaved/garbled record observed: {garbled:?}"),
+            }
+        }
+        assert_eq!(a_count, ITERATIONS, "missing or corrupted 'aaaa' records");
+        assert_eq!(b_count, ITERATIONS, "missing or corrupted 'bbbb' records");
     }
 }

--- a/sdk/patina/src/peripheral/serial/shared.rs
+++ b/sdk/patina/src/peripheral/serial/shared.rs
@@ -19,17 +19,44 @@ use crate::{arch::with_interrupts_disabled, base::error::EfiError, peripheral::s
 /// reentrant. Otherwise, spurious errors may be observed.
 pub struct SharedSerial<T: SerialIO> {
     serial: Mutex<T>,
+    /// When `true`, acquisition blocks (spins) until the port is free instead of failing
+    /// fast on contention. See [`SharedSerial::with_blocking`].
+    blocking: bool,
 }
 
 impl<T: SerialIO> SharedSerial<T> {
     /// Creates a new shared serial port wrapper.
+    ///
+    /// Acquisition is non-blocking: if the port is already held, the operation returns
+    /// [`EfiError::DeviceError`] rather than waiting. Use [`SharedSerial::with_blocking`] for
+    /// lossless output under contention.
     pub const fn new(serial: T) -> Self {
-        SharedSerial { serial: Mutex::new(serial) }
+        SharedSerial { serial: Mutex::new(serial), blocking: false }
+    }
+
+    /// Enables blocking (spinning) acquisition, consuming and returning `self`.
+    ///
+    /// When blocking is enabled, operations spin until the port is available rather than
+    /// returning [`EfiError::DeviceError`] on contention. This guarantees no output is dropped
+    /// under multi-core contention, at the cost of reintroducing a self-deadlock hazard if the
+    /// same core re-enters the port while already holding it (e.g. logging from a panic handler
+    /// mid-write). Prefer [`SharedSerial::new`] unless you specifically need lossless output.
+    pub fn with_blocking(mut self) -> Self {
+        self.blocking = true;
+        self
+    }
+
+    /// Acquire the underlying serial port, honoring the configured blocking behavior.
+    ///
+    /// In blocking mode this spins until the port is free; otherwise it fails fast with
+    /// [`EfiError::DeviceError`] when the port is already held.
+    fn acquire(&self) -> Result<spin::MutexGuard<'_, T, spin::Spin>, EfiError> {
+        if self.blocking { Ok(self.serial.lock()) } else { self.serial.try_lock().ok_or(EfiError::DeviceError) }
     }
     /// Initialize the serial port.
     pub fn init(&self) -> Result<(), EfiError> {
         with_interrupts_disabled(|| {
-            let mut serial = self.serial.try_lock().ok_or(EfiError::DeviceError)?;
+            let mut serial = self.acquire()?;
             serial.init();
             Ok(())
         })
@@ -38,7 +65,7 @@ impl<T: SerialIO> SharedSerial<T> {
     /// Write a buffer to the serial port.
     pub fn write(&self, buffer: &[u8]) -> Result<(), EfiError> {
         with_interrupts_disabled(|| {
-            let mut serial = self.serial.try_lock().ok_or(EfiError::DeviceError)?;
+            let mut serial = self.acquire()?;
             serial.write(buffer);
             Ok(())
         })
@@ -50,7 +77,7 @@ impl<T: SerialIO> SharedSerial<T> {
     /// interrupts. [`SharedSerial::try_read`] should be used in most scenarios.
     pub fn read(&self) -> Result<u8, EfiError> {
         with_interrupts_disabled(|| {
-            let mut serial = self.serial.try_lock().ok_or(EfiError::DeviceError)?;
+            let mut serial = self.acquire()?;
             Ok(serial.read())
         })
     }
@@ -58,7 +85,7 @@ impl<T: SerialIO> SharedSerial<T> {
     /// Try to read a byte from the serial port, returning `None` if no byte is available.
     pub fn try_read(&self) -> Result<Option<u8>, EfiError> {
         with_interrupts_disabled(|| {
-            let mut serial = self.serial.try_lock().ok_or(EfiError::DeviceError)?;
+            let mut serial = self.acquire()?;
             Ok(serial.try_read())
         })
     }


### PR DESCRIPTION
## Description

The existing `SharedSerial` implementation uses non-blocking serial port acquisition and returns `DeviceError` when the port is unavailable. When used by the Rust MM Supervisor, this can result in log messages being dropped, especially when multiple cores attempt to log concurrently.

Add an opt-in blocking mode that lets callers block while acquiring the serial port instead of returning `DeviceError`:

- `SharedSerial::into_blocking()` converts a wrapper to spin (block) on acquisition rather than failing fast on contention.
- `Logger::with_blocking()` enables blocking mode on the serial logger.

Blocking the port alone only makes each individual `write_str` fragment atomic, not a whole record. Because `Format::write()` emits a single log record via multiple `write_str` calls (prefix, level, message, terminator), concurrent cores could still interleave those fragments and produce corrupted lines such as:

    INFO - AP (CPU INFO - AP (CPU 64) exiting holding pen

To fix this, add a logger-level `write_lock` that is held for the entire record when blocking mode is enabled, so a message is emitted atomically with respect to other cores.

```
UEFI_UART: 8/8/2026 12:42:14 AM | INFO - EBS completed successfully.
UEFI_UART: 8/8/2026 12:42:20 AM | INFO - BSP (CPU 0) waiting for APs to arrive...
UEFI_UART: 8/8/2026 12:42:20 AM | INFO - AP (CPU 68) checked in, entering holding pen...
UEFI_UART: 8/8/2026 12:42:20 AM | INFO - AP (CPU 16) checked in, entering holding pen...
UEFI_UART: 8/8/2026 12:42:20 AM | INFO - AP (CPU 24) checked in, entering holding pen...
UEFI_UART: 8/8/2026 12:42:20 AM | INFO - AP (CPU 64) checked in, entering holding pen...
UEFI_UART: 8/8/2026 12:42:20 AM | INFO - AP (CPU 8) checked in, entering holding pen...
UEFI_UART: 8/8/2026 12:42:20 AM | INFO - AP (CPU 66) checked in, entering holding pen...
UEFI_UART: 8/8/2026 12:42:20 AM | INFO - AP (CPU 70) checked in, entering holding pen...
UEFI_UART: 8/8/2026 12:42:20 AM | INFO - All 7 APs arrived
...
UEFI_UART: 8/8/2026 12:42:20 AM | INFO - AP (CPU 8) exiting holding pen
UEFI_UART: 8/8/2026 12:42:20 AM | INFO - AP (CPU 24) exiting holding pen
UEFI_UART: 8/8/2026 12:42:20 AM | INFO - AP (CPU 16) exiting holding pen
UEFI_UART: 8/8/2026 12:42:20 AM | INFO - AP (CPU 64) exiting holding pen
UEFI_UART: 8/8/2026 12:42:20 AM | INFO - AP (CPU 66) exiting holding pen
UEFI_UART: 8/8/2026 12:42:20 AM | INFO - AP (CPU 68) exiting holding pen
UEFI_UART: 8/8/2026 12:42:20 AM | INFO - AP (CPU 70) exiting holding pen
```

Existing consumers continue to use the default `new()` constructor and retain the current non-blocking, best-effort (lossy) behavior, making this change non-breaking. Consumers with use cases that require guaranteed, uncorrupted logging, such as the Rust MM Supervisor, can opt in through `with_blocking()`.

Note: blocking mode reintroduces a self-deadlock hazard if the same core re-enters the logger/port while already writing a record (e.g. logging from a panic handler mid-write); it is intended for opt-in use where guaranteed logging outweighs that risk.

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [x] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Validated on physical platforms.

## Integration Instructions

NA

(cherry picked from commit 213f689676b35cc177df92b3ac552231a491eff7)
