### PR TITLE
SDK: SerDe HOB: Implement Interval for FvHobSerDe

### DIFF
--- a/sdk/patina/src/pi/serializable.rs
+++ b/sdk/patina/src/pi/serializable.rs
@@ -65,7 +65,7 @@ pub trait Interval: Clone + Ord {
     }
 
     /// Check if this interval fully contains another one.
-    fn contains(&self, other: &Self) -> bool {
+    fn contains<T: Interval>(&self, other: &T) -> bool {
         self.start() <= other.start() && self.end() >= other.end()
     }
 
@@ -78,7 +78,7 @@ pub trait Interval: Clone + Ord {
     /// - [o[]s] - overlapping
     /// - [o] [s] - non overlapping
     /// ```
-    fn overlaps(&self, other: &Self) -> bool {
+    fn overlaps<T: Interval>(&self, other: &T) -> bool {
         self.start() < other.end() && other.start() < self.end()
     }
 
@@ -87,7 +87,7 @@ pub trait Interval: Clone + Ord {
     /// ```ignore
     /// - [s][o] or [o][s] (end of one is exactly the start of the other)
     /// ```
-    fn adjacent(&self, other: &Self) -> bool {
+    fn adjacent<T: Interval>(&self, other: &T) -> bool {
         self.end() == other.start() || other.end() == self.start()
     }
 

--- a/sdk/patina/src/pi/serializable/serializable_hob.rs
+++ b/sdk/patina/src/pi/serializable/serializable_hob.rs
@@ -80,6 +80,25 @@ pub struct FvHobSerDe {
     pub length: u64,
 }
 
+impl Interval for FvHobSerDe {
+    fn start(&self) -> u64 {
+        self.base_address
+    }
+
+    fn end(&self) -> u64 {
+        self.base_address + self.length
+    }
+
+    /// Merge two firmware volume descriptors into one (including non-overlapping
+    /// intervals).
+    fn merge(&self, other: &Self) -> Self {
+        Self {
+            base_address: core::cmp::min(self.start(), other.start()),
+            length: core::cmp::max(self.end(), other.end()) - core::cmp::min(self.start(), other.start()),
+        }
+    }
+}
+
 /// Serializable representation of one `EFI_MEMORY_TYPE_INFORMATION` entry inside a Memory
 /// Type Information GUID Extension HOB.
 #[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
@@ -554,5 +573,141 @@ mod tests {
 
         assert!(json.contains(r#""type": "memory_type_information""#), "Memory Type Information HOB missing");
         assert!(json.contains(r#""number_of_pages": 200"#), "Entry page count incorrect");
+    }
+
+    #[test]
+    fn test_fv_hob_serde_interval_bounds() {
+        let a = FvHobSerDe { base_address: 0x1000, length: 0x1000 };
+        assert_eq!(a.start(), 0x1000);
+        assert_eq!(a.end(), 0x2000);
+        assert_eq!(a.length(), 0x1000);
+
+        let empty = FvHobSerDe { base_address: 0x1000, length: 0 };
+        assert_eq!(empty.start(), empty.end());
+        assert_eq!(empty.length(), 0);
+    }
+
+    #[test]
+    fn test_fv_hob_serde_interval_contains() {
+        let outer = FvHobSerDe { base_address: 0x1000, length: 0x4000 };
+        assert!(outer.contains(&outer));
+        assert!(outer.contains(&FvHobSerDe { base_address: 0x2000, length: 0x1000 }));
+        assert!(outer.contains(&FvHobSerDe { base_address: 0x1000, length: 0x4000 }));
+        assert!(!outer.contains(&FvHobSerDe { base_address: 0x0, length: 0x1000 }));
+        assert!(!outer.contains(&FvHobSerDe { base_address: 0x4000, length: 0x2000 }));
+        assert!(!FvHobSerDe { base_address: 0x2000, length: 0x1000 }.contains(&outer));
+    }
+
+    #[test]
+    fn test_fv_hob_serde_interval_overlaps() {
+        let a = FvHobSerDe { base_address: 0x1000, length: 0x1000 };
+        assert!(a.overlaps(&a));
+        assert!(a.overlaps(&FvHobSerDe { base_address: 0x1800, length: 0x1000 }));
+        assert!(a.overlaps(&FvHobSerDe { base_address: 0x0800, length: 0x1000 }));
+        assert!(a.overlaps(&FvHobSerDe { base_address: 0x1400, length: 0x0400 }));
+
+        // Touching endpoints are adjacent, not overlapping.
+        assert!(!a.overlaps(&FvHobSerDe { base_address: 0x2000, length: 0x1000 }));
+        assert!(!a.overlaps(&FvHobSerDe { base_address: 0x0000, length: 0x1000 }));
+        assert!(!a.overlaps(&FvHobSerDe { base_address: 0x3000, length: 0x1000 }));
+    }
+
+    #[test]
+    fn test_fv_hob_serde_interval_adjacent() {
+        let a = FvHobSerDe { base_address: 0x1000, length: 0x1000 };
+        assert!(a.adjacent(&FvHobSerDe { base_address: 0x2000, length: 0x1000 }));
+        assert!(a.adjacent(&FvHobSerDe { base_address: 0x0000, length: 0x1000 }));
+        assert!(!a.adjacent(&FvHobSerDe { base_address: 0x3000, length: 0x1000 }));
+        assert!(!a.adjacent(&FvHobSerDe { base_address: 0x1800, length: 0x1000 }));
+    }
+
+    #[test]
+    fn test_fv_hob_serde_interval_merge() {
+        // Overlapping.
+        assert_eq!(
+            FvHobSerDe { base_address: 0x1000, length: 0x1000 }
+                .merge(&FvHobSerDe { base_address: 0x1800, length: 0x1000 }),
+            FvHobSerDe { base_address: 0x1000, length: 0x1800 }
+        );
+        // Adjacent.
+        assert_eq!(
+            FvHobSerDe { base_address: 0x1000, length: 0x1000 }
+                .merge(&FvHobSerDe { base_address: 0x2000, length: 0x1000 }),
+            FvHobSerDe { base_address: 0x1000, length: 0x2000 }
+        );
+        // Contained.
+        assert_eq!(
+            FvHobSerDe { base_address: 0x1000, length: 0x4000 }
+                .merge(&FvHobSerDe { base_address: 0x2000, length: 0x1000 }),
+            FvHobSerDe { base_address: 0x1000, length: 0x4000 }
+        );
+        // Disjoint intervals are still spanned by `merge`.
+        assert_eq!(
+            FvHobSerDe { base_address: 0x1000, length: 0x1000 }
+                .merge(&FvHobSerDe { base_address: 0x8000, length: 0x1000 }),
+            FvHobSerDe { base_address: 0x1000, length: 0x8000 }
+        );
+        // Order independent.
+        assert_eq!(
+            FvHobSerDe { base_address: 0x8000, length: 0x1000 }
+                .merge(&FvHobSerDe { base_address: 0x1000, length: 0x1000 }),
+            FvHobSerDe { base_address: 0x1000, length: 0x8000 }
+        );
+    }
+
+    #[test]
+    fn test_fv_hob_serde_interval_try_merge() {
+        assert_eq!(
+            FvHobSerDe { base_address: 0x1000, length: 0x1000 }
+                .try_merge(&FvHobSerDe { base_address: 0x1800, length: 0x1000 }),
+            Some(FvHobSerDe { base_address: 0x1000, length: 0x1800 })
+        );
+        assert_eq!(
+            FvHobSerDe { base_address: 0x1000, length: 0x1000 }
+                .try_merge(&FvHobSerDe { base_address: 0x2000, length: 0x1000 }),
+            Some(FvHobSerDe { base_address: 0x1000, length: 0x2000 })
+        );
+        assert_eq!(
+            FvHobSerDe { base_address: 0x1000, length: 0x1000 }
+                .try_merge(&FvHobSerDe { base_address: 0x8000, length: 0x1000 }),
+            None
+        );
+    }
+
+    #[test]
+    fn test_fv_hob_serde_interval_merge_intervals() {
+        assert!(FvHobSerDe::merge_intervals(&[]).is_empty());
+
+        let single = FvHobSerDe { base_address: 0x1000, length: 0x1000 };
+        assert_eq!(FvHobSerDe::merge_intervals(&[&single]), alloc::vec![single]);
+
+        // Unsorted input with overlapping, adjacent, and disjoint intervals.
+        let a = FvHobSerDe { base_address: 0x2000, length: 0x1000 };
+        let b = FvHobSerDe { base_address: 0x1000, length: 0x1000 };
+        let c = FvHobSerDe { base_address: 0x2800, length: 0x0800 };
+        let d = FvHobSerDe { base_address: 0x8000, length: 0x1000 };
+        assert_eq!(
+            FvHobSerDe::merge_intervals(&[&a, &b, &c, &d]),
+            alloc::vec![
+                FvHobSerDe { base_address: 0x1000, length: 0x2000 },
+                FvHobSerDe { base_address: 0x8000, length: 0x1000 }
+            ]
+        );
+    }
+
+    #[test]
+    fn test_fv_hob_serde_interval_compare_across_types() {
+        let fv_hob = FvHobSerDe { base_address: 0x1000, length: 0x4000 };
+        let alloc_desc = MemAllocDescriptorSerDe {
+            name: String::from("00000000-0000-0000-0000-000000000000"),
+            memory_base_address: 0x2000,
+            memory_length: 0x1000,
+            memory_type: 0,
+        };
+
+        assert!(fv_hob.contains(&alloc_desc));
+        assert!(fv_hob.overlaps(&alloc_desc));
+        assert!(!fv_hob.adjacent(&alloc_desc));
+        assert!(fv_hob.adjacent(&MemAllocDescriptorSerDe { memory_base_address: 0x5000, ..alloc_desc }));
     }
 }


### PR DESCRIPTION
## Description

Adds an Interval implementation for FvHobSerDe so firmware volume
descriptors can be compared and merged. Generalizes Interval::contains,
overlaps, and adjacent to accept any Interval type instead of only
Self.

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [x] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

`cargo make all`

## Integration Instructions

NA: Not a breaking change because Self already implements T: Interval