### PR TITLE
[major] adv_logger: Create adv_logger HW Port Trait

### DIFF
--- a/components/patina_acpi/src/lib.rs
+++ b/components/patina_acpi/src/lib.rs
@@ -16,7 +16,7 @@
 //!
 //! impl ComponentInfo for Intel {
 //! fn components(mut add: Add<Component>) {
-//!         add.component(AdvancedLoggerComponent::<Uart16550>::new(&LOGGER));
+//!         add.component(AdvancedLoggerComponent::<SerialHardwarePort<Uart16550>>::new(&LOGGER));
 //!         // Other platform components...
 //!         add.component(patina_acpi::component::AcpiProviderManager::new(oem_id, ... /* Other platform init. */));
 //!         add.component(patina_acpi::component::AcpiSystemProtocolManager::default());

--- a/components/patina_adv_logger/Cargo.toml
+++ b/components/patina_adv_logger/Cargo.toml
@@ -30,6 +30,7 @@ clap = { workspace = true, features = ['derive'], optional = true }
 
 [dev-dependencies]
 patina_dxe_core = { path = "../../patina_dxe_core" }
+mockall = { workspace = true }
 serial_test = { workspace = true }
 
 [features]

--- a/components/patina_adv_logger/README.md
+++ b/components/patina_adv_logger/README.md
@@ -13,6 +13,21 @@ The crate stores records in a shared memory buffer that begins with an `ADVANCED
 - Aligned entries follow in the memory buffer after the header.
 - Each entry records the boot phase identifier, EFI debug level mask, timestamp counter, and message bytes.
 
+## Hardware Port Behavior
+
+In addition to the memory log, records may be emitted to a hardware port. The port is abstracted behind the
+`patina_adv_logger::hardware_port::AdvancedLoggerHardwarePort` trait. This allows a platform to control the
+serial port and any filtering logic required.
+
+- `SerialHardwarePort<S>` is the default implementation and writes every message it receives to the provided
+  `SerialIO` instance.
+- The logger applies the memory log's `HwPrintLevel` / `HwPortDisabled` filtering (including any per-target
+  `hw_filter_override`) before calling the port, so a port implementation only sees records that already passed
+  the standard filtering. The record's debug level is still passed to the port so platforms can apply
+  additional, platform specific gating.
+- Platforms that need to gate output (for example, on a debug jumper or GPIO) or emit to something other than a
+  serial port can supply their own implementation of the trait instead of using `SerialHardwarePort`.
+
 ## Parser Support
 
 This crate includes a bare-bones log parser executable for parsing the logs produced via the logger, and a public log
@@ -31,7 +46,7 @@ Below are the instructions for setting up and configuring the patina component a
 your platform's Patina DXE Core binary. Additional setup will be required for your Platform, which is discussed further
 below.
 
-1. Instantiate `AdvancedLogger` with the desired format, filters, level, and serial implementation.
+1. Instantiate `AdvancedLogger` with the desired format, filters, level, and hardware port implementation.
    Register it with `log::set_logger` as early as possible.
 2. Call `AdvancedLogger::init` with the physical HOB list pointer.
    This allows the logger to adopt the buffer and record its address for later protocol publication.
@@ -45,23 +60,27 @@ below.
 # {
 use patina_dxe_core::*;
 use patina::{debug::log::Format, peripheral::serial::uart::UartNull};
-use patina_adv_logger::{component::AdvancedLoggerComponent, logger::{AdvancedLogger, TargetFilter}};
+use patina_adv_logger::{
+   component::AdvancedLoggerComponent,
+   hardware_port::SerialHardwarePort,
+   logger::{AdvancedLogger, TargetFilter},
+};
 
 use log::LevelFilter;
 use core::ffi::c_void;
 
-static LOGGER: AdvancedLogger<UartNull> = AdvancedLogger::new(
+static LOGGER: AdvancedLogger<SerialHardwarePort<UartNull>> = AdvancedLogger::new(
    Format::Standard, // How logs are formatted
    &[TargetFilter { target: "allocations", log_level: LevelFilter::Off, hw_filter_override: None }], // set custom log levels per module
    log::LevelFilter::Info, // Default log level
-   UartNull { }, // Serial writer instance
+   SerialHardwarePort::new(UartNull { }), // Hardware port instance
 );
 
 struct ExamplePlatform;
 
 impl ComponentInfo for ExamplePlatform {
    fn components(mut add: Add<Component>) {
-      add.component(AdvancedLoggerComponent::<UartNull>::new(&LOGGER));
+      add.component(AdvancedLoggerComponent::<SerialHardwarePort<UartNull>>::new(&LOGGER));
    }
 }
 

--- a/components/patina_adv_logger/src/component.rs
+++ b/components/patina_adv_logger/src/component.rs
@@ -17,40 +17,39 @@ use patina::{
         service::{Service, perf_timer::ArchTimerFunctionality},
     },
     error::{EfiError, Result},
-    peripheral::serial::SerialIO,
     uefi::boot_services::{BootServices, StandardBootServices},
 };
 
-use crate::{logger::AdvancedLogger, protocol::AdvancedLoggerProtocol};
+use crate::{hardware_port::AdvancedLoggerHardwarePort, logger::AdvancedLogger, protocol::AdvancedLoggerProtocol};
 
 /// C struct for the internal Advanced Logger protocol for the component.
 #[repr(C)]
-struct AdvancedLoggerProtocolInternal<S>
+struct AdvancedLoggerProtocolInternal<P>
 where
-    S: SerialIO + Send + 'static,
+    P: AdvancedLoggerHardwarePort + 'static,
 {
     // The public protocol that external callers will depend on.
     protocol: AdvancedLoggerProtocol,
 
     // Internal component access only! Does not exist in C definition.
-    adv_logger: &'static AdvancedLogger<'static, S>,
+    adv_logger: &'static AdvancedLogger<'static, P>,
 }
 
 /// The component that will install the Advanced Logger protocol.
-pub struct AdvancedLoggerComponent<S>
+pub struct AdvancedLoggerComponent<P>
 where
-    S: SerialIO + Send + 'static,
+    P: AdvancedLoggerHardwarePort + 'static,
 {
-    adv_logger: &'static AdvancedLogger<'static, S>,
+    adv_logger: &'static AdvancedLogger<'static, P>,
 }
 
 #[component]
-impl<S> AdvancedLoggerComponent<S>
+impl<P> AdvancedLoggerComponent<P>
 where
-    S: SerialIO + Send + 'static,
+    P: AdvancedLoggerHardwarePort + 'static,
 {
     /// Creates a new `AdvancedLoggerComponent`.
-    pub const fn new(adv_logger: &'static AdvancedLogger<S>) -> Self {
+    pub const fn new(adv_logger: &'static AdvancedLogger<P>) -> Self {
         Self { adv_logger }
     }
 
@@ -72,7 +71,7 @@ where
 
         // SAFETY: `this` is null-checked above. The protocol struct is installed by Patina with
         //         `Box::leak`, so its alignment and validity are guaranteed.
-        let internal = unsafe { &*this.cast::<AdvancedLoggerProtocolInternal<S>>() };
+        let internal = unsafe { &*this.cast::<AdvancedLoggerProtocolInternal<P>>() };
 
         internal.adv_logger.log_write(error_level, None, data);
         efi::Status::SUCCESS
@@ -111,6 +110,7 @@ where
 mod tests {
     use super::*;
     use crate::{
+        hardware_port::SerialHardwarePort,
         logger::{AdvancedLogger, TargetFilter},
         writer::AdvancedLogWriter,
     };
@@ -134,11 +134,11 @@ mod tests {
         }
     }
 
-    static TEST_LOGGER: AdvancedLogger<UartNull> = AdvancedLogger::new(
+    static TEST_LOGGER: AdvancedLogger<SerialHardwarePort<UartNull>> = AdvancedLogger::new(
         Format::Standard,
         &[TargetFilter { target: "", log_level: log::LevelFilter::Trace, hw_filter_override: None }],
         log::LevelFilter::Trace,
-        UartNull {},
+        SerialHardwarePort::new(UartNull {}),
     );
 
     /// Initializes `TEST_LOGGER` with a newly allocated memory log and a mock timer.
@@ -155,9 +155,9 @@ mod tests {
     /// Builds a leaked `AdvancedLoggerProtocolInternal` structure and returns a `*const AdvancedLoggerProtocol`
     /// that can be passed as `this` to `adv_log_write`.
     fn leak_protocol_this() -> *const AdvancedLoggerProtocol {
-        let internal = Box::leak(Box::new(AdvancedLoggerProtocolInternal::<UartNull> {
+        let internal = Box::leak(Box::new(AdvancedLoggerProtocolInternal::<SerialHardwarePort<UartNull>> {
             protocol: AdvancedLoggerProtocol::new(
-                AdvancedLoggerComponent::<UartNull>::adv_log_write,
+                AdvancedLoggerComponent::<SerialHardwarePort<UartNull>>::adv_log_write,
                 TEST_LOGGER.get_log_address().unwrap_or(0),
             ),
             adv_logger: &TEST_LOGGER,
@@ -168,8 +168,12 @@ mod tests {
     #[test]
     fn adv_log_write_null_this_returns_invalid_parameter() {
         let data = b"hello";
-        let status =
-            AdvancedLoggerComponent::<UartNull>::adv_log_write(core::ptr::null(), 0, data.as_ptr(), data.len());
+        let status = AdvancedLoggerComponent::<SerialHardwarePort<UartNull>>::adv_log_write(
+            core::ptr::null(),
+            0,
+            data.as_ptr(),
+            data.len(),
+        );
         assert_eq!(status, efi::Status::INVALID_PARAMETER);
     }
 
@@ -179,11 +183,13 @@ mod tests {
         // because the buffer null check is tripped first.
         let this = core::ptr::dangling::<AdvancedLoggerProtocol>();
         // Non-zero length.
-        let status = AdvancedLoggerComponent::<UartNull>::adv_log_write(this, 0, core::ptr::null(), 4);
+        let status =
+            AdvancedLoggerComponent::<SerialHardwarePort<UartNull>>::adv_log_write(this, 0, core::ptr::null(), 4);
         assert_eq!(status, efi::Status::INVALID_PARAMETER);
         // Zero length still invalid because `slice::from_raw_parts` requires a non-null pointer
         // even for zero-length slices.
-        let status = AdvancedLoggerComponent::<UartNull>::adv_log_write(this, 0, core::ptr::null(), 0);
+        let status =
+            AdvancedLoggerComponent::<SerialHardwarePort<UartNull>>::adv_log_write(this, 0, core::ptr::null(), 0);
         assert_eq!(status, efi::Status::INVALID_PARAMETER);
     }
 
@@ -195,7 +201,8 @@ mod tests {
         let this = leak_protocol_this();
 
         let data = b"hello, advanced logger";
-        let status = AdvancedLoggerComponent::<UartNull>::adv_log_write(this, 0, data.as_ptr(), data.len());
+        let status =
+            AdvancedLoggerComponent::<SerialHardwarePort<UartNull>>::adv_log_write(this, 0, data.as_ptr(), data.len());
         assert_eq!(status, efi::Status::SUCCESS);
     }
 }

--- a/components/patina_adv_logger/src/hardware_port.rs
+++ b/components/patina_adv_logger/src/hardware_port.rs
@@ -1,0 +1,88 @@
+//! UEFI Advanced Logger Hardware Port Support
+//!
+//! This module provides the [`AdvancedLoggerHardwarePort`] abstraction used by the advanced logger
+//! to emit log messages to a hardware port, along with [`SerialHardwarePort`], the default
+//! implementation that writes to a [`SerialIO`] instance.
+//!
+//! Platforms that need to gate, redirect, or otherwise customize hardware port output can provide
+//! their own implementation of [`AdvancedLoggerHardwarePort`] instead of using
+//! [`SerialHardwarePort`]. This is the Patina equivalent of the EDK II `AdvancedLoggerHdwPortLib`
+//! library class.
+//!
+//! ## License
+//!
+//! Copyright (c) Microsoft Corporation.
+//!
+//! SPDX-License-Identifier: Apache-2.0
+//!
+use patina::{
+    error::EfiError,
+    peripheral::serial::{SerialIO, shared::SharedSerial},
+};
+
+/// The hardware port used by the advanced logger to emit log messages.
+///
+/// The advanced logger applies the memory log's hardware print level filtering before invoking the
+/// port, so implementations are only called for messages that the logger has already determined
+/// should reach the hardware port. `error_level` is still provided so that implementations may
+/// apply additional platform specific filtering.
+///
+/// Implementations must be usable from a `static` and are expected to provide their own
+/// synchronization, as the advanced logger holds the port behind a shared reference.
+///
+/// ## Errors
+///
+/// Returns an error if the message could not be emitted. Implementations that intentionally
+/// suppress output should return `Ok(())` rather than an error, as a suppressed message is not a
+/// failure.
+#[cfg_attr(test, mockall::automock)]
+pub trait AdvancedLoggerHardwarePort: Send + Sync {
+    /// Writes the provided message bytes to the hardware port.
+    fn write(&self, error_level: u32, buffer: &[u8]) -> Result<(), EfiError>;
+}
+
+/// The default [`AdvancedLoggerHardwarePort`] implementation, which writes every message it
+/// receives to the provided serial port.
+pub struct SerialHardwarePort<S: SerialIO> {
+    serial: SharedSerial<S>,
+}
+
+impl<S: SerialIO> SerialHardwarePort<S> {
+    /// Creates a new hardware port that writes to the provided serial port.
+    pub const fn new(serial: S) -> Self {
+        Self { serial: SharedSerial::new(serial) }
+    }
+
+    /// Enables blocking (spinning) acquisition of the serial port, consuming and returning `self`.
+    ///
+    /// See [`SharedSerial::with_blocking`] for the tradeoffs of enabling this behavior.
+    #[must_use]
+    pub fn with_blocking(self) -> Self {
+        Self { serial: self.serial.with_blocking() }
+    }
+}
+
+impl<S: SerialIO> AdvancedLoggerHardwarePort for SerialHardwarePort<S> {
+    fn write(&self, _error_level: u32, buffer: &[u8]) -> Result<(), EfiError> {
+        self.serial.write(buffer)
+    }
+}
+
+#[cfg(test)]
+#[cfg_attr(coverage, coverage(off))]
+mod tests {
+    use super::*;
+    use patina::peripheral::serial::uart::UartNull;
+
+    #[test]
+    fn test_serial_hardware_port_forwards_writes() {
+        let port = SerialHardwarePort::new(UartNull {});
+        assert_eq!(port.write(0x8000_0000, b"hello"), Ok(()));
+    }
+
+    #[test]
+    fn test_serial_hardware_port_blocking_forwards_writes() {
+        let port = SerialHardwarePort::new(UartNull {}).with_blocking();
+        assert_eq!(port.write(0, b"hello"), Ok(()));
+    }
+}

--- a/components/patina_adv_logger/src/lib.rs
+++ b/components/patina_adv_logger/src/lib.rs
@@ -14,6 +14,7 @@ extern crate alloc;
 mod memory_log;
 mod writer;
 
+pub mod hardware_port;
 pub mod logger;
 
 #[cfg(any(doc, feature = "reader"))]

--- a/components/patina_adv_logger/src/logger.rs
+++ b/components/patina_adv_logger/src/logger.rs
@@ -1,7 +1,8 @@
 //! UEFI Advanced Logger Support
 //!
-//! This module provides a struct that implements `log::Log` for writing to a `SerialIO`
-//! and the advanced logger memory log. This module is written to be phase agnostic.
+//! This module provides a struct that implements `log::Log` for writing to an
+//! [`AdvancedLoggerHardwarePort`] and the advanced logger memory log. This module is written to be
+//! phase agnostic.
 //!
 //! ## License
 //!
@@ -10,17 +11,17 @@
 //! SPDX-License-Identifier: Apache-2.0
 //!
 use crate::{
+    hardware_port::AdvancedLoggerHardwarePort,
     memory_log::{self, LogEntry},
     writer::AdvancedLogWriter,
 };
-use core::{ffi::c_void, marker::Send, ptr};
+use core::{ffi::c_void, ptr};
 use log::Level;
 use patina::standard::efi;
 use patina::{
     component::service::{Service, perf_timer::ArchTimerFunctionality},
     debug::log::Format,
     error::EfiError,
-    peripheral::serial::{SerialIO, shared::SharedSerial},
     pi::hob::{Hob, PhaseHandoffInformationTable},
 };
 use spin::RwLock;
@@ -44,11 +45,11 @@ pub struct TargetFilter<'a> {
 }
 
 /// The logger for memory/hardware port logging.
-pub struct AdvancedLogger<'a, S>
+pub struct AdvancedLogger<'a, P>
 where
-    S: SerialIO + Send,
+    P: AdvancedLoggerHardwarePort,
 {
-    hardware_port: SharedSerial<S>,
+    hardware_port: P,
     target_filters: &'a [TargetFilter<'a>],
     max_level: log::LevelFilter,
     format: Format,
@@ -56,9 +57,9 @@ where
     pub(crate) timer: Service<dyn ArchTimerFunctionality>,
 }
 
-impl<'a, S> AdvancedLogger<'a, S>
+impl<'a, P> AdvancedLogger<'a, P>
 where
-    S: SerialIO + Send,
+    P: AdvancedLoggerHardwarePort,
 {
     /// Creates a new `AdvancedLogger`.
     ///
@@ -73,10 +74,10 @@ where
         format: Format,
         target_filters: &'a [TargetFilter<'a>],
         max_level: log::LevelFilter,
-        hardware_port: S,
+        hardware_port: P,
     ) -> Self {
         Self {
-            hardware_port: SharedSerial::new(hardware_port),
+            hardware_port,
             target_filters,
             max_level,
             format,
@@ -152,7 +153,7 @@ where
         }
 
         if hw_write {
-            let result = self.hardware_port.write(data);
+            let result = self.hardware_port.write(error_level, data);
             debug_assert!(result.is_ok(), "Failed to write to hardware port: {result:?}");
         }
     }
@@ -226,9 +227,9 @@ where
     }
 }
 
-impl<S> log::Log for AdvancedLogger<'_, S>
+impl<P> log::Log for AdvancedLogger<'_, P>
 where
-    S: SerialIO + Send,
+    P: AdvancedLoggerHardwarePort,
 {
     fn enabled(&self, metadata: &log::Metadata) -> bool {
         let max_level = self.target_filter(metadata.target()).map_or(self.max_level, |f| f.log_level);
@@ -285,23 +286,23 @@ const fn log_level_filter_to_debug_mask(level_filter: log::LevelFilter) -> u32 {
 const WRITER_BUFFER_SIZE: usize = 128;
 
 /// A wrapper for buffering and redirecting writes from the formatter.
-struct BufferedWriter<'a, S>
+struct BufferedWriter<'a, P>
 where
-    S: SerialIO + Send,
+    P: AdvancedLoggerHardwarePort,
 {
     level: u32,
     hw_print_mask_override: Option<u32>,
-    writer: &'a AdvancedLogger<'a, S>,
+    writer: &'a AdvancedLogger<'a, P>,
     buffer: [u8; WRITER_BUFFER_SIZE],
     buffer_size: usize,
 }
 
-impl<'a, S> BufferedWriter<'a, S>
+impl<'a, P> BufferedWriter<'a, P>
 where
-    S: SerialIO + Send,
+    P: AdvancedLoggerHardwarePort,
 {
     /// Creates a new `BufferedWriter` with the specified log level, optional hardware print mask override, and writer.
-    const fn new(level: u32, hw_print_mask_override: Option<u32>, writer: &'a AdvancedLogger<'a, S>) -> Self {
+    const fn new(level: u32, hw_print_mask_override: Option<u32>, writer: &'a AdvancedLogger<'a, P>) -> Self {
         Self { level, hw_print_mask_override, writer, buffer: [0; WRITER_BUFFER_SIZE], buffer_size: 0 }
     }
 
@@ -318,9 +319,9 @@ where
     }
 }
 
-impl<S> core::fmt::Write for BufferedWriter<'_, S>
+impl<P> core::fmt::Write for BufferedWriter<'_, P>
 where
-    S: SerialIO + Send,
+    P: AdvancedLoggerHardwarePort,
 {
     fn write_str(&mut self, s: &str) -> core::fmt::Result {
         let data = s.as_bytes();
@@ -362,6 +363,7 @@ mod tests {
     };
 
     use crate::{
+        hardware_port::{MockAdvancedLoggerHardwarePort, SerialHardwarePort},
         logger::{AdvancedLogger, TargetFilter},
         memory_log,
         writer::AdvancedLogWriter,
@@ -384,11 +386,11 @@ mod tests {
     #[test]
     fn test_uninit() {
         let serial = UartNull {};
-        let logger_uninit = AdvancedLogger::<UartNull>::new(
+        let logger_uninit = AdvancedLogger::new(
             Format::Standard,
             &[TargetFilter { target: "test_target", log_level: log::LevelFilter::Info, hw_filter_override: None }],
             log::LevelFilter::Debug,
-            serial,
+            SerialHardwarePort::new(serial),
         );
         assert!(logger_uninit.timer.map_or(0, |timer| timer.cpu_count()) == 0);
     }
@@ -396,18 +398,22 @@ mod tests {
     #[test]
     fn test_init() {
         let serial = UartNull {};
-        let logger_uninit = AdvancedLogger::<UartNull>::new(
+        let logger_uninit = AdvancedLogger::new(
             Format::Standard,
             &[TargetFilter { target: "test_target", log_level: log::LevelFilter::Info, hw_filter_override: None }],
             log::LevelFilter::Debug,
-            serial,
+            SerialHardwarePort::new(serial),
         );
         logger_uninit.init_timer(patina::component::service::Service::mock(Box::new(MockTimer {})));
         assert!(logger_uninit.timer.cpu_count() > 0);
     }
 
-    static TEST_LOGGER: AdvancedLogger<UartNull> =
-        AdvancedLogger::new(patina::debug::log::Format::Standard, &[], log::LevelFilter::Trace, UartNull {});
+    static TEST_LOGGER: AdvancedLogger<SerialHardwarePort<UartNull>> = AdvancedLogger::new(
+        patina::debug::log::Format::Standard,
+        &[],
+        log::LevelFilter::Trace,
+        SerialHardwarePort::new(UartNull {}),
+    );
 
     fn create_adv_logger_hob_list() -> (u64, *const c_void) {
         const LOG_LEN: usize = 0x2000;
@@ -466,7 +472,8 @@ mod tests {
 
     #[test]
     fn enabled_respects_global_max_level() {
-        let logger = AdvancedLogger::new(Format::Standard, &[], log::LevelFilter::Info, UartNull {});
+        let logger =
+            AdvancedLogger::new(Format::Standard, &[], log::LevelFilter::Info, SerialHardwarePort::new(UartNull {}));
 
         assert!(logger.enabled(&metadata("any", log::Level::Error)));
         assert!(logger.enabled(&metadata("any", log::Level::Warn)));
@@ -477,7 +484,8 @@ mod tests {
 
     #[test]
     fn enabled_at_trace_allows_everything() {
-        let logger = AdvancedLogger::new(Format::Standard, &[], log::LevelFilter::Trace, UartNull {});
+        let logger =
+            AdvancedLogger::new(Format::Standard, &[], log::LevelFilter::Trace, SerialHardwarePort::new(UartNull {}));
 
         assert!(logger.enabled(&metadata("x", log::Level::Error)));
         assert!(logger.enabled(&metadata("x", log::Level::Warn)));
@@ -488,7 +496,8 @@ mod tests {
 
     #[test]
     fn enabled_at_off_blocks_everything() {
-        let logger = AdvancedLogger::new(Format::Standard, &[], log::LevelFilter::Off, UartNull {});
+        let logger =
+            AdvancedLogger::new(Format::Standard, &[], log::LevelFilter::Off, SerialHardwarePort::new(UartNull {}));
 
         assert!(!logger.enabled(&metadata("x", log::Level::Error)));
         assert!(!logger.enabled(&metadata("x", log::Level::Trace)));
@@ -499,7 +508,12 @@ mod tests {
     #[test]
     fn target_filter_overrides_global_to_be_more_permissive() {
         let filters = [TargetFilter { target: "my_mod", log_level: log::LevelFilter::Info, hw_filter_override: None }];
-        let logger = AdvancedLogger::new(Format::Standard, &filters, log::LevelFilter::Error, UartNull {});
+        let logger = AdvancedLogger::new(
+            Format::Standard,
+            &filters,
+            log::LevelFilter::Error,
+            SerialHardwarePort::new(UartNull {}),
+        );
 
         // Matching target uses the filter's level (Info)
         assert!(logger.enabled(&metadata("my_mod", log::Level::Info)));
@@ -514,7 +528,12 @@ mod tests {
     #[test]
     fn target_filter_restricts_below_global() {
         let filters = [TargetFilter { target: "noisy", log_level: log::LevelFilter::Error, hw_filter_override: None }];
-        let logger = AdvancedLogger::new(Format::Standard, &filters, log::LevelFilter::Trace, UartNull {});
+        let logger = AdvancedLogger::new(
+            Format::Standard,
+            &filters,
+            log::LevelFilter::Trace,
+            SerialHardwarePort::new(UartNull {}),
+        );
 
         // "noisy" target is restricted to Error only
         assert!(!logger.enabled(&metadata("noisy", log::Level::Info)));
@@ -530,7 +549,12 @@ mod tests {
         let filters =
             [TargetFilter { target: "my_crate", log_level: log::LevelFilter::Info, hw_filter_override: None }];
         // Global is Off so anything not matching the filter is blocked.
-        let logger = AdvancedLogger::new(Format::Standard, &filters, log::LevelFilter::Off, UartNull {});
+        let logger = AdvancedLogger::new(
+            Format::Standard,
+            &filters,
+            log::LevelFilter::Off,
+            SerialHardwarePort::new(UartNull {}),
+        );
 
         // Prefix match
         assert!(logger.enabled(&metadata("my_crate::submod", log::Level::Info)));
@@ -538,5 +562,85 @@ mod tests {
         assert!(logger.enabled(&metadata("my_crate", log::Level::Info)));
         // No match → falls to global Off
         assert!(!logger.enabled(&metadata("other_crate", log::Level::Error)));
+    }
+
+    // === Hardware port dispatch ===
+
+    /// Creates a memory log with the requested global hardware print level and returns its address.
+    fn create_memory_log(hw_print_level: u32) -> efi::PhysicalAddress {
+        const LOG_LEN: usize = 0x2000;
+        let log_buff = Box::into_raw(Box::new([0_u8; LOG_LEN]));
+        let log_address = log_buff as *const u8 as efi::PhysicalAddress;
+
+        // SAFETY: We just allocated this memory so it is valid for the header.
+        unsafe {
+            ptr::write(
+                log_buff.cast::<memory_log::AdvLoggerInfo>(),
+                memory_log::AdvLoggerInfo::new(LOG_LEN as u32, false, 0, 0, efi::Time::default(), hw_print_level),
+            );
+        };
+
+        log_address
+    }
+
+    fn error_record<'a>(target: &'a str, args: core::fmt::Arguments<'a>) -> log::Record<'a> {
+        log::Record::builder().level(log::Level::Error).target(target).args(args).build()
+    }
+
+    #[test]
+    fn test_advanced_logger_writes_message_to_hardware_port() {
+        let mut port = MockAdvancedLoggerHardwarePort::new();
+        port.expect_write()
+            .times(1)
+            .withf(|error_level, data| {
+                *error_level == memory_log::DEBUG_LEVEL_ERROR
+                    && core::str::from_utf8(data).is_ok_and(|s| s.contains("hello port"))
+            })
+            .returning(|_, _| Ok(()));
+
+        let logger = AdvancedLogger::new(Format::Standard, &[], log::LevelFilter::Trace, port);
+        logger.set_log_info_address(create_memory_log(memory_log::DEBUG_LEVEL_ERROR));
+
+        logger.log(&error_record("any", format_args!("hello port")));
+    }
+
+    #[test]
+    fn test_advanced_logger_suppresses_hardware_port_below_hw_print_level() {
+        let mut port = MockAdvancedLoggerHardwarePort::new();
+        port.expect_write().never();
+
+        let logger = AdvancedLogger::new(Format::Standard, &[], log::LevelFilter::Trace, port);
+        // The global hardware print level masks off every level, so the port must not be used.
+        logger.set_log_info_address(create_memory_log(0));
+
+        logger.log(&error_record("any", format_args!("hello port")));
+    }
+
+    #[test]
+    fn test_advanced_logger_suppresses_hardware_port_for_target_override() {
+        let mut port = MockAdvancedLoggerHardwarePort::new();
+        port.expect_write().never();
+
+        let filters = [TargetFilter {
+            target: "quiet",
+            log_level: log::LevelFilter::Trace,
+            hw_filter_override: Some(log::LevelFilter::Off),
+        }];
+        let logger = AdvancedLogger::new(Format::Standard, &filters, log::LevelFilter::Trace, port);
+        // The global level would allow the write, but the per-target override does not.
+        logger.set_log_info_address(create_memory_log(memory_log::DEBUG_LEVEL_ERROR));
+
+        logger.log(&error_record("quiet", format_args!("hello port")));
+    }
+
+    #[test]
+    fn test_advanced_logger_writes_to_hardware_port_without_memory_log() {
+        let mut port = MockAdvancedLoggerHardwarePort::new();
+        port.expect_write().times(1).returning(|_, _| Ok(()));
+
+        // Without a memory log there is no hardware print level to consult, so output is not filtered.
+        let logger = AdvancedLogger::new(Format::Standard, &[], log::LevelFilter::Trace, port);
+
+        logger.log(&error_record("any", format_args!("hello port")));
     }
 }

--- a/docs/src/dev/principles/error-handling.md
+++ b/docs/src/dev/principles/error-handling.md
@@ -46,18 +46,22 @@ This code which `unwrap`s on logger initialization panics unnecessarily:
 # extern crate log;
 # extern crate patina;
 # let hob_list = std::ptr::null();
-use patina_adv_logger::{component::AdvancedLoggerComponent, logger::AdvancedLogger};
+use patina_adv_logger::{
+    component::AdvancedLoggerComponent,
+    hardware_port::SerialHardwarePort,
+    logger::AdvancedLogger,
+};
 use log::LevelFilter;
 use patina::{
     debug::log::Format,
     peripheral::serial::uart::UartNull,
 };
 
-static LOGGER: AdvancedLogger<UartNull> = AdvancedLogger::new(
+static LOGGER: AdvancedLogger<SerialHardwarePort<UartNull>> = AdvancedLogger::new(
     Format::Standard,
     &[],
     LevelFilter::Debug,
-    UartNull {}
+    SerialHardwarePort::new(UartNull {})
 );
 
 unsafe { LOGGER.init(hob_list).unwrap() };
@@ -71,17 +75,21 @@ Consider replacing it with `match` and returning a `Result`:
 # extern crate log;
 # extern crate patina;
 # let hob_list = std::ptr::null();
-# use patina_adv_logger::{component::AdvancedLoggerComponent, logger::AdvancedLogger};
+# use patina_adv_logger::{
+#     component::AdvancedLoggerComponent,
+#     hardware_port::SerialHardwarePort,
+#     logger::AdvancedLogger,
+# };
 # use log::LevelFilter;
 # use patina::{
 #     debug::log::Format,
 #     peripheral::serial::uart::UartNull,
 # };
-# static LOGGER: AdvancedLogger<UartNull> = AdvancedLogger::new(
+# static LOGGER: AdvancedLogger<SerialHardwarePort<UartNull>> = AdvancedLogger::new(
 #     Format::Standard,
 #     &[],
 #     LevelFilter::Debug,
-#     UartNull {}
+#     SerialHardwarePort::new(UartNull {})
 # );
 match unsafe { LOGGER.init(hob_list) } {
     Ok(()) => {},


### PR DESCRIPTION
## Description

The C based adv logger supports a platform provided hardware port library to let platforms control what kind of hardware port should be logged to.

This functionality is added to patina in the form of a trait. Now Patina doesn't rely directly on a serial port being instantiated and instead abstracts this through the HW port trait. A default serial port trait is provided for platforms that do not wish to use a different serial port or do runtime log filtering.

- [x] Impacts functionality?
- [ ] Impacts security?
- [x] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Tested on a platform that uses the C AdvancedLoggerHdwPortLib. This interface allowed the same functionality.

## Integration Instructions

Platforms must update their bin wrapper repos. To get the same behavior as today, they need to use the `SerialHardwarePort` trait.

e.g.

```rust
// old

