### PR TITLE
[patina::pi::hob] Adjust hob misc design

### DIFF
--- a/patina_dxe_core/src/component_dispatcher.rs
+++ b/patina_dxe_core/src/component_dispatcher.rs
@@ -411,10 +411,18 @@ mod tests {
             name: GUID3,
         };
 
+        let unused_hob = patina::pi::hob::GenericHob {
+            header: patina::pi::hob::HobHeader {
+                r#type: patina::pi::hob::UNUSED,
+                length: core::mem::size_of::<patina::pi::hob::GenericHob>() as u16,
+                reserved: 0,
+            },
+        };
+
         hob_list.push(patina::pi::hob::Hob::GuidHob(&guid_hob1, hob1_bytes));
         hob_list.push(patina::pi::hob::Hob::GuidHob(&guid_hob2, hob2_bytes));
         hob_list.push(patina::pi::hob::Hob::GuidHob(&guid_hob3, hob3_bytes));
-        hob_list.push(patina::pi::hob::Hob::Misc(30)); // Non-guid HOB to ensure it's ignored.
+        hob_list.push(patina::pi::hob::Hob::Misc(&unused_hob)); // Non-guid HOB to ensure it's ignored.
 
         struct TestComponent;
 

--- a/sdk/patina/src/pi/hob.rs
+++ b/sdk/patina/src/pi/hob.rs
@@ -1049,7 +1049,6 @@ impl<'a> Iterator for HobIter<'a> {
                     Hob::Misc((self.hob_ptr as *const GenericHob).as_ref().expect(NOT_NULL))
                 }
                 _ => {
-                    // unreachable!("Unknown HOB type: {}", hob_header.r#type);
                     debug_assert!(false, "Unknown HOB type: {}", hob_header.r#type);
                     Hob::Misc((self.hob_ptr as *const GenericHob).as_ref().expect(NOT_NULL))
                 }

--- a/sdk/patina/src/pi/hob.rs
+++ b/sdk/patina/src/pi/hob.rs
@@ -140,9 +140,14 @@ use crate::standard::efi::MemoryType;
 /// Note:
 ///  - All HOBs must start with a HOB generic header.
 ///  - All HOBs must be multiples of 8 bytes in length.
-///  - All HOBs will begin on an 8-byte boundry.
+///  - All HOBs will begin on an 8-byte boundary.
 ///
-/// See [PI spec 1.8A III - 4.5.2. HOB Construction Rules](https://uefi.org/specs/PI/1.8A/V3_HOB_Design_Discussion.html#hob-construction-rules)
+/// See [PI spec 1.10 III - 4.5.2. HOB Construction Rules](https://uefi.org/specs/PI/1.10/V3_HOB_Design_Discussion.html#hob-construction-rules)  
+/// Since [PI spec 1.2B](https://uefi.org/sites/default/files/resources/PI_Spec_1.2_B.zip)
+///
+/// Note:
+///  The align(8) makes the Rust object conform to the PI alignment requirement.
+///  However, this does not bring obvious benefits to the parser or compiler, though it may help code analysis tools.
 ///
 #[repr(C, align(8))]
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
@@ -207,36 +212,17 @@ pub struct MemoryAllocationHeader {
     pub reserved: [u8; 4],
 }
 
-/// Describes pool memory allocations.
-///
-/// The memory pool HOB is produced by the HOB producer phase and describes pool
-/// memory allocations. The HOB consumer phase should be able to ignore these HOBs.
-/// The purpose of this HOB is to allow for the HOB producer phase to have a simple
-/// memory allocation mechanism within the HOB list. The size of the memory allocation
-/// is stipulated by the `HobLength` field in the generic HOB header.
-///
-/// The allocated memory is stored inline and immediately follows the header.
-///
-// pub type MemoryPool = HobHeader;
-
-/// Indicates that the contents of the HOB can be ignored.
-///
-/// This HOB type means that the contents of the HOB can be ignored. This type is necessary to
-/// support the simple, allocate-only architecture of HOBs that have no delete service. The consumer of
-/// the HOB list should ignore HOB entries with this type field.
-///
-// pub type Unused = HobHeader;
-
-/// Generic HOB structure for HOBs that do not have a specific type.
-///
-/// NOTE: the `clone()` is shallow clone.
+/// Generic HOB structure for HOBs that are defined by the PI spec but unused by Patina now.
+/// - MEMORY_POOL
+/// - UNUSED
+/// - LOAD_PEIM_UNUSED
+/// - (etc.)
 ///
 #[repr(C)]
 #[derive(Debug)]
 pub struct GenericHob {
     pub header: HobHeader,
 }
-const _: () = assert!(core::mem::align_of::<GenericHob>() == 8);
 
 /// Indicates the end of the HOB list. This HOB must be the last one in the HOB list.
 ///
@@ -958,6 +944,10 @@ impl Hob<'_> {
 
 /// A HOB iterator.
 ///
+/// - HOBs of interest are returned as their corresponding `Hob` enum variant, bound to the corresponding HOB type
+/// - Other HOBs are returned as `Hob::Misc`, bound to `hob::GenericHob`
+/// - `END_OF_HOB_LIST` stops the iterator and returns `None`
+///
 pub struct HobIter<'a> {
     hob_ptr: *const HobHeader,
     _a: PhantomData<&'a ()>,
@@ -1142,7 +1132,7 @@ pub(crate) mod tests {
         hob::ResourceDescriptorV2 { v1, attributes: 8 }
     }
 
-    // Generate a test memoy allocation hob
+    // Generate a test memory allocation hob
     // # Returns
     // A MemoryAllocation hob
     pub(crate) fn gen_memory_allocation() -> hob::MemoryAllocation {
@@ -1273,8 +1263,9 @@ pub(crate) mod tests {
         let mut buffer = [0u8; 0x18];
 
         unsafe {
-            let header = buffer.as_mut_ptr().cast::<hob::GenericHob>();
-            header.write_unaligned(hob::GenericHob {
+            // Write GenericHob bytes to buffer
+            let hob = buffer.as_mut_ptr().cast::<hob::GenericHob>();
+            hob.write_unaligned(hob::GenericHob {
                 header: hob::HobHeader { r#type: hob::MEMORY_POOL, length, reserved: 0 },
             });
         }
@@ -1291,9 +1282,13 @@ pub(crate) mod tests {
     fn test_gen_memory_pool() {
         let buffer = gen_memory_pool();
         assert_eq!(buffer.len(), 0x18);
-        let header = unsafe { &*(buffer.as_ptr() as *const hob::GenericHob) };
-        assert_eq!(header.header.r#type, hob::MEMORY_POOL);
-        assert_eq!(header.header.length, 0x18);
+        // SAFETY: The hob alignment is ensured by `read_unaligned()`
+        let hob = unsafe {
+            // Decode GenericHob from buffer
+            core::ptr::read_unaligned(buffer.as_ptr().cast::<hob::GenericHob>())
+        };
+        assert_eq!(hob.header.r#type, hob::MEMORY_POOL);
+        assert_eq!(hob.header.length, 0x18);
     }
 
     #[test]
@@ -1307,6 +1302,28 @@ pub(crate) mod tests {
 
         assert_eq!(size, size_of::<EndOfHobList>());
     }
+
+    /// Declare a 8-byte aligned buffer pointer.
+    ///
+    /// Use a macro because we need a lifetime helper variable `_aligned_storage`
+    ///
+    macro_rules! declare_aligned_buffer {
+        ($ptr:ident, $buffer:expr) => {
+            let mut _aligned_storage: Option<Vec<u64>> = None;
+
+            let $ptr: *const c_void = if ($buffer.as_ptr() as usize) % 8 == 0 {
+                $buffer.as_ptr() as *const c_void
+            } else {
+                let mut aligned = vec![0u64; $buffer.len().div_ceil(8)];
+                unsafe {
+                    core::ptr::copy_nonoverlapping($buffer.as_ptr(), aligned.as_mut_ptr() as *mut u8, $buffer.len());
+                }
+                _aligned_storage = Some(aligned);
+                _aligned_storage.as_ref().unwrap().as_ptr() as *const c_void
+            };
+        };
+    }
+    pub(super) use declare_aligned_buffer;
 
     #[test]
     fn test_get_pi_hob_list_size_multiple_hobs() {
@@ -1341,8 +1358,11 @@ pub(crate) mod tests {
             unsafe { core::slice::from_raw_parts(&raw const end_of_list as *const u8, size_of::<EndOfHobList>()) };
         buffer.extend_from_slice(end_bytes);
 
+        // assert_eq!((buffer.as_ptr() as usize) % 8, 0); // if allocator already provides 8-byte alignment
+        declare_aligned_buffer!(aligned_buffer, buffer); // ensure 8-byte alignment
+
         // SAFETY: The list is created in this test with headers and an end-of-list marker that should be valid
-        let size = unsafe { get_pi_hob_list_size(buffer.as_ptr() as *const c_void) };
+        let size = unsafe { get_pi_hob_list_size(aligned_buffer) };
 
         assert_eq!(size, expected_size);
     }
@@ -1383,8 +1403,10 @@ pub(crate) mod tests {
             core::slice::from_raw_parts(&raw const end_of_list as *const u8, size_of::<EndOfHobList>())
         });
 
+        declare_aligned_buffer!(aligned_buffer, buffer); // ensure 8-byte alignment
+
         // SAFETY: The list is created in this test with headers and an end-of-list marker that should be valid
-        let size = unsafe { get_pi_hob_list_size(buffer.as_ptr() as *const c_void) };
+        let size = unsafe { get_pi_hob_list_size(aligned_buffer) };
 
         assert_eq!(size, expected_size);
     }

--- a/sdk/patina/src/pi/hob.rs
+++ b/sdk/patina/src/pi/hob.rs
@@ -32,22 +32,15 @@
 //!   }
 //! }
 //!
-//! fn gen_end_of_hoblist() -> hob::PhaseHandoffInformationTable {
+//! fn gen_end_of_hoblist() -> hob::EndOfHobList {
 //!   let header = hob::HobHeader {
 //!     r#type: hob::END_OF_HOB_LIST,
-//!     length: size_of::<hob::PhaseHandoffInformationTable>() as u16,
+//!     length: size_of::<hob::GenericHob>() as u16,
 //!     reserved: 0,
 //!   };
 //!
-//!   hob::PhaseHandoffInformationTable {
+//!   hob::EndOfHobList {
 //!     header,
-//!     version: 0x00010000,
-//!     boot_mode: BootMode::BootWithFullConfiguration,
-//!     memory_top: 0xdeadbeef,
-//!     memory_bottom: 0xdeadc0de,
-//!     free_memory_top: 104,
-//!     free_memory_bottom: 255,
-//!     end_of_hob_list: 0xdeaddeadc0dec0de,
 //!   }
 //! }
 //!
@@ -144,7 +137,14 @@ use crate::standard::efi::MemoryType;
 /// HOB structures that allows iteration from one HOB to the next until the end-of-list
 /// marker is encountered.
 ///
-#[repr(C)]
+/// Note:
+///  - All HOBs must start with a HOB generic header.
+///  - All HOBs must be multiples of 8 bytes in length.
+///  - All HOBs will begin on an 8-byte boundry.
+///
+/// See [PI spec 1.8A III - 4.5.2. HOB Construction Rules](https://uefi.org/specs/PI/1.8A/V3_HOB_Design_Discussion.html#hob-construction-rules)
+///
+#[repr(C, align(8))]
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub struct HobHeader {
     // EFI_HOB_GENERIC_HEADER
@@ -162,6 +162,8 @@ pub struct HobHeader {
     ///
     pub reserved: u32,
 }
+const _: () = assert!(core::mem::size_of::<HobHeader>() == 8);
+const _: () = assert!(core::mem::align_of::<HobHeader>() == 8);
 
 /// Memory allocation HOB header that describes allocated memory regions.
 ///
@@ -213,7 +215,40 @@ pub struct MemoryAllocationHeader {
 /// memory allocation mechanism within the HOB list. The size of the memory allocation
 /// is stipulated by the `HobLength` field in the generic HOB header.
 ///
-pub type MemoryPool = HobHeader;
+/// The allocated memory is stored inline and immediately follows the header.
+///
+// pub type MemoryPool = HobHeader;
+
+/// Indicates that the contents of the HOB can be ignored.
+///
+/// This HOB type means that the contents of the HOB can be ignored. This type is necessary to
+/// support the simple, allocate-only architecture of HOBs that have no delete service. The consumer of
+/// the HOB list should ignore HOB entries with this type field.
+///
+// pub type Unused = HobHeader;
+
+/// Generic HOB structure for HOBs that do not have a specific type.
+///
+/// NOTE: the `clone()` is shallow clone.
+///
+#[repr(C)]
+#[derive(Debug)]
+pub struct GenericHob {
+    pub header: HobHeader,
+}
+const _: () = assert!(core::mem::align_of::<GenericHob>() == 8);
+
+/// Indicates the end of the HOB list. This HOB must be the last one in the HOB list.
+///
+/// This HOB type indicates the end of the HOB list. This HOB type must be the last HOB type in the
+/// HOB list and terminates the HOB list. A HOB list should be considered ill formed if it does not have
+/// a final HOB of type EFI_HOB_TYPE_END_OF_HOB_LIST.
+///
+#[repr(C)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub struct EndOfHobList {
+    pub header: HobHeader,
+}
 
 /// Phase Handoff Information Table (PHIT) HOB.
 ///
@@ -772,6 +807,8 @@ pub struct Capsule {
 pub enum Hob<'a> {
     /// Phase handoff information table HOB.
     Handoff(&'a PhaseHandoffInformationTable),
+    /// End of HOB list HOB.    
+    EndOfHobList(&'a EndOfHobList),
     /// Memory allocation HOB.
     MemoryAllocation(&'a MemoryAllocation),
     /// Memory allocation module HOB.
@@ -793,12 +830,16 @@ pub enum Hob<'a> {
     /// Resource descriptor v2 HOB.
     ResourceDescriptorV2(&'a ResourceDescriptorV2),
     /// Miscellaneous HOB type.
-    Misc(u16),
+    /// The type that is defined by the PI spec but unused by Patina now.
+    /// - MEMORY_POOL
+    /// - UNUSED
+    /// - LOAD_PEIM_UNUSED
+    Misc(&'a GenericHob),
 }
 
 /// Trait for Hand-Off Block types.
 pub trait HobTrait {
-    /// Returns the size of the HOB.
+    /// Returns the entire size of the HOB, including header and data.
     fn size(&self) -> usize;
     /// Returns a pointer to the HOB data.
     fn as_ptr<T>(&self) -> *const T;
@@ -810,6 +851,7 @@ impl HobTrait for Hob<'_> {
     fn size(&self) -> usize {
         match self {
             Hob::Handoff(_) => size_of::<PhaseHandoffInformationTable>(),
+            Hob::EndOfHobList(_) => size_of::<EndOfHobList>(),
             Hob::MemoryAllocation(_) => size_of::<MemoryAllocation>(),
             Hob::MemoryAllocationModule(_) => size_of::<MemoryAllocationModule>(),
             Hob::Capsule(_) => size_of::<Capsule>(),
@@ -820,7 +862,7 @@ impl HobTrait for Hob<'_> {
             Hob::FirmwareVolume3(_) => size_of::<FirmwareVolume3>(),
             Hob::Cpu(_) => size_of::<Cpu>(),
             Hob::ResourceDescriptorV2(_) => size_of::<ResourceDescriptorV2>(),
-            Hob::Misc(_) => size_of::<u16>(),
+            Hob::Misc(hob) => hob.header.length as usize,
         }
     }
 
@@ -828,6 +870,7 @@ impl HobTrait for Hob<'_> {
     fn as_ptr<T>(&self) -> *const T {
         match self {
             Hob::Handoff(hob) => core::ptr::from_ref::<PhaseHandoffInformationTable>(*hob) as *const _,
+            Hob::EndOfHobList(hob) => core::ptr::from_ref::<EndOfHobList>(*hob) as *const _,
             Hob::MemoryAllocation(hob) => core::ptr::from_ref::<MemoryAllocation>(*hob) as *const _,
             Hob::MemoryAllocationModule(hob) => core::ptr::from_ref::<MemoryAllocationModule>(*hob) as *const _,
             Hob::Capsule(hob) => core::ptr::from_ref::<Capsule>(*hob) as *const _,
@@ -838,7 +881,7 @@ impl HobTrait for Hob<'_> {
             Hob::FirmwareVolume3(hob) => core::ptr::from_ref::<FirmwareVolume3>(*hob) as *const _,
             Hob::Cpu(hob) => core::ptr::from_ref::<Cpu>(*hob) as *const _,
             Hob::ResourceDescriptorV2(hob) => core::ptr::from_ref::<ResourceDescriptorV2>(*hob) as *const _,
-            Hob::Misc(hob) => *hob as *const u16 as *const _,
+            Hob::Misc(hob) => core::ptr::from_ref::<GenericHob>(*hob) as *const _,
         }
     }
 }
@@ -897,6 +940,7 @@ impl Hob<'_> {
     pub fn header(&self) -> HobHeader {
         match self {
             Hob::Handoff(hob) => hob.header,
+            Hob::EndOfHobList(hob) => hob.header,
             Hob::MemoryAllocation(hob) => hob.header,
             Hob::MemoryAllocationModule(hob) => hob.header,
             Hob::Capsule(hob) => hob.header,
@@ -907,9 +951,7 @@ impl Hob<'_> {
             Hob::FirmwareVolume3(hob) => hob.header,
             Hob::Cpu(hob) => hob.header,
             Hob::ResourceDescriptorV2(hob) => hob.v1.header,
-            Hob::Misc(hob_type) => {
-                HobHeader { r#type: *hob_type, length: mem::size_of::<HobHeader>() as u16, reserved: 0 }
-            }
+            Hob::Misc(hob) => hob.header,
         }
     }
 }
@@ -985,7 +1027,15 @@ impl<'a> Iterator for HobIter<'a> {
                     Hob::ResourceDescriptorV2((self.hob_ptr as *const ResourceDescriptorV2).as_ref().expect(NOT_NULL))
                 }
                 END_OF_HOB_LIST => return None,
-                hob_type => Hob::Misc(hob_type),
+                MEMORY_POOL | LOAD_PEIM_UNUSED | UNUSED => {
+                    // Intentionally ignored
+                    Hob::Misc((self.hob_ptr as *const GenericHob).as_ref().expect(NOT_NULL))
+                }
+                _ => {
+                    // unreachable!("Unknown HOB type: {}", hob_header.r#type);
+                    debug_assert!(false, "Unknown HOB type: {}", hob_header.r#type);
+                    Hob::Misc((self.hob_ptr as *const GenericHob).as_ref().expect(NOT_NULL))
+                }
             }
         };
         self.hob_ptr = (self.hob_ptr as usize + hob_header.length as usize) as *const HobHeader;
@@ -1013,10 +1063,7 @@ pub struct EFiMemoryTypeInformation {
 pub(crate) mod tests {
     use crate::pi::{
         BootMode, hob,
-        hob::{
-            Capsule, Cpu, FirmwareVolume, MemoryAllocation, PhaseHandoffInformationTable, ResourceDescriptor,
-            get_pi_hob_list_size,
-        },
+        hob::{Capsule, Cpu, EndOfHobList, FirmwareVolume, MemoryAllocation, ResourceDescriptor, get_pi_hob_list_size},
     };
 
     use core::{mem::size_of, slice::from_raw_parts};
@@ -1095,7 +1142,7 @@ pub(crate) mod tests {
         hob::ResourceDescriptorV2 { v1, attributes: 8 }
     }
 
-    // Generate a test phase handoff information table hob
+    // Generate a test memoy allocation hob
     // # Returns
     // A MemoryAllocation hob
     pub(crate) fn gen_memory_allocation() -> hob::MemoryAllocation {
@@ -1206,31 +1253,47 @@ pub(crate) mod tests {
     }
 
     // Generate a test end of hoblist hob
-    // # Returns
-    // A PhaseHandoffInformationTable hob
-    pub(crate) fn gen_end_of_hoblist() -> hob::PhaseHandoffInformationTable {
-        let header = hob::HobHeader {
-            r#type: hob::END_OF_HOB_LIST,
-            length: size_of::<hob::PhaseHandoffInformationTable>() as u16,
-            reserved: 0,
-        };
+    //
+    pub(crate) fn gen_end_of_hoblist() -> hob::EndOfHobList {
+        let header =
+            hob::HobHeader { r#type: hob::END_OF_HOB_LIST, length: size_of::<hob::HobHeader>() as u16, reserved: 0 };
 
-        hob::PhaseHandoffInformationTable {
-            header,
-            version: 0x00010000,
-            boot_mode: BootMode::BootWithFullConfiguration,
-            memory_top: 0xdeadbeef,
-            memory_bottom: 0xdeadc0de,
-            free_memory_top: 104,
-            free_memory_bottom: 255,
-            end_of_hob_list: 0xdeaddeadc0dec0de,
-        }
+        hob::EndOfHobList { header }
     }
 
     pub(crate) fn gen_cpu() -> hob::Cpu {
         let header = hob::HobHeader { r#type: hob::CPU, length: size_of::<hob::Cpu>() as u16, reserved: 0 };
 
         hob::Cpu { header, size_of_memory_space: 0, size_of_io_space: 0, reserved: [0; 6] }
+    }
+
+    pub(crate) fn gen_memory_pool() -> [u8; 0x18] {
+        let length = (size_of::<hob::GenericHob>() + 0x10) as u16;
+        assert_eq!(length, 0x18);
+        let mut buffer = [0u8; 0x18];
+
+        unsafe {
+            let header = buffer.as_mut_ptr().cast::<hob::GenericHob>();
+            header.write_unaligned(hob::GenericHob {
+                header: hob::HobHeader { r#type: hob::MEMORY_POOL, length, reserved: 0 },
+            });
+        }
+        buffer
+    }
+
+    pub(crate) fn gen_unused() -> hob::GenericHob {
+        let header = hob::HobHeader { r#type: hob::UNUSED, length: size_of::<hob::HobHeader>() as u16, reserved: 0 };
+
+        hob::GenericHob { header }
+    }
+
+    #[test]
+    fn test_gen_memory_pool() {
+        let buffer = gen_memory_pool();
+        assert_eq!(buffer.len(), 0x18);
+        let header = unsafe { &*(buffer.as_ptr() as *const hob::GenericHob) };
+        assert_eq!(header.header.r#type, hob::MEMORY_POOL);
+        assert_eq!(header.header.length, 0x18);
     }
 
     #[test]
@@ -1242,7 +1305,7 @@ pub(crate) mod tests {
         // SAFETY: The list is created in this test with a valid end-of-list marker
         let size = unsafe { get_pi_hob_list_size(&raw const end_of_list as *const c_void) };
 
-        assert_eq!(size, size_of::<PhaseHandoffInformationTable>());
+        assert_eq!(size, size_of::<EndOfHobList>());
     }
 
     #[test]
@@ -1254,8 +1317,7 @@ pub(crate) mod tests {
         let firmware_volume = gen_firmware_volume();
         let end_of_list = gen_end_of_hoblist();
 
-        let expected_size =
-            size_of::<Capsule>() + size_of::<FirmwareVolume>() + size_of::<PhaseHandoffInformationTable>();
+        let expected_size = size_of::<Capsule>() + size_of::<FirmwareVolume>() + size_of::<EndOfHobList>();
 
         // This buffer will hold the contiguous HOBs
         let mut buffer = Vec::new();
@@ -1275,9 +1337,8 @@ pub(crate) mod tests {
 
         // Add an end-of-list HOB
         // SAFETY: Creating a byte slice from a struct for test purposes.
-        let end_bytes = unsafe {
-            core::slice::from_raw_parts(&raw const end_of_list as *const u8, size_of::<PhaseHandoffInformationTable>())
-        };
+        let end_bytes =
+            unsafe { core::slice::from_raw_parts(&raw const end_of_list as *const u8, size_of::<EndOfHobList>()) };
         buffer.extend_from_slice(end_bytes);
 
         // SAFETY: The list is created in this test with headers and an end-of-list marker that should be valid
@@ -1299,7 +1360,7 @@ pub(crate) mod tests {
         let expected_size = size_of::<Cpu>()
             + size_of::<ResourceDescriptor>()
             + size_of::<MemoryAllocation>()
-            + size_of::<PhaseHandoffInformationTable>();
+            + size_of::<EndOfHobList>();
 
         // This buffer will hold the contiguous HOBs
         let mut buffer = Vec::new();
@@ -1319,7 +1380,7 @@ pub(crate) mod tests {
 
         // SAFETY: Creating a byte slice from a struct for test purposes.
         buffer.extend_from_slice(unsafe {
-            core::slice::from_raw_parts(&raw const end_of_list as *const u8, size_of::<PhaseHandoffInformationTable>())
+            core::slice::from_raw_parts(&raw const end_of_list as *const u8, size_of::<EndOfHobList>())
         });
 
         // SAFETY: The list is created in this test with headers and an end-of-list marker that should be valid

--- a/sdk/patina/src/pi/hob.rs
+++ b/sdk/patina/src/pi/hob.rs
@@ -35,7 +35,7 @@
 //! fn gen_end_of_hoblist() -> hob::EndOfHobList {
 //!   let header = hob::HobHeader {
 //!     r#type: hob::END_OF_HOB_LIST,
-//!     length: size_of::<hob::GenericHob>() as u16,
+//!     length: size_of::<hob::HobHeader>() as u16,
 //!     reserved: 0,
 //!   };
 //!
@@ -221,7 +221,31 @@ pub struct MemoryAllocationHeader {
 #[repr(C)]
 #[derive(Debug)]
 pub struct GenericHob {
+    /// The common header shared by all HOBs.
     pub header: HobHeader,
+}
+
+impl GenericHob {
+    /// Returns the variant part as a byte slice.
+    pub fn payload(&self) -> &[u8] {
+        let struct_size: usize = core::mem::size_of::<Self>();
+        debug_assert!((self.header.length as usize) >= struct_size);
+        let data_len = (self.header.length as usize).saturating_sub(struct_size);
+
+        unsafe {
+            let data_ptr = core::ptr::from_ref(self).cast::<u8>().add(struct_size);
+            core::slice::from_raw_parts(data_ptr, data_len)
+        }
+    }
+
+    /// Returns the entire HOB as a byte slice
+    pub fn as_slice(&self) -> &[u8] {
+        let total_size = self.header.length as usize;
+        unsafe {
+            let data_ptr = core::ptr::from_ref(self).cast::<u8>();
+            core::slice::from_raw_parts(data_ptr, total_size)
+        }
+    }
 }
 
 /// Indicates the end of the HOB list. This HOB must be the last one in the HOB list.
@@ -624,6 +648,21 @@ pub struct GuidHob {
     pub name: crate::BinaryGuid,
     // Guid specific data goes here
     //
+}
+
+impl GuidHob {
+    /// Returns the data portion of the GUID HOB as a byte slice.
+    ///
+    pub fn guid_data_slice(&self) -> &[u8] {
+        let struct_size: usize = core::mem::size_of::<Self>();
+        debug_assert!((self.header.length as usize) >= struct_size);
+        let guid_data_size = (self.header.length as usize).saturating_sub(struct_size);
+
+        unsafe {
+            let guid_data_ptr = core::ptr::from_ref(self).cast::<u8>().add(struct_size);
+            core::slice::from_raw_parts(guid_data_ptr, guid_data_size)
+        }
+    }
 }
 
 /// Details the location of firmware volumes that contain firmware files.
@@ -1289,7 +1328,7 @@ pub(crate) mod tests {
     pub(crate) fn gen_memory_pool() -> [u8; 0x18] {
         let length = (size_of::<hob::GenericHob>() + 0x10) as u16;
         assert_eq!(length, 0x18);
-        let mut buffer = [0u8; 0x18];
+        let mut buffer = [0x33u8; 0x18];
 
         unsafe {
             // Write GenericHob bytes to buffer
@@ -1311,13 +1350,34 @@ pub(crate) mod tests {
     fn test_gen_memory_pool() {
         let buffer = gen_memory_pool();
         assert_eq!(buffer.len(), 0x18);
-        // SAFETY: The hob alignment is ensured by `read_unaligned()`
-        let hob = unsafe {
-            // Decode GenericHob from buffer
-            core::ptr::read_unaligned(buffer.as_ptr().cast::<hob::GenericHob>())
-        };
+
+        // // Wrong!! Decode GenericHob from buffer
+        // let hob = unsafe { core::ptr::read_unaligned(buffer.as_ptr().cast::<hob::GenericHob>()) };
+
+        // Must be cast to keep tailing data.
+        declare_aligned_buffer!(aligned_buffer, buffer);
+        let hob = aligned_buffer.cast::<hob::GenericHob>();
+        // SAFETY: The hob alignment is ensured by `declare_aligned_buffer!`
+        let hob = unsafe { hob.as_ref() }.unwrap();
+
         assert_eq!(hob.header.r#type, hob::MEMORY_POOL);
         assert_eq!(hob.header.length, 0x18);
+        assert_eq!(hob.payload().as_ptr() as usize, hob.as_slice().as_ptr() as usize + 0x8);
+        assert_eq!(hob.payload(), [0x33u8; 0x10]);
+    }
+
+    #[test]
+    fn test_gen_guid_hob() {
+        let buffer = gen_guid_hob();
+        assert_eq!(buffer.len(), size_of::<hob::GuidHob>() + 8);
+
+        declare_aligned_buffer!(aligned_buffer, buffer);
+        let guid_hob = aligned_buffer.cast::<hob::GuidHob>();
+        // SAFETY: The hob alignment is ensured by `declare_aligned_buffer!`
+        let guid_hob = unsafe { guid_hob.as_ref() }.unwrap();
+        assert_eq!(guid_hob.header.r#type, hob::GUID_EXTENSION);
+        assert_eq!(guid_hob.header.length as usize, size_of::<hob::GuidHob>() + 8);
+        assert_eq!(guid_hob.guid_data_slice(), [1_u8, 2, 3, 4, 5, 6, 7, 8]);
     }
 
     #[test]

--- a/sdk/patina/src/pi/hob.rs
+++ b/sdk/patina/src/pi/hob.rs
@@ -942,11 +942,38 @@ impl Hob<'_> {
     }
 }
 
-/// A HOB iterator.
+/// A HOB iterator over the `PI spec HOB list`
 ///
+/// ## Start
+///
+///  The `PI spec HOB list` is a contiguous region of memory. The first node is PHIT, and the last node is END_OF_HOB_LIST.
+///
+///  To start iteration from any HOB (beginning or middle) in the `PI spec HOB list`:
+///
+///   1. Cast the pointer to a `GenericHob` reference
+///   2. Create a `Hob::Misc` from the reference
+///   3. Use `.iter()` to start iteration.
+///  
+///  To start iteration from the beginning of the `PI spec HOB list`:
+///
+///   1. Cast the pointer to a `PhaseHandoffInformationTable` reference
+///   2. Create a `Hob::Handoff` from the reference
+///   3. Use `.iter()` to start iteration.
+///
+/// ## Iteration
+///
+///  During iteration:
+///   
 /// - HOBs of interest are returned as their corresponding `Hob` enum variant, bound to the corresponding HOB type
 /// - Other HOBs are returned as `Hob::Misc`, bound to `hob::GenericHob`
 /// - `END_OF_HOB_LIST` stops the iterator and returns `None`
+///
+/// ## See Also
+///
+/// See [PI spec 1.10 III - 4.2. HOB Overview](https://uefi.org/specs/PI/1.10/V3_HOB_Design_Discussion.html#hob-overview)
+///
+///  HOBs are allocated sequentially in memory ...
+///  The sequential list of HOBs in memory will be referred to as the HOB list.
 ///
 pub struct HobIter<'a> {
     hob_ptr: *const HobHeader,
@@ -1052,8 +1079,11 @@ pub struct EFiMemoryTypeInformation {
 #[cfg(test)]
 pub(crate) mod tests {
     use crate::pi::{
-        BootMode, hob,
-        hob::{Capsule, Cpu, EndOfHobList, FirmwareVolume, MemoryAllocation, ResourceDescriptor, get_pi_hob_list_size},
+        BootMode,
+        hob::{
+            self, Capsule, Cpu, EndOfHobList, FirmwareVolume, GenericHob, Hob, MemoryAllocation,
+            PhaseHandoffInformationTable, ResourceDescriptor, get_pi_hob_list_size,
+        },
     };
 
     use core::{mem::size_of, slice::from_raw_parts};
@@ -1311,15 +1341,15 @@ pub(crate) mod tests {
         ($ptr:ident, $buffer:expr) => {
             let mut _aligned_storage: Option<Vec<u64>> = None;
 
-            let $ptr: *const c_void = if ($buffer.as_ptr() as usize) % 8 == 0 {
-                $buffer.as_ptr() as *const c_void
+            let $ptr: *const core::ffi::c_void = if ($buffer.as_ptr() as usize) % 8 == 0 {
+                $buffer.as_ptr() as *const core::ffi::c_void
             } else {
                 let mut aligned = vec![0u64; $buffer.len().div_ceil(8)];
                 unsafe {
                     core::ptr::copy_nonoverlapping($buffer.as_ptr(), aligned.as_mut_ptr() as *mut u8, $buffer.len());
                 }
                 _aligned_storage = Some(aligned);
-                _aligned_storage.as_ref().unwrap().as_ptr() as *const c_void
+                _aligned_storage.as_ref().unwrap().as_ptr() as *const core::ffi::c_void
             };
         };
     }
@@ -1327,8 +1357,6 @@ pub(crate) mod tests {
 
     #[test]
     fn test_get_pi_hob_list_size_multiple_hobs() {
-        use core::ffi::c_void;
-
         // Create a HOB list with multiple HOBs in contiguous memory
         let capsule = gen_capsule();
         let firmware_volume = gen_firmware_volume();
@@ -1369,8 +1397,6 @@ pub(crate) mod tests {
 
     #[test]
     fn test_get_pi_hob_list_size_varied_hob_types() {
-        use core::ffi::c_void;
-
         // Create a HOB list with various HOB types
         let cpu = gen_cpu();
         let resource = gen_resource_descriptor();
@@ -1409,5 +1435,70 @@ pub(crate) mod tests {
         let size = unsafe { get_pi_hob_list_size(aligned_buffer) };
 
         assert_eq!(size, expected_size);
+    }
+
+    #[test]
+    fn test_pi_hob_list_iter() {
+        // generate some test hobs
+        let handoff = gen_phase_handoff_information_table();
+        let cpu = gen_cpu();
+        let resource = gen_resource_descriptor();
+        let memory_alloc = gen_memory_allocation();
+        let end_of_list = gen_end_of_hoblist();
+
+        let expected_size = size_of::<PhaseHandoffInformationTable>()
+            + size_of::<Cpu>()
+            + size_of::<ResourceDescriptor>()
+            + size_of::<MemoryAllocation>()
+            + size_of::<EndOfHobList>();
+
+        // SAFETY: Creating a contiguous memory from structs for test purposes.
+        let buffer = unsafe {
+            [
+                core::slice::from_raw_parts(&raw const handoff as *const u8, size_of::<PhaseHandoffInformationTable>()),
+                core::slice::from_raw_parts(&raw const cpu as *const u8, size_of::<Cpu>()),
+                core::slice::from_raw_parts(&raw const resource as *const u8, size_of::<ResourceDescriptor>()),
+                core::slice::from_raw_parts(&raw const memory_alloc as *const u8, size_of::<MemoryAllocation>()),
+                core::slice::from_raw_parts(&raw const end_of_list as *const u8, size_of::<EndOfHobList>()),
+            ]
+        }
+        .concat();
+
+        declare_aligned_buffer!(aligned_buffer, buffer); // ensure 8-byte alignment
+
+        // SAFETY: The list is created in this test with headers and an end-of-list marker that should be valid
+        let size = unsafe { get_pi_hob_list_size(aligned_buffer) };
+        assert_eq!(size, expected_size);
+
+        //
+        // Test iteration from the beginning.
+        //
+
+        let hob_list_begin = aligned_buffer.cast::<PhaseHandoffInformationTable>();
+        let hob_list_begin = unsafe { hob_list_begin.as_ref() }.unwrap();
+
+        let hob_list = Hob::Handoff(hob_list_begin);
+
+        let mut count: u32 = 0;
+        for _hob in hob_list.iter() {
+            count += 1;
+        }
+        assert_eq!(count, 4); // found all HOBs except END_OF_HOB_LIST
+
+        //
+        // Test iteration from the middle.
+        //
+        let shift = size_of::<PhaseHandoffInformationTable>() + size_of::<Cpu>();
+        let middle = unsafe { aligned_buffer.byte_add(shift) };
+        let middle = middle.cast::<GenericHob>();
+        let middle = unsafe { middle.as_ref() }.unwrap();
+
+        let middle_list = Hob::Misc(middle);
+
+        let mut count_from_middle: u32 = 0;
+        for _hob in middle_list.iter() {
+            count_from_middle += 1;
+        }
+        assert_eq!(count_from_middle, 2); // from middle to END_OF_HOB_LIST (exclusive)
     }
 }

--- a/sdk/patina/src/pi/hob.rs
+++ b/sdk/patina/src/pi/hob.rs
@@ -1354,7 +1354,7 @@ pub(crate) mod tests {
         // // Wrong!! Decode GenericHob from buffer
         // let hob = unsafe { core::ptr::read_unaligned(buffer.as_ptr().cast::<hob::GenericHob>()) };
 
-        // Must be cast to keep tailing data.
+        // Must be cast to preserve trailing data.
         declare_aligned_buffer!(aligned_buffer, buffer);
         let hob = aligned_buffer.cast::<hob::GenericHob>();
         // SAFETY: The hob alignment is ensured by `declare_aligned_buffer!`

--- a/sdk/patina/src/pi/hob/hob_list.rs
+++ b/sdk/patina/src/pi/hob/hob_list.rs
@@ -1254,8 +1254,6 @@ mod tests {
 
     #[test]
     fn test_get_pi_hob_list_size_multiple_hobs() {
-        use core::ffi::c_void;
-
         // Create a HOB list with multiple HOBs in contiguous memory
         let capsule = gen_capsule();
         let firmware_volume = gen_firmware_volume();
@@ -1295,8 +1293,6 @@ mod tests {
 
     #[test]
     fn test_get_pi_hob_list_size_varied_hob_types() {
-        use core::ffi::c_void;
-
         // Create a HOB list with various HOB types
         let cpu = gen_cpu();
         let resource = gen_resource_descriptor();

--- a/sdk/patina/src/pi/hob/hob_list.rs
+++ b/sdk/patina/src/pi/hob/hob_list.rs
@@ -16,9 +16,9 @@
 
 use crate::pi::hob::{
     CPU, Capsule, Cpu, END_OF_HOB_LIST, FV, FV2, FV3, FirmwareVolume, FirmwareVolume2, FirmwareVolume3, GUID_EXTENSION,
-    GuidHob, HANDOFF, Hob, HobHeader, HobTrait, MEMORY_ALLOCATION, MemoryAllocation, MemoryAllocationModule,
-    PhaseHandoffInformationTable, RESOURCE_DESCRIPTOR, RESOURCE_DESCRIPTOR2, ResourceDescriptor, ResourceDescriptorV2,
-    UEFI_CAPSULE,
+    GuidHob, HANDOFF, Hob, HobHeader, HobTrait, LOAD_PEIM_UNUSED, MEMORY_ALLOCATION, MEMORY_POOL, MemoryAllocation,
+    MemoryAllocationModule, PhaseHandoffInformationTable, RESOURCE_DESCRIPTOR, RESOURCE_DESCRIPTOR2,
+    ResourceDescriptor, ResourceDescriptorV2, UEFI_CAPSULE, UNUSED,
 };
 use core::{ffi::c_void, mem, slice};
 
@@ -199,6 +199,8 @@ impl<'a> HobList<'a> {
 
     /// Discovers hobs from a C style void* and adds them to a rust structure.
     ///
+    /// Note: This is not a complete copy of the original HOB list. Unused HOBs are filtered out.
+    ///
     /// # Example(s)
     ///
     /// ```no_run
@@ -325,16 +327,30 @@ impl<'a> HobList<'a> {
                     }
                 }
                 END_OF_HOB_LIST => {
+                    // NOTE: The END_OF_HOB_LIST HOB is not added to the list
                     break;
                 }
+                MEMORY_POOL | LOAD_PEIM_UNUSED | UNUSED => {
+                    // NOTE: Intentionally filtered out.
+                    // Do nothing
+                }
                 _ => {
-                    self.0.push(Hob::Misc(current_header.r#type));
+                    // NOTE: Unexpected.
+                    // unreachable!("Unknown HOB type: {}", current_header.r#type);
+                    debug_assert!(false, "Unknown HOB type: {}", current_header.r#type);
                 }
             }
             let next_hob = hob_header as usize + current_header.length as usize;
             // Guard against malformed HOBs: length must advance past the header to avoid infinite
             // loops, and the addition must not overflow the address space.
             if (current_header.length as usize) < mem::size_of::<HobHeader>() || next_hob < hob_header as usize {
+                debug_assert!(
+                    false,
+                    "Malformed HOB: type {:?} has length {} which is smaller than the header size {} or causes overflow.",
+                    current_header.r#type,
+                    current_header.length,
+                    mem::size_of::<HobHeader>()
+                );
                 break;
             }
             hob_header = next_hob as *const HobHeader;
@@ -377,7 +393,12 @@ impl<'a> HobList<'a> {
                 Hob::FirmwareVolume3(hob) => *hob = Box::leak(Box::new(FirmwareVolume3::clone(hob))),
                 Hob::Cpu(hob) => *hob = Box::leak(Box::new(Cpu::clone(hob))),
                 Hob::ResourceDescriptorV2(hob) => *hob = Box::leak(Box::new(ResourceDescriptorV2::clone(hob))),
-                Hob::Misc(_) => (), // Data is owned in Misc (nothing to move),
+                Hob::EndOfHobList(_) => {
+                    unreachable!("EndOfHobList Shoul not in list.")
+                }
+                Hob::Misc(_) => {
+                    unreachable!("Unused HOB shoul not in list. Unused HOB type: {}", hob.header().r#type)
+                }
             }
         }
     }
@@ -508,17 +529,17 @@ impl fmt::Debug for HobList<'_> {
 
 #[cfg(test)]
 mod tests {
-    use crate::pi::{
-        hob,
-        hob::{
-            Capsule, Cpu, FirmwareVolume, Hob, HobTrait, MemoryAllocation, PhaseHandoffInformationTable,
-            ResourceDescriptor, get_pi_hob_list_size,
+    use crate::{
+        component::service::memory,
+        pi::hob::{
+            self, Capsule, Cpu, EndOfHobList, FirmwareVolume, Hob, HobTrait, MemoryAllocation,
+            PhaseHandoffInformationTable, ResourceDescriptor, get_pi_hob_list_size,
             hob_list::HobList,
             tests::{
                 gen_capsule, gen_cpu, gen_end_of_hoblist, gen_firmware_volume, gen_firmware_volume2,
                 gen_firmware_volume3, gen_guid_hob, gen_memory_allocation, gen_memory_allocation_module,
-                gen_phase_handoff_information_table, gen_resource_descriptor, gen_resource_descriptor_v2,
-                guid_hob_refs,
+                gen_memory_pool, gen_phase_handoff_information_table, gen_resource_descriptor,
+                gen_resource_descriptor_v2, gen_unused, guid_hob_refs,
             },
         },
     };
@@ -609,6 +630,7 @@ mod tests {
         let firmware_volume = gen_firmware_volume();
         let firmware_volume2 = gen_firmware_volume2();
         let firmware_volume3 = gen_firmware_volume3();
+        let phit_hob = gen_phase_handoff_information_table();
         let end_of_hob_list = gen_end_of_hoblist();
         let capsule = gen_capsule();
         let guid_hob_buf = gen_guid_hob();
@@ -616,6 +638,7 @@ mod tests {
         let memory_allocation = gen_memory_allocation();
         let memory_allocation_module = gen_memory_allocation_module();
 
+        hoblist.push(Hob::Handoff(&phit_hob));
         hoblist.push(Hob::ResourceDescriptor(&resource));
         hoblist.push(Hob::FirmwareVolume(&firmware_volume));
         hoblist.push(Hob::FirmwareVolume2(&firmware_volume2));
@@ -624,7 +647,7 @@ mod tests {
         hoblist.push(Hob::GuidHob(guid_hob, guid_hob_data));
         hoblist.push(Hob::MemoryAllocation(&memory_allocation));
         hoblist.push(Hob::MemoryAllocationModule(&memory_allocation_module));
-        hoblist.push(Hob::Handoff(&end_of_hob_list));
+        hoblist.push(Hob::EndOfHobList(&end_of_hob_list));
 
         let mut count = 0;
         hoblist.iter().for_each(|hob| {
@@ -660,13 +683,17 @@ mod tests {
                 Hob::Handoff(handoff) => {
                     assert_eq!(handoff.memory_top, 0xdeadbeef);
                 }
+                Hob::EndOfHobList(end) => {
+                    assert_eq!(end.header.r#type, hob::END_OF_HOB_LIST);
+                    assert_eq!(end.header.length, size_of::<hob::HobHeader>() as u16);
+                }
                 _ => {
                     panic!("Unexpected hob type");
                 }
             }
             count += 1;
         });
-        assert_eq!(count, 9);
+        assert_eq!(count, 10);
     }
 
     #[test]
@@ -710,6 +737,58 @@ mod tests {
     }
 
     #[test]
+    fn test_discover_filter_out_unused_hobs() {
+        let phit_hob = gen_phase_handoff_information_table();
+        let end_of_hob_list = gen_end_of_hoblist();
+        let resource = gen_resource_descriptor();
+        let memory_allocation = gen_memory_allocation();
+        let unused = gen_unused();
+        let memory_pool = gen_memory_pool();
+
+        // Create a PI spec HOB list with multiple HOBs in contiguous memory
+        let mut buffer = Vec::new();
+
+        // HANDOFF
+        buffer.extend_from_slice(unsafe {
+            core::slice::from_raw_parts(&raw const phit_hob as *const u8, size_of_val(&phit_hob))
+        });
+
+        // RESOURCE_DESCRIPTOR
+        buffer.extend_from_slice(unsafe {
+            core::slice::from_raw_parts(&raw const resource as *const u8, size_of_val(&resource))
+        });
+
+        // MEMORY_POOL (filtered out)
+        buffer.extend_from_slice(&memory_pool);
+
+        // UNUSED  (filtered out)
+        buffer.extend_from_slice(unsafe {
+            core::slice::from_raw_parts(&raw const unused as *const u8, unused.header.length as usize)
+        });
+
+        // MEMORY_ALLOCATION
+        buffer.extend_from_slice(unsafe {
+            core::slice::from_raw_parts(&raw const memory_allocation as *const u8, size_of_val(&memory_allocation))
+        });
+
+        // END_OF_HOB_LIST (filtered out)
+        buffer.extend_from_slice(unsafe {
+            core::slice::from_raw_parts(&raw const end_of_hob_list as *const u8, end_of_hob_list.header.length as usize)
+        });
+
+        let mut hoblist = HobList::new();
+
+        hoblist.discover_hobs(buffer.as_ptr() as *const c_void);
+
+        match hoblist.iter().next().unwrap() {
+            Hob::Handoff(handoff) => assert_eq!(handoff.memory_top, 0xdeadbeef),
+            other => panic!("expected HANDOFF HOB, got {other:?}"),
+        }
+        // Assert that Misc HOBs and END_OF_HOB_LIST were filtered out
+        assert_eq!(hoblist.len(), 3);
+    }
+
+    #[test]
     fn test_hoblist_discover() {
         // generate some test hobs
         let resource = gen_resource_descriptor();
@@ -741,9 +820,9 @@ mod tests {
         hoblist.push(Hob::MemoryAllocationModule(&memory_allocation_module));
         hoblist.push(Hob::Cpu(&cpu));
         hoblist.push(Hob::ResourceDescriptorV2(&resource_v2));
-        hoblist.push(Hob::Handoff(&end_of_hob_list));
+        hoblist.push(Hob::EndOfHobList(&end_of_hob_list));
 
-        // assert that the hoblist has 3 hobs and they are of the correct type
+        // assert that the hoblist has 12 hobs and they are of the correct type
 
         let mut count = 0;
         hoblist.iter().for_each(|hob| {
@@ -779,6 +858,10 @@ mod tests {
                 Hob::Handoff(handoff) => {
                     assert_eq!(handoff.memory_top, 0xdeadbeef);
                 }
+                Hob::EndOfHobList(end) => {
+                    assert_eq!(end.header.r#type, hob::END_OF_HOB_LIST);
+                    assert_eq!(end.header.length, size_of::<hob::HobHeader>() as u16);
+                }
                 Hob::Cpu(cpu) => {
                     assert_eq!(cpu.size_of_memory_space, 0);
                 }
@@ -802,11 +885,12 @@ mod tests {
         let mut cloned_hoblist = HobList::new();
         cloned_hoblist.discover_hobs(c_array_hoblist);
 
-        // assert that the hoblist has 2 hobs and they are of the correct type
+        // assert that the hoblist has 11 hobs and they are of the correct type
+        //
         // we don't need to check the end of hoblist hob as it will not be 'discovered'
         // by the discover_hobs function and simply end the iteration
         count = 0;
-        hoblist.into_iter().for_each(|hob| {
+        cloned_hoblist.into_iter().for_each(|hob| {
             match hob {
                 Hob::ResourceDescriptor(resource) => {
                     assert_eq!(resource.resource_type, hob::EFI_RESOURCE_SYSTEM_MEMORY);
@@ -839,6 +923,9 @@ mod tests {
                 Hob::Handoff(handoff) => {
                     assert_eq!(handoff.memory_top, 0xdeadbeef);
                 }
+                Hob::EndOfHobList(_) => {
+                    panic!("Unexpected EndOfHobList");
+                }
                 Hob::ResourceDescriptorV2(resource) => {
                     assert_eq!(resource.v1.header.r#type, hob::RESOURCE_DESCRIPTOR2);
                     assert_eq!(resource.v1.resource_type, hob::EFI_RESOURCE_SYSTEM_MEMORY);
@@ -853,7 +940,7 @@ mod tests {
             count += 1;
         });
 
-        assert_eq!(count, 12);
+        assert_eq!(count, 11);
 
         // free the c array
         manually_free_c_array(c_array_hoblist, length);
@@ -889,7 +976,7 @@ mod tests {
         hoblist.push(Hob::MemoryAllocation(&memory_allocation));
         hoblist.push(Hob::MemoryAllocationModule(&memory_allocation_module));
         hoblist.push(Hob::Cpu(&cpu));
-        hoblist.push(Hob::Handoff(&end_of_hob_list));
+        hoblist.push(Hob::EndOfHobList(&end_of_hob_list));
 
         let (c_array_hoblist, length) = to_c_array(&hoblist);
 
@@ -935,7 +1022,7 @@ mod tests {
         hoblist.push(Hob::MemoryAllocationModule(&memory_allocation_module));
         hoblist.push(Hob::Cpu(&cpu));
         hoblist.push(Hob::ResourceDescriptorV2(&resource_v2));
-        hoblist.push(Hob::Handoff(&end_of_hob_list));
+        hoblist.push(Hob::EndOfHobList(&end_of_hob_list));
 
         // Make sure we can iterate over a reference to a HobList without
         // consuming it.
@@ -946,6 +1033,46 @@ mod tests {
         for hob in hoblist {
             println!("{:?}", hob.header());
         }
+    }
+
+    #[test]
+    #[should_panic(expected = "Unused HOB shoul not in list. Unused HOB type: ")]
+    fn test_relocate_hobs_has_unused() {
+        // generate some test hobs
+        let cpu = gen_cpu();
+        let resource_v2 = gen_resource_descriptor_v2();
+        let end_of_hob_list = gen_end_of_hoblist();
+        let unused = gen_unused();
+
+        // create a new hoblist
+        let mut hoblist = HobList::new();
+
+        // Push the resource descriptor to the hoblist
+        hoblist.push(Hob::Cpu(&cpu));
+        hoblist.push(Hob::Misc(&unused));
+        hoblist.push(Hob::ResourceDescriptorV2(&resource_v2));
+        hoblist.push(Hob::EndOfHobList(&end_of_hob_list));
+
+        hoblist.relocate_hobs();
+    }
+
+    #[test]
+    #[should_panic(expected = "EndOfHobList Shoul not in list.")]
+    fn test_relocate_hobs_has_end() {
+        // generate some test hobs
+        let cpu = gen_cpu();
+        let resource_v2 = gen_resource_descriptor_v2();
+        let end_of_hob_list = gen_end_of_hoblist();
+
+        // create a new hoblist
+        let mut hoblist = HobList::new();
+
+        // Push the resource descriptor to the hoblist
+        hoblist.push(Hob::Cpu(&cpu));
+        hoblist.push(Hob::ResourceDescriptorV2(&resource_v2));
+        hoblist.push(Hob::EndOfHobList(&end_of_hob_list));
+
+        hoblist.relocate_hobs();
     }
 
     #[test]
@@ -963,7 +1090,6 @@ mod tests {
         let memory_allocation_module = gen_memory_allocation_module();
         let cpu = gen_cpu();
         let resource_v2 = gen_resource_descriptor_v2();
-        let end_of_hob_list = gen_end_of_hoblist();
 
         // create a new hoblist
         let mut hoblist = HobList::new();
@@ -979,9 +1105,7 @@ mod tests {
         hoblist.push(Hob::MemoryAllocation(&memory_allocation));
         hoblist.push(Hob::MemoryAllocationModule(&memory_allocation_module));
         hoblist.push(Hob::Cpu(&cpu));
-        hoblist.push(Hob::Misc(12345));
         hoblist.push(Hob::ResourceDescriptorV2(&resource_v2));
-        hoblist.push(Hob::Handoff(&end_of_hob_list));
 
         let hoblist_address = hoblist.as_mut_ptr::<()>() as usize;
         let hoblist_len = hoblist.len();
@@ -1039,16 +1163,10 @@ mod tests {
                     assert_ne!(ptr::addr_of!(cpu), hob);
                     assert_eq!(cpu, *hob);
                 }
-                Hob::Misc(hob) if i == 10 => {
-                    assert_eq!(12345, hob);
-                }
-                Hob::ResourceDescriptorV2(hob) if i == 11 => {
+
+                Hob::ResourceDescriptorV2(hob) if i == 10 => {
                     assert_ne!(ptr::addr_of!(resource_v2), hob);
                     assert_eq!(resource_v2, *hob);
-                }
-                Hob::Handoff(hob) if i == 12 => {
-                    assert_ne!(ptr::addr_of!(end_of_hob_list), hob);
-                    assert_eq!(end_of_hob_list, *hob);
                 }
                 _ => panic!("Hob at index: {i}."),
             }
@@ -1085,7 +1203,7 @@ mod tests {
         // SAFETY: The list is created in this test with a valid end-of-list marker
         let size = unsafe { get_pi_hob_list_size(&raw const end_of_list as *const c_void) };
 
-        assert_eq!(size, size_of::<PhaseHandoffInformationTable>());
+        assert_eq!(size, size_of::<EndOfHobList>());
     }
 
     #[test]
@@ -1097,8 +1215,7 @@ mod tests {
         let firmware_volume = gen_firmware_volume();
         let end_of_list = gen_end_of_hoblist();
 
-        let expected_size =
-            size_of::<Capsule>() + size_of::<FirmwareVolume>() + size_of::<PhaseHandoffInformationTable>();
+        let expected_size = size_of::<Capsule>() + size_of::<FirmwareVolume>() + size_of::<EndOfHobList>();
 
         // This buffer will hold the contiguous HOBs
         let mut buffer = Vec::new();
@@ -1118,9 +1235,8 @@ mod tests {
 
         // Add an end-of-list HOB
         // SAFETY: Creating a byte slice from a struct for test purposes.
-        let end_bytes = unsafe {
-            core::slice::from_raw_parts(&raw const end_of_list as *const u8, size_of::<PhaseHandoffInformationTable>())
-        };
+        let end_bytes =
+            unsafe { core::slice::from_raw_parts(&raw const end_of_list as *const u8, size_of::<EndOfHobList>()) };
         buffer.extend_from_slice(end_bytes);
 
         // SAFETY: The list is created in this test with headers and an end-of-list marker that should be valid
@@ -1142,7 +1258,7 @@ mod tests {
         let expected_size = size_of::<Cpu>()
             + size_of::<ResourceDescriptor>()
             + size_of::<MemoryAllocation>()
-            + size_of::<PhaseHandoffInformationTable>();
+            + size_of::<EndOfHobList>();
 
         // This buffer will hold the contiguous HOBs
         let mut buffer = Vec::new();
@@ -1162,7 +1278,7 @@ mod tests {
 
         // SAFETY: Creating a byte slice from a struct for test purposes.
         buffer.extend_from_slice(unsafe {
-            core::slice::from_raw_parts(&raw const end_of_list as *const u8, size_of::<PhaseHandoffInformationTable>())
+            core::slice::from_raw_parts(&raw const end_of_list as *const u8, size_of::<EndOfHobList>())
         });
 
         // SAFETY: The list is created in this test with headers and an end-of-list marker that should be valid

--- a/sdk/patina/src/pi/hob/hob_list.rs
+++ b/sdk/patina/src/pi/hob/hob_list.rs
@@ -336,7 +336,6 @@ impl<'a> HobList<'a> {
                 }
                 _ => {
                     // NOTE: Unexpected.
-                    // unreachable!("Unknown HOB type: {}", current_header.r#type);
                     debug_assert!(false, "Unknown HOB type: {}", current_header.r#type);
                 }
             }
@@ -394,10 +393,12 @@ impl<'a> HobList<'a> {
                 Hob::Cpu(hob) => *hob = Box::leak(Box::new(Cpu::clone(hob))),
                 Hob::ResourceDescriptorV2(hob) => *hob = Box::leak(Box::new(ResourceDescriptorV2::clone(hob))),
                 Hob::EndOfHobList(_) => {
-                    unreachable!("EndOfHobList Shoul not in list.")
+                    debug_assert!(false, "EndOfHobList should not be in list.");
+                    // It will not be relocated.
                 }
-                Hob::Misc(_) => {
-                    unreachable!("Unused HOB shoul not in list. Unused HOB type: {}", hob.header().r#type)
+                Hob::Misc(hob) => {
+                    debug_assert!(false, "Unused HOB should not be in list. Unused HOB type: {}", hob.header.r#type);
+                    // It will not be relocated.
                 }
             }
         }
@@ -529,18 +530,15 @@ impl fmt::Debug for HobList<'_> {
 
 #[cfg(test)]
 mod tests {
-    use crate::{
-        component::service::memory,
-        pi::hob::{
-            self, Capsule, Cpu, EndOfHobList, FirmwareVolume, Hob, HobTrait, MemoryAllocation,
-            PhaseHandoffInformationTable, ResourceDescriptor, get_pi_hob_list_size,
-            hob_list::HobList,
-            tests::{
-                gen_capsule, gen_cpu, gen_end_of_hoblist, gen_firmware_volume, gen_firmware_volume2,
-                gen_firmware_volume3, gen_guid_hob, gen_memory_allocation, gen_memory_allocation_module,
-                gen_memory_pool, gen_phase_handoff_information_table, gen_resource_descriptor,
-                gen_resource_descriptor_v2, gen_unused, guid_hob_refs,
-            },
+    use crate::pi::hob::{
+        self, Capsule, Cpu, EndOfHobList, FirmwareVolume, Hob, HobTrait, MemoryAllocation, ResourceDescriptor,
+        get_pi_hob_list_size,
+        hob_list::HobList,
+        tests::{
+            declare_aligned_buffer, gen_capsule, gen_cpu, gen_end_of_hoblist, gen_firmware_volume,
+            gen_firmware_volume2, gen_firmware_volume3, gen_guid_hob, gen_memory_allocation,
+            gen_memory_allocation_module, gen_memory_pool, gen_phase_handoff_information_table,
+            gen_resource_descriptor, gen_resource_descriptor_v2, gen_unused, guid_hob_refs,
         },
     };
 
@@ -776,9 +774,11 @@ mod tests {
             core::slice::from_raw_parts(&raw const end_of_hob_list as *const u8, end_of_hob_list.header.length as usize)
         });
 
+        declare_aligned_buffer!(aligned_buffer, buffer); // ensure 8-byte alignment
+
         let mut hoblist = HobList::new();
 
-        hoblist.discover_hobs(buffer.as_ptr() as *const c_void);
+        hoblist.discover_hobs(aligned_buffer);
 
         match hoblist.iter().next().unwrap() {
             Hob::Handoff(handoff) => assert_eq!(handoff.memory_top, 0xdeadbeef),
@@ -1035,9 +1035,12 @@ mod tests {
         }
     }
 
+    // cargo make test test_relocate_hobs_has_unused_dev -p patina --profile dev
+    //
     #[test]
-    #[should_panic(expected = "Unused HOB shoul not in list. Unused HOB type: ")]
-    fn test_relocate_hobs_has_unused() {
+    #[cfg(debug_assertions)]
+    #[should_panic(expected = "Unused HOB should not be in list. Unused HOB type: ")]
+    fn test_relocate_hobs_has_unused_dev() {
         // generate some test hobs
         let cpu = gen_cpu();
         let resource_v2 = gen_resource_descriptor_v2();
@@ -1057,8 +1060,51 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "EndOfHobList Shoul not in list.")]
-    fn test_relocate_hobs_has_end() {
+    #[cfg(not(debug_assertions))]
+    fn test_relocate_hobs_has_unused_release() {
+        // generate some test hobs
+        let cpu = gen_cpu();
+        let resource_v2 = gen_resource_descriptor_v2();
+        let end_of_hob_list = gen_end_of_hoblist();
+        let unused = gen_unused();
+
+        // create a new hoblist
+        let mut hoblist = HobList::new();
+
+        // Push the resource descriptor to the hoblist
+        hoblist.push(Hob::Cpu(&cpu));
+        hoblist.push(Hob::Misc(&unused));
+        hoblist.push(Hob::ResourceDescriptorV2(&resource_v2));
+        hoblist.push(Hob::EndOfHobList(&end_of_hob_list));
+
+        hoblist.relocate_hobs();
+    }
+
+    // cargo make test test_relocate_hobs_has_end_dev -p patina --profile dev
+    //
+    #[test]
+    #[cfg(debug_assertions)]
+    #[should_panic(expected = "EndOfHobList should not be in list.")]
+    fn test_relocate_hobs_has_end_dev() {
+        // generate some test hobs
+        let cpu = gen_cpu();
+        let resource_v2 = gen_resource_descriptor_v2();
+        let end_of_hob_list = gen_end_of_hoblist();
+
+        // create a new hoblist
+        let mut hoblist = HobList::new();
+
+        // Push the resource descriptor to the hoblist
+        hoblist.push(Hob::Cpu(&cpu));
+        hoblist.push(Hob::ResourceDescriptorV2(&resource_v2));
+        hoblist.push(Hob::EndOfHobList(&end_of_hob_list));
+
+        hoblist.relocate_hobs();
+    }
+
+    #[test]
+    #[cfg(not(debug_assertions))]
+    fn test_relocate_hobs_has_end_release() {
         // generate some test hobs
         let cpu = gen_cpu();
         let resource_v2 = gen_resource_descriptor_v2();
@@ -1239,8 +1285,10 @@ mod tests {
             unsafe { core::slice::from_raw_parts(&raw const end_of_list as *const u8, size_of::<EndOfHobList>()) };
         buffer.extend_from_slice(end_bytes);
 
+        declare_aligned_buffer!(aligned_buffer, buffer); // ensure 8-byte alignment
+
         // SAFETY: The list is created in this test with headers and an end-of-list marker that should be valid
-        let size = unsafe { get_pi_hob_list_size(buffer.as_ptr() as *const c_void) };
+        let size = unsafe { get_pi_hob_list_size(aligned_buffer) };
 
         assert_eq!(size, expected_size);
     }
@@ -1281,8 +1329,10 @@ mod tests {
             core::slice::from_raw_parts(&raw const end_of_list as *const u8, size_of::<EndOfHobList>())
         });
 
+        declare_aligned_buffer!(aligned_buffer, buffer); // ensure 8-byte alignment
+
         // SAFETY: The list is created in this test with headers and an end-of-list marker that should be valid
-        let size = unsafe { get_pi_hob_list_size(buffer.as_ptr() as *const c_void) };
+        let size = unsafe { get_pi_hob_list_size(aligned_buffer) };
 
         assert_eq!(size, expected_size);
     }


### PR DESCRIPTION
## Description

Refactor the `Hob::Misc` design.

Introduce `hob::GenericHob` to hold the HOB generic header for `Hob::Misc`.

Per the PI spec, HOB is an open design, and all HOBs share a common header. Binding to a generic header is more intuitive than using a heterogeneous integer representation.

Bug Fix:
Introduce `hob::EndOfHobList` for unit tests, this is the correct struct for end-of-hob per PI Spec.
Correct related unit tests to use `hob::EndOfHobList`

Code Enhancement:
Add `align(8)` for `hob::HobHeader`. This is optional for consumers, but following PI Spec is not a bad choice.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [X] Includes tests?
- [x] Includes documentation?

## How This Was Tested

Pass `cargo make test`

## Integration Instructions

N/A