### PR TITLE
patina_dxe_core: Allow malformed debug directory in TE images [Rebase & FF]

### DIFF
--- a/patina_dxe_core/src/pecoff.rs
+++ b/patina_dxe_core/src/pecoff.rs
@@ -119,40 +119,59 @@ impl UefiPeInfo {
     /// Parses a PE with a TE header, gathering the necessary data for operating on the image in a UEFI environment.
     fn from_te(bytes: &[u8]) -> error::Result<Self> {
         let mut pe = UefiPeInfo::default();
-        let parsed_te = goblin::pe::TE::parse(bytes)?;
+        let mut offset = 0;
+        let header = goblin::pe::header::TeHeader::parse(bytes, &mut offset)?;
+        let rva_offset = header.stripped_size as usize - core::mem::size_of::<goblin::pe::header::TeHeader>();
+        let sections = header.sections(bytes, &mut offset)?;
 
         // Set the simple fields.
         pe.image_base_header_field_offset = TE_IMAGE_BASE_HEADER_FIELD_OFFSET;
-        pe.header_type = HeaderType::Te(parsed_te.rva_offset);
-        pe.entry_point_offset = parsed_te.header.entry_point as usize;
-        pe.image_type = u16::from(parsed_te.header.subsystem);
-        pe.machine = parsed_te.header.machine;
+        pe.header_type = HeaderType::Te(rva_offset);
+        pe.entry_point_offset = header.entry_point as usize;
+        pe.image_type = u16::from(header.subsystem);
+        pe.machine = header.machine;
         pe.section_alignment = 0;
-        pe.size_of_headers = parsed_te.header.base_of_code as usize;
-        pe.sections = parsed_te.sections;
+        pe.size_of_headers = header.base_of_code as usize;
+        pe.sections = sections;
         // TE doesn't have the optional header with DLL Characteristics, so we have to assume the image is NX_COMPAT
         pe.nx_compat = true;
 
         // TE headers always have a reloc dir, even if it's empty
         // unlike PE32 headers.
-        if parsed_te.header.reloc_dir.size != 0 {
-            pe.reloc_dir = Some(parsed_te.header.reloc_dir);
+        if header.reloc_dir.size != 0 {
+            pe.reloc_dir = Some(header.reloc_dir);
         }
 
         // TE headers don't have a size of image filed like PE32 headers
         // so it needs to be calculated.
-        if let Some(last_section) = pe.sections.last() {
-            pe.size_of_image = last_section.virtual_address + last_section.virtual_size;
+        let Some(last_section) = pe.sections.last() else {
+            return Err(error::Error::Goblin(goblin::error::Error::Malformed("No sections found in PE.".to_string())));
+        };
+        pe.size_of_image = last_section.virtual_address + last_section.virtual_size;
 
-            // Parse the filename from the debug data if it exists.
-            if let Some(codeview_data) = &parsed_te.debug_data.codeview_pdb70_debug_info {
-                pe.filename = UefiPeInfo::read_filename(codeview_data.filename)?;
+        // Debug data is optional metadata. Use it when valid, but do not reject an otherwise
+        // loadable image when its debug directory cannot be resolved or parsed.
+        let mut debug_opts = goblin::pe::options::ParseOptions::default();
+        debug_opts.resolve_rva = false;
+        match goblin::pe::debug::DebugData::parse_with_opts_and_fixup(
+            bytes,
+            header.debug_dir,
+            &pe.sections,
+            0,
+            &debug_opts,
+            rva_offset as u32,
+        ) {
+            Ok(debug_data) => {
+                if let Some(codeview_data) = debug_data.codeview_pdb70_debug_info {
+                    pe.filename = UefiPeInfo::read_filename(codeview_data.filename)?;
+                }
             }
-
-            Ok(pe)
-        } else {
-            Err(error::Error::Goblin(goblin::error::Error::Malformed("No sections found in PE.".to_string())))
+            Err(err) => {
+                log::warn!("Failed to parse optional TE/COFF debug metadata: {err:?}");
+            }
         }
+
+        Ok(pe)
     }
 
     /// Parses a PE image with a PE32 header, gathering the necessary data for operating on the image in a UEFI environment.

--- a/patina_dxe_core/src/pecoff.rs
+++ b/patina_dxe_core/src/pecoff.rs
@@ -109,7 +109,6 @@ impl UefiPeInfo {
     pub fn parse_mapped(bytes: &[u8]) -> error::Result<Self> {
         let mut opts = goblin::pe::options::ParseOptions::default();
         opts.resolve_rva = false;
-        opts.parse_attribute_certificates = false;
         match scroll::Pread::gread_with::<u16>(bytes, &mut 0, scroll::LE)? {
             PE32_MAGIC => UefiPeInfo::from_pe(bytes, &opts),
             TE_MAGIC => UefiPeInfo::from_te(bytes),
@@ -183,8 +182,8 @@ impl UefiPeInfo {
             != 0;
 
         // Set the relocation diretory if it exists
-        if let Some(reloc_section) = optional_header.data_directories.get_base_relocation_table() {
-            pe.reloc_dir = Some(*reloc_section);
+        if let Some(&reloc_section) = optional_header.data_directories.get_base_relocation_table() {
+            pe.reloc_dir = Some(reloc_section);
         }
 
         // Calculate the image base offset by finding the offset of the windows fields
@@ -1117,5 +1116,25 @@ mod tests {
 
         let mut loaded_image = vec![0; image_info.size_of_image as usize];
         load_image(&image_info, image, &mut loaded_image).unwrap();
+    }
+
+    #[test]
+    fn test_te_image_with_malformed_debug_directory_loads_without_filename() {
+        test_support::init_test_logger();
+        let mut image = include_bytes!("../resources/test/te/test_image.te").to_vec();
+
+        // debug_dir is the last field of TeHeader (a DataDirectory { virtual_address, size }).
+        // Corrupt its size so the debug directory can no longer be resolved, without disturbing
+        // anything else about the image.
+        const HEADER_SIZE: usize = core::mem::size_of::<goblin::pe::header::TeHeader>();
+        image[HEADER_SIZE - 8..HEADER_SIZE - 4].copy_from_slice(&0u32.to_le_bytes());
+        image[HEADER_SIZE - 4..HEADER_SIZE].copy_from_slice(&u32::MAX.to_le_bytes());
+
+        let image_info = UefiPeInfo::parse(&image).unwrap();
+
+        assert!(image_info.filename.is_none());
+
+        let mut loaded_image = vec![0; image_info.size_of_image as usize];
+        load_image(&image_info, &image, &mut loaded_image).unwrap();
     }
 }


### PR DESCRIPTION
## Description

I wasn't able to submit my PR review feedback for https://github.com/OpenDevicePartnership/patina/pull/1762 in time. So, I made the changes I was going to propose in the PR.

---

**patina_dxe_core/pecoff: Minor UefiPeInfo cleanup**

Since commit 48d1fbf removed the `PE::parse_with_opts()` call in
`from_pe()`, setting `opts.parse_attribute_certificates` no longer
has an effect, so it's dropped here.

Also updates the relocation table directory logic to use the same
pattern as the debug table logic where `Some(&reloc_section)` is used
instead of `Some(reloc_section)`.

---

**patina_dxe_core: Allow malformed debug directory in TE images**

Updates `from_te()` to match the changes in 48d1fbf.

After that commit, `from_te()` still rejects images with a malformed
debug directory, since `goblin::pe::TE::parse()` parses it eagerly
and returns `Err`.

This commit refactors `from_te()` to build the header and sections
directly, then parse the debug directory separately so a bad entry
only drops the filename instead of failing the whole image, to match
the `from_pe()` change.

---

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [x] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

- Unit test that corrupts the debug dir size so it does not resolve correctly
- `cargo make all`

## Integration Instructions

- N/A