### PR TITLE
[feature/supv] Guard save state result write inside SMAP disable routine

### DIFF
--- a/core/patina_internal_cpu/Cargo.toml
+++ b/core/patina_internal_cpu/Cargo.toml
@@ -20,6 +20,8 @@ spin = { workspace = true, features = ["rwlock"] }
 patina_paging = { workspace = true }
 cfg-if = { workspace = true }
 patina_stacktrace = { workspace = true }
+zerocopy = { workspace = true }
+zerocopy-derive = { workspace = true }
 
 [target.'cfg(all(target_arch="x86_64"))'.dependencies]
 patina_mtrr = { workspace = true }

--- a/core/patina_internal_cpu/src/save_state.rs
+++ b/core/patina_internal_cpu/src/save_state.rs
@@ -42,6 +42,8 @@ pub mod intel;
 
 pub mod amd;
 
+use zerocopy_derive::{Immutable, IntoBytes};
+
 /// `EFI_MM_SAVE_STATE_REGISTER` values from the PI Specification.
 ///
 /// These correspond to the registers that can be read from the SMRAM save
@@ -281,16 +283,20 @@ pub struct ParsedIoInfo {
 /// `EFI_MM_SAVE_STATE_IO_INFO` — written to the user buffer when reading
 /// the IO pseudo-register.
 #[repr(C)]
-#[derive(Debug, Clone, Copy, Default)]
+#[derive(Debug, Clone, Copy, Default, IntoBytes, Immutable)]
 pub struct MmSaveStateIoInfo {
     /// I/O data value (from RAX, zero-extended).
     pub io_data: u64,
     /// I/O port address.
     pub io_port: u16,
+    /// Explicit padding required by the C ABI.
+    pub _pad0: [u8; 2],
     /// I/O width enum (`EFI_MM_SAVE_STATE_IO_WIDTH`).
     pub io_width: u32,
     /// I/O type enum (`EFI_MM_SAVE_STATE_IO_TYPE`).
     pub io_type: u32,
+    /// Explicit trailing padding required by the C ABI.
+    pub _pad1: [u8; 4],
 }
 
 const _: () = assert!(core::mem::size_of::<MmSaveStateIoInfo>() == IO_INFO_SIZE);
@@ -392,8 +398,15 @@ mod tests {
         assert_eq!(core::mem::size_of::<MmSaveStateIoInfo>(), 24);
         assert_eq!(core::mem::offset_of!(MmSaveStateIoInfo, io_data), 0);
         assert_eq!(core::mem::offset_of!(MmSaveStateIoInfo, io_port), 8);
+        assert_eq!(core::mem::offset_of!(MmSaveStateIoInfo, _pad0), 10);
         assert_eq!(core::mem::offset_of!(MmSaveStateIoInfo, io_width), 12);
         assert_eq!(core::mem::offset_of!(MmSaveStateIoInfo, io_type), 16);
+        assert_eq!(core::mem::offset_of!(MmSaveStateIoInfo, _pad1), 20);
+
+        let info = MmSaveStateIoInfo { io_data: 0, io_port: 0, _pad0: [0; 2], io_width: 0, io_type: 0, _pad1: [0; 4] };
+        let bytes = zerocopy::IntoBytes::as_bytes(&info);
+        assert_eq!(&bytes[10..12], &[0; 2]);
+        assert_eq!(&bytes[20..24], &[0; 4]);
     }
 
     /// Verifies the active-vendor dispatch resolves to AMD only when

--- a/patina_mm_supervisor/src/runtime.rs
+++ b/patina_mm_supervisor/src/runtime.rs
@@ -72,9 +72,7 @@ unsafe fn enable_smap() {
 
 /// Keeps SMAP disabled while the guard is alive and restores it when dropped.
 #[must_use = "SMAP is re-enabled when the guard is dropped"]
-struct UserAccessGuard {
-    _private: (),
-}
+struct UserAccessGuard;
 
 impl UserAccessGuard {
     /// Disables SMAP until the returned guard is dropped.
@@ -86,7 +84,7 @@ impl UserAccessGuard {
     unsafe fn new() -> Self {
         // SAFETY: the caller upholds the user-memory access requirements for the guard's lifetime.
         unsafe { disable_smap() };
-        Self { _private: () }
+        Self
     }
 }
 

--- a/patina_mm_supervisor/src/runtime.rs
+++ b/patina_mm_supervisor/src/runtime.rs
@@ -70,19 +70,40 @@ unsafe fn enable_smap() {
     }
 }
 
-/// Runs `access` with SMAP temporarily disabled so the supervisor can read or
-/// write user-owned memory, restoring SMAP protection when it returns.
-pub(crate) fn with_user_access<R>(access: impl FnOnce() -> R) -> R {
-    // SAFETY: `disable_smap`/`enable_smap` are called as a balanced pair around `access`,
-    // upholding the invariant that SMAP protection is always restored before returning. The
-    // caller of `with_user_access` is responsible for ensuring `access` only touches valid,
-    // correctly-owned user memory while SMAP is lifted.
-    unsafe {
-        disable_smap();
-        let result = access();
-        enable_smap();
-        result
+/// Keeps SMAP disabled while the guard is alive and restores it when dropped.
+#[must_use = "SMAP is re-enabled when the guard is dropped"]
+struct UserAccessGuard {
+    _private: (),
+}
+
+impl UserAccessGuard {
+    /// Disables SMAP until the returned guard is dropped.
+    ///
+    /// ## Safety
+    ///
+    /// The guarded scope must only access valid, correctly-owned user memory. Guards must
+    /// not be nested, and the guard must remain on the CPU where it was created.
+    unsafe fn new() -> Self {
+        // SAFETY: the caller upholds the user-memory access requirements for the guard's lifetime.
+        unsafe { disable_smap() };
+        Self { _private: () }
     }
+}
+
+impl Drop for UserAccessGuard {
+    fn drop(&mut self) {
+        // SAFETY: this guard can only be constructed by `new`, which disables SMAP once.
+        unsafe { enable_smap() };
+    }
+}
+
+/// Runs `access` with SMAP temporarily disabled so the supervisor can read or
+/// write user-owned memory, restoring SMAP protection when the guard is dropped.
+pub(crate) fn with_user_access<R>(access: impl FnOnce() -> R) -> R {
+    // SAFETY: the closure is scoped to the guard's lifetime, and callers are responsible
+    // for ensuring it only accesses valid, correctly-owned user memory.
+    let _user_access = unsafe { UserAccessGuard::new() };
+    access()
 }
 
 impl<P: PlatformInfo, const MAX_CPUS: usize> MmSupervisorCore<P, MAX_CPUS> {

--- a/patina_mm_supervisor/src/runtime.rs
+++ b/patina_mm_supervisor/src/runtime.rs
@@ -72,7 +72,7 @@ unsafe fn enable_smap() {
 
 /// Runs `access` with SMAP temporarily disabled so the supervisor can read or
 /// write user-owned memory, restoring SMAP protection when it returns.
-fn with_user_access<R>(access: impl FnOnce() -> R) -> R {
+pub(crate) fn with_user_access<R>(access: impl FnOnce() -> R) -> R {
     // SAFETY: `disable_smap`/`enable_smap` are called as a balanced pair around `access`,
     // upholding the invariant that SMAP protection is always restored before returning. The
     // caller of `with_user_access` is responsible for ensuring `access` only touches valid,

--- a/patina_mm_supervisor/src/save_state.rs
+++ b/patina_mm_supervisor/src/save_state.rs
@@ -192,7 +192,7 @@ pub fn save_state_read_phase2(protocol: u64, width: u64, buffer: u64) -> Syscall
     }
 
     let mut out = [0u8; IO_INFO_SIZE];
-    let out = &mut out[..write_size];
+    let out = out.get_mut(..write_size).ok_or(Status::BUFFER_TOO_SMALL)?;
 
     // Special case: PROCESSOR_ID — always allowed, no policy check
     if register == MmSaveStateRegister::ProcessorId {
@@ -555,10 +555,12 @@ fn read_io_register(view: &SaveStateView, out: &mut [u8]) -> SyscallResult {
     let io_port = core::mem::offset_of!(MmSaveStateIoInfo, io_port);
     let io_width = core::mem::offset_of!(MmSaveStateIoInfo, io_width);
     let io_type = core::mem::offset_of!(MmSaveStateIoInfo, io_type);
-    out[..8].copy_from_slice(&io_info.io_data.to_le_bytes());
-    out[io_port..io_port + 2].copy_from_slice(&io_info.io_port.to_le_bytes());
-    out[io_width..io_width + 4].copy_from_slice(&io_info.io_width.to_le_bytes());
-    out[io_type..io_type + 4].copy_from_slice(&io_info.io_type.to_le_bytes());
+    out.get_mut(..8).ok_or(Status::BUFFER_TOO_SMALL)?.copy_from_slice(&io_info.io_data.to_le_bytes());
+    out.get_mut(io_port..io_port + 2).ok_or(Status::BUFFER_TOO_SMALL)?.copy_from_slice(&io_info.io_port.to_le_bytes());
+    out.get_mut(io_width..io_width + 4)
+        .ok_or(Status::BUFFER_TOO_SMALL)?
+        .copy_from_slice(&io_info.io_width.to_le_bytes());
+    out.get_mut(io_type..io_type + 4).ok_or(Status::BUFFER_TOO_SMALL)?.copy_from_slice(&io_info.io_type.to_le_bytes());
 
     Ok(0)
 }

--- a/patina_mm_supervisor/src/save_state.rs
+++ b/patina_mm_supervisor/src/save_state.rs
@@ -197,11 +197,8 @@ pub fn save_state_read_phase2(protocol: u64, width: u64, buffer: u64) -> Syscall
     // Special case: PROCESSOR_ID — always allowed, no policy check
     if register == MmSaveStateRegister::ProcessorId {
         read_processor_id(cpu_index, out)?;
-        with_user_access(|| {
-            // SAFETY: `buffer` was validated above as a user-owned.
-            // `out` is an equally sized, non-overlapping supervisor stack buffer, and SMAP is masked here.
-            unsafe { core::ptr::copy_nonoverlapping(out.as_ptr(), buffer as *mut u8, out.len()) };
-        });
+        // SAFETY: `buffer` was validated above as a user-owned region of at least `out.len()` bytes.
+        unsafe { copy_to_user(buffer as *mut u8, out) };
         return Ok(0);
     }
 
@@ -250,11 +247,8 @@ pub fn save_state_read_phase2(protocol: u64, width: u64, buffer: u64) -> Syscall
         _ => read_architectural_register(&view, register, width, out),
     }?;
 
-    with_user_access(|| {
-        // SAFETY: `buffer` was validated above as a user-owned.
-        // `out` is an equally sized, non-overlapping supervisor stack buffer, and SMAP is masked here.
-        unsafe { core::ptr::copy_nonoverlapping(out.as_ptr(), buffer as *mut u8, out.len()) };
-    });
+    // SAFETY: `buffer` was validated above as a user-owned region of at least `out.len()` bytes.
+    unsafe { copy_to_user(buffer as *mut u8, out) };
 
     Ok(0)
 }
@@ -389,6 +383,19 @@ fn actual_write_size(register: MmSaveStateRegister, width: u64) -> usize {
             }
         }
     }
+}
+
+/// Copies a staged save-state result into a validated user buffer while SMAP is disabled.
+///
+/// ## Safety
+///
+/// `buffer` must reference a writable user-owned region of at least `out.len()` bytes and
+/// must not overlap `out`.
+unsafe fn copy_to_user(buffer: *mut u8, out: &[u8]) {
+    with_user_access(|| {
+        // SAFETY: guaranteed by the caller's contract; SMAP is disabled for this copy.
+        unsafe { core::ptr::copy_nonoverlapping(out.as_ptr(), buffer, out.len()) };
+    });
 }
 
 /// Reads the PROCESSOR_ID for a given CPU and writes it to the user buffer.
@@ -635,6 +642,52 @@ mod tests {
         assert_eq!(actual_write_size(MmSaveStateRegister::Rax, 4), 4);
         assert_eq!(actual_write_size(MmSaveStateRegister::Rax, 8), 8);
         assert_eq!(actual_write_size(MmSaveStateRegister::Rax, 16), 0);
+    }
+
+    #[test]
+    fn test_save_state_copy_to_user() {
+        let source = [0x12, 0x34, 0x56, 0x78];
+        let mut destination = [0u8; 4];
+
+        // SAFETY: `destination` is writable, exactly `source.len()` bytes, and does not overlap `source`.
+        unsafe { copy_to_user(destination.as_mut_ptr(), &source) };
+
+        assert_eq!(destination, source);
+    }
+
+    #[test]
+    fn test_save_state_io_register_serialization() {
+        const IO_PORT: u16 = 0xB2;
+        const IO_DATA: u8 = 0x5A;
+
+        let constants = save_state::vendor_constants();
+        let mut save_state_bytes = Box::new([0u8; SMRAM_SAVE_STATE_MAP_SIZE as usize]);
+        let revision = constants.min_rev_id_io;
+        save_state_bytes[constants.smmrevid_offset as usize..constants.smmrevid_offset as usize + 4]
+            .copy_from_slice(&revision.to_le_bytes());
+
+        // This encodes a valid one-byte IN for both the Intel and AMD save-state layouts.
+        let io_field = ((IO_PORT as u32) << 16) | (1 << 4) | (1 << 1) | 1;
+        save_state_bytes[constants.io_info_offset as usize..constants.io_info_offset as usize + 4]
+            .copy_from_slice(&io_field.to_le_bytes());
+        save_state_bytes[constants.rax_offset as usize] = IO_DATA;
+
+        // SAFETY: the boxed save-state map remains alive and immutable while `view` is used.
+        let view = unsafe { SaveStateView::new(save_state_bytes.as_ptr(), save_state_bytes.len()) };
+        let mut out = [0xFF; IO_INFO_SIZE];
+
+        assert_eq!(read_io_register(&view, &mut out), Ok(0));
+
+        let parsed = save_state::parse_io_field(io_field).unwrap();
+        let io_port = core::mem::offset_of!(MmSaveStateIoInfo, io_port);
+        let io_width = core::mem::offset_of!(MmSaveStateIoInfo, io_width);
+        let io_type = core::mem::offset_of!(MmSaveStateIoInfo, io_type);
+        assert_eq!(u64::from_le_bytes(out[..8].try_into().unwrap()), IO_DATA as u64);
+        assert_eq!(u16::from_le_bytes(out[io_port..io_port + 2].try_into().unwrap()), IO_PORT);
+        assert_eq!(u32::from_le_bytes(out[io_width..io_width + 4].try_into().unwrap()), parsed.io_width);
+        assert_eq!(u32::from_le_bytes(out[io_type..io_type + 4].try_into().unwrap()), parsed.io_type);
+        assert!(out[io_port + 2..io_width].iter().all(|byte| *byte == 0));
+        assert!(out[io_type + 4..].iter().all(|byte| *byte == 0));
     }
 
     #[test]

--- a/patina_mm_supervisor/src/save_state.rs
+++ b/patina_mm_supervisor/src/save_state.rs
@@ -39,7 +39,10 @@ use patina_internal_cpu::save_state::{
     MmSaveStateRegister, PROCESSOR_INFO_ENTRY_SIZE,
 };
 
-use crate::{PageOwnership, privilege_mgmt::SyscallResult, query_address_ownership, state::security_state};
+use crate::{
+    PageOwnership, privilege_mgmt::SyscallResult, query_address_ownership, runtime::with_user_access,
+    state::security_state,
+};
 
 /// Size in bytes of one `SMRAM_SAVE_STATE_MAP` region.
 ///
@@ -188,17 +191,18 @@ pub fn save_state_read_phase2(protocol: u64, width: u64, buffer: u64) -> Syscall
         }
     }
 
-    // Create a single mutable slice over the validated user output buffer so the
-    // individual read handlers write through safe slice operations.
-    //
-    // SAFETY: `buffer` was validated above as a user-owned, writable region of
-    // at least `write_size` bytes.  User code is not executing concurrently
-    // while the supervisor services this syscall, so there is no aliasing.
-    let out = unsafe { core::slice::from_raw_parts_mut(buffer as *mut u8, write_size) };
+    let mut out = [0u8; IO_INFO_SIZE];
+    let out = &mut out[..write_size];
 
     // Special case: PROCESSOR_ID — always allowed, no policy check
     if register == MmSaveStateRegister::ProcessorId {
-        return read_processor_id(cpu_index, out);
+        read_processor_id(cpu_index, out)?;
+        with_user_access(|| {
+            // SAFETY: `buffer` was validated above as a user-owned.
+            // `out` is an equally sized, non-overlapping supervisor stack buffer, and SMAP is masked here.
+            unsafe { core::ptr::copy_nonoverlapping(out.as_ptr(), buffer as *mut u8, out.len()) };
+        });
+        return Ok(0);
     }
 
     // Build a safe view over this CPU's save state region.
@@ -244,7 +248,15 @@ pub fn save_state_read_phase2(protocol: u64, width: u64, buffer: u64) -> Syscall
         MmSaveStateRegister::Io => read_io_register(&view, out),
         MmSaveStateRegister::Lma => read_lma_register(&view, width, out),
         _ => read_architectural_register(&view, register, width, out),
-    }
+    }?;
+
+    with_user_access(|| {
+        // SAFETY: `buffer` was validated above as a user-owned.
+        // `out` is an equally sized, non-overlapping supervisor stack buffer, and SMAP is masked here.
+        unsafe { core::ptr::copy_nonoverlapping(out.as_ptr(), buffer as *mut u8, out.len()) };
+    });
+
+    Ok(0)
 }
 
 /// Returns the per-CPU save-state metadata captured at initialization.
