### PR TITLE
GCD: Add Better Logs on InvalidStateTransition

### DIFF
--- a/patina_dxe_core/src/gcd/memory_block.rs
+++ b/patina_dxe_core/src/gcd/memory_block.rs
@@ -219,7 +219,13 @@ impl MemoryBlock {
                 md.attributes = attributes;
                 Ok(())
             }
-            _ => Err(Error::InvalidStateTransition),
+            _ => {
+                log::error!(
+                    "Invalid GCD state transition: Add({memory_type:?}) requires an unallocated NonExistent block and \
+                     a non-NonExistent target type. Block: {self:#x?}"
+                );
+                Err(Error::InvalidStateTransition)
+            }
         }
     }
 
@@ -230,7 +236,13 @@ impl MemoryBlock {
                 md.capabilities = 0;
                 Ok(())
             }
-            _ => Err(Error::InvalidStateTransition),
+            _ => {
+                log::error!(
+                    "Invalid GCD state transition: Remove requires an unallocated, non-NonExistent block. \
+                     Block: {self:#x?}"
+                );
+                Err(Error::InvalidStateTransition)
+            }
         }
     }
 
@@ -273,7 +285,12 @@ impl MemoryBlock {
                 *self = Self::Unallocated(*md);
                 Ok(())
             }
-            _ => Err(Error::InvalidStateTransition),
+            _ => {
+                log::error!(
+                    "Invalid GCD state transition: Free requires an allocated, Existent block. Block: {self:#x?}"
+                );
+                Err(Error::InvalidStateTransition)
+            }
         }
     }
 
@@ -286,10 +303,21 @@ impl MemoryBlock {
                     md.attributes = attributes;
                     Ok(())
                 } else {
+                    log::error!(
+                        "Invalid GCD state transition: SetAttributes({attributes:#x}) requests attributes not present \
+                         in the block capabilities {:#x}. Block: {md:#x?}",
+                        md.capabilities
+                    );
                     Err(Error::InvalidStateTransition)
                 }
             }
-            _ => Err(Error::InvalidStateTransition),
+            _ => {
+                log::error!(
+                    "Invalid GCD state transition: SetAttributes({attributes:#x}) requires a non-NonExistent block. \
+                     Block: {self:#x?}"
+                );
+                Err(Error::InvalidStateTransition)
+            }
         }
     }
 
@@ -305,10 +333,21 @@ impl MemoryBlock {
                     //
                     // Current attributes must still be supported with new capabilities
                     //
+                    log::error!(
+                        "Invalid GCD state transition: SetCapabilities({capabilities:#x}) does not support the \
+                         current block attributes {:#x}. Block: {md:#x?}",
+                        md.attributes
+                    );
                     Err(Error::InvalidStateTransition)
                 }
             }
-            _ => Err(Error::InvalidStateTransition),
+            _ => {
+                log::error!(
+                    "Invalid GCD state transition: SetCapabilities({capabilities:#x}) requires a non-NonExistent \
+                     block. Block: {self:#x?}"
+                );
+                Err(Error::InvalidStateTransition)
+            }
         }
     }
 


### PR DESCRIPTION
## Description

Currently, invalid state transitions in the memory block layer all return the same error code and the GCD just prints/asserts that an invalid state transition occurred, which is not easily debuggable.

This adds prints to the memory block layer to identify why an invalid state transition occurred. Allocate is expected to fail when testing regions to allocate from, so a print is not added there.

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Printing on a system where an invalid state transition was occurring.

## Integration Instructions

N/A.