### PR TITLE
sdk: Implement ProtocolInterface for TimerProtocol

### DIFF
--- a/sdk/patina/src/pi/protocol/timer.rs
+++ b/sdk/patina/src/pi/protocol/timer.rs
@@ -12,6 +12,7 @@
 //! SPDX-License-Identifier: Apache-2.0
 //!
 
+use crate::base::protocol::ProtocolInterface;
 use crate::standard::efi;
 
 /// Timer Arch Protocol GUID.
@@ -117,4 +118,10 @@ pub struct TimerProtocol {
     pub get_timer_period: EfiTimerGetTimerPeriod,
     /// Generates a software timer interrupt.
     pub generate_soft_interrupt: EfiTimerGenerateSoftInterrupt,
+}
+
+// SAFETY: `TimerProtocol` is `#[repr(C)]` and `PROTOCOL_GUID` is the PI-spec GUID that
+// identifies its layout (EFI_TIMER_ARCH_PROTOCOL).
+unsafe impl ProtocolInterface for TimerProtocol {
+    const PROTOCOL_GUID: crate::BinaryGuid = PROTOCOL_GUID;
 }


### PR DESCRIPTION
## Description

Associate the `TimerProtocol` structure with the PI-defined GUID so that the protocol can be used more safely in code.

Note: This is an improvement on its own, but it's being made to support backing the upcoming Timer Services.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

- `cargo make all`

## Integration Instructions

- N/A