### PR TITLE
Patina: Gate architecture specific code on UEFI targets

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ patina_internal_cpu = { version = "23.1.0", path = "core/patina_internal_cpu" }
 lzma-rust2 = { version = "0.16", default-features = false }
 patina_macro = { version = "23.1.0", path = "sdk/patina_macro" }
 patina_mm = { version = "23.1.0", path = "components/patina_mm" }
-patina_mtrr = { version = "1.1.6" }
+patina_mtrr = { version = "1.1.9" }
 patina_paging = { version = "11.0.4" }
 patina_performance = { version = "23.1.0", path = "components/patina_performance" }
 patina_smbios = { version = "23.1.0", path = "components/patina_smbios" }

--- a/core/patina_debugger/src/lib.rs
+++ b/core/patina_debugger/src/lib.rs
@@ -122,7 +122,7 @@ extern crate alloc;
 
 pub use debugger::PatinaDebugger;
 
-#[cfg(not(test))]
+#[cfg(target_os = "uefi")]
 use arch::{DebuggerArch, SystemArch};
 use patina::{component::service::perf_timer::ArchTimerFunctionality, peripheral::serial::SerialIO};
 use patina_internal_cpu::interrupts::{ExceptionContext, InterruptManager};
@@ -255,7 +255,7 @@ pub fn breakpoint() {
 /// execution in the current state and an CPU exception must be raised.
 #[inline(always)]
 pub fn breakpoint_unchecked() {
-    #[cfg(not(test))]
+    #[cfg(target_os = "uefi")]
     SystemArch::breakpoint();
     #[cfg(test)]
     panic!("breakpoint_unchecked");

--- a/core/patina_internal_cpu/src/interrupts/aarch64/interrupt_manager.rs
+++ b/core/patina_internal_cpu/src/interrupts/aarch64/interrupt_manager.rs
@@ -18,7 +18,7 @@ use crate::interrupts::{
 };
 
 cfg_if::cfg_if! {
-    if #[cfg(not(test))] {
+    if #[cfg(target_os = "uefi")] {
         use core::arch::global_asm;
         use patina::{read_sysreg, write_sysreg, arch::aarch64::{AArch64El, get_current_el}};
 
@@ -64,7 +64,7 @@ impl InterruptManager for InterruptsAarch64 {}
 #[cfg_attr(coverage, coverage(off))]
 fn enable_fiq() {
     cfg_if::cfg_if! {
-        if #[cfg(not(test))]  {
+        if #[cfg(target_os = "uefi")]  {
             write_sysreg!(reg daifclr, imm 0x01, "isb sy");
         } else {
             unimplemented!()
@@ -75,7 +75,7 @@ fn enable_fiq() {
 #[cfg_attr(coverage, coverage(off))]
 fn disable_fiq() {
     cfg_if::cfg_if! {
-        if #[cfg(not(test))]  {
+        if #[cfg(target_os = "uefi")]  {
             write_sysreg!(reg daifset, imm 0x01, "isb sy");
         } else {
             unimplemented!()
@@ -86,7 +86,7 @@ fn disable_fiq() {
 #[cfg_attr(coverage, coverage(off))]
 fn get_fiq_state() -> Result<bool, EfiError> {
     cfg_if::cfg_if! {
-        if #[cfg(not(test))]  {
+        if #[cfg(target_os = "uefi")]  {
             let daif = read_sysreg!(daif);
             Ok(daif & 0x40 == 0)
         } else {
@@ -98,7 +98,7 @@ fn get_fiq_state() -> Result<bool, EfiError> {
 #[cfg_attr(coverage, coverage(off))]
 fn enable_async_abort() {
     cfg_if::cfg_if! {
-        if #[cfg(not(test))]  {
+        if #[cfg(target_os = "uefi")]  {
             write_sysreg!(reg daifclr, imm 0x04, "isb sy");
         } else {
             unimplemented!()
@@ -109,7 +109,7 @@ fn enable_async_abort() {
 #[cfg_attr(coverage, coverage(off))]
 fn initialize_exception() -> Result<(), EfiError> {
     // Set the stack pointer for EL0 to be used for synchronous exceptions
-    #[cfg(not(test))]
+    #[cfg(target_os = "uefi")]
     {
         // SAFETY: We are using the address of a symbol defined in assembly as the stack pointer for EL0.
         let mut sp_el0_reg = unsafe { core::ptr::from_ref(&sp_el0_end) as u64 };

--- a/core/patina_stacktrace/src/stacktrace.rs
+++ b/core/patina_stacktrace/src/stacktrace.rs
@@ -1,8 +1,5 @@
 use crate::{error::StResult, pe::PE};
-use core::{
-    arch::asm,
-    fmt::{self, Display, Formatter},
-};
+use core::fmt::{self, Display, Formatter};
 
 cfg_if::cfg_if! {
     if #[cfg(all(target_os = "uefi", target_arch = "aarch64"))] {
@@ -142,18 +139,17 @@ impl StackTrace {
     #[cfg_attr(coverage, coverage(off))]
     #[inline(never)]
     pub unsafe fn dump() -> StResult<()> {
-        let mut stack_frame = StackFrame::default();
-
         cfg_if::cfg_if! {
-            if #[cfg(target_arch = "aarch64")] {
+            if #[cfg(all(target_os = "uefi", target_arch = "aarch64"))] {
+                let mut stack_frame = StackFrame::default();
                 // SAFETY: Inline assembly reads the current program counter
                 // (PC), stack pointer (SP), and frame pointer (FP). It does not
                 // modify memory or violate Rust safety invariants. The caller
-                // must ensure that using these register values is safe.
-                // SAFETY: Reading PC/SP/FP does not mutate memory and the hardware
-                // guarantees those registers exist on aarch64.
+                // must ensure that using these register values is safe. Reading
+                // PC/SP/FP does not mutate memory and the hardware guarantees
+                // those registers exist on aarch64.
                 unsafe {
-                    asm!(
+                    core::arch::asm!(
                         "adr {pc}, .",   // Get current PC (program counter)
                         "mov {sp}, sp",  // Get current SP (stack pointer)
                         "mov {fp}, x29", // Get current FP (frame pointer)
@@ -161,17 +157,18 @@ impl StackTrace {
                         sp = out(reg) stack_frame.sp,
                         fp = out(reg) stack_frame.fp,
                     );
+                    StackTrace::dump_with(stack_frame)
                 }
-            } else {
+            } else if #[cfg(all(target_os = "uefi", target_arch = "x86_64"))] {
+                let mut stack_frame = StackFrame::default();
                 // SAFETY: Inline assembly reads the current program counter
                 // (PC), stack pointer (SP), and frame pointer (FP) on x86_64.
                 // It does not modify the memory or violate Rust safety
                 // invariants. The caller must ensure that using these register
-                // values is safe.
-                // SAFETY: Reading PC/SP/FP does not mutate memory and the hardware
-                // guarantees those registers exist on x86_64.
+                // values is safe. Reading PC/SP/FP does not mutate memory and
+                // the hardware guarantees those registers exist on x86_64.
                 unsafe {
-                    asm!(
+                    core::arch::asm!(
                         "lea {pc}, [rip]", // Get current PC (program counter)
                         "mov {sp}, rsp",   // Get current SP (stack pointer)
                         "mov {fp}, rbp",   // Get current FP (frame pointer) - Not used
@@ -179,13 +176,12 @@ impl StackTrace {
                         sp = out(reg) stack_frame.sp,
                         fp = out(reg) stack_frame.fp,
                     );
+                    StackTrace::dump_with(stack_frame)
                 }
+            } else {
+                unimplemented!("Stack trace dumping is only implemented for UEFI on AArch64 and x86_64 architectures.");
             }
         }
-
-        // SAFETY: `stack_frame` originates from trusted register snapshots; all
-        // invariants for `dump_with` are upheld locally before forwarding.
-        unsafe { StackTrace::dump_with(stack_frame) }
     }
 
     /// Dumps the stack trace by walking the FP/LR registers, without relying on unwind

--- a/core/patina_stacktrace/src/stacktrace.rs
+++ b/core/patina_stacktrace/src/stacktrace.rs
@@ -147,7 +147,9 @@ impl StackTrace {
                 // modify memory or violate Rust safety invariants. The caller
                 // must ensure that using these register values is safe. Reading
                 // PC/SP/FP does not mutate memory and the hardware guarantees
-                // those registers exist on aarch64.
+                // those registers exist on aarch64. `stack_frame` originates
+                // from trusted register snapshots; all invariants for
+                // `dump_with` are upheld locally before forwarding.
                 unsafe {
                     core::arch::asm!(
                         "adr {pc}, .",   // Get current PC (program counter)
@@ -167,6 +169,9 @@ impl StackTrace {
                 // invariants. The caller must ensure that using these register
                 // values is safe. Reading PC/SP/FP does not mutate memory and
                 // the hardware guarantees those registers exist on x86_64.
+                // `stack_frame` originates from trusted register snapshots; all
+                // invariants for `dump_with` are upheld locally before
+                // forwarding.
                 unsafe {
                     core::arch::asm!(
                         "lea {pc}, [rip]", // Get current PC (program counter)

--- a/patina_dxe_core/src/cpu/efi_cpu/x64/cpu.rs
+++ b/patina_dxe_core/src/cpu/efi_cpu/x64/cpu.rs
@@ -6,7 +6,7 @@
 //!
 //! SPDX-License-Identifier: Apache-2.0
 //!
-#[cfg(not(test))]
+#[cfg(target_os = "uefi")]
 use core::arch::asm;
 use patina::arch as interrupts;
 use patina::error::EfiError;
@@ -36,13 +36,13 @@ impl EfiCpuX64 {
     }
 
     fn initialize_gdt(&self) {
-        #[cfg(not(test))]
+        #[cfg(target_os = "uefi")]
         patina_internal_cpu::gdt::init();
     }
 
     #[cfg_attr(coverage, coverage(off))]
     fn initialize_fpu(&self) {
-        #[cfg(not(test))]
+        #[cfg(target_os = "uefi")]
         // SAFETY: This assembly writes only hard coded values to CR4 register, and MMX and FPU control words. No
         // inputs are used that could violate memory safety.
         unsafe {


### PR DESCRIPTION
## Description

Patina: Gate architecture specific code on UEFI targets

Following the `patina-paging` [PR #223](https://github.com/OpenDevicePartnership/patina-paging/pull/223), apply a similar change to the
Patina repo. This ensures architecture specific code is properly
guarded and only compiled for the appropriate UEFI targets.

Note that some external crates intentionally use inline assembly in host
builds:

- `corosensei` includes `global_asm!` in `x86_64_windows.rs` conditioned
  on `cfg(windows and x86_64)`.
- `uart_16550` includes a PIO backend that uses inline assembly
  conditioned on `cfg(x86_64)`.

So this commit is a best effort to keep Patina code free of inline
assembly when building for host targets.

NOTE: This PR only addresses the conversion of `cfg(not(test))` to
`cfg(target_os = "uefi")`. There are still many raw asm! blocks that
are not flagged by the internal toolchain, so they are being left as-is.

NIT: Update to the latest MTRR version due to coverage attribute
changes.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

`cargo make all` with public and internal toolchains(excluding above exceptions).

## Integration Instructions

NA