@@ -535,17 +547,18 @@ fn read_io_register(view: &SaveStateView, out: &mut [u8]) -> SyscallResult {
         }
     };
 
-    // 4. Serialize the EFI_MM_SAVE_STATE_IO_INFO structure into the output
-    //    buffer by writing the whole #[repr(C)] struct at once.
+    // 4. Serialize the EFI_MM_SAVE_STATE_IO_INFO structure into the output buffer.
     let io_info =
         MmSaveStateIoInfo { io_data, io_port: parsed.io_port, io_width: parsed.io_width, io_type: parsed.io_type };
-
-    // SAFETY: `out` was validated as a user owned, writable region of at least
-    // `IO_INFO_SIZE` bytes, which equals `size_of::<MmSaveStateIoInfo>()`.
-    // `write_unaligned` accounts for the buffer's unknown alignment.
-    unsafe {
-        core::ptr::write_unaligned(out.as_mut_ptr() as *mut MmSaveStateIoInfo, io_info);
-    }
+    let out = out.get_mut(..IO_INFO_SIZE).ok_or(Status::BUFFER_TOO_SMALL)?;
+    out.fill(0);
+    let io_port = core::mem::offset_of!(MmSaveStateIoInfo, io_port);
+    let io_width = core::mem::offset_of!(MmSaveStateIoInfo, io_width);
+    let io_type = core::mem::offset_of!(MmSaveStateIoInfo, io_type);
+    out[..8].copy_from_slice(&io_info.io_data.to_le_bytes());
+    out[io_port..io_port + 2].copy_from_slice(&io_info.io_port.to_le_bytes());
+    out[io_width..io_width + 4].copy_from_slice(&io_info.io_width.to_le_bytes());
+    out[io_type..io_type + 4].copy_from_slice(&io_info.io_type.to_le_bytes());
 
     Ok(0)
 }

