### PR TITLE
sdk: Allow char16!/char8! to be used inside const and static items

### DIFF
--- a/sdk/patina/src/base/string.rs
+++ b/sdk/patina/src/base/string.rs
@@ -215,7 +215,9 @@ macro_rules! char16 {
     ($s:literal) => {{
         static CHAR16_LITERAL: $crate::string::Char16Array<{ $crate::string::ucs2_capacity($s) }> =
             $crate::string::Char16Array::from_str($s);
-        CHAR16_LITERAL.as_char16_str()
+        // SAFETY: `ucs2_capacity($s)` is the encoded length plus one for the NUL terminator, so
+        // the array has no padding and its only NUL is the final element.
+        unsafe { $crate::string::Char16Str::from_units_with_nul_unchecked(CHAR16_LITERAL.as_array()) }
     }};
 }
 
@@ -238,7 +240,9 @@ macro_rules! char8 {
     ($s:literal) => {{
         static CHAR8_LITERAL: $crate::string::Char8Array<{ $crate::string::latin1_capacity($s) }> =
             $crate::string::Char8Array::from_str($s);
-        CHAR8_LITERAL.as_char8_str()
+        // SAFETY: `latin1_capacity($s)` is the encoded length plus one for the NUL terminator, so
+        // the array has no padding and its only NUL is the final element.
+        unsafe { $crate::string::Char8Str::from_bytes_with_nul_unchecked(CHAR8_LITERAL.as_array()) }
     }};
 }
 

--- a/sdk/patina/src/base/string/char16.rs
+++ b/sdk/patina/src/base/string/char16.rs
@@ -1152,6 +1152,16 @@ mod tests {
         assert!(name == "café");
     }
 
+    const CHAR16_MACRO_CONST: &Char16Str = char16!("Firmware");
+    static CHAR16_MACRO_STATIC_TABLE: [&Char16Str; 2] = [char16!("A"), char16!("B")];
+
+    #[test]
+    fn test_char16_macro_in_const_and_static_context() {
+        assert!(CHAR16_MACRO_CONST == "Firmware");
+        assert!(CHAR16_MACRO_STATIC_TABLE[0] == "A");
+        assert!(CHAR16_MACRO_STATIC_TABLE[1] == "B");
+    }
+
     #[test]
     fn test_char16_array_binary_layout() {
         assert_eq!(core::mem::size_of::<Char16Array<8>>(), 16);

--- a/sdk/patina/src/base/string/char8.rs
+++ b/sdk/patina/src/base/string/char8.rs
@@ -994,6 +994,16 @@ mod tests {
         assert!(name == "Firmware");
     }
 
+    const CHAR8_MACRO_CONST: &Char8Str = char8!("Firmware");
+    static CHAR8_MACRO_STATIC_TABLE: [&Char8Str; 2] = [char8!("A"), char8!("B")];
+
+    #[test]
+    fn test_char8_macro_in_const_and_static_context() {
+        assert!(CHAR8_MACRO_CONST == "Firmware");
+        assert!(CHAR8_MACRO_STATIC_TABLE[0] == "A");
+        assert!(CHAR8_MACRO_STATIC_TABLE[1] == "B");
+    }
+
     #[test]
     fn test_char8_array_binary_layout() {
         assert_eq!(core::mem::size_of::<Char8Array<8>>(), 8);


### PR DESCRIPTION
## Description

Both macros built their literal through `Char16Array`/`Char8Array` and then called `as_char16_str()`/`as_char8_str()` to borrow it as a `Char16Str`/`Char8Str`.

This required scanning the array at runtime to find the terminator, which rustc will not evaluate in a const context, so the macros could only be called from a function body.

Since the macros size the backing array with `ucs2_capacity()` and `latin1_capacity()`, the array does not have trailing padding and its terminator is always the last element, the borrow can go straight through to already const `as_array()` and `from_units...()` & `from_bytes...()` functions and skip the scan.

This lets a static table be built with `char16!()`/`char8!()` entries. 

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [x] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

- `cargo make all` (including new unit tests)

## Integration Instructions

- N/A