### PR TITLE
[feature/supv] Populate processor ID instead of CPU index into `cpu_manager`

### DIFF
--- a/patina_mm_supervisor/src/cpu.rs
+++ b/patina_mm_supervisor/src/cpu.rs
@@ -15,7 +15,7 @@
 //! SPDX-License-Identifier: Apache-2.0
 //!
 
-use core::sync::atomic::{AtomicU8, AtomicU32, AtomicU64, Ordering};
+use core::sync::atomic::{AtomicU8, AtomicU32, Ordering};
 
 use crate::semaphore::{sem_signal, sem_try_take, sem_wait};
 
@@ -48,16 +48,14 @@ impl From<u8> for ApState {
 /// Information about a registered CPU stored in a fixed-size slot.
 #[repr(C)]
 struct CpuSlot {
-    /// The CPU's UEFI ProcessorId (Local APIC ID on x64).
-    processor_id: AtomicU64,
-    /// Whether this CPU has registered in MM (0 = absent, 1 = registered).
-    registered: AtomicU8,
+    /// The CPU's APIC ID. u32::MAX means slot is unused.
+    cpu_id: AtomicU32,
     /// Whether this CPU is the BSP (0 = AP, 1 = BSP).
     is_bsp: AtomicU8,
     /// Current state (for APs only).
     state: AtomicU8,
     /// Padding for alignment.
-    _padding: [u8; 1],
+    _padding: [u8; 2],
     /// Rendezvous semaphore for the SMI exit barrier.
     run: AtomicU32,
 }
@@ -66,28 +64,23 @@ impl CpuSlot {
     /// Creates a new empty CPU slot.
     const fn new() -> Self {
         Self {
-            processor_id: AtomicU64::new(u64::MAX),
-            registered: AtomicU8::new(0),
+            cpu_id: AtomicU32::new(u32::MAX),
             is_bsp: AtomicU8::new(0),
             state: AtomicU8::new(ApState::NotPresent as u8),
-            _padding: [0; 1],
+            _padding: [0; 2],
             run: AtomicU32::new(0),
         }
     }
 
     /// Checks if this slot is in use.
     fn is_used(&self) -> bool {
-        self.registered.load(Ordering::Acquire) != 0
+        self.cpu_id.load(Ordering::Acquire) != u32::MAX
     }
 
     /// Gets the CPU ID if the slot is used.
     fn get_cpu_id(&self) -> Option<u32> {
-        self.get_processor_id()?.try_into().ok()
-    }
-
-    /// Gets the UEFI ProcessorId if the slot is used.
-    fn get_processor_id(&self) -> Option<u64> {
-        if self.is_used() { Some(self.processor_id.load(Ordering::Acquire)) } else { None }
+        let id = self.cpu_id.load(Ordering::Acquire);
+        if id == u32::MAX { None } else { Some(id) }
     }
 }
 
@@ -139,35 +132,27 @@ impl<const MAX_CPUS: usize> CpuManager<MAX_CPUS> {
         }
 
         let slot = self.slots.get(cpu_index)?;
-        let processor_id = u64::from(cpu_id);
-        let expected_processor_id = slot.processor_id.load(Ordering::Acquire);
-        if expected_processor_id == u64::MAX {
-            slot.processor_id.store(processor_id, Ordering::Relaxed);
-        } else if expected_processor_id != processor_id {
-            log::error!(
-                "cpu_index {} expects ProcessorId {}, cannot register APIC {}",
-                cpu_index,
-                expected_processor_id,
-                cpu_id
-            );
-            return None;
-        }
-
-        if slot.is_used() {
-            match slot.get_cpu_id() {
-                Some(existing) if existing == cpu_id => {
-                    // Idempotent re-registration.
-                    log::trace!("CPU {} already registered at index {}", cpu_id, cpu_index);
-                    return Some(cpu_index);
-                }
-                _ => return None,
+        match slot.get_cpu_id() {
+            Some(existing) if existing == cpu_id => {
+                log::trace!("CPU {} already registered at index {}", cpu_id, cpu_index);
+                return Some(cpu_index);
             }
+            Some(existing) => {
+                log::error!(
+                    "cpu_index {} already occupied by APIC {}, cannot register APIC {}",
+                    cpu_index,
+                    existing,
+                    cpu_id
+                );
+                return None;
+            }
+            None => {}
         }
 
         slot.is_bsp.store(if is_bsp { 1 } else { 0 }, Ordering::Release);
         slot.state.store(if is_bsp { ApState::Busy as u8 } else { ApState::NotPresent as u8 }, Ordering::Release);
-        // Publish registration last so readers that observe it also see the fields above.
-        slot.registered.store(1, Ordering::Release);
+        // Publish the CPU ID last so readers that observe it also see the fields above.
+        slot.cpu_id.store(cpu_id, Ordering::Release);
 
         self.registered_count.fetch_add(1, Ordering::SeqCst);
 
@@ -179,27 +164,6 @@ impl<const MAX_CPUS: usize> CpuManager<MAX_CPUS> {
         }
 
         Some(cpu_index)
-    }
-
-    /// Caches a UEFI ProcessorId in its dense CPU-index slot before runtime.
-    pub(crate) fn set_processor_id_by_index(&self, cpu_index: usize, processor_id: u64) -> bool {
-        let Some(slot) = self.slots.get(cpu_index) else {
-            return false;
-        };
-
-        match slot.processor_id.compare_exchange(u64::MAX, processor_id, Ordering::AcqRel, Ordering::Acquire) {
-            Ok(_) => true,
-            Err(existing) if existing == processor_id => true,
-            Err(existing) => {
-                log::error!(
-                    "cpu_index {} already has ProcessorId {}, cannot cache {}",
-                    cpu_index,
-                    existing,
-                    processor_id
-                );
-                false
-            }
-        }
     }
 
     /// Gets the number of registered CPUs.
@@ -243,11 +207,6 @@ impl<const MAX_CPUS: usize> CpuManager<MAX_CPUS> {
     /// Returns `None` if the index is out of range or the slot is unused.
     pub fn get_cpu_id_by_index(&self, index: usize) -> Option<u32> {
         self.slots.get(index)?.get_cpu_id()
-    }
-
-    /// Gets the UEFI ProcessorId of the registered CPU at a slot index.
-    pub fn get_processor_id_by_index(&self, index: usize) -> Option<u64> {
-        self.slots.get(index)?.get_processor_id()
     }
 
     /// Gets the AP state by slot index.
@@ -443,17 +402,6 @@ mod tests {
 
         // A different APIC ID cannot take an already-occupied cpu_index.
         assert_eq!(manager.register_cpu(0x30, 1, false), None);
-    }
-
-    #[test]
-    fn test_processor_id_is_owned_by_registered_slot() {
-        let manager: CpuManager<4> = CpuManager::new();
-
-        assert!(manager.set_processor_id_by_index(2, 0x20));
-        assert_eq!(manager.get_processor_id_by_index(2), None);
-        assert_eq!(manager.register_cpu(0x20, 2, false), Some(2));
-        assert_eq!(manager.get_processor_id_by_index(2), Some(0x20));
-        assert_eq!(manager.register_cpu(0x21, 2, false), None);
     }
 
     #[test]

--- a/patina_mm_supervisor/src/cpu.rs
+++ b/patina_mm_supervisor/src/cpu.rs
@@ -131,9 +131,13 @@ impl<const MAX_CPUS: usize> CpuManager<MAX_CPUS> {
             return None;
         }
 
+        // Each physical CPU owns a distinct, stable `cpu_index`, so this slot is only
+        // ever written by this CPU. That makes the load-check-then-store below safe
+        // without a compare-exchange.
         let slot = self.slots.get(cpu_index)?;
         match slot.get_cpu_id() {
             Some(existing) if existing == cpu_id => {
+                // Idempotent re-registration.
                 log::trace!("CPU {} already registered at index {}", cpu_id, cpu_index);
                 return Some(cpu_index);
             }

--- a/patina_mm_supervisor/src/cpu.rs
+++ b/patina_mm_supervisor/src/cpu.rs
@@ -15,7 +15,7 @@
 //! SPDX-License-Identifier: Apache-2.0
 //!
 
-use core::sync::atomic::{AtomicU8, AtomicU32, Ordering};
+use core::sync::atomic::{AtomicU8, AtomicU32, AtomicU64, Ordering};
 
 use crate::semaphore::{sem_signal, sem_try_take, sem_wait};
 
@@ -48,14 +48,16 @@ impl From<u8> for ApState {
 /// Information about a registered CPU stored in a fixed-size slot.
 #[repr(C)]
 struct CpuSlot {
-    /// The CPU's APIC ID. u32::MAX means slot is unused.
-    cpu_id: AtomicU32,
+    /// The CPU's UEFI ProcessorId (Local APIC ID on x64).
+    processor_id: AtomicU64,
+    /// Whether this CPU has registered in MM (0 = absent, 1 = registered).
+    registered: AtomicU8,
     /// Whether this CPU is the BSP (0 = AP, 1 = BSP).
     is_bsp: AtomicU8,
     /// Current state (for APs only).
     state: AtomicU8,
     /// Padding for alignment.
-    _padding: [u8; 2],
+    _padding: [u8; 1],
     /// Rendezvous semaphore for the SMI exit barrier.
     run: AtomicU32,
 }
@@ -64,23 +66,28 @@ impl CpuSlot {
     /// Creates a new empty CPU slot.
     const fn new() -> Self {
         Self {
-            cpu_id: AtomicU32::new(u32::MAX),
+            processor_id: AtomicU64::new(u64::MAX),
+            registered: AtomicU8::new(0),
             is_bsp: AtomicU8::new(0),
             state: AtomicU8::new(ApState::NotPresent as u8),
-            _padding: [0; 2],
+            _padding: [0; 1],
             run: AtomicU32::new(0),
         }
     }
 
     /// Checks if this slot is in use.
     fn is_used(&self) -> bool {
-        self.cpu_id.load(Ordering::Acquire) != u32::MAX
+        self.registered.load(Ordering::Acquire) != 0
     }
 
     /// Gets the CPU ID if the slot is used.
     fn get_cpu_id(&self) -> Option<u32> {
-        let id = self.cpu_id.load(Ordering::Acquire);
-        if id == u32::MAX { None } else { Some(id) }
+        self.get_processor_id()?.try_into().ok()
+    }
+
+    /// Gets the UEFI ProcessorId if the slot is used.
+    fn get_processor_id(&self) -> Option<u64> {
+        if self.is_used() { Some(self.processor_id.load(Ordering::Acquire)) } else { None }
     }
 }
 
@@ -131,32 +138,36 @@ impl<const MAX_CPUS: usize> CpuManager<MAX_CPUS> {
             return None;
         }
 
-        // Each physical CPU owns a distinct, stable `cpu_index`, so this slot is only
-        // ever written by this CPU. That makes the load-check-then-store below safe
-        // without a compare-exchange.
         let slot = self.slots.get(cpu_index)?;
-        match slot.get_cpu_id() {
-            Some(existing) if existing == cpu_id => {
-                // Idempotent re-registration.
-                log::trace!("CPU {} already registered at index {}", cpu_id, cpu_index);
-                return Some(cpu_index);
+        let processor_id = u64::from(cpu_id);
+        let expected_processor_id = slot.processor_id.load(Ordering::Acquire);
+        if expected_processor_id == u64::MAX {
+            slot.processor_id.store(processor_id, Ordering::Relaxed);
+        } else if expected_processor_id != processor_id {
+            log::error!(
+                "cpu_index {} expects ProcessorId {}, cannot register APIC {}",
+                cpu_index,
+                expected_processor_id,
+                cpu_id
+            );
+            return None;
+        }
+
+        if slot.is_used() {
+            match slot.get_cpu_id() {
+                Some(existing) if existing == cpu_id => {
+                    // Idempotent re-registration.
+                    log::trace!("CPU {} already registered at index {}", cpu_id, cpu_index);
+                    return Some(cpu_index);
+                }
+                _ => return None,
             }
-            Some(existing) => {
-                log::error!(
-                    "cpu_index {} already occupied by APIC {}, cannot register APIC {}",
-                    cpu_index,
-                    existing,
-                    cpu_id
-                );
-                return None;
-            }
-            None => {}
         }
 
         slot.is_bsp.store(if is_bsp { 1 } else { 0 }, Ordering::Release);
         slot.state.store(if is_bsp { ApState::Busy as u8 } else { ApState::NotPresent as u8 }, Ordering::Release);
-        // Publish the CPU ID last so readers that observe it also see the fields above.
-        slot.cpu_id.store(cpu_id, Ordering::Release);
+        // Publish registration last so readers that observe it also see the fields above.
+        slot.registered.store(1, Ordering::Release);
 
         self.registered_count.fetch_add(1, Ordering::SeqCst);
 
@@ -168,6 +179,27 @@ impl<const MAX_CPUS: usize> CpuManager<MAX_CPUS> {
         }
 
         Some(cpu_index)
+    }
+
+    /// Caches a UEFI ProcessorId in its dense CPU-index slot before runtime.
+    pub(crate) fn set_processor_id_by_index(&self, cpu_index: usize, processor_id: u64) -> bool {
+        let Some(slot) = self.slots.get(cpu_index) else {
+            return false;
+        };
+
+        match slot.processor_id.compare_exchange(u64::MAX, processor_id, Ordering::AcqRel, Ordering::Acquire) {
+            Ok(_) => true,
+            Err(existing) if existing == processor_id => true,
+            Err(existing) => {
+                log::error!(
+                    "cpu_index {} already has ProcessorId {}, cannot cache {}",
+                    cpu_index,
+                    existing,
+                    processor_id
+                );
+                false
+            }
+        }
     }
 
     /// Gets the number of registered CPUs.
@@ -211,6 +243,11 @@ impl<const MAX_CPUS: usize> CpuManager<MAX_CPUS> {
     /// Returns `None` if the index is out of range or the slot is unused.
     pub fn get_cpu_id_by_index(&self, index: usize) -> Option<u32> {
         self.slots.get(index)?.get_cpu_id()
+    }
+
+    /// Gets the UEFI ProcessorId of the registered CPU at a slot index.
+    pub fn get_processor_id_by_index(&self, index: usize) -> Option<u64> {
+        self.slots.get(index)?.get_processor_id()
     }
 
     /// Gets the AP state by slot index.
@@ -406,6 +443,17 @@ mod tests {
 
         // A different APIC ID cannot take an already-occupied cpu_index.
         assert_eq!(manager.register_cpu(0x30, 1, false), None);
+    }
+
+    #[test]
+    fn test_processor_id_is_owned_by_registered_slot() {
+        let manager: CpuManager<4> = CpuManager::new();
+
+        assert!(manager.set_processor_id_by_index(2, 0x20));
+        assert_eq!(manager.get_processor_id_by_index(2), None);
+        assert_eq!(manager.register_cpu(0x20, 2, false), Some(2));
+        assert_eq!(manager.get_processor_id_by_index(2), Some(0x20));
+        assert_eq!(manager.register_cpu(0x21, 2, false), None);
     }
 
     #[test]

--- a/patina_mm_supervisor/src/init.rs
+++ b/patina_mm_supervisor/src/init.rs
@@ -273,7 +273,7 @@ impl<P: PlatformInfo, const MAX_CPUS: usize> MmSupervisorCore<P, MAX_CPUS> {
             self.remap_hob_list_to_user(hob_list);
         }
 
-        log::trace!("BSP one-time initialization complete.");
+        log::info!("BSP one-time initialization complete.");
     }
 
     /// Initializes the page and paging allocators from the HOB list.

--- a/patina_mm_supervisor/src/init.rs
+++ b/patina_mm_supervisor/src/init.rs
@@ -661,7 +661,7 @@ impl<P: PlatformInfo, const MAX_CPUS: usize> MmSupervisorCore<P, MAX_CPUS> {
         // 1b. Process the MP Information HOB (`gMpInformationHobGuid`) for the CPU count.
         let mp_information =
             find_guid_hob(hob_list_info, crate::MP_INFORMATION_HOB_GUID).ok_or(PolicyInitError::HobNotFound)?;
-        let number_of_cpus = self.cache_processor_ids(mp_information).ok_or(PolicyInitError::InvalidPolicyData)?;
+        let number_of_cpus = self.parse_mp_information_hob(mp_information).ok_or(PolicyInitError::InvalidPolicyData)?;
         security_state().set_save_state_info(SaveStateInfo { number_of_cpus, sm_base });
         log::info!("Save-state metadata initialized for {} CPU(s)", number_of_cpus);
 
@@ -748,8 +748,8 @@ impl<P: PlatformInfo, const MAX_CPUS: usize> MmSupervisorCore<P, MAX_CPUS> {
         Ok(())
     }
 
-    /// Copies ProcessorId values from the MP Information HOB into the CPU manager.
-    fn cache_processor_ids(&self, data: &[u8]) -> Option<u64> {
+    /// Returns the CPU count from the MP Information HOB.
+    fn parse_mp_information_hob(&self, data: &[u8]) -> Option<u64> {
         /// Offset of `ProcessorInfoBuffer[]` within `MP_INFORMATION_HOB_DATA`.
         const PROCESSOR_INFO_BUFFER_OFFSET: usize = 16;
 
@@ -761,23 +761,11 @@ impl<P: PlatformInfo, const MAX_CPUS: usize> MmSupervisorCore<P, MAX_CPUS> {
         let number_of_cpus = u64::from_le_bytes(data.get(0..8)?.try_into().ok()?);
         let cpu_count: usize = number_of_cpus.try_into().ok()?;
         if cpu_count > MAX_CPUS {
-            panic!(
-                "MP Information HOB CPU count {} exceeds supervisor maximum {}",
-                cpu_count,
-                MAX_CPUS
-            );
+            panic!("MP Information HOB CPU count {} exceeds supervisor maximum {}", cpu_count, MAX_CPUS);
         }
 
         let processor_info_size = cpu_count.checked_mul(PROCESSOR_INFO_ENTRY_SIZE)?;
-        let processor_info =
-            data.get(PROCESSOR_INFO_BUFFER_OFFSET..PROCESSOR_INFO_BUFFER_OFFSET.checked_add(processor_info_size)?)?;
-
-        for (cpu_index, entry) in processor_info.chunks_exact(PROCESSOR_INFO_ENTRY_SIZE).enumerate() {
-            let processor_id = u64::from_le_bytes(entry.get(..8)?.try_into().ok()?);
-            if !self.cpu_manager.set_processor_id_by_index(cpu_index, processor_id) {
-                return None;
-            }
-        }
+        data.get(PROCESSOR_INFO_BUFFER_OFFSET..PROCESSOR_INFO_BUFFER_OFFSET.checked_add(processor_info_size)?)?;
 
         Some(number_of_cpus)
     }
@@ -1123,7 +1111,7 @@ mod tests {
     impl PlatformInfo for TestPlatform {}
 
     #[test]
-    fn test_cache_processor_ids_into_cpu_manager() {
+    fn test_parse_mp_information_hob() {
         let supervisor = MmSupervisorCore::<TestPlatform, 4>::new();
         let processor_ids = [0x00_u64, 0x10, 0x20];
         let mut data = [0_u8; 16 + 3 * PROCESSOR_INFO_ENTRY_SIZE];
@@ -1133,26 +1121,17 @@ mod tests {
             data[offset..offset + 8].copy_from_slice(&processor_id.to_le_bytes());
         }
 
-        assert_eq!(supervisor.cache_processor_ids(&data), Some(3));
-        assert_eq!(supervisor.cpu_manager().get_processor_id_by_index(1), None);
-
-        for (cpu_index, processor_id) in processor_ids.iter().enumerate() {
-            assert_eq!(
-                supervisor.cpu_manager().register_cpu(*processor_id as u32, cpu_index, cpu_index == 0),
-                Some(cpu_index)
-            );
-            assert_eq!(supervisor.cpu_manager().get_processor_id_by_index(cpu_index), Some(*processor_id));
-        }
+        assert_eq!(supervisor.parse_mp_information_hob(&data), Some(3));
     }
 
     #[test]
     #[should_panic(expected = "MP Information HOB CPU count 5 exceeds supervisor maximum 4")]
-    fn test_cache_processor_ids_panics_when_cpu_count_exceeds_maximum() {
+    fn test_parse_mp_information_hob_panics_when_cpu_count_exceeds_maximum() {
         let supervisor = MmSupervisorCore::<TestPlatform, 4>::new();
         let mut data = [0_u8; 16];
         data[..8].copy_from_slice(&5_u64.to_le_bytes());
 
-        let _ = supervisor.cache_processor_ids(&data);
+        let _ = supervisor.parse_mp_information_hob(&data);
     }
 
     fn mseg_smram_hob_data(

--- a/patina_mm_supervisor/src/init.rs
+++ b/patina_mm_supervisor/src/init.rs
@@ -44,7 +44,7 @@ use crate::{
     state::{init_state, security_state},
 };
 
-use patina_internal_cpu::interrupts::Interrupts;
+use patina_internal_cpu::{interrupts::Interrupts, save_state::PROCESSOR_INFO_ENTRY_SIZE};
 use zerocopy::FromBytes;
 use zerocopy_derive::Immutable;
 
@@ -658,12 +658,11 @@ impl<P: PlatformInfo, const MAX_CPUS: usize> MmSupervisorCore<P, MAX_CPUS> {
         // it carries reference live memory as `init_from_pass_down_hob` requires.
         let (sm_base, mmi_entry_size) = unsafe { self.init_from_pass_down_hob(pass_down_data)? };
 
-        // 1b. Process the MP Information HOB (`gMpInformationHobGuid`) for the CPU
-        //     count and the `EFI_PROCESSOR_INFORMATION` array (APIC IDs).
-        let (number_of_cpus, processor_info) = find_guid_hob(hob_list_info, crate::MP_INFORMATION_HOB_GUID)
-            .and_then(parse_mp_information_hob)
-            .ok_or(PolicyInitError::HobNotFound)?;
-        security_state().set_save_state_info(SaveStateInfo { number_of_cpus, processor_info, sm_base });
+        // 1b. Process the MP Information HOB (`gMpInformationHobGuid`) for the CPU count.
+        let mp_information =
+            find_guid_hob(hob_list_info, crate::MP_INFORMATION_HOB_GUID).ok_or(PolicyInitError::HobNotFound)?;
+        let number_of_cpus = self.cache_processor_ids(mp_information).ok_or(PolicyInitError::InvalidPolicyData)?;
+        security_state().set_save_state_info(SaveStateInfo { number_of_cpus, sm_base });
         log::info!("Save-state metadata initialized for {} CPU(s)", number_of_cpus);
 
         // 1b-ii. Process the MSEG SMRAM HOB (`gMsegSmramGuid`), if published. It carries the
@@ -747,6 +746,37 @@ impl<P: PlatformInfo, const MAX_CPUS: usize> MmSupervisorCore<P, MAX_CPUS> {
         );
 
         Ok(())
+    }
+
+    /// Copies ProcessorId values from the MP Information HOB into the CPU manager.
+    fn cache_processor_ids(&self, data: &[u8]) -> Option<u64> {
+        /// Offset of `ProcessorInfoBuffer[]` within `MP_INFORMATION_HOB_DATA`.
+        const PROCESSOR_INFO_BUFFER_OFFSET: usize = 16;
+
+        if data.len() < PROCESSOR_INFO_BUFFER_OFFSET {
+            log::error!("MP Information HOB too small: {} < {}", data.len(), PROCESSOR_INFO_BUFFER_OFFSET);
+            return None;
+        }
+
+        let number_of_cpus = u64::from_le_bytes(data.get(0..8)?.try_into().ok()?);
+        let cpu_count: usize = number_of_cpus.try_into().ok()?;
+        if cpu_count > MAX_CPUS {
+            log::error!("MP Information HOB CPU count {} exceeds supervisor maximum {}", cpu_count, MAX_CPUS);
+            return None;
+        }
+
+        let processor_info_size = cpu_count.checked_mul(PROCESSOR_INFO_ENTRY_SIZE)?;
+        let processor_info =
+            data.get(PROCESSOR_INFO_BUFFER_OFFSET..PROCESSOR_INFO_BUFFER_OFFSET.checked_add(processor_info_size)?)?;
+
+        for (cpu_index, entry) in processor_info.chunks_exact(PROCESSOR_INFO_ENTRY_SIZE).enumerate() {
+            let processor_id = u64::from_le_bytes(entry.get(..8)?.try_into().ok()?);
+            if !self.cpu_manager.set_processor_id_by_index(cpu_index, processor_id) {
+                return None;
+            }
+        }
+
+        Some(number_of_cpus)
     }
 
     /// Processes the MM Supervisor PassDown HOB.
@@ -930,24 +960,6 @@ fn parse_mseg_smram_hob(data: &[u8]) -> Option<u64> {
     Some(base)
 }
 
-/// Parses an `MP_INFORMATION_HOB_DATA` payload (`gMpInformationHobGuid`).
-///
-/// Returns `(number_of_cpus, processor_info_ptr)` where `processor_info_ptr`
-/// points at the first `EFI_PROCESSOR_INFORMATION` entry.
-fn parse_mp_information_hob(data: &[u8]) -> Option<(u64, u64)> {
-    /// Offset of `ProcessorInfoBuffer[]` within `MP_INFORMATION_HOB_DATA`.
-    const PROCESSOR_INFO_BUFFER_OFFSET: usize = 16;
-
-    if data.len() < PROCESSOR_INFO_BUFFER_OFFSET {
-        log::error!("MP Information HOB too small: {} < {}", data.len(), PROCESSOR_INFO_BUFFER_OFFSET);
-        return None;
-    }
-
-    let number_of_cpus = u64::from_le_bytes(data.get(0..8)?.try_into().ok()?);
-    let processor_info = data.get(PROCESSOR_INFO_BUFFER_OFFSET..)?.as_ptr() as u64;
-    Some((number_of_cpus, processor_info))
-}
-
 /// Processes the supervisor communication buffer HOB (`MM_COMMON_REGION_HOB_GUID`).
 ///
 /// Returns `(buffer_addr, buffer_size, internal_copy_addr, status_buffer_addr)`.
@@ -1102,6 +1114,33 @@ unsafe fn init_user_comm_buffer(data: &[u8]) -> Result<(u64, u64, u64, u64), Pol
 #[cfg_attr(coverage, coverage(off))]
 mod tests {
     use super::*;
+
+    struct TestPlatform;
+
+    impl PlatformInfo for TestPlatform {}
+
+    #[test]
+    fn test_cache_processor_ids_into_cpu_manager() {
+        let supervisor = MmSupervisorCore::<TestPlatform, 4>::new();
+        let processor_ids = [0x00_u64, 0x10, 0x20];
+        let mut data = [0_u8; 16 + 3 * PROCESSOR_INFO_ENTRY_SIZE];
+        data[..8].copy_from_slice(&(processor_ids.len() as u64).to_le_bytes());
+        for (cpu_index, processor_id) in processor_ids.iter().enumerate() {
+            let offset = 16 + cpu_index * PROCESSOR_INFO_ENTRY_SIZE;
+            data[offset..offset + 8].copy_from_slice(&processor_id.to_le_bytes());
+        }
+
+        assert_eq!(supervisor.cache_processor_ids(&data), Some(3));
+        assert_eq!(supervisor.cpu_manager().get_processor_id_by_index(1), None);
+
+        for (cpu_index, processor_id) in processor_ids.iter().enumerate() {
+            assert_eq!(
+                supervisor.cpu_manager().register_cpu(*processor_id as u32, cpu_index, cpu_index == 0),
+                Some(cpu_index)
+            );
+            assert_eq!(supervisor.cpu_manager().get_processor_id_by_index(cpu_index), Some(*processor_id));
+        }
+    }
 
     fn mseg_smram_hob_data(
         physical_start: u64,

--- a/patina_mm_supervisor/src/init.rs
+++ b/patina_mm_supervisor/src/init.rs
@@ -761,8 +761,11 @@ impl<P: PlatformInfo, const MAX_CPUS: usize> MmSupervisorCore<P, MAX_CPUS> {
         let number_of_cpus = u64::from_le_bytes(data.get(0..8)?.try_into().ok()?);
         let cpu_count: usize = number_of_cpus.try_into().ok()?;
         if cpu_count > MAX_CPUS {
-            log::error!("MP Information HOB CPU count {} exceeds supervisor maximum {}", cpu_count, MAX_CPUS);
-            return None;
+            panic!(
+                "MP Information HOB CPU count {} exceeds supervisor maximum {}",
+                cpu_count,
+                MAX_CPUS
+            );
         }
 
         let processor_info_size = cpu_count.checked_mul(PROCESSOR_INFO_ENTRY_SIZE)?;
@@ -1140,6 +1143,16 @@ mod tests {
             );
             assert_eq!(supervisor.cpu_manager().get_processor_id_by_index(cpu_index), Some(*processor_id));
         }
+    }
+
+    #[test]
+    #[should_panic(expected = "MP Information HOB CPU count 5 exceeds supervisor maximum 4")]
+    fn test_cache_processor_ids_panics_when_cpu_count_exceeds_maximum() {
+        let supervisor = MmSupervisorCore::<TestPlatform, 4>::new();
+        let mut data = [0_u8; 16];
+        data[..8].copy_from_slice(&5_u64.to_le_bytes());
+
+        let _ = supervisor.cache_processor_ids(&data);
     }
 
     fn mseg_smram_hob_data(

--- a/patina_mm_supervisor/src/init.rs
+++ b/patina_mm_supervisor/src/init.rs
@@ -1125,6 +1125,17 @@ mod tests {
     }
 
     #[test]
+    fn test_parse_mp_information_hob_rejects_invalid_size() {
+        let supervisor = MmSupervisorCore::<TestPlatform, 4>::new();
+        let mut data = [0_u8; 16 + PROCESSOR_INFO_ENTRY_SIZE];
+
+        assert_eq!(supervisor.parse_mp_information_hob(&data[..15]), None);
+
+        data[..8].copy_from_slice(&2_u64.to_le_bytes());
+        assert_eq!(supervisor.parse_mp_information_hob(&data), None);
+    }
+
+    #[test]
     #[should_panic(expected = "MP Information HOB CPU count 5 exceeds supervisor maximum 4")]
     fn test_parse_mp_information_hob_panics_when_cpu_count_exceeds_maximum() {
         let supervisor = MmSupervisorCore::<TestPlatform, 4>::new();

--- a/patina_mm_supervisor/src/lib.rs
+++ b/patina_mm_supervisor/src/lib.rs
@@ -355,10 +355,9 @@ impl<P: PlatformInfo, const MAX_CPUS: usize> MmSupervisorCore<P, MAX_CPUS> {
             log::info!("MM Supervisor Core v{}", env!("CARGO_PKG_VERSION"));
             log::info!("BSP (CPU {}, index {}) starting one-time initialization...", cpu_id, cpu_index);
 
-            // Register BSP with CPU manager
             self.cpu_manager.register_cpu(cpu_id, cpu_index, true);
 
-            // Perform BSP-only one-time initialization (this sets up MM_INITIALIZED_BUFFER)
+            // Perform BSP-only one-time initialization.
             self.bsp_init(hob_list);
 
             // Dispatch to the user level entry point discovered from the HOB list (if found)
@@ -408,7 +407,6 @@ impl<P: PlatformInfo, const MAX_CPUS: usize> MmSupervisorCore<P, MAX_CPUS> {
                 core::hint::spin_loop();
             }
 
-            // Register this AP with the CPU manager
             self.cpu_manager.register_cpu(cpu_id, cpu_index, false);
         }
 
@@ -443,7 +441,7 @@ impl<P: PlatformInfo, const MAX_CPUS: usize> MmSupervisorCore<P, MAX_CPUS> {
 
     /// Returns the UEFI processor ID registered at a dense CPU index.
     fn processor_id_by_index(cpu_index: usize) -> Option<u64> {
-        Self::instance().cpu_manager.get_processor_id_by_index(cpu_index)
+        Self::instance().cpu_manager.get_cpu_id_by_index(cpu_index).map(u64::from)
     }
 
     /// Get the mailbox manager.

--- a/patina_mm_supervisor/src/lib.rs
+++ b/patina_mm_supervisor/src/lib.rs
@@ -352,8 +352,8 @@ impl<P: PlatformInfo, const MAX_CPUS: usize> MmSupervisorCore<P, MAX_CPUS> {
             assert!(self.set_instance(), "MM Supervisor Core instance was already set!");
             assert!(!hob_list.is_null(), "MM Supervisor Core requires a non-null HOB list pointer.");
 
-            log::trace!("MM Supervisor Core v{}", env!("CARGO_PKG_VERSION"));
-            log::trace!("BSP (CPU {}, index {}) starting one-time initialization...", cpu_id, cpu_index);
+            log::info!("MM Supervisor Core v{}", env!("CARGO_PKG_VERSION"));
+            log::info!("BSP (CPU {}, index {}) starting one-time initialization...", cpu_id, cpu_index);
 
             // Register BSP with CPU manager
             self.cpu_manager.register_cpu(cpu_id, cpu_index, true);
@@ -392,16 +392,16 @@ impl<P: PlatformInfo, const MAX_CPUS: usize> MmSupervisorCore<P, MAX_CPUS> {
                     0,
                 )
             };
-            log::trace!("Returned from user entry point with value: 0x{:016x}", ret);
+            log::info!("Returned from user entry point with value: 0x{:016x}", ret);
 
             // Mark BSP init as complete so APs can proceed
             self.initialized.store(true, Ordering::Release);
             init_state().mark_bsp_init_complete();
 
-            log::trace!("BSP one-time initialization complete.");
+            log::info!("BSP initialization complete.");
         } else {
             // AP path: Wait for BSP to complete one-time initialization
-            log::trace!("AP (CPU {}, index {}) waiting for BSP initialization...", cpu_id, cpu_index);
+            log::info!("AP (CPU {}, index {}) waiting for BSP initialization...", cpu_id, cpu_index);
 
             // Spin until BSP completes initialization
             while !init_state().is_bsp_init_complete() {
@@ -420,7 +420,7 @@ impl<P: PlatformInfo, const MAX_CPUS: usize> MmSupervisorCore<P, MAX_CPUS> {
 
         // Track that this core has completed per-core init
         let init_count = init_state().inc_per_core_init_count();
-        log::trace!("CPU {} (index {}) completed per-core init ({} cores initialized)", cpu_id, cpu_index, init_count);
+        log::info!("CPU {} (index {}) completed per-core init ({} cores initialized)", cpu_id, cpu_index, init_count);
 
         // BSP waits for all registered CPUs to complete per-core init before returning
         if is_bsp {
@@ -429,7 +429,7 @@ impl<P: PlatformInfo, const MAX_CPUS: usize> MmSupervisorCore<P, MAX_CPUS> {
                 core::hint::spin_loop();
             }
 
-            log::trace!("All {} cores completed initialization, returning to caller.", expected_cpus);
+            log::info!("All {} cores completed initialization, returning to caller.", expected_cpus);
         }
 
         // First entry returns to caller after init is complete

--- a/patina_mm_supervisor/src/lib.rs
+++ b/patina_mm_supervisor/src/lib.rs
@@ -283,6 +283,7 @@ impl<P: PlatformInfo, const MAX_CPUS: usize> MmSupervisorCore<P, MAX_CPUS> {
         let physical_address = NonNull::from_ref(self).expose_provenance();
         let stored = init_state().set_supervisor(physical_address);
         if stored {
+            init_state().set_processor_id_lookup_fn(Self::processor_id_by_index);
             // Register the conformed AP startup function for this platform
             init_state().set_ap_startup_fn(Self::start_ap_procedure_trampoline);
         }
@@ -438,6 +439,11 @@ impl<P: PlatformInfo, const MAX_CPUS: usize> MmSupervisorCore<P, MAX_CPUS> {
     /// Get the CPU manager.
     pub fn cpu_manager(&self) -> &CpuManager<MAX_CPUS> {
         &self.cpu_manager
+    }
+
+    /// Returns the UEFI processor ID registered at a dense CPU index.
+    fn processor_id_by_index(cpu_index: usize) -> Option<u64> {
+        Self::instance().cpu_manager.get_processor_id_by_index(cpu_index)
     }
 
     /// Get the mailbox manager.

--- a/patina_mm_supervisor/src/save_state.rs
+++ b/patina_mm_supervisor/src/save_state.rs
@@ -36,13 +36,16 @@ use crate::mm_policy::{SaveStateCondition, SaveStateField};
 use patina::standard::efi::Status;
 use patina_internal_cpu::save_state::{
     self, IA32_EFER_LMA, IO_INFO_SIZE, IO_TYPE_INPUT, IO_TYPE_OUTPUT, LMA_32BIT, LMA_64BIT, MmSaveStateIoInfo,
-    MmSaveStateRegister, PROCESSOR_INFO_ENTRY_SIZE,
+    MmSaveStateRegister,
 };
 use zerocopy::IntoBytes;
 
 use crate::{
-    PageOwnership, privilege_mgmt::SyscallResult, query_address_ownership, runtime::with_user_access,
-    state::security_state,
+    PageOwnership,
+    privilege_mgmt::SyscallResult,
+    query_address_ownership,
+    runtime::with_user_access,
+    state::{init_state, security_state},
 };
 
 /// Size in bytes of one `SMRAM_SAVE_STATE_MAP` region.
@@ -67,8 +70,7 @@ const SMRAM_SAVE_STATE_MAP_OFFSET: u64 = 0xfc00;
 /// Assembled at initialization from two public sources instead of the private
 /// `SMM_CPU_PRIVATE_DATA` layout:
 ///
-/// - `number_of_cpus` and `processor_info` come from the MP Information HOB
-///   (`gMpInformationHobGuid`).
+/// - `number_of_cpus` comes from the MP Information HOB (`gMpInformationHobGuid`).
 /// - `sm_base` (the per-CPU SMBASE array) is passed through the MM Supervisor
 ///   PassDown HOB. The save-state region base is derived as
 ///   `sm_base[i] + SMRAM_SAVE_STATE_MAP_OFFSET` with the fixed
@@ -77,8 +79,6 @@ const SMRAM_SAVE_STATE_MAP_OFFSET: u64 = 0xfc00;
 pub(crate) struct SaveStateInfo {
     /// Number of CPUs (from `MP_INFORMATION_HOB_DATA.NumberOfProcessors`).
     pub(crate) number_of_cpus: u64,
-    /// Pointer to the `EFI_PROCESSOR_INFORMATION[]` array (from the MP Information HOB).
-    pub(crate) processor_info: u64,
     /// Pointer to the per-CPU SMBASE array (`u64[number_of_cpus]`).
     pub(crate) sm_base: u64,
 }
@@ -401,35 +401,10 @@ unsafe fn copy_to_user(buffer: *mut u8, out: &[u8]) {
 
 /// Reads the PROCESSOR_ID for a given CPU and writes it to the user buffer.
 ///
-/// The ProcessorId (APIC ID) is read from the `EFI_PROCESSOR_INFORMATION` array
-/// carried by the MP Information HOB (`gMpInformationHobGuid`).
+/// The ProcessorId (APIC ID) is read from the supervisor-owned [`CpuManager`](crate::cpu::CpuManager).
 fn read_processor_id(cpu_index: u64, out: &mut [u8]) -> SyscallResult {
-    let info = save_state_info()?;
-
-    if info.processor_info == 0 {
-        log::error!("PROCESSOR_ID: ProcessorInfo array is null");
-        return Err(Status::NOT_READY);
-    }
-
-    let num_cpus = info.number_of_cpus;
-
-    // View the processor information array as bytes so the per-CPU entry can be
-    // read through safe slice operations.
-    //
-    // SAFETY: `processor_info` points to a valid array of `num_cpus`
-    // `EFI_PROCESSOR_INFORMATION` entries (PROCESSOR_INFO_ENTRY_SIZE bytes
-    // each) in firmware memory, and `cpu_index` is < `num_cpus`.
-    let entries = unsafe {
-        core::slice::from_raw_parts(info.processor_info as *const u8, num_cpus as usize * PROCESSOR_INFO_ENTRY_SIZE)
-    };
-
-    // ProcessorId is the first field (u64) of EFI_PROCESSOR_INFORMATION.
-    let offset = cpu_index as usize * PROCESSOR_INFO_ENTRY_SIZE;
-    let processor_id = entries
-        .get(offset..offset + 8)
-        .and_then(|b| b.try_into().ok())
-        .map(u64::from_le_bytes)
-        .ok_or(Status::INVALID_PARAMETER)?;
+    let lookup = init_state().processor_id_lookup_fn().ok_or(Status::NOT_READY)?;
+    let processor_id = lookup(cpu_index as usize).ok_or(Status::NOT_FOUND)?;
 
     // Write the 8-byte ProcessorId to the user buffer.
     out.get_mut(..8).ok_or(Status::BUFFER_TOO_SMALL)?.copy_from_slice(&processor_id.to_le_bytes());

--- a/patina_mm_supervisor/src/save_state.rs
+++ b/patina_mm_supervisor/src/save_state.rs
@@ -576,6 +576,27 @@ fn read_lma_register(view: &SaveStateView, width: u64, out: &mut [u8]) -> Syscal
 mod tests {
     use super::*;
 
+    struct TestPlatform;
+
+    impl crate::PlatformInfo for TestPlatform {}
+
+    #[test]
+    fn test_save_state_processor_id_from_cpu_manager() {
+        static SUPERVISOR: crate::MmSupervisorCore<TestPlatform, 4> = crate::MmSupervisorCore::new();
+
+        assert_eq!(SUPERVISOR.cpu_manager().register_cpu(0x20, 2, false), Some(2));
+
+        let mut out = [0u8; 8];
+        assert_eq!(read_processor_id(2, &mut out), Err(Status::NOT_READY));
+
+        assert!(SUPERVISOR.set_instance());
+
+        assert_eq!(read_processor_id(2, &mut out), Ok(0));
+        assert_eq!(u64::from_le_bytes(out), 0x20);
+        assert_eq!(read_processor_id(1, &mut out), Err(Status::NOT_FOUND));
+        assert_eq!(read_processor_id(2, &mut out[..4]), Err(Status::BUFFER_TOO_SMALL));
+    }
+
     #[test]
     fn test_register_from_u64() {
         assert_eq!(MmSaveStateRegister::from_u64(38), Some(MmSaveStateRegister::Rax));

--- a/patina_mm_supervisor/src/state.rs
+++ b/patina_mm_supervisor/src/state.rs
@@ -48,6 +48,8 @@ type SupervisorPageTable = X64PageTable<SharedPagingAllocator>;
 pub(crate) struct InitState {
     /// Physical address of the global `MmSupervisorCore` instance.
     supervisor: Once<NonZeroUsize>,
+    /// Type-erased lookup for the processor ID at a dense CPU index.
+    processor_id_lookup_fn: Once<fn(usize) -> Option<u64>>,
     /// Set once BSP one-time initialization has completed.
     bsp_init_complete: AtomicBool,
     /// Pointer to the per-core initialized buffer from the PassDown HOB.
@@ -72,6 +74,7 @@ impl InitState {
     pub(crate) const fn new() -> Self {
         Self {
             supervisor: Once::new(),
+            processor_id_lookup_fn: Once::new(),
             bsp_init_complete: AtomicBool::new(false),
             mm_initialized_buffer: Once::new(),
             per_core_init_count: AtomicU32::new(0),
@@ -94,6 +97,16 @@ impl InitState {
     /// Returns the stored supervisor instance address, if set.
     pub(crate) fn supervisor(&self) -> Option<NonZeroUsize> {
         self.supervisor.get().copied()
+    }
+
+    /// Stores the type-erased processor-ID lookup (one-time).
+    pub(crate) fn set_processor_id_lookup_fn(&self, func: fn(usize) -> Option<u64>) {
+        self.processor_id_lookup_fn.call_once(|| func);
+    }
+
+    /// Returns the type-erased processor-ID lookup, if initialized.
+    pub(crate) fn processor_id_lookup_fn(&self) -> Option<fn(usize) -> Option<u64>> {
+        self.processor_id_lookup_fn.get().copied()
     }
 
     /// Marks BSP one-time initialization as complete (Release ordering).

--- a/patina_mm_supervisor/src/state.rs
+++ b/patina_mm_supervisor/src/state.rs
@@ -330,3 +330,58 @@ pub(crate) static DEFAULT_SUPERVISOR_MMI_HANDLERS: &[SupervisorMmiHandler] = &[
         handle: mm_exit_boot_services_handler,
     },
 ];
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn processor_id_lookup(cpu_index: usize) -> Option<u64> {
+        Some(cpu_index as u64 + 0x10)
+    }
+
+    fn replacement_processor_id_lookup(_: usize) -> Option<u64> {
+        None
+    }
+
+    #[test]
+    fn test_init_state_defaults() {
+        let state = InitState::new();
+
+        assert!(state.supervisor().is_none());
+        assert!(state.processor_id_lookup_fn().is_none());
+        assert!(!state.is_bsp_init_complete());
+        assert_eq!(state.per_core_init_count(), 0);
+        assert!(state.user_entry_point().is_none());
+        assert!(state.mseg_base().is_none());
+        assert!(state.ap_startup_fn().is_none());
+        assert!(!state.is_at_runtime());
+        assert!(state.smrr_range().is_none());
+    }
+
+    #[test]
+    fn test_init_state_processor_id_lookup_is_initialized_once() {
+        let state = InitState::new();
+
+        state.set_processor_id_lookup_fn(processor_id_lookup);
+        assert_eq!(state.processor_id_lookup_fn().unwrap()(3), Some(0x13));
+
+        state.set_processor_id_lookup_fn(replacement_processor_id_lookup);
+        assert_eq!(state.processor_id_lookup_fn().unwrap()(3), Some(0x13));
+    }
+
+    #[test]
+    fn test_init_state_synchronization_updates() {
+        let state = InitState::new();
+
+        state.mark_bsp_init_complete();
+        assert!(state.is_bsp_init_complete());
+
+        assert_eq!(state.inc_per_core_init_count(), 1);
+        assert_eq!(state.inc_per_core_init_count(), 2);
+        assert_eq!(state.per_core_init_count(), 2);
+
+        assert!(state.mark_at_runtime());
+        assert!(!state.mark_at_runtime());
+        assert!(state.is_at_runtime());
+    }
+}


### PR DESCRIPTION
## Description

This change updates the hob parser to populate the processor ID into the `cpu_manager` static. This will allow the save_state module to query processor ID without going through the access into HOB buffer, which is marked as user RO during runtime.

This change also promotes some critical prints to info level.

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

This was tested on QEMU Q35.

## Integration Instructions

N/A
