### PR TITLE
SDK: BinaryGuid: Use Guid's Debug Impl

### DIFF
--- a/sdk/patina/src/base/guid.rs
+++ b/sdk/patina/src/base/guid.rs
@@ -202,7 +202,7 @@ pub type OwnedGuid = Guid<'static>;
 /// println!("Header GUID: {}", header.guid.as_guid());
 /// ```
 #[repr(transparent)]
-#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct BinaryGuid(pub efi::Guid);
 
 impl BinaryGuid {
@@ -369,6 +369,13 @@ impl<'a> PartialEq<BinaryGuid> for Guid<'a> {
 
 // Display using Guid's implementation
 impl core::fmt::Display for BinaryGuid {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        self.as_guid().fmt(f)
+    }
+}
+
+// Debug using Guid's implementation
+impl core::fmt::Debug for BinaryGuid {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         self.as_guid().fmt(f)
     }
@@ -1528,8 +1535,8 @@ mod tests {
             BinaryGuid::from_fields(0x550e8400, 0xe29b, 0x41d4, 0xa7, 0x16, &[0x44, 0x66, 0x55, 0x44, 0x00, 0x00]);
         let debug_string = format!("{:?}", binary_guid);
 
-        // Debug should show the full type and inner value
-        assert!(debug_string.contains("BinaryGuid"));
+        // Defers to Guid's Debug impl
+        assert_eq!(debug_string, TEST_GUID_STRING_UPPER);
     }
 
     #[test]


### PR DESCRIPTION
## Description

Currently, BinaryGuid's Display impl uses Guid's Display impl, which is also used by Guid's Debug impl, because splitting out the fields of a GUID is often worse for the reader who wants to see a canonical form GUID for easy visual reading, copying, etc.

However, BinaryGuid derived its Debug impl, which leads to all the fields being printed which is both actively hard to read and doesn't use CRLF, making it very hard to read on some terminal emulators.

This simply makes both scenarios better by having BinaryGuid use Guid's Debug impl to get a better print.

Before this change, print a single GUID looked like this:

<img width="714" height="500" alt="image" src="https://github.com/user-attachments/assets/2f050c1f-3950-444b-be95-0bfc2dea5b2a" />

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

The unit test; on a terminal emulator that doesn't auto CRLF.

## Integration Instructions

N/A.