--- a/patina_mm_supervisor/src/save_state.rs
+++ b/patina_mm_supervisor/src/save_state.rs
@@ -38,6 +38,7 @@ use patina_internal_cpu::save_state::{
     self, IA32_EFER_LMA, IO_INFO_SIZE, IO_TYPE_INPUT, IO_TYPE_OUTPUT, LMA_32BIT, LMA_64BIT, MmSaveStateIoInfo,
     MmSaveStateRegister, PROCESSOR_INFO_ENTRY_SIZE,
 };
+use zerocopy::IntoBytes;
 
 use crate::{
     PageOwnership, privilege_mgmt::SyscallResult, query_address_ownership, runtime::with_user_access,
@@ -555,19 +556,16 @@ fn read_io_register(view: &SaveStateView, out: &mut [u8]) -> SyscallResult {
     };
 
     // 4. Serialize the EFI_MM_SAVE_STATE_IO_INFO structure into the output buffer.
-    let io_info =
-        MmSaveStateIoInfo { io_data, io_port: parsed.io_port, io_width: parsed.io_width, io_type: parsed.io_type };
+    let io_info = MmSaveStateIoInfo {
+        io_data,
+        io_port: parsed.io_port,
+        _pad0: [0; 2],
+        io_width: parsed.io_width,
+        io_type: parsed.io_type,
+        _pad1: [0; 4],
+    };
     let out = out.get_mut(..IO_INFO_SIZE).ok_or(Status::BUFFER_TOO_SMALL)?;
-    out.fill(0);
-    let io_port = core::mem::offset_of!(MmSaveStateIoInfo, io_port);
-    let io_width = core::mem::offset_of!(MmSaveStateIoInfo, io_width);
-    let io_type = core::mem::offset_of!(MmSaveStateIoInfo, io_type);
-    out.get_mut(..8).ok_or(Status::BUFFER_TOO_SMALL)?.copy_from_slice(&io_info.io_data.to_le_bytes());
-    out.get_mut(io_port..io_port + 2).ok_or(Status::BUFFER_TOO_SMALL)?.copy_from_slice(&io_info.io_port.to_le_bytes());
-    out.get_mut(io_width..io_width + 4)
-        .ok_or(Status::BUFFER_TOO_SMALL)?
-        .copy_from_slice(&io_info.io_width.to_le_bytes());
-    out.get_mut(io_type..io_type + 4).ok_or(Status::BUFFER_TOO_SMALL)?.copy_from_slice(&io_info.io_type.to_le_bytes());
+    out.copy_from_slice(io_info.as_bytes());
 
     Ok(0)
 }