static LOGGER: AdvancedLogger<UartPl011> = AdvancedLogger::new(
    Format::Standard,
    &[
        TargetFilter { target: "goblin", log_level: log::LevelFilter::Off, hw_filter_override: None },
        TargetFilter { target: "gcd_measure", log_level: log::LevelFilter::Off, hw_filter_override: None },
        TargetFilter { target: "allocations", log_level: log::LevelFilter::Off, hw_filter_override: None },
        TargetFilter { target: "efi_memory_map", log_level: log::LevelFilter::Off, hw_filter_override: None },
    ],
    LOG_LEVEL,
    // SAFETY: 0xF0000 is the base address of the PL011 MMIO register block used for logging
    unsafe { UartPl011::new(0xF0000) },
);

add.component(AdvancedLoggerComponent::<UartPl011>::new(&LOGGER));

// new

static LOGGER: AdvancedLogger<SerialHardwarePort<UartPl011>> = AdvancedLogger::new(
    Format::Standard,
    &[
        TargetFilter { target: "goblin", log_level: log::LevelFilter::Off, hw_filter_override: None },
        TargetFilter { target: "gcd_measure", log_level: log::LevelFilter::Off, hw_filter_override: None },
        TargetFilter { target: "allocations", log_level: log::LevelFilter::Off, hw_filter_override: None },
        TargetFilter { target: "efi_memory_map", log_level: log::LevelFilter::Off, hw_filter_override: None },
    ],
    LOG_LEVEL,
    // SAFETY: 0xF0000 is the base address of the PL011 MMIO register block used for logging
    SerialHardwarePort::new(unsafe { UartPl011::new(0xF0000) }),
);

add.component(AdvancedLoggerComponent::<SerialHardwarePort<UartPl011>>::new(&LOGGER));
```
Platforms may now implement their own hardware port trait to do custom behavior on hardware port writes.
