### PR TITLE
[REBASE & FF] [feature/supv] Fix Ring 3 stack indexing, sizing, and user mapping

### DIFF
--- a/patina_mm_supervisor/src/init.rs
+++ b/patina_mm_supervisor/src/init.rs
@@ -651,17 +651,19 @@ impl<P: PlatformInfo, const MAX_CPUS: usize> MmSupervisorCore<P, MAX_CPUS> {
         let hob_list_info =
             unsafe { (hob_list as *const PhaseHandoffInformationTable).as_ref().ok_or(PolicyInitError::NullHobList)? };
 
-        // 1. Process the PassDown HOB (policy, syscall, memory policy)
+        // 1. Process the MP Information HOB (`gMpInformationHobGuid`) for the CPU count. It sizes
+        //    the Ring 3 stack array the PassDown HOB describes, so it is needed first.
+        let mp_information =
+            find_guid_hob(hob_list_info, crate::MP_INFORMATION_HOB_GUID).ok_or(PolicyInitError::HobNotFound)?;
+        let number_of_cpus = self.parse_mp_information_hob(mp_information).ok_or(PolicyInitError::InvalidPolicyData)?;
+
+        // 1b. Process the PassDown HOB (policy, syscall, memory policy)
         let pass_down_data =
             find_guid_hob(hob_list_info, crate::MM_SUPV_PASS_DOWN_HOB_GUID).ok_or(PolicyInitError::HobNotFound)?;
         // SAFETY: `pass_down_data` is a slice into the validated HOB list, so the buffer pointers
         // it carries reference live memory as `init_from_pass_down_hob` requires.
-        let (sm_base, mmi_entry_size) = unsafe { self.init_from_pass_down_hob(pass_down_data)? };
+        let (sm_base, mmi_entry_size) = unsafe { self.init_from_pass_down_hob(pass_down_data, number_of_cpus)? };
 
-        // 1b. Process the MP Information HOB (`gMpInformationHobGuid`) for the CPU count.
-        let mp_information =
-            find_guid_hob(hob_list_info, crate::MP_INFORMATION_HOB_GUID).ok_or(PolicyInitError::HobNotFound)?;
-        let number_of_cpus = self.parse_mp_information_hob(mp_information).ok_or(PolicyInitError::InvalidPolicyData)?;
         security_state().set_save_state_info(SaveStateInfo { number_of_cpus, sm_base });
         log::info!("Save-state metadata initialized for {} CPU(s)", number_of_cpus);
 
@@ -782,7 +784,7 @@ impl<P: PlatformInfo, const MAX_CPUS: usize> MmSupervisorCore<P, MAX_CPUS> {
     ///
     /// The buffer pointers carried in `data` (e.g. the firmware policy buffer)
     /// must reference valid memory, as they are dereferenced during setup.
-    unsafe fn init_from_pass_down_hob(&self, data: &[u8]) -> Result<(u64, u64), PolicyInitError> {
+    unsafe fn init_from_pass_down_hob(&self, data: &[u8], number_of_cpus: u64) -> Result<(u64, u64), PolicyInitError> {
         // Copy the HOB bytes once into an owned, naturally-aligned struct so the rest of
         // the function uses ordinary, safe field access. `read_from_prefix` validates the
         // length and copies the bytes, imposing no alignment or validity precondition on
@@ -863,10 +865,11 @@ impl<P: PlatformInfo, const MAX_CPUS: usize> MmSupervisorCore<P, MAX_CPUS> {
             }
         }
 
-        // Initialize syscall interface
+        // Initialize syscall interface. The CPU count bounds `get_cpl3_stack`, so it must be the
+        // count the MM IPL sized the stack array for, not the supervisor's `MAX_CPUS` capacity.
         self.syscall_interface
             .init(
-                self.cpu_manager.max_cpus(),
+                number_of_cpus.try_into().unwrap_or_else(|err| panic!("Invalid CPU count: {:?}", err)),
                 cpl3_stack_buffer,
                 cpl3_stack_buffer_size
                     .try_into()

--- a/patina_mm_supervisor/src/lib.rs
+++ b/patina_mm_supervisor/src/lib.rs
@@ -339,7 +339,7 @@ impl<P: PlatformInfo, const MAX_CPUS: usize> MmSupervisorCore<P, MAX_CPUS> {
                 cpu_index
             );
             smrr_enable();
-            self.enter_runtime(cpu_id);
+            self.enter_runtime(cpu_id, cpu_index);
 
             return;
         }

--- a/patina_mm_supervisor/src/runtime.rs
+++ b/patina_mm_supervisor/src/runtime.rs
@@ -107,6 +107,9 @@ pub(crate) fn with_user_access<R>(access: impl FnOnce() -> R) -> R {
 impl<P: PlatformInfo, const MAX_CPUS: usize> MmSupervisorCore<P, MAX_CPUS> {
     /// Enter runtime mode (called on subsequent entries after init is complete).
     ///
+    /// `cpu_id` is the APIC ID; `cpu_index` is the dense, 0-based UEFI processor index that
+    /// selects this CPU's per-core resources (Ring 3 stack, mailbox).
+    ///
     /// Implements the MP synchronization protocol:
     /// 1. APs check in by setting their state to `InHoldingPen` and entering the holding pen
     /// 2. BSP waits for all registered APs, all cores must be in MM before servicing a request
@@ -114,7 +117,7 @@ impl<P: PlatformInfo, const MAX_CPUS: usize> MmSupervisorCore<P, MAX_CPUS> {
     /// 4. BSP releases every AP via the per-CPU rendezvous semaphore
     /// 5. BSP waits indefinitely for every released AP to acknowledge it has left
     /// 6. Each AP clears its `InHoldingPen` state and acknowledges the BSP
-    pub(crate) fn enter_runtime(&'static self, cpu_id: u32) {
+    pub(crate) fn enter_runtime(&'static self, cpu_id: u32, cpu_index: usize) {
         let is_bsp = is_bsp();
 
         if is_bsp {
@@ -126,7 +129,7 @@ impl<P: PlatformInfo, const MAX_CPUS: usize> MmSupervisorCore<P, MAX_CPUS> {
 
             // Every registered AP is now in MM - service the request.
             log::trace!("BSP (CPU {}) entering request serving routine...", cpu_id);
-            self.bsp_request_loop(cpu_id as usize);
+            self.bsp_request_loop(cpu_index);
 
             // Exit barrier: release every penned AP and wait for each to acknowledge it has left.
             log::trace!("BSP (CPU {}) releasing all APs from the holding pen...", cpu_id);


### PR DESCRIPTION
## Description

-  **Pass the dense CPU index into the runtime request path**: `enter_runtime`
   received the APIC ID and forwarded it to `bsp_request_loop` as a CPU index.
   On platforms whose APIC IDs are not `0..N-1` (observed: 0, 2, 4 … 46, BSP =
   16) this selected a Ring 3 stack outside the array the MM IPL provisioned, so
   the demoted routine faulted writing to a supervisor-owned page. The dense
   index the C core hands to `entry_point` is now used for the request path,
   while the APIC ID is still used for the `CpuManager` APIs keyed by it.

---

-  **Size the syscall interface from the MP Information HOB CPU count**:
   `SyscallInterface::init` was given the `MAX_CPUS` const generic capacity (32)
   rather than the number of CPUs the IPL provisioned stacks for (16), so
   `get_cpl3_stack` returned pointers past the end of that array, into
   supervisor memory, for any index in between. The MP Information HOB is now
   parsed before the PassDown HOB and its count is passed in, so out of range
   indices are rejected with `InvalidCpuIndex`.

---

-  **Map the Ring 3 stacks user-accessible during BSP init**: the supervisor
   relied on the MM IPL to leave the per-CPU CPL3 stacks user-accessible. The
   provisioned range is now mapped read/write, non-executable and
   user-accessible during BSP init, after confirming it lies inside MMRAM so
   nothing outside MMRAM is exposed to Ring 3, and every page is verified
   afterwards so a misconfiguration fails at init instead of at the first
   demotion.

---

- [x] Impacts functionality?
- [x] Impacts security?
- [ ] Breaking change?
- [x] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

- Validated on internal hardware platform.

## Integration Instructions

N/A