### PR TITLE
Consolidate CRC-32 Fast in the SDK [Rebase & FF]

### DIFF
--- a/patina_dxe_core/Cargo.toml
+++ b/patina_dxe_core/Cargo.toml
@@ -15,7 +15,6 @@ workspace = true
 [dependencies]
 bitfield-struct = { workspace = true }
 cfg-if = { workspace = true }
-crc32fast = { workspace = true }
 goblin = { workspace = true, features = ["pe32", "pe64", "te"] }
 linked_list_allocator = { workspace = true }
 log = { workspace = true }

--- a/patina_dxe_core/src/dxe_services.rs
+++ b/patina_dxe_core/src/dxe_services.rs
@@ -12,6 +12,7 @@ use core::{
     mem,
     slice::{self, from_raw_parts},
 };
+use patina::crc32;
 use patina::error::EfiError;
 use patina_ffs::volume::VolumeRef;
 
@@ -397,7 +398,7 @@ impl<P: PlatformInfo> Core<P> {
         let dxe_services_system_table_ptr = &raw const dxe_services_system_table;
         // SAFETY: dxe_services_system_table is a local value, its byte representation is valid for hashing.
         let crc32 = unsafe {
-            crc32fast::hash(from_raw_parts(
+            crc32::calculate_crc32(from_raw_parts(
                 dxe_services_system_table_ptr as *const u8,
                 mem::size_of::<dxe_services::DxeServicesTable>(),
             ))
@@ -2318,7 +2319,7 @@ mod tests {
             let mut copy = unsafe { core::ptr::read(dxe_tbl) };
             copy.header.crc32 = 0;
             // SAFETY: copy is a local value. Creating a slice from its pointer and size is valid.
-            let crc = crc32fast::hash(unsafe {
+            let crc = patina::crc32::calculate_crc32(unsafe {
                 core::slice::from_raw_parts(
                     (&raw const copy) as *const u8,
                     core::mem::size_of::<dxe_services::DxeServicesTable>(),

--- a/patina_dxe_core/src/gcd/spin_locked_gcd.rs
+++ b/patina_dxe_core/src/gcd/spin_locked_gcd.rs
@@ -9,7 +9,7 @@
 use crate::pecoff::UefiPeInfo;
 use alloc::{boxed::Box, slice, vec, vec::Vec};
 use core::{fmt::Display, ptr};
-use patina::{DEFAULT_CACHE_ATTR, error::EfiError, log_debug_assert};
+use patina::{DEFAULT_CACHE_ATTR, crc32, error::EfiError, log_debug_assert};
 
 use patina::standard::efi;
 use patina::{
@@ -2972,7 +2972,7 @@ impl SpinLockedGcd {
     ///
     /// * `memory_map_bytes` - The byte slice representing the EFI memory map
     pub fn set_last_efi_memory_map_key(&self, memory_map_bytes: &[u8]) {
-        let key = crc32fast::hash(memory_map_bytes) as usize;
+        let key = crc32::calculate_crc32(memory_map_bytes) as usize;
         *self.last_efi_memory_map_key.lock() = Some(key);
     }
 }

--- a/patina_dxe_core/src/misc_boot_services.rs
+++ b/patina_dxe_core/src/misc_boot_services.rs
@@ -10,7 +10,7 @@ use core::{ffi::c_void, slice::from_raw_parts, sync::atomic::Ordering};
 use patina::arch as interrupts;
 use patina::standard::efi;
 use patina::{
-    guid as base_guids, log_debug_assert,
+    crc32, guid as base_guids, log_debug_assert,
     pi::{protocol, status_code},
     uefi::event::EXIT_BOOT_SERVICES_FAILED_EVENT_GROUP_GUID,
 };
@@ -78,7 +78,7 @@ unsafe extern "efiapi" fn calculate_crc32(data: *mut c_void, data_size: usize, c
     // SAFETY: caller must ensure that data and crc_32 are valid pointers. They are null-checked above.
     unsafe {
         let buffer = from_raw_parts(data as *mut u8, data_size);
-        crc_32.write_unaligned(crc32fast::hash(buffer));
+        crc_32.write_unaligned(crc32::calculate_crc32(buffer));
     }
 
     efi::Status::SUCCESS
@@ -366,7 +366,7 @@ mod tests {
             };
             // Verify the function succeeded and CRC32 was calculated correctly for zero buffer
             if status == efi::Status::SUCCESS {
-                let expected_crc = crc32fast::hash(&BUFFER);
+                let expected_crc = crc32::calculate_crc32(&BUFFER);
                 if data_crc == expected_crc {
                     log::debug!("CRC32 calculation successful: {data_crc:#x}");
                 } else {

--- a/patina_dxe_core/src/pi_dispatcher.rs
+++ b/patina_dxe_core/src/pi_dispatcher.rs
@@ -25,6 +25,7 @@ use patina::standard::efi;
 use patina::{
     BinaryGuid, Char16Str, OwnedGuid,
     component::service::Service,
+    crc32,
     error::EfiError,
     pi::{
         fw_fs::ffs,
@@ -241,8 +242,10 @@ impl<P: PlatformInfo> PiDispatcher<P> {
                 },
             );
 
-            let crc32 =
-                crc32fast::hash(alloc::slice::from_raw_parts(ptr as *const u8, size_of::<efi::SystemTablePointer>()));
+            let crc32 = crc32::calculate_crc32(alloc::slice::from_raw_parts(
+                ptr as *const u8,
+                size_of::<efi::SystemTablePointer>(),
+            ));
 
             core::ptr::write_volatile(&raw mut (*ptr).crc32, crc32);
         }

--- a/patina_dxe_core/src/systemtables.rs
+++ b/patina_dxe_core/src/systemtables.rs
@@ -12,7 +12,7 @@ use core::{ffi::c_void, mem::size_of, slice::from_raw_parts};
 
 use alloc::boxed::Box;
 use patina::standard::efi;
-use patina::{component::component, pi::error_codes::EFI_NOT_AVAILABLE_YET, uefi::boot_services::BootServices};
+use patina::{component::component, crc32, pi::error_codes::EFI_NOT_AVAILABLE_YET, uefi::boot_services::BootServices};
 
 use crate::{allocator::EFI_RUNTIME_SERVICES_DATA_ALLOCATOR, tpl_mutex};
 
@@ -50,7 +50,7 @@ impl EfiRuntimeServicesTable {
         // SAFETY: table_copy is a valid, initialized RuntimeServices value on the stack.
         let tbl_slice =
             unsafe { from_raw_parts(&raw const table_copy as *const u8, size_of::<efi::RuntimeServices>()) };
-        table_copy.hdr.crc32 = crc32fast::hash(tbl_slice);
+        table_copy.hdr.crc32 = crc32::calculate_crc32(tbl_slice);
 
         // SAFETY: structure construction ensures pointer is valid.
         unsafe { self.runtime_services.write(table_copy) }
@@ -250,7 +250,7 @@ impl EfiBootServicesTable {
 
         // SAFETY: table_copy is a valid, initialized BootServices value on the stack.
         let tbl_slice = unsafe { from_raw_parts(&raw const table_copy as *const u8, size_of::<efi::BootServices>()) };
-        table_copy.hdr.crc32 = crc32fast::hash(tbl_slice);
+        table_copy.hdr.crc32 = crc32::calculate_crc32(tbl_slice);
 
         // SAFETY: structure construction ensures pointer is valid.
         unsafe { self.boot_services.write(table_copy) }
@@ -740,7 +740,7 @@ impl EfiSystemTable {
 
         // SAFETY: table_copy is a valid, initialized SystemTable value on the stack.
         let st_slice = unsafe { from_raw_parts(&raw const table_copy as *const u8, size_of::<efi::SystemTable>()) };
-        table_copy.hdr.crc32 = crc32fast::hash(st_slice);
+        table_copy.hdr.crc32 = crc32::calculate_crc32(st_slice);
 
         // SAFETY: structure construction ensures pointer is valid.
         unsafe { self.system_table.write(table_copy) }

--- a/sdk/patina/Cargo.toml
+++ b/sdk/patina/Cargo.toml
@@ -51,6 +51,7 @@ fixedbitset = { workspace = true, optional = true }
 bitvec = { workspace = true }
 cfg-if = { workspace = true }
 compile-time = { workspace = true }
+crc32fast = { workspace = true }
 goblin = { workspace = true, features = ["pe32", "pe64", "te", "alloc"], optional = true }
 log = { workspace = true }
 r-efi = { version = "7.1", default-features = false }

--- a/sdk/patina/src/base.rs
+++ b/sdk/patina/src/base.rs
@@ -12,6 +12,7 @@ use crate::base::error::EfiError;
 use crate::standard::efi;
 
 pub mod c_ptr;
+pub mod crc32;
 pub mod error;
 pub mod guid;
 pub mod hash;

--- a/sdk/patina/src/base/crc32.rs
+++ b/sdk/patina/src/base/crc32.rs
@@ -1,0 +1,47 @@
+//! CRC-32 checksum calculation for Patina.
+//!
+//! Provides a general-purpose CRC-32 checksum function for use across Patina.
+//!
+//! ## License
+//!
+//! Copyright (c) Microsoft Corporation.
+//!
+//! SPDX-License-Identifier: Apache-2.0
+
+/// Computes the CRC-32 of `data`, matching what is expected from the UEFI `CalculateCrc32`
+/// boot service.
+///
+/// # Examples
+///
+/// ```rust,no_run
+/// use patina::crc32::calculate_crc32;
+///
+/// let checksum = calculate_crc32(b"hello");
+/// log::info!("crc32 = {checksum:#x}");
+/// ```
+pub fn calculate_crc32(data: &[u8]) -> u32 {
+    crc32fast::hash(data)
+}
+
+#[cfg(test)]
+#[cfg_attr(coverage, coverage(off))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_calculate_crc32_empty_slice() {
+        assert_eq!(calculate_crc32(&[]), crc32fast::hash(&[]));
+    }
+
+    #[test]
+    fn test_calculate_crc32_known_vector() {
+        // "123456789" is the standard CRC-32 check-value test vector.
+        let data = b"123456789";
+        assert_eq!(calculate_crc32(data), crc32fast::hash(data));
+    }
+
+    #[test]
+    fn test_calculate_crc32_different_inputs_produce_different_hashes() {
+        assert_ne!(calculate_crc32(b"abc"), calculate_crc32(b"abd"));
+    }
+}

--- a/sdk/patina_ffs_extractors/Cargo.toml
+++ b/sdk/patina_ffs_extractors/Cargo.toml
@@ -17,14 +17,13 @@ patina = { workspace = true }
 patina_ffs = { workspace = true }
 brotli-decompressor = { workspace = true, optional = true }
 alloc-no-stdlib = { workspace = true, optional = true }
-crc32fast = { workspace = true, optional = true }
 lzma-rust2 = { workspace = true, optional = true, default-features = false }
 
 [features]
 default = ["brotli", "crc32", "lzma"]
 std = []
 brotli = ["dep:brotli-decompressor", "dep:alloc-no-stdlib"]
-crc32 = ["dep:crc32fast"]
+crc32 = []
 lzma = ["dep:lzma-rust2"]
 # All non-std features to test in CI
 ci_features = ["brotli", "crc32", "lzma"]

--- a/sdk/patina_ffs_extractors/src/composite.rs
+++ b/sdk/patina_ffs_extractors/src/composite.rs
@@ -89,6 +89,7 @@ impl SectionExtractor for CompositeSectionExtractor {
 #[cfg_attr(coverage, coverage(off))]
 mod tests {
     use super::*;
+    use patina::crc32;
 
     #[test]
     #[cfg(feature = "crc32")]
@@ -96,7 +97,7 @@ mod tests {
         use crate::tests::create_crc32_section;
 
         let content = b"Test CRC32 content";
-        let crc32 = crc32fast::hash(content);
+        let crc32 = crc32::calculate_crc32(content);
         let section = create_crc32_section(content, crc32.to_le_bytes().to_vec());
 
         let extractor = CompositeSectionExtractor::default();

--- a/sdk/patina_ffs_extractors/src/crc32.rs
+++ b/sdk/patina_ffs_extractors/src/crc32.rs
@@ -6,6 +6,7 @@
 //!
 //! SPDX-License-Identifier: Apache-2.0
 //!
+use patina::crc32;
 use patina::pi::fw_fs;
 use patina_ffs::{
     FirmwareFileSystemError,
@@ -32,7 +33,7 @@ impl SectionExtractor for Crc32SectionExtractor {
             let crc32_bytes = crc_header.get(..4).ok_or(FirmwareFileSystemError::DataCorrupt)?;
             let crc32 = u32::from_le_bytes(crc32_bytes.try_into().unwrap());
             let content = section.try_content_as_slice()?;
-            if crc32 != crc32fast::hash(content) {
+            if crc32 != crc32::calculate_crc32(content) {
                 //TODO: in EDK2 C reference implementation, data is returned along with EFI_AUTH_STATUS_TEST_FAILED.
                 //For now, just return an error if the CRC fails to check.
                 Err(FirmwareFileSystemError::DataCorrupt)?;
@@ -55,7 +56,7 @@ mod tests {
     #[test]
     fn test_crc32_extractor_valid() {
         let content = b"Hello, CRC32!";
-        let crc32 = crc32fast::hash(content);
+        let crc32 = crc32::calculate_crc32(content);
         let section = create_crc32_section(content, crc32.to_le_bytes().to_vec());
 
         let extractor = Crc32SectionExtractor;
@@ -79,7 +80,7 @@ mod tests {
     #[test]
     fn test_crc32_extractor_empty_content() {
         let content = b"";
-        let crc32 = crc32fast::hash(content);
+        let crc32 = crc32::calculate_crc32(content);
         let section = create_crc32_section(content, crc32.to_le_bytes().to_vec());
 
         let extractor = Crc32SectionExtractor;
@@ -93,7 +94,7 @@ mod tests {
         // A malformed section whose GUID-specific data is larger than the 4-byte CRC32 value
         // should only have the first 4 bytes interpreted as the checksum.
         let content = b"Hello, CRC32!";
-        let crc32 = crc32fast::hash(content);
+        let crc32 = crc32::calculate_crc32(content);
         let mut guid_data = crc32.to_le_bytes().to_vec();
         guid_data.extend_from_slice(&[0xAA, 0xBB, 0xCC, 0xDD]); // give trailing bytes beyond the CRC32
         let section = create_crc32_section(content, guid_data);
@@ -134,7 +135,7 @@ mod tests {
             attributes: 0x01,
         };
 
-        let crc32_bytes = crc32fast::hash(content).to_le_bytes().to_vec();
+        let crc32_bytes = crc32::calculate_crc32(content).to_le_bytes().to_vec();
         let header = SectionHeader::GuidDefined(guid_header, crc32_bytes, content.len() as u32);
         let section =
             Section::new_from_header_with_data(header, content.to_vec()).expect("Failed to create test section");


### PR DESCRIPTION
## Description

A series of commits to abstract a single CRC-32 wrapper from Patina SDK and replace third-party crate dependencies with the export SDK functionality.

---

**sdk: Add a dedicated CRC-32 module for Patina**

Abstracts the underlying CRC-32 implementation from the rest of the
Patina codebase, providing a single, direct function for computing
CRC-32 checksums. Can be used to provide the `CalculateCrc32` boot
service.

---

**sdk: Remove direct dependency on crc32fast from patina_ffs_extractors**

Uses the Patina SDK CRC-32 calculation function instead of directly
depending on `crc32fast`.

The `crc-32` feature is left in the `patina_ffs_extractors` Cargo.toml
file since it still gates whether `Crc32SectionExtractor` is compiled.
However, the direct dependency on the `crc32fast` crate is removed.

---

**patina_dxe_core: Use the Patina SDK CRC-32 implementation**

Drops a direct dependency on the `crc32fast` crate in the DXE Core,
so Patina code can align behind a single abstraction defined in the
Patina SDK.

Updates callers to use the `patina::crc32::calculate_crc32` function.

---

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

- `cargo make all`
- QEMU ArmVirt & Q35 boot

## Integration Instructions

- N/A