@@ -679,15 +677,15 @@ mod tests {
         assert_eq!(read_io_register(&view, &mut out), Ok(0));
 
         let parsed = save_state::parse_io_field(io_field).unwrap();
-        let io_port = core::mem::offset_of!(MmSaveStateIoInfo, io_port);
-        let io_width = core::mem::offset_of!(MmSaveStateIoInfo, io_width);
-        let io_type = core::mem::offset_of!(MmSaveStateIoInfo, io_type);
-        assert_eq!(u64::from_le_bytes(out[..8].try_into().unwrap()), IO_DATA as u64);
-        assert_eq!(u16::from_le_bytes(out[io_port..io_port + 2].try_into().unwrap()), IO_PORT);
-        assert_eq!(u32::from_le_bytes(out[io_width..io_width + 4].try_into().unwrap()), parsed.io_width);
-        assert_eq!(u32::from_le_bytes(out[io_type..io_type + 4].try_into().unwrap()), parsed.io_type);
-        assert!(out[io_port + 2..io_width].iter().all(|byte| *byte == 0));
-        assert!(out[io_type + 4..].iter().all(|byte| *byte == 0));
+        let expected = MmSaveStateIoInfo {
+            io_data: IO_DATA as u64,
+            io_port: IO_PORT,
+            _pad0: [0; 2],
+            io_width: parsed.io_width,
+            io_type: parsed.io_type,
+            _pad1: [0; 4],
+        };
+        assert_eq!(out, expected.as_bytes());
     }
 
     #[test]


### PR DESCRIPTION
## Description

This change wraps the current raw memory writes into SMAP disable -> write memory -> reenable SMAP routine.

This will allow us to enable the SMAP from MMI entry block again.

- [x] Impacts functionality?
- [x] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

This was tested on QEMU Q35 platform with artificial save state transactions.

## Integration Instructions

The CR4 value from the MMI entry block can enable SMAP bit now